### PR TITLE
fix: clear collectedMetrics between workouts

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
@@ -672,6 +672,7 @@ class MainViewModel constructor(
                 _workoutState.value = WorkoutState.Active
                 workoutStartTime = currentTimeMillis()
                 currentSessionId = KmpUtils.randomUUID()
+                collectedMetrics.clear()  // Clear metrics from previous workout
                 _hapticEvents.emit(HapticEvent.WORKOUT_START)
 
                 // Bodyweight timer - auto-complete after duration
@@ -775,6 +776,7 @@ class MainViewModel constructor(
             // 7. Start Monitoring
             _workoutState.value = WorkoutState.Active
             workoutStartTime = currentTimeMillis()
+            collectedMetrics.clear()  // Clear metrics from previous workout
             _hapticEvents.emit(HapticEvent.WORKOUT_START)
 
             // Set initial baseline position for position bars calibration


### PR DESCRIPTION
Fix memory leak where collectedMetrics accumulated across workouts. Now properly cleared at workout start for both bodyweight and normal cable-based exercises.