### PR TITLE
Resolve long-standing Project Phoenix issue

### DIFF
--- a/shared/src/androidMain/kotlin/com/devil/phoenixproject/presentation/components/VideoPlayer.android.kt
+++ b/shared/src/androidMain/kotlin/com/devil/phoenixproject/presentation/components/VideoPlayer.android.kt
@@ -59,6 +59,9 @@ actual fun VideoPlayer(
                                 Logger.d("VideoPlayer") { "Video prepared, starting playback" }
                                 isLoading = false
                                 mp.isLooping = true
+                                // Mute the video to prevent audio focus theft from other apps (e.g., Spotify)
+                                // These are silent preview videos that play like GIFs
+                                mp.setVolume(0f, 0f)
                                 start()
                             }
 

--- a/shared/src/iosMain/kotlin/com/devil/phoenixproject/presentation/components/VideoPlayer.ios.kt
+++ b/shared/src/iosMain/kotlin/com/devil/phoenixproject/presentation/components/VideoPlayer.ios.kt
@@ -213,6 +213,9 @@ private class LoopingPlayerView : UIView(frame = CGRectZero.readValue()) {
 
         val item = AVPlayerItem(uRL = url)
         val avPlayer = AVPlayer(playerItem = item)
+        // Mute the video to prevent audio focus theft from other apps (e.g., Spotify)
+        // These are silent preview videos that play like GIFs
+        avPlayer.volume = 0f
         player = avPlayer
 
         val layer = playerLayer ?: AVPlayerLayer().also { createdLayer ->


### PR DESCRIPTION
When exercise details load, the VideoPlayer component plays preview videos that were inadvertently stealing audio focus from other apps like Spotify. This caused external audio to pause or create a "clipping" sound.

Since these are silent demonstration videos (like GIFs), they should not request audio focus. Muting the video players prevents the system from taking audio control.

Fixes #16