### PR TITLE
Implement user authentication system

### DIFF
--- a/iosApp/VitruvianPhoenix/VitruvianPhoenix/Info.plist
+++ b/iosApp/VitruvianPhoenix/VitruvianPhoenix/Info.plist
@@ -40,7 +40,7 @@
     </dict>
     <key>UIRequiredDeviceCapabilities</key>
     <array>
-        <string>armv7</string>
+        <string>arm64</string>
         <string>bluetooth-le</string>
     </array>
     <key>UISupportedInterfaceOrientations</key>


### PR DESCRIPTION
…rash

The iOS app was crashing immediately when users tapped the "Continue" button on the Bluetooth permission screen. This fix addresses two issues:

1. Implemented proper iOS BLE permission handling using CBCentralManager:
   - Added BluetoothPermissionManager class that properly interacts with CoreBluetooth to check and request Bluetooth authorization
   - Permission state is now checked on app launch using CBManager.authorization
   - The iOS permission dialog is properly triggered via CBCentralManager
   - Added delegate handling for centralManagerDidUpdateState to track permission changes
   - Added "Requesting" state with loading UI while permission dialog is shown
   - Re-checking permission status works correctly for users who enable Bluetooth in Settings

2. Fixed incorrect UIRequiredDeviceCapabilities in Info.plist:
   - Changed from armv7 to arm64 (modern iPhones are 64-bit only)
   - armv7 has not been supported since iOS 11

Fixes #18