### PR TITLE
fix: exclude SetSummary from connection lost detection

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/WorkoutTab.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/WorkoutTab.kt
@@ -322,10 +322,11 @@ fun WorkoutTab(
             }
 
             // Show "Workout Paused" card when connection is lost during an active workout (Issue #42)
+            // Note: SetSummary is excluded because the summary screen doesn't need connection
+            // and should remain fully visible to show workout results and save to history
             val isWorkoutInProgress = workoutState is WorkoutState.Active ||
                 workoutState is WorkoutState.Countdown ||
-                workoutState is WorkoutState.Resting ||
-                workoutState is WorkoutState.SetSummary
+                workoutState is WorkoutState.Resting
             val isDisconnected = connectionState is ConnectionState.Disconnected ||
                 connectionState is ConnectionState.Error
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
@@ -560,13 +560,14 @@ class MainViewModel constructor(
                     }
                     is ConnectionState.Disconnected, is ConnectionState.Error -> {
                         // Only trigger alert if we were previously connected
-                        // and a workout is in progress
+                        // and a workout is actively in progress (not in summary)
+                        // SetSummary is excluded since the summary screen doesn't need connection
+                        // and users need to interact with it to save workout history
                         if (wasConnected) {
                             val workoutActive = when (_workoutState.value) {
                                 is WorkoutState.Active,
                                 is WorkoutState.Countdown,
-                                is WorkoutState.Resting,
-                                is WorkoutState.SetSummary -> true
+                                is WorkoutState.Resting -> true
                                 else -> false
                             }
                             if (workoutActive) {


### PR DESCRIPTION
The previous fix for Issue #42 incorrectly included SetSummary in the workout states that trigger the connection lost dialog and paused card.

This caused issues because:
- SetSummary screen doesn't need BLE connection to function
- Users need to interact with the summary to log RPE and proceed
- The summary data needs to be saved to workout history
- Showing the connection lost dialog/card blocks this flow

Now only Active, Countdown, and Resting states trigger the connection lost UI, allowing the post-exercise summary to function normally.