### PR TITLE
Fix critical crash in latest release

### DIFF
--- a/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/migrations/5.sqm
+++ b/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/migrations/5.sqm
@@ -1,0 +1,28 @@
+-- Migration 5: Add set summary metrics columns to WorkoutSession
+-- These columns store aggregate workout statistics calculated at the end of each set
+
+-- Peak force measurements (nullable since not all sessions will have these)
+ALTER TABLE WorkoutSession ADD COLUMN peakForceConcentricA REAL;
+ALTER TABLE WorkoutSession ADD COLUMN peakForceConcentricB REAL;
+ALTER TABLE WorkoutSession ADD COLUMN peakForceEccentricA REAL;
+ALTER TABLE WorkoutSession ADD COLUMN peakForceEccentricB REAL;
+
+-- Average force measurements
+ALTER TABLE WorkoutSession ADD COLUMN avgForceConcentricA REAL;
+ALTER TABLE WorkoutSession ADD COLUMN avgForceConcentricB REAL;
+ALTER TABLE WorkoutSession ADD COLUMN avgForceEccentricA REAL;
+ALTER TABLE WorkoutSession ADD COLUMN avgForceEccentricB REAL;
+
+-- Summary statistics
+ALTER TABLE WorkoutSession ADD COLUMN heaviestLiftKg REAL;
+ALTER TABLE WorkoutSession ADD COLUMN totalVolumeKg REAL;
+ALTER TABLE WorkoutSession ADD COLUMN estimatedCalories REAL;
+
+-- Average weights by workout phase
+ALTER TABLE WorkoutSession ADD COLUMN warmupAvgWeightKg REAL;
+ALTER TABLE WorkoutSession ADD COLUMN workingAvgWeightKg REAL;
+ALTER TABLE WorkoutSession ADD COLUMN burnoutAvgWeightKg REAL;
+ALTER TABLE WorkoutSession ADD COLUMN peakWeightKg REAL;
+
+-- Rate of Perceived Exertion (1-10 scale, user-entered)
+ALTER TABLE WorkoutSession ADD COLUMN rpe INTEGER;


### PR DESCRIPTION
Users updating from v0.2.0 were experiencing instant crashes because 16 new columns were added to the WorkoutSession table schema but no migration file was created to add them for existing databases.

SQLDelight expected these columns to exist after running all migrations, but since there was no migration to create them, the app crashed on startup when trying to access the database.

This adds migration 5.sqm with ALTER TABLE statements to add:
- Peak force measurements (concentric/eccentric for A/B cables)
- Average force measurements
- Summary statistics (heaviest lift, total volume, calories)
- Phase-based average weights (warmup, working, burnout, peak)
- RPE (Rate of Perceived Exertion)