### PR TITLE
fix: enable Backup All Data sharing via FileProvider and revert unrelated CSV change

### DIFF
--- a/androidApp/src/main/res/xml/file_paths.xml
+++ b/androidApp/src/main/res/xml/file_paths.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths>
-    <!-- Cache directory for CSV exports -->
+    <!-- Cache directories for sharing exported files -->
     <cache-path name="exports" path="exports/" />
+    <cache-path name="backups" path="backups/" />
 </paths>


### PR DESCRIPTION
### Motivation
- The Android "Backup All Data → Share" flow failed because `FileProvider` was not configured to expose the app cache `backups` directory where temporary backup files are written. 
- A prior CSV-duration tweak was unrelated to the backup share issue and was reverted to avoid unintended behavior changes.

### Description
- Added `<cache-path name="backups" path="backups/" />` to `androidApp/src/main/res/xml/file_paths.xml` so `FileProvider.getUriForFile(...)` can generate URIs for files under `context.cacheDir/backups` used by `AndroidDataBackupManager`.
- Restored the previous behavior in `shared/src/androidMain/kotlin/com/devil/phoenixproject/util/CsvExporter.android.kt` (undoing the accidental CSV duration unit change) to keep this PR focused on the backup share fix.

### Testing
- Parsed the updated XML with `xml.etree.ElementTree` to validate `androidApp/src/main/res/xml/file_paths.xml`, which succeeded (`xml ok`).
- Verified path alignment across code with `rg` to ensure `cache-path name="backups"` matches the `AndroidDataBackupManager` cache usage, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699556a466f48322b2b4ec8223d01cdf)