### PR TITLE
Add framework-template distribution target and framework governance docs

### DIFF
--- a/.github/release-checklist-framework.md
+++ b/.github/release-checklist-framework.md
@@ -1,0 +1,33 @@
+# Framework Release Checklist
+
+Use this checklist for any framework-core / protocol-spi release.
+
+## Versioning & API Governance
+
+- [ ] Semantic versions selected for `framework-core` and `framework-protocol-spi`.
+- [ ] API diff reviewed for breaking changes.
+- [ ] Deprecations documented with replacement paths and removal target.
+- [ ] Stability annotations (`@StableApi`, `@ExperimentalApi`, `@InternalApi`) reviewed for changed APIs.
+
+## Documentation
+
+- [ ] Release notes published with compatibility statement.
+- [ ] Upgrade guide updated for plugin authors.
+- [ ] Compatibility matrix updated.
+
+## Template & Samples
+
+- [ ] `framework-template` branch regenerated with `framework-template/generate-framework-template.sh`.
+- [ ] Sample adapter updated and validated against latest SPI.
+
+## Quality Gates
+
+- [ ] Unit/integration test suite passed.
+- [ ] Conformance suite updated (if protocol behavior changed) and passing.
+- [ ] CI workflows green for target release commit.
+
+## Publish
+
+- [ ] Release tags pushed.
+- [ ] Artifacts published.
+- [ ] Release announcement includes migration and compatibility notes.

--- a/README.md
+++ b/README.md
@@ -158,6 +158,16 @@ Project-Phoenix-MP/
 
 ---
 
+
+## Framework Governance
+
+- [Framework Template Distribution Target](framework-template/README.md)
+- [Framework API Versioning, Stability, and Deprecation Policy](docs/framework/versioning-and-compatibility.md)
+- [Plugin Author Upgrade Guide](docs/framework/plugin-upgrade-guide.md)
+- [Framework Release Checklist](.github/release-checklist-framework.md)
+
+---
+
 ## Contributing
 
 This is a proprietary project. Contributions are not currently accepted.

--- a/docs/framework/plugin-upgrade-guide.md
+++ b/docs/framework/plugin-upgrade-guide.md
@@ -1,0 +1,43 @@
+# Plugin Author Upgrade Guide
+
+This guide explains how plugin authors should evaluate and upgrade against framework releases.
+
+## Compatibility Matrix
+
+| Framework Core | Protocol SPI | Expected Plugin Impact |
+|---|---|---|
+| PATCH | PATCH | No source changes expected |
+| MINOR | PATCH/MINOR | Optional feature adoption only |
+| MAJOR | MAJOR or mixed | Migration required; check release notes |
+
+## Upgrade Workflow
+
+1. **Read release notes** for both `framework-core` and `framework-protocol-spi`.
+2. **Check deprecations** and replacement APIs.
+3. **Run adapter tests** against the new target versions.
+4. **Run conformance suite** before publishing plugin updates.
+5. **Publish plugin compatibility declaration** (supported framework version range).
+
+## Migration Notes Template (for each release)
+
+For each framework release, maintain this section in release docs:
+
+- Breaking changes
+- Deprecated APIs and replacement path
+- Behavioral changes in protocol handling
+- Required configuration updates
+- Conformance suite result delta
+
+## Risk-based Upgrade Recommendations
+
+- **From PATCH to PATCH:** safe for immediate upgrade after CI passes.
+- **From MINOR to MINOR:** schedule normal sprint validation; verify optional SPI additions do not shadow custom logic.
+- **Across MAJOR versions:** allocate explicit migration sprint and complete full regression + conformance run.
+
+## Backward Compatibility Notes for Maintainers
+
+When publishing framework releases, include:
+
+- Whether prior plugin binaries still load.
+- Whether plugin source changes are required.
+- Whether protocol defaults changed.

--- a/docs/framework/versioning-and-compatibility.md
+++ b/docs/framework/versioning-and-compatibility.md
@@ -1,0 +1,74 @@
+# Framework API Versioning, Stability, and Deprecation Policy
+
+## Scope
+
+This policy applies to:
+
+- **Core Framework API:** public Kotlin APIs consumed by host applications.
+- **Protocol SPI:** plugin/service provider interfaces and protocol integration points.
+
+## Semantic Versioning
+
+Both Core API and Protocol SPI follow **Semantic Versioning** (`MAJOR.MINOR.PATCH`).
+
+### Core API SemVer Rules
+
+- **MAJOR:** breaking API change, removed public type/member, changed behavior requiring consumer code changes.
+- **MINOR:** backward-compatible feature additions.
+- **PATCH:** backward-compatible bug fixes and internal changes.
+
+### Protocol SPI SemVer Rules
+
+- **MAJOR:** SPI contract or protocol behavior breaks existing plugins/adapters.
+- **MINOR:** additive SPI capability that does not break existing implementations.
+- **PATCH:** SPI bug fixes without contract changes.
+
+### Version Publication
+
+Each release must publish:
+
+- `framework-core` version
+- `framework-protocol-spi` version
+- compatibility statement in release notes
+
+## Compatibility Contract for Plugin Authors
+
+- Core `PATCH` and `MINOR` releases are required to preserve source compatibility unless explicitly documented.
+- SPI `PATCH` releases are required to preserve binary and source compatibility.
+- SPI `MINOR` releases may add optional extension points but cannot invalidate existing plugin registrations.
+
+## Deprecation Policy
+
+Deprecations are handled in three stages:
+
+1. **Soft deprecation (N):** mark API as deprecated with replacement guidance.
+2. **Transition window (N+1):** retain deprecated API, update docs/examples, and warn in release notes.
+3. **Removal (N+2 or next major):** remove only in a major release unless an urgent security issue requires earlier removal.
+
+Default minimum deprecation period:
+
+- Core API: **2 minor releases**.
+- Protocol SPI: **3 minor releases** (to allow ecosystem migration).
+
+## Stability Annotations
+
+Framework packages should use explicit stability markers:
+
+- `@StableApi` for APIs with semver compatibility guarantees.
+- `@ExperimentalApi` for opt-in features with no stability guarantees.
+- `@InternalApi` for non-public APIs (not for plugin consumption).
+
+When Kotlin annotations are not yet implemented, document intended stability using KDoc tags:
+
+- `@since`
+- `@deprecated`
+- `@replacement`
+- `@stability Stable|Experimental|Internal`
+
+## Breaking Change Exception Process
+
+A breaking change outside a major release requires:
+
+1. Security or critical correctness rationale.
+2. Written migration instructions.
+3. Explicit compatibility exception section in release notes.

--- a/framework-template/README.md
+++ b/framework-template/README.md
@@ -1,0 +1,27 @@
+# Framework Template Distribution Target
+
+This repository now supports a dedicated distribution target named `framework-template`.
+
+## Strategy
+
+- **Distribution model:** maintained branch in this repository (`framework-template`).
+- **Source of truth:** `main` remains canonical; template artifacts are generated from source and published from `framework-template`.
+- **Generator:** `framework-template/generate-framework-template.sh`.
+
+## Release Flow
+
+1. Checkout the `framework-template` branch.
+2. Rebase/merge from `main`.
+3. Run:
+   ```bash
+   ./framework-template/generate-framework-template.sh
+   ```
+4. Validate generated output (`./gradlew :shared:check`).
+5. Commit generated template snapshot.
+6. Tag with `v<core-version>-template`.
+
+## Why a branch instead of a separate repository?
+
+- Keeps code and template evolution synchronized.
+- Preserves one issue tracker and one release cadence.
+- Reduces cross-repo automation overhead while retaining a dedicated install target for consumers.

--- a/framework-template/generate-framework-template.sh
+++ b/framework-template/generate-framework-template.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Generates a distributable framework template from the current repository.
+# Intended to run on the maintained `framework-template` branch.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT_DIR="${1:-${ROOT_DIR}/build/framework-template-dist}"
+
+INCLUDE_FILES=(
+  "README.md"
+  "build.gradle.kts"
+  "settings.gradle.kts"
+  "gradle.properties"
+)
+
+INCLUDE_DIRS=(
+  "gradle"
+  "shared"
+)
+
+rm -rf "${OUT_DIR}"
+mkdir -p "${OUT_DIR}"
+
+for file in "${INCLUDE_FILES[@]}"; do
+  if [[ -f "${ROOT_DIR}/${file}" ]]; then
+    mkdir -p "${OUT_DIR}/$(dirname "${file}")"
+    cp "${ROOT_DIR}/${file}" "${OUT_DIR}/${file}"
+  fi
+done
+
+for dir in "${INCLUDE_DIRS[@]}"; do
+  if [[ -d "${ROOT_DIR}/${dir}" ]]; then
+    rsync -a --delete \
+      --exclude 'build/' \
+      --exclude '.gradle/' \
+      --exclude '*.iml' \
+      --exclude '.DS_Store' \
+      "${ROOT_DIR}/${dir}/" "${OUT_DIR}/${dir}/"
+  fi
+done
+
+cat <<MSG
+Framework template generated:
+  ${OUT_DIR}
+
+Next steps:
+  1. Validate with ./gradlew :shared:check
+  2. Tag the framework-template branch (vX.Y.Z-template)
+MSG


### PR DESCRIPTION
### Motivation

- Provide a dedicated, reproducible distribution target for framework consumers and maintain a generator for template snapshots. 
- Establish clear semantic versioning, API stability, and deprecation rules covering both core framework APIs and the protocol SPI to help plugin authors plan upgrades. 
- Standardize release steps and checks (docs, sample adapter, conformance suite) so framework releases are predictable and auditable.

### Description

- Add `framework-template/generate-framework-template.sh` which produces a distributable template snapshot from selected project sources (`README.md`, Gradle config, `gradle/`, and `shared/`) and excludes build artifacts. 
- Add `framework-template/README.md` documenting the distribution-branch workflow and generation steps. 
- Add governance documentation under `docs/framework/` including `versioning-and-compatibility.md` and `plugin-upgrade-guide.md` with SemVer rules, deprecation policy, stability annotations, upgrade workflow, and a compatibility matrix. 
- Add a release checklist at `.github/release-checklist-framework.md` and link all new governance artifacts from the root `README.md` for discoverability.

### Testing

- Performed a syntax check with `bash -n framework-template/generate-framework-template.sh` which succeeded. 
- Executed `./framework-template/generate-framework-template.sh /tmp/framework-template-dist-test` and confirmed the script generated the expected output path without errors. 
- No runtime application behavior was modified; changes are documentation and release-tooling only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2adeb79088322b6dba95003c456e0)