### PR TITLE
Add shared vendor conformance suite, fake peripheral fixtures, docs and CI matrix for Phoenix + demo adapters

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -71,6 +71,52 @@ jobs:
           check_name: 'Unit Test Results'
           fail_on_failure: true
 
+
+  vendor-conformance:
+    name: Vendor Conformance (${{ matrix.vendor_adapter }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        vendor_adapter: [phoenix, demo]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Run vendor conformance suite
+        env:
+          VENDOR_ADAPTER: ${{ matrix.vendor_adapter }}
+        run: ./gradlew :shared:testAndroidHostTest --tests "com.devil.phoenixproject.conformance.*" --continue
+
+      - name: Publish vendor conformance report
+        uses: mikepenz/action-junit-report@v4
+        if: always()
+        with:
+          report_paths: 'shared/build/test-results/testAndroidHostTest/TEST-*.xml'
+          check_name: 'Vendor Conformance (${{ matrix.vendor_adapter }})'
+          fail_on_failure: true
+
   build-android:
     name: Build Android
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -126,6 +126,15 @@ See [Release Notes](https://github.com/DasBluEyedDevil/Project-Phoenix-MP/releas
 open iosApp/VitruvianPhoenix/VitruvianPhoenix.xcodeproj
 ```
 
+
+### Vendor adapter conformance tests
+```bash
+./gradlew :shared:testAndroidHostTest --tests "com.devil.phoenixproject.conformance.*"
+```
+
+Use `VENDOR_ADAPTER=<id>` (for example `phoenix` or `demo`) to run adapter-specific conformance checks.
+See [Vendor Adapter Conformance Suite](docs/vendor-adapter-conformance.md) for the full workflow.
+
 ---
 
 ## Technology Stack

--- a/docs/vendor-adapter-conformance.md
+++ b/docs/vendor-adapter-conformance.md
@@ -1,0 +1,36 @@
+# Vendor Adapter Conformance Suite
+
+When adding or updating a vendor BLE adapter, run the shared conformance suite before opening a PR.
+
+## What it validates
+
+The suite checks cross-vendor invariants:
+
+1. **Command encoding invariants** (start/stop/activation packet shape)
+2. **Telemetry decoding validity** (valid monitor packets decode, invalid packets are rejected)
+3. **Workout lifecycle state transitions** (Idle → Active → SetSummary)
+4. **Reconnect/error semantics** (connection-loss alert behavior)
+
+## Run locally
+
+Run all adapter targets:
+
+```bash
+./gradlew :shared:testAndroidHostTest --tests "com.devil.phoenixproject.conformance.*"
+```
+
+Run for a single adapter target:
+
+```bash
+VENDOR_ADAPTER=phoenix ./gradlew :shared:testAndroidHostTest --tests "com.devil.phoenixproject.conformance.*"
+VENDOR_ADAPTER=demo ./gradlew :shared:testAndroidHostTest --tests "com.devil.phoenixproject.conformance.*"
+```
+
+## CI coverage
+
+The `CI Tests` workflow includes a `vendor-conformance` matrix job that runs the suite for:
+
+- `phoenix`
+- `demo`
+
+Add new vendor IDs to the matrix and `VendorConformanceTargets` when introducing a new plugin.

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/conformance/CommandEncodingConformanceTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/conformance/CommandEncodingConformanceTest.kt
@@ -1,0 +1,32 @@
+package com.devil.phoenixproject.conformance
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CommandEncodingConformanceTest {
+
+    @Test
+    fun `start and stop commands keep invariant framing`() {
+        VendorConformanceTargets.selected().forEach { target ->
+            val start = target.encodeStartCommand()
+            val stop = target.encodeStopCommand()
+
+            assertEquals(4, start.size, "${target.id}: start command must be 4 bytes")
+            assertEquals(0x03.toByte(), start[0], "${target.id}: start opcode must be 0x03")
+            assertEquals(4, stop.size, "${target.id}: stop command must be 4 bytes")
+            assertEquals(0x05.toByte(), stop[0], "${target.id}: stop opcode must be 0x05")
+        }
+    }
+
+    @Test
+    fun `activation command keeps 96-byte layout invariant`() {
+        VendorConformanceTargets.selected().forEach { target ->
+            val activation = target.encodeActivationCommand()
+
+            assertEquals(96, activation.size, "${target.id}: activation packet must be 96 bytes")
+            assertEquals(0x04.toByte(), activation[0], "${target.id}: activation opcode must be 0x04")
+            assertTrue(activation.any { it != 0.toByte() }, "${target.id}: activation packet should not be all zeros")
+        }
+    }
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/conformance/ReconnectErrorSemanticsConformanceTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/conformance/ReconnectErrorSemanticsConformanceTest.kt
@@ -1,0 +1,85 @@
+package com.devil.phoenixproject.conformance
+
+import com.devil.phoenixproject.domain.model.ConnectionState
+import com.devil.phoenixproject.presentation.manager.BleConnectionManager
+import com.devil.phoenixproject.presentation.manager.SettingsManager
+import com.devil.phoenixproject.presentation.manager.WorkoutStateProvider
+import com.devil.phoenixproject.testutil.FakeBleRepository
+import com.devil.phoenixproject.testutil.FakePreferencesManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ReconnectErrorSemanticsConformanceTest {
+
+    @Test
+    fun `connection loss during active workout triggers reconnect alert and clears on reconnect`() = runTest {
+        VendorConformanceTargets.selected().forEach { _ ->
+            val dispatcher = StandardTestDispatcher(testScheduler)
+            val scope = CoroutineScope(coroutineContext + dispatcher)
+            val fakeBleRepo = FakeBleRepository()
+            val settingsManager = SettingsManager(FakePreferencesManager(), fakeBleRepo, scope)
+
+            val stateProvider = object : WorkoutStateProvider {
+                override val isWorkoutActiveForConnectionAlert: Boolean
+                    get() = true
+            }
+
+            val manager = BleConnectionManager(
+                bleRepository = fakeBleRepo,
+                settingsManager = settingsManager,
+                workoutStateProvider = stateProvider,
+                bleErrorEvents = MutableSharedFlow(),
+                scope = scope
+            )
+
+            fakeBleRepo.simulateConnect("Vee_Test")
+            advanceUntilIdle()
+            assertFalse(manager.connectionLostDuringWorkout.value)
+
+            fakeBleRepo.simulateDisconnect()
+            advanceUntilIdle()
+            assertTrue(manager.connectionLostDuringWorkout.value)
+
+            fakeBleRepo.simulateConnect("Vee_Test")
+            advanceUntilIdle()
+            assertFalse(manager.connectionLostDuringWorkout.value)
+        }
+    }
+
+    @Test
+    fun `connection loss outside active workout does not trigger reconnect alert`() = runTest {
+        VendorConformanceTargets.selected().forEach { _ ->
+            val dispatcher = StandardTestDispatcher(testScheduler)
+            val scope = CoroutineScope(coroutineContext + dispatcher)
+            val fakeBleRepo = FakeBleRepository()
+            val settingsManager = SettingsManager(FakePreferencesManager(), fakeBleRepo, scope)
+
+            val stateProvider = object : WorkoutStateProvider {
+                override val isWorkoutActiveForConnectionAlert: Boolean
+                    get() = false
+            }
+
+            val manager = BleConnectionManager(
+                bleRepository = fakeBleRepo,
+                settingsManager = settingsManager,
+                workoutStateProvider = stateProvider,
+                bleErrorEvents = MutableSharedFlow(),
+                scope = scope
+            )
+
+            fakeBleRepo.simulateConnect("Vee_Test")
+            fakeBleRepo.simulateError("signal dropped")
+            advanceUntilIdle()
+
+            assertFalse(manager.connectionLostDuringWorkout.value)
+            assertTrue(fakeBleRepo.connectionState.value is ConnectionState.Error)
+            assertFalse(manager.connectionState.value is ConnectionState.Connected)
+        }
+    }
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/conformance/TelemetryDecodingConformanceTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/conformance/TelemetryDecodingConformanceTest.kt
@@ -1,0 +1,42 @@
+package com.devil.phoenixproject.conformance
+
+import com.devil.phoenixproject.testutil.FakePeripheralFixtures
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class TelemetryDecodingConformanceTest {
+
+    @Test
+    fun `valid monitor telemetry decodes to expected values`() {
+        val telemetry = FakePeripheralFixtures.monitorPacket(
+            ticks = 123,
+            posAmm = 210.5f,
+            posBmm = 190.0f,
+            loadAkg = 25.25f,
+            loadBkg = 26.0f,
+            status = 0x1234,
+        )
+
+        VendorConformanceTargets.selected().forEach { target ->
+            val decoded = target.decodeTelemetry(telemetry)
+            assertNotNull(decoded, "${target.id}: expected valid telemetry to decode")
+            assertEquals(123, decoded.ticks)
+            assertEquals(210.5f, decoded.posA)
+            assertEquals(190.0f, decoded.posB)
+            assertEquals(25.25f, decoded.loadA)
+            assertEquals(26.0f, decoded.loadB)
+            assertEquals(0x1234, decoded.status)
+        }
+    }
+
+    @Test
+    fun `invalid short telemetry is rejected`() {
+        val invalidPacket = ByteArray(10)
+
+        VendorConformanceTargets.selected().forEach { target ->
+            assertNull(target.decodeTelemetry(invalidPacket), "${target.id}: short telemetry should be rejected")
+        }
+    }
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/conformance/VendorConformanceTargets.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/conformance/VendorConformanceTargets.kt
@@ -1,0 +1,48 @@
+package com.devil.phoenixproject.conformance
+
+import com.devil.phoenixproject.data.ble.MonitorPacket
+import com.devil.phoenixproject.testutil.FakePeripheralFixtures
+
+interface VendorConformanceTarget {
+    val id: String
+
+    fun encodeStartCommand(): ByteArray
+    fun encodeStopCommand(): ByteArray
+    fun encodeActivationCommand(): ByteArray
+    fun decodeTelemetry(packet: ByteArray): MonitorPacket?
+}
+
+private class PhoenixVendorTarget : VendorConformanceTarget {
+    override val id: String = "phoenix"
+
+    override fun encodeStartCommand(): ByteArray = FakePeripheralFixtures.startCommandPacket()
+    override fun encodeStopCommand(): ByteArray = FakePeripheralFixtures.stopCommandPacket()
+    override fun encodeActivationCommand(): ByteArray = FakePeripheralFixtures.activationPacket()
+    override fun decodeTelemetry(packet: ByteArray): MonitorPacket? = FakePeripheralFixtures.decodeMonitorPayload(packet)
+}
+
+/**
+ * Demo vendor target currently mirrors Phoenix packet semantics and serves as
+ * a template for new adapter plugins to satisfy the shared conformance suite.
+ */
+private class DemoVendorTarget : VendorConformanceTarget {
+    override val id: String = "demo"
+
+    override fun encodeStartCommand(): ByteArray = FakePeripheralFixtures.startCommandPacket()
+    override fun encodeStopCommand(): ByteArray = FakePeripheralFixtures.stopCommandPacket()
+    override fun encodeActivationCommand(): ByteArray = FakePeripheralFixtures.activationPacket()
+    override fun decodeTelemetry(packet: ByteArray): MonitorPacket? = FakePeripheralFixtures.decodeMonitorPayload(packet)
+}
+
+object VendorConformanceTargets {
+    val all: List<VendorConformanceTarget> = listOf(
+        PhoenixVendorTarget(),
+        DemoVendorTarget(),
+    )
+
+    fun selected(): List<VendorConformanceTarget> {
+        val requested = System.getenv("VENDOR_ADAPTER")?.trim()?.lowercase().orEmpty()
+        if (requested.isBlank()) return all
+        return all.filter { it.id == requested }
+    }
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/conformance/WorkoutLifecycleConformanceTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/conformance/WorkoutLifecycleConformanceTest.kt
@@ -1,0 +1,31 @@
+package com.devil.phoenixproject.conformance
+
+import com.devil.phoenixproject.domain.model.WorkoutState
+import com.devil.phoenixproject.testutil.DWSMTestHarness
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertIs
+
+class WorkoutLifecycleConformanceTest {
+
+    @Test
+    fun `workout transitions Idle to Active to SetSummary`() = runTest {
+        VendorConformanceTargets.selected().forEach { _ ->
+            val harness = DWSMTestHarness(this)
+            harness.fakeBleRepo.simulateConnect("Vee_Test")
+
+            assertIs<WorkoutState.Idle>(harness.coordinator.workoutState.value)
+
+            harness.dwsm.startWorkout(skipCountdown = true)
+            advanceUntilIdle()
+            assertIs<WorkoutState.Active>(harness.coordinator.workoutState.value)
+
+            harness.dwsm.stopWorkout(exitingWorkout = false)
+            advanceUntilIdle()
+            assertIs<WorkoutState.SetSummary>(harness.coordinator.workoutState.value)
+
+            harness.cleanup()
+        }
+    }
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakePeripheralFixtures.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakePeripheralFixtures.kt
@@ -1,0 +1,60 @@
+package com.devil.phoenixproject.testutil
+
+import com.devil.phoenixproject.data.ble.MonitorPacket
+import com.devil.phoenixproject.data.ble.parseMonitorPacket
+import com.devil.phoenixproject.domain.model.ProgramMode
+import com.devil.phoenixproject.domain.model.WorkoutParameters
+import com.devil.phoenixproject.util.BlePacketFactory
+
+/**
+ * Shared fake-peripheral fixtures for vendor adapter tests.
+ *
+ * Built from the simulator's connection/workout behavior and existing BLE packet tests.
+ */
+object FakePeripheralFixtures {
+    val defaultWorkoutParameters = WorkoutParameters(
+        programMode = ProgramMode.OldSchool,
+        reps = 10,
+        weightPerCableKg = 20f,
+    )
+
+    fun monitorPacket(
+        ticks: Int = 42,
+        posAmm: Float = 123.4f,
+        posBmm: Float = 121.0f,
+        loadAkg: Float = 17.5f,
+        loadBkg: Float = 18.0f,
+        status: Int = 0x0102,
+    ): ByteArray {
+        val payload = ByteArray(18)
+
+        putInt32Le(payload, 0, ticks)
+        putInt16Le(payload, 4, (posAmm * 10f).toInt())
+        putInt16Le(payload, 8, (posBmm * 10f).toInt())
+        putInt16Le(payload, 10, (loadAkg * 100f).toInt())
+        putInt16Le(payload, 14, (loadBkg * 100f).toInt())
+        payload[16] = (status and 0xFF).toByte()
+        payload[17] = ((status shr 8) and 0xFF).toByte()
+
+        return payload
+    }
+
+    fun decodeMonitorPayload(packet: ByteArray): MonitorPacket? = parseMonitorPacket(packet)
+
+    fun startCommandPacket(): ByteArray = BlePacketFactory.createStartCommand()
+    fun stopCommandPacket(): ByteArray = BlePacketFactory.createStopCommand()
+    fun activationPacket(params: WorkoutParameters = defaultWorkoutParameters): ByteArray =
+        BlePacketFactory.createProgramParams(params)
+
+    private fun putInt16Le(buffer: ByteArray, offset: Int, value: Int) {
+        buffer[offset] = (value and 0xFF).toByte()
+        buffer[offset + 1] = ((value shr 8) and 0xFF).toByte()
+    }
+
+    private fun putInt32Le(buffer: ByteArray, offset: Int, value: Int) {
+        buffer[offset] = (value and 0xFF).toByte()
+        buffer[offset + 1] = ((value shr 8) and 0xFF).toByte()
+        buffer[offset + 2] = ((value shr 16) and 0xFF).toByte()
+        buffer[offset + 3] = ((value shr 24) and 0xFF).toByte()
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a shared, repeatable conformance suite to validate vendor BLE adapters against the same protocol and lifecycle invariants. 
- Make it easy to onboard new vendor plugins by supplying reusable fake-peripheral fixtures and a documented workflow. 
- Run adapter-specific checks in CI so regressions in packet encoding, telemetry parsing, lifecycle transitions, or reconnect semantics are caught early. 

### Description
- Added a `conformance` test package under `shared/src/commonTest/kotlin/com/devil/phoenixproject/conformance` with tests for command encoding, telemetry decoding, workout lifecycle transitions, and reconnect/error semantics. 
- Introduced `VendorConformanceTargets` to register vendor adapter targets (`phoenix`, `demo`) with `VENDOR_ADAPTER` env-var filtering to run the suite per-adapter. 
- Added reusable fake-peripheral fixtures in `FakePeripheralFixtures` to generate monitor payloads and command packets derived from the simulator and existing BLE packet utilities. 
- Documented the workflow in `docs/vendor-adapter-conformance.md`, linked it from `README.md`, and added a `vendor-conformance` matrix job to `.github/workflows/ci-tests.yml` to run the suite for `phoenix` and `demo`. 

### Testing
- Attempted to run the new conformance suite locally with `./gradlew :shared:testAndroidHostTest --tests "com.devil.phoenixproject.conformance.*"`, but the run failed in this environment due to missing Android SDK configuration (`ANDROID_HOME`/`local.properties`), so tests could not be executed locally. 
- An attempted compile task (`:shared:compileCommonTestKotlinMetadata`) was not available in this environment and therefore did not run. 
- CI is configured to execute the conformance suite per-adapter via the new matrix job so full automated test execution will occur in CI (matrix entries: `phoenix`, `demo`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2ade74be88322910662bda8284aa5)