### PR TITLE
Add vendor integration template, bootstrap scripts, and DemoGym example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,9 @@ CHANGELOG.md
 /reference/
 /vitruvian-decompiled/
 /scripts/
+!/scripts/
+!/scripts/new_vendor_template.sh
+!/scripts/new_vendor_template.ps1
 /apktool.jar
 /vitruvian-official.apk
 /parent repo/

--- a/docs/vendor-integration-guide.md
+++ b/docs/vendor-integration-guide.md
@@ -1,0 +1,88 @@
+# Vendor Integration Guide
+
+This guide explains how to build and ship a new machine vendor adapter using the `template/` scaffolding.
+
+## 1) What is included
+
+- `template/starter/`
+  - `VendorPlugin.kt`: plugin entrypoint interface.
+  - `MachineProfile.kt`: capability declaration model.
+  - `CommandEncoder.kt`: outbound command contract.
+  - `TelemetryDecoder.kt`: inbound telemetry contract.
+  - `PluginRegistry.kt`: simple plugin registration point.
+- `template/examples/demogym/`
+  - Full `DemoGym` adapter implementation.
+  - `DemoGymSimulatorHooks.kt` for local packet simulation.
+- `template/config/vendor-template.config.json`
+  - Placeholder IDs and BLE UUIDs.
+- `template/assets/brand-logo-placeholder.svg`
+  - Replace with your branded art.
+
+## 2) Bootstrap a new vendor package
+
+### Bash
+
+```bash
+scripts/new_vendor_template.sh --vendor Acme --package com.phoenix.vendor.acme
+```
+
+### PowerShell
+
+```powershell
+./scripts/new_vendor_template.ps1 -Vendor Acme -Package com.phoenix.vendor.acme
+```
+
+Optional flags:
+
+- `--out` / `-Out`: output folder for generated files.
+- `--registry` / `-Registry`: existing registry file where `register(<Vendor>Plugin())` is appended.
+
+## 3) Required interfaces
+
+Your adapter must implement the following interface set:
+
+1. `VendorPlugin`
+   - Stable `id` for persistence/lookup.
+   - Human readable `displayName`.
+   - One or more `supportedProfiles`.
+   - Factory methods for an encoder and decoder.
+2. `MachineProfile`
+   - Model name.
+   - Protocol version.
+   - Feature flags (`supportsEccentricControl`, `supportsLiveTelemetry`).
+   - Operational bounds (`maxResistance`).
+3. `CommandEncoder`
+   - Session start payload.
+   - Resistance or load control payload.
+   - Session stop payload.
+4. `TelemetryDecoder`
+   - Packet validation.
+   - Byte-to-domain conversion into `TelemetryFrame`.
+
+## 4) Local development with simulator hooks
+
+Use the `DemoGymSimulatorHooks` example to:
+
+- Create deterministic telemetry streams for UI/integration testing.
+- Produce encoded byte packets to validate decoder behavior.
+- Regression-test protocol changes before hardware is available.
+
+Typical loop:
+
+1. Build a `TelemetryFrame` from simulator values.
+2. Encode it into a packet.
+3. Decode it with your adapter decoder.
+4. Assert field parity.
+
+## 5) Conformance checklist
+
+Before opening a PR, verify:
+
+- [ ] Vendor package ID and class names are vendor-specific (no `template` leftovers).
+- [ ] `VendorPlugin.id` is stable and unique.
+- [ ] At least one `MachineProfile` accurately describes protocol capabilities.
+- [ ] `CommandEncoder` validates bounds and does not emit malformed payloads.
+- [ ] `TelemetryDecoder` handles invalid/short packets safely (`null` or error path).
+- [ ] Config file contains final UUIDs/endpoints and branded asset references.
+- [ ] Plugin is registered through `PluginRegistry` or your app DI equivalent.
+- [ ] Simulator hook can emit packets that round-trip through decoder.

--- a/scripts/new_vendor_template.ps1
+++ b/scripts/new_vendor_template.ps1
@@ -1,0 +1,47 @@
+param(
+    [Parameter(Mandatory=$true)][string]$Vendor,
+    [Parameter(Mandatory=$true)][string]$Package,
+    [string]$Out,
+    [string]$Registry
+)
+
+$ErrorActionPreference = 'Stop'
+$Root = Resolve-Path (Join-Path $PSScriptRoot '..')
+$TemplateDir = Join-Path $Root 'template/starter'
+
+if (-not (Test-Path $TemplateDir)) {
+    throw "Starter template not found at $TemplateDir"
+}
+
+$VendorLower = $Vendor.ToLowerInvariant()
+$TargetDir = if ($Out) { $Out } else { Join-Path $Root "template/generated/$VendorLower" }
+New-Item -ItemType Directory -Force -Path $TargetDir | Out-Null
+Copy-Item -Path (Join-Path $TemplateDir '*') -Destination $TargetDir -Recurse -Force
+
+Get-ChildItem -Path $TargetDir -Filter '*.kt' | ForEach-Object {
+    $content = Get-Content -Raw -Path $_.FullName
+    $content = $content -replace 'package com\.phoenix\.vendor\.template', "package $Package"
+    $content = $content -replace 'interface VendorPlugin', "interface ${Vendor}Plugin"
+    $content = $content -replace 'object PluginRegistry', "object ${Vendor}PluginRegistry"
+    Set-Content -Path $_.FullName -Value $content
+}
+
+$vendorPlugin = Join-Path $TargetDir 'VendorPlugin.kt'
+if (Test-Path $vendorPlugin) {
+    Move-Item -Path $vendorPlugin -Destination (Join-Path $TargetDir "$Vendor`Plugin.kt") -Force
+}
+
+$pluginRegistry = Join-Path $TargetDir 'PluginRegistry.kt'
+if (Test-Path $pluginRegistry) {
+    Move-Item -Path $pluginRegistry -Destination (Join-Path $TargetDir "$Vendor`PluginRegistry.kt") -Force
+}
+
+if ($Registry -and (Test-Path $Registry)) {
+    $entry = "register($Vendor`Plugin())"
+    $existing = Get-Content -Raw -Path $Registry
+    if (-not ($existing -match [regex]::Escape($entry))) {
+        Add-Content -Path $Registry -Value "`n    // Added by new_vendor_template.ps1`n    $entry"
+    }
+}
+
+Write-Output "Created vendor scaffold for $Vendor at $TargetDir"

--- a/scripts/new_vendor_template.sh
+++ b/scripts/new_vendor_template.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEMPLATE_DIR="$ROOT_DIR/template/starter"
+
+usage() {
+  cat <<USAGE
+Usage: scripts/new_vendor_template.sh --vendor <VendorName> --package <package.id> [--out <dir>] [--registry <file>]
+USAGE
+}
+
+VENDOR=""
+PACKAGE_ID=""
+OUT_DIR=""
+REGISTRY_FILE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --vendor) VENDOR="$2"; shift 2 ;;
+    --package) PACKAGE_ID="$2"; shift 2 ;;
+    --out) OUT_DIR="$2"; shift 2 ;;
+    --registry) REGISTRY_FILE="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown arg: $1"; usage; exit 1 ;;
+  esac
+done
+
+if [[ -z "$VENDOR" || -z "$PACKAGE_ID" ]]; then
+  usage
+  exit 1
+fi
+
+VENDOR_LOWER="$(echo "$VENDOR" | tr '[:upper:]' '[:lower:]')"
+TARGET_DIR="${OUT_DIR:-$ROOT_DIR/template/generated/$VENDOR_LOWER}"
+
+mkdir -p "$TARGET_DIR"
+cp -R "$TEMPLATE_DIR"/. "$TARGET_DIR/"
+
+for file in "$TARGET_DIR"/*.kt; do
+  sed -i "s/package com\.phoenix\.vendor\.template/package ${PACKAGE_ID//./\.}/g" "$file"
+  sed -i "s/interface VendorPlugin/interface ${VENDOR}Plugin/g" "$file"
+  sed -i "s/object PluginRegistry/object ${VENDOR}PluginRegistry/g" "$file"
+done
+
+[[ -f "$TARGET_DIR/VendorPlugin.kt" ]] && mv "$TARGET_DIR/VendorPlugin.kt" "$TARGET_DIR/${VENDOR}Plugin.kt"
+[[ -f "$TARGET_DIR/PluginRegistry.kt" ]] && mv "$TARGET_DIR/PluginRegistry.kt" "$TARGET_DIR/${VENDOR}PluginRegistry.kt"
+
+if [[ -n "$REGISTRY_FILE" && -f "$REGISTRY_FILE" ]]; then
+  ENTRY="register(${VENDOR}Plugin())"
+  if ! grep -q "$ENTRY" "$REGISTRY_FILE"; then
+    printf '\n    // Added by new_vendor_template.sh\n    %s\n' "$ENTRY" >> "$REGISTRY_FILE"
+  fi
+fi
+
+echo "Created vendor scaffold for $VENDOR at $TARGET_DIR"

--- a/template/README.md
+++ b/template/README.md
@@ -1,0 +1,10 @@
+# Vendor Integration Template
+
+This directory contains scaffolding for building a new equipment vendor adapter:
+
+- `starter/`: required interfaces (`VendorPlugin`, `MachineProfile`, `CommandEncoder`, `TelemetryDecoder`) and a registry scaffold.
+- `examples/demogym/`: complete DemoGym adapter plus simulator hooks.
+- `assets/`: branded asset placeholders.
+- `config/`: starter vendor config file.
+
+Use `scripts/new_vendor_template.sh` (or `.ps1`) to clone the starter package, rename package IDs, and register your plugin class.

--- a/template/assets/brand-logo-placeholder.svg
+++ b/template/assets/brand-logo-placeholder.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="120" viewBox="0 0 400 120" role="img" aria-label="Vendor logo placeholder">
+  <rect width="400" height="120" fill="#171717" rx="12"/>
+  <text x="200" y="68" fill="#f5f5f5" text-anchor="middle" font-size="28" font-family="Arial, sans-serif">YOUR BRAND LOGO</text>
+</svg>

--- a/template/config/vendor-template.config.json
+++ b/template/config/vendor-template.config.json
@@ -1,0 +1,15 @@
+{
+  "vendorId": "vendor-template",
+  "packageId": "com.phoenix.vendor.template",
+  "displayName": "Vendor Template",
+  "defaultModel": "Template-Rack-1",
+  "assets": {
+    "logo": "../assets/brand-logo-placeholder.svg"
+  },
+  "transport": {
+    "type": "ble",
+    "serviceUuid": "0000FFFF-0000-1000-8000-00805F9B34FB",
+    "txCharacteristicUuid": "0000FF01-0000-1000-8000-00805F9B34FB",
+    "rxCharacteristicUuid": "0000FF02-0000-1000-8000-00805F9B34FB"
+  }
+}

--- a/template/examples/demogym/DemoGymAdapter.kt
+++ b/template/examples/demogym/DemoGymAdapter.kt
@@ -1,0 +1,59 @@
+package com.phoenix.vendor.demogym
+
+import com.phoenix.vendor.template.CommandEncoder
+import com.phoenix.vendor.template.MachineProfile
+import com.phoenix.vendor.template.TelemetryDecoder
+import com.phoenix.vendor.template.TelemetryFrame
+import com.phoenix.vendor.template.VendorPlugin
+
+class DemoGymPlugin : VendorPlugin {
+    override val id: String = "demogym"
+    override val displayName: String = "DemoGym"
+
+    private val v1Profile = MachineProfile(
+        model = "DemoGym-Rack-1",
+        protocolVersion = 1,
+        supportsEccentricControl = true,
+        supportsLiveTelemetry = true,
+        maxResistance = 400
+    )
+
+    override val supportedProfiles: Set<MachineProfile> = setOf(v1Profile)
+
+    override fun encoder(profile: MachineProfile): CommandEncoder = DemoGymCommandEncoder()
+
+    override fun decoder(profile: MachineProfile): TelemetryDecoder = DemoGymTelemetryDecoder()
+}
+
+class DemoGymCommandEncoder : CommandEncoder {
+    override fun startSession(profile: MachineProfile): ByteArray = byteArrayOf(0x55, 0x01, profile.protocolVersion.toByte())
+
+    override fun setResistance(level: Int): ByteArray {
+        val clamped = level.coerceIn(0, 400)
+        return byteArrayOf(0x55, 0x10, clamped.toByte())
+    }
+
+    override fun stopSession(): ByteArray = byteArrayOf(0x55, 0x02)
+}
+
+class DemoGymTelemetryDecoder : TelemetryDecoder {
+    override fun decode(packet: ByteArray): TelemetryFrame? {
+        if (packet.size < 9 || packet[0] != 0x33.toByte()) return null
+
+        val reps = packet[1].toInt() and 0xFF
+        val forceRaw = packet[2].toInt() and 0xFF
+        val velocityRaw = packet[3].toInt() and 0xFF
+        val romRaw = ((packet[4].toInt() and 0xFF) shl 8) or (packet[5].toInt() and 0xFF)
+        val timeRaw = ((packet[6].toLong() and 0xFF) shl 16) or
+            ((packet[7].toLong() and 0xFF) shl 8) or
+            (packet[8].toLong() and 0xFF)
+
+        return TelemetryFrame(
+            reps = reps,
+            forceNewtons = forceRaw * 5f,
+            velocityMps = velocityRaw / 100f,
+            rangeOfMotionMm = romRaw,
+            timestampMs = timeRaw * 100L
+        )
+    }
+}

--- a/template/examples/demogym/DemoGymSimulatorHooks.kt
+++ b/template/examples/demogym/DemoGymSimulatorHooks.kt
@@ -1,0 +1,38 @@
+package com.phoenix.vendor.demogym
+
+import com.phoenix.vendor.template.TelemetryFrame
+import kotlin.math.sin
+
+/**
+ * Local simulator helpers for quickly validating adapter integrations.
+ */
+class DemoGymSimulatorHooks {
+    fun nextFrame(rep: Int, elapsedMs: Long): TelemetryFrame {
+        val normalized = (sin(elapsedMs / 450.0) + 1.0) / 2.0
+        return TelemetryFrame(
+            reps = rep,
+            forceNewtons = (180 + normalized * 220).toFloat(),
+            velocityMps = (0.35 + normalized * 0.75).toFloat(),
+            rangeOfMotionMm = (200 + normalized * 500).toInt(),
+            timestampMs = elapsedMs
+        )
+    }
+
+    fun encodedPacket(frame: TelemetryFrame): ByteArray {
+        val force = (frame.forceNewtons / 5f).toInt().coerceIn(0, 255)
+        val velocity = (frame.velocityMps * 100).toInt().coerceIn(0, 255)
+        val rom = frame.rangeOfMotionMm.coerceIn(0, 65535)
+        val time = (frame.timestampMs / 100).coerceIn(0, 0xFFFFFF)
+        return byteArrayOf(
+            0x33,
+            frame.reps.toByte(),
+            force.toByte(),
+            velocity.toByte(),
+            ((rom shr 8) and 0xFF).toByte(),
+            (rom and 0xFF).toByte(),
+            ((time shr 16) and 0xFF).toByte(),
+            ((time shr 8) and 0xFF).toByte(),
+            (time and 0xFF).toByte()
+        )
+    }
+}

--- a/template/starter/CommandEncoder.kt
+++ b/template/starter/CommandEncoder.kt
@@ -1,0 +1,10 @@
+package com.phoenix.vendor.template
+
+/**
+ * Converts app-level intent into BLE or transport payloads.
+ */
+interface CommandEncoder {
+    fun startSession(profile: MachineProfile): ByteArray
+    fun setResistance(level: Int): ByteArray
+    fun stopSession(): ByteArray
+}

--- a/template/starter/MachineProfile.kt
+++ b/template/starter/MachineProfile.kt
@@ -1,0 +1,12 @@
+package com.phoenix.vendor.template
+
+/**
+ * Declares machine capabilities exposed by a vendor.
+ */
+data class MachineProfile(
+    val model: String,
+    val protocolVersion: Int,
+    val supportsEccentricControl: Boolean,
+    val supportsLiveTelemetry: Boolean,
+    val maxResistance: Int
+)

--- a/template/starter/PluginRegistry.kt
+++ b/template/starter/PluginRegistry.kt
@@ -1,0 +1,16 @@
+package com.phoenix.vendor.template
+
+/**
+ * Minimal registry used by bootstrap script when adding a new plugin.
+ */
+object PluginRegistry {
+    private val plugins = mutableMapOf<String, VendorPlugin>()
+
+    fun register(plugin: VendorPlugin) {
+        plugins[plugin.id] = plugin
+    }
+
+    fun find(id: String): VendorPlugin? = plugins[id]
+
+    fun all(): List<VendorPlugin> = plugins.values.toList()
+}

--- a/template/starter/TelemetryDecoder.kt
+++ b/template/starter/TelemetryDecoder.kt
@@ -1,0 +1,16 @@
+package com.phoenix.vendor.template
+
+/**
+ * Converts raw packets from vendor hardware into canonical telemetry.
+ */
+interface TelemetryDecoder {
+    fun decode(packet: ByteArray): TelemetryFrame?
+}
+
+data class TelemetryFrame(
+    val reps: Int,
+    val forceNewtons: Float,
+    val velocityMps: Float,
+    val rangeOfMotionMm: Int,
+    val timestampMs: Long
+)

--- a/template/starter/VendorPlugin.kt
+++ b/template/starter/VendorPlugin.kt
@@ -1,0 +1,13 @@
+package com.phoenix.vendor.template
+
+/**
+ * Entry point for a machine vendor integration.
+ */
+interface VendorPlugin {
+    val id: String
+    val displayName: String
+    val supportedProfiles: Set<MachineProfile>
+
+    fun encoder(profile: MachineProfile): CommandEncoder
+    fun decoder(profile: MachineProfile): TelemetryDecoder
+}


### PR DESCRIPTION
### Motivation
- Provide a reusable scaffold for third‑party equipment vendor adapters so integrations can be developed consistently. 
- Enable local development and protocol validation with a complete example adapter and simulator hooks. 
- Make it easy to bootstrap new vendor packages via cross‑platform scripts and document required interfaces and conformance checks. 

### Description
- Add `template/starter/` with the core contracts `VendorPlugin`, `MachineProfile`, `CommandEncoder`, `TelemetryDecoder`, and a minimal `PluginRegistry`. 
- Add a full example adapter in `template/examples/demogym/` (`DemoGymAdapter.kt`) plus `DemoGymSimulatorHooks.kt` for deterministic telemetry generation and encoded packet round‑trips. 
- Add placeholder branded assets and a starter config in `template/assets/` and `template/config/vendor-template.config.json`. 
- Add bootstrap scripts `scripts/new_vendor_template.sh` and `scripts/new_vendor_template.ps1`, a `docs/vendor-integration-guide.md` describing usage and conformance checklist, and update `.gitignore` to allow the scripts to be tracked. 

### Testing
- Executed `scripts/new_vendor_template.sh --vendor Acme --package com.phoenix.vendor.acme --out /tmp/acme-template` and confirmed scaffold generation succeeded. 
- Verified generated Kotlin files with `find /tmp/acme-template -maxdepth 1 -type f -name '*.kt' -printf '%f\n' | sort` and package/class renames with `rg -n "package |interface AcmePlugin|object AcmePluginRegistry" /tmp/acme-template/*.kt`, both succeeding. 
- Performed a syntax check on the Bash script with `bash -n scripts/new_vendor_template.sh`, which succeeded. 
- Attempted to validate the PowerShell script with `pwsh` but `pwsh` is not available in this environment, so PowerShell validation was not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2ade3fba48322966a2e09805e6299)