### PR TITLE
Add vendorId/protocolVersion metadata, migration and vendor-scoped repository changes

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -201,9 +201,9 @@ sqldelight {
     databases {
         create("VitruvianDatabase") {
             packageName.set("com.devil.phoenixproject.database")
-            // Version 13 = initial schema (1) + 12 migrations (1.sqm through 12.sqm)
+            // Version 14 = initial schema (1) + 13 migrations (1.sqm through 13.sqm)
             // Fixed: was incorrectly 11, now accounts for all migrations including 11.sqm (sync) and 12.sqm (routineId)
-            version = 13
+            version = 14
         }
     }
 }

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/migration/MigrationManagerTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/migration/MigrationManagerTest.kt
@@ -32,7 +32,7 @@ class MigrationManagerTest {
         migrationManager.checkAndRunMigrations()
         Thread.sleep(500) // migrations run async
 
-        val session = queries.selectSessionById("session-1").executeAsOneOrNull()
+        val session = queries.selectSessionById("session-1", "phoenix", "v1").executeAsOneOrNull()
         assertNotNull(session)
         assertNull(session.routineSessionId, "Exact-match legacy_session_<id> should be stripped")
         assertEquals("Upper Day", session.routineName, "Routine name should be preserved")
@@ -50,7 +50,7 @@ class MigrationManagerTest {
         migrationManager.checkAndRunMigrations()
         Thread.sleep(500)
 
-        val session = queries.selectSessionById("session-2").executeAsOneOrNull()
+        val session = queries.selectSessionById("session-2", "phoenix", "v1").executeAsOneOrNull()
         assertNotNull(session)
         assertEquals("real-routine-session-uuid-123", session.routineSessionId, "Legitimate routineSessionId should be preserved")
     }
@@ -68,7 +68,7 @@ class MigrationManagerTest {
         migrationManager.checkAndRunMigrations()
         Thread.sleep(500)
 
-        val session = queries.selectSessionById("session-3").executeAsOneOrNull()
+        val session = queries.selectSessionById("session-3", "phoenix", "v1").executeAsOneOrNull()
         assertNotNull(session)
         // Migration uses exact match: legacy_session_${session.id}
         // "legacy_session_some-other-session" != "legacy_session_session-3"
@@ -94,7 +94,7 @@ class MigrationManagerTest {
         migrationManager.checkAndRunMigrations()
         Thread.sleep(500)
 
-        val session = queries.selectSessionById("session-garbage").executeAsOneOrNull()
+        val session = queries.selectSessionById("session-garbage", "phoenix", "v1").executeAsOneOrNull()
         assertNotNull(session)
         assertNull(session.routineName, "Garbage routine name should be cleared to null when inference fails")
     }
@@ -128,7 +128,7 @@ class MigrationManagerTest {
         migrationManager.checkAndRunMigrations()
         Thread.sleep(500)
 
-        val session = queries.selectSessionById("session-garbage-infer").executeAsOneOrNull()
+        val session = queries.selectSessionById("session-garbage-infer", "phoenix", "v1").executeAsOneOrNull()
         assertNotNull(session)
         assertEquals("Upper Day", session.routineName, "Garbage name should be replaced with inferred routine name")
     }
@@ -162,7 +162,7 @@ class MigrationManagerTest {
         migrationManager.checkAndRunMigrations()
         Thread.sleep(500)
 
-        val session = queries.selectSessionById("session-placeholder").executeAsOneOrNull()
+        val session = queries.selectSessionById("session-placeholder", "phoenix", "v1").executeAsOneOrNull()
         assertNotNull(session)
         assertEquals("Upper Day", session.routineName, "Exercise-placeholder name should be replaced with actual routine name")
     }
@@ -179,7 +179,7 @@ class MigrationManagerTest {
         migrationManager.checkAndRunMigrations()
         Thread.sleep(500)
 
-        val session = queries.selectSessionById("session-legit").executeAsOneOrNull()
+        val session = queries.selectSessionById("session-legit", "phoenix", "v1").executeAsOneOrNull()
         assertNotNull(session)
         assertEquals("My Custom Routine", session.routineName, "Legitimate routine name should be preserved")
     }
@@ -273,6 +273,8 @@ class MigrationManagerTest {
             burnoutAvgWeightKg = null,
             peakWeightKg = null,
             rpe = null,
+            vendorId = "phoenix",
+            protocolVersion = "v1",
         )
     }
 }

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/migration/VendorMigrationTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/migration/VendorMigrationTest.kt
@@ -1,0 +1,79 @@
+package com.devil.phoenixproject.data.migration
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import com.devil.phoenixproject.database.VitruvianDatabase
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class VendorMigrationTest {
+
+    @Test
+    fun `migration 13 assigns phoenix defaults to legacy rows`() {
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        createLegacyTables(driver)
+
+        driver.execute(null, "INSERT INTO WorkoutSession (id, timestamp, mode, targetReps, weightPerCableKg) VALUES ('s1', 1, 'Old School', 10, 20.0)", 0)
+        driver.execute(null, "INSERT INTO Routine (id, name, createdAt) VALUES ('r1', 'Legacy', 1)", 0)
+        driver.execute(null, "INSERT INTO ConnectionLog (timestamp, eventType, level, message) VALUES (1, 'CONNECT', 'INFO', 'ok')", 0)
+
+        VitruvianDatabase.Schema.migrate(driver, 13, 14)
+
+        assertEquals("phoenix", stringValue(driver, "SELECT vendorId FROM WorkoutSession WHERE id = 's1'"))
+        assertEquals("v1", stringValue(driver, "SELECT protocolVersion FROM WorkoutSession WHERE id = 's1'"))
+        assertEquals("phoenix", stringValue(driver, "SELECT vendorId FROM Routine WHERE id = 'r1'"))
+        assertEquals("v1", stringValue(driver, "SELECT protocolVersion FROM ConnectionLog LIMIT 1"))
+    }
+
+
+    @Test
+    fun `fixture upgrade path migrates legacy rows`() {
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        val fixture = checkNotNull(javaClass.classLoader?.getResource("migrations/vendor-upgrade-fixture.sql"))
+            .readText()
+
+        fixture.split(";")
+            .map { it.trim() }
+            .filter { it.isNotBlank() }
+            .forEach { stmt -> driver.execute(null, stmt, 0) }
+
+        VitruvianDatabase.Schema.migrate(driver, 13, 14)
+
+        assertEquals("phoenix", stringValue(driver, "SELECT vendorId FROM WorkoutSession WHERE id = 'fixture-session'"))
+        assertEquals("phoenix", stringValue(driver, "SELECT vendorId FROM Routine WHERE id = 'fixture-routine'"))
+    }
+
+    private fun createLegacyTables(driver: JdbcSqliteDriver) {
+        driver.execute(null, """
+            CREATE TABLE WorkoutSession (
+                id TEXT NOT NULL PRIMARY KEY,
+                timestamp INTEGER NOT NULL,
+                mode TEXT NOT NULL,
+                targetReps INTEGER NOT NULL,
+                weightPerCableKg REAL NOT NULL
+            )
+        """.trimIndent(), 0)
+        driver.execute(null, """
+            CREATE TABLE Routine (
+                id TEXT NOT NULL PRIMARY KEY,
+                name TEXT NOT NULL,
+                createdAt INTEGER NOT NULL
+            )
+        """.trimIndent(), 0)
+        driver.execute(null, """
+            CREATE TABLE ConnectionLog (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp INTEGER NOT NULL,
+                eventType TEXT NOT NULL,
+                level TEXT NOT NULL,
+                message TEXT NOT NULL
+            )
+        """.trimIndent(), 0)
+    }
+
+    private fun stringValue(driver: JdbcSqliteDriver, sql: String): String {
+        return driver.executeQuery(null, sql, { cursor ->
+            cursor.next()
+            cursor.getString(0)!!
+        }, 0)
+    }
+}

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/util/DataBackupManagerRoutineNameTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/util/DataBackupManagerRoutineNameTest.kt
@@ -136,7 +136,7 @@ class DataBackupManagerRoutineNameTest {
         assertTrue(importResult.isSuccess)
 
         val imported = database.vitruvianDatabaseQueries
-            .selectSessionById("session-import-1")
+            .selectSessionById("session-import-1", "phoenix", "v1")
             .executeAsOneOrNull()
         assertNotNull(imported)
         assertEquals("Tuesday Upper", imported.routineName)
@@ -199,7 +199,7 @@ class DataBackupManagerRoutineNameTest {
         assertTrue(importResult.isSuccess)
 
         val imported = database.vitruvianDatabaseQueries
-            .selectSessionById("session-import-2")
+            .selectSessionById("session-import-2", "phoenix", "v1")
             .executeAsOneOrNull()
         assertNotNull(imported)
         assertEquals("Arms Day", imported.routineName)
@@ -296,6 +296,8 @@ class DataBackupManagerRoutineNameTest {
             burnoutAvgWeightKg = null,
             peakWeightKg = null,
             rpe = null,
+            vendorId = "phoenix",
+            protocolVersion = "v1",
         )
 
         val backup = backupManager.exportAllData()
@@ -339,7 +341,7 @@ class DataBackupManagerRoutineNameTest {
         assertTrue(importResult.isSuccess)
 
         val imported = database.vitruvianDatabaseQueries
-            .selectSessionById("session-import-fabricated")
+            .selectSessionById("session-import-fabricated", "phoenix", "v1")
             .executeAsOneOrNull()
         assertNotNull(imported)
         assertNull(imported.routineSessionId, "Fabricated legacy_session_* ID should be stripped on import")
@@ -381,7 +383,7 @@ class DataBackupManagerRoutineNameTest {
         assertTrue(importResult.isSuccess)
 
         val imported = database.vitruvianDatabaseQueries
-            .selectSessionById("session-import-garbage")
+            .selectSessionById("session-import-garbage", "phoenix", "v1")
             .executeAsOneOrNull()
         assertNotNull(imported)
         assertNull(imported.routineName, "Garbage routine name should be filtered out on import")

--- a/shared/src/androidHostTest/resources/migrations/vendor-upgrade-fixture.sql
+++ b/shared/src/androidHostTest/resources/migrations/vendor-upgrade-fixture.sql
@@ -1,0 +1,22 @@
+CREATE TABLE WorkoutSession (
+    id TEXT NOT NULL PRIMARY KEY,
+    timestamp INTEGER NOT NULL,
+    mode TEXT NOT NULL,
+    targetReps INTEGER NOT NULL,
+    weightPerCableKg REAL NOT NULL
+);
+CREATE TABLE Routine (
+    id TEXT NOT NULL PRIMARY KEY,
+    name TEXT NOT NULL,
+    createdAt INTEGER NOT NULL
+);
+CREATE TABLE ConnectionLog (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp INTEGER NOT NULL,
+    eventType TEXT NOT NULL,
+    level TEXT NOT NULL,
+    message TEXT NOT NULL
+);
+INSERT INTO WorkoutSession (id, timestamp, mode, targetReps, weightPerCableKg) VALUES ('fixture-session', 2, 'Pump', 12, 30.0);
+INSERT INTO Routine (id, name, createdAt) VALUES ('fixture-routine', 'Fixture Routine', 2);
+INSERT INTO ConnectionLog (timestamp, eventType, level, message) VALUES (2, 'SCAN', 'DEBUG', 'fixture');

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/context/VendorContext.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/context/VendorContext.kt
@@ -1,0 +1,25 @@
+package com.devil.phoenixproject.data.context
+
+data class VendorContext(
+    val vendorId: String,
+    val protocolVersion: String
+)
+
+class VendorContextProvider(
+    initialContext: VendorContext = DEFAULT_CONTEXT
+) {
+    private var context: VendorContext = initialContext
+
+    fun current(): VendorContext = context
+
+    fun setActiveContext(newContext: VendorContext) {
+        context = newContext
+    }
+
+    companion object {
+        val DEFAULT_CONTEXT = VendorContext(
+            vendorId = "phoenix",
+            protocolVersion = "v1"
+        )
+    }
+}

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/Stubs.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/Stubs.kt
@@ -13,5 +13,7 @@ data class ConnectionLogEntity(
     val deviceName: String? = null,
     val message: String,
     val details: String? = null,
-    val metadata: String? = null  // Additional metadata as JSON string if needed
+    val metadata: String? = null,  // Additional metadata as JSON string if needed
+    val vendorId: String = "phoenix",
+    val protocolVersion: String = "v1"
 )

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/migration/MigrationManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/migration/MigrationManager.kt
@@ -4,6 +4,7 @@ import co.touchlab.kermit.Logger
 import com.devil.phoenixproject.database.Routine
 import com.devil.phoenixproject.database.RoutineExercise
 import com.devil.phoenixproject.database.VitruvianDatabase
+import com.devil.phoenixproject.data.context.VendorContextProvider
 import com.devil.phoenixproject.database.WorkoutSession
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -70,7 +71,9 @@ class MigrationManager(
                 if (rawId.equals("legacy_session_${session.id}", ignoreCase = true)) {
                     queries.updateSessionRoutineSessionId(
                         routineSessionId = null,
-                        id = session.id
+                        id = session.id,
+                        vendorId = VendorContextProvider.DEFAULT_CONTEXT.vendorId,
+                        protocolVersion = VendorContextProvider.DEFAULT_CONTEXT.protocolVersion
                     )
                     cleaned++
                 }
@@ -112,7 +115,9 @@ class MigrationManager(
                     if (resolvedRoutineId != null) {
                         queries.updateSessionRoutineId(
                             routineId = resolvedRoutineId,
-                            id = session.id
+                            id = session.id,
+                            vendorId = VendorContextProvider.DEFAULT_CONTEXT.vendorId,
+                            protocolVersion = VendorContextProvider.DEFAULT_CONTEXT.protocolVersion
                         )
                         updatedIdRows++
                     }
@@ -125,7 +130,9 @@ class MigrationManager(
                 if (updatedRoutineName == null && session.routineName == null) return@forEach
                 queries.updateSessionRoutineName(
                     routineName = updatedRoutineName,
-                    id = session.id
+                    id = session.id,
+                    vendorId = VendorContextProvider.DEFAULT_CONTEXT.vendorId,
+                    protocolVersion = VendorContextProvider.DEFAULT_CONTEXT.protocolVersion
                 )
                 updatedNameRows++
             }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/ConnectionLogRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/ConnectionLogRepository.kt
@@ -1,6 +1,7 @@
 package com.devil.phoenixproject.data.repository
 
 import com.devil.phoenixproject.data.local.ConnectionLogEntity
+import com.devil.phoenixproject.data.context.VendorContextProvider
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -92,7 +93,9 @@ class ConnectionLogRepository {
             deviceName = deviceName,
             message = message,
             details = details,
-            metadata = null
+            metadata = null,
+            vendorId = vendorContextProvider.current().vendorId,
+            protocolVersion = vendorContextProvider.current().protocolVersion
         )
 
         _logs.update { currentLogs ->
@@ -158,6 +161,10 @@ class ConnectionLogRepository {
         sb.appendLine()
 
         _logs.value.forEach { log ->
+            val context = vendorContextProvider.current()
+            if (log.vendorId != context.vendorId || log.protocolVersion != context.protocolVersion) {
+                return@forEach
+            }
             sb.appendLine("[${formatTimestamp(log.timestamp)}] [${log.level}] ${log.eventType}")
             sb.appendLine("  ${log.message}")
             if (log.deviceName != null || log.deviceAddress != null) {
@@ -179,7 +186,11 @@ class ConnectionLogRepository {
         val sb = StringBuilder()
         sb.appendLine("timestamp,level,event_type,message,device_name,device_address,details")
 
+        val context = vendorContextProvider.current()
         _logs.value.forEach { log ->
+            if (log.vendorId != context.vendorId || log.protocolVersion != context.protocolVersion) {
+                return@forEach
+            }
             sb.appendLine(
                 "${log.timestamp},${log.level},${log.eventType}," +
                 "\"${log.message.replace("\"", "\"\"")}\","+
@@ -195,21 +206,36 @@ class ConnectionLogRepository {
      * Get logs filtered by level.
      */
     fun getLogsByLevel(level: LogLevel): List<ConnectionLogEntity> {
-        return _logs.value.filter { it.level == level.name }
+        val context = vendorContextProvider.current()
+        return _logs.value.filter {
+            it.level == level.name &&
+                it.vendorId == context.vendorId &&
+                it.protocolVersion == context.protocolVersion
+        }
     }
 
     /**
      * Get logs filtered by event type.
      */
     fun getLogsByEventType(eventType: String): List<ConnectionLogEntity> {
-        return _logs.value.filter { it.eventType == eventType }
+        val context = vendorContextProvider.current()
+        return _logs.value.filter {
+            it.eventType == eventType &&
+                it.vendorId == context.vendorId &&
+                it.protocolVersion == context.protocolVersion
+        }
     }
 
     /**
      * Get logs for a specific device.
      */
     fun getLogsForDevice(deviceAddress: String): List<ConnectionLogEntity> {
-        return _logs.value.filter { it.deviceAddress == deviceAddress }
+        val context = vendorContextProvider.current()
+        return _logs.value.filter {
+            it.deviceAddress == deviceAddress &&
+                it.vendorId == context.vendorId &&
+                it.protocolVersion == context.protocolVersion
+        }
     }
 
     private fun formatTimestamp(timestamp: Long): String {
@@ -223,3 +249,4 @@ class ConnectionLogRepository {
 
     private fun currentTimeMillis(): Long = Clock.System.now().toEpochMilliseconds()
 }
+    private val vendorContextProvider = VendorContextProvider()

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightGamificationRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightGamificationRepository.kt
@@ -6,6 +6,7 @@ import app.cash.sqldelight.coroutines.mapToOneOrNull
 import co.touchlab.kermit.Logger
 import com.devil.phoenixproject.data.local.BadgeDefinitions
 import com.devil.phoenixproject.database.VitruvianDatabase
+import com.devil.phoenixproject.data.context.VendorContextProvider
 import com.devil.phoenixproject.domain.model.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
@@ -276,7 +277,7 @@ class SqlDelightGamificationRepository(
         val weekStartMs = weekStart.atStartOfDayIn(TimeZone.currentSystemDefault()).toEpochMilliseconds()
 
         // Count sessions with timestamp >= weekStartMs
-        val sessions = queries.selectAllSessions().executeAsList()
+        val sessions = queries.selectAllSessions(VendorContextProvider.DEFAULT_CONTEXT.vendorId, VendorContextProvider.DEFAULT_CONTEXT.protocolVersion).executeAsList()
         return sessions.count { it.timestamp >= weekStartMs }
     }
 
@@ -285,7 +286,7 @@ class SqlDelightGamificationRepository(
      * Prefer measured totalVolumeKg when available (v0.2.1+), fallback to legacy approximation.
      */
     private fun getMaxSingleSessionVolume(): Int {
-        val sessions = queries.selectAllSessions().executeAsList()
+        val sessions = queries.selectAllSessions(VendorContextProvider.DEFAULT_CONTEXT.vendorId, VendorContextProvider.DEFAULT_CONTEXT.protocolVersion).executeAsList()
         if (sessions.isEmpty()) return 0
 
         return sessions.maxOfOrNull { session ->
@@ -299,7 +300,7 @@ class SqlDelightGamificationRepository(
      * @param hourEnd End hour (0-23, inclusive)
      */
     private fun hasWorkoutAtTime(hourStart: Int, hourEnd: Int): Boolean {
-        val sessions = queries.selectAllSessions().executeAsList()
+        val sessions = queries.selectAllSessions(VendorContextProvider.DEFAULT_CONTEXT.vendorId, VendorContextProvider.DEFAULT_CONTEXT.protocolVersion).executeAsList()
 
         return sessions.any { session ->
             val sessionTime = Instant.fromEpochMilliseconds(session.timestamp)
@@ -320,7 +321,7 @@ class SqlDelightGamificationRepository(
      * Count workouts completed within a specific time range
      */
     private fun countWorkoutsAtTime(hourStart: Int, hourEnd: Int): Int {
-        val sessions = queries.selectAllSessions().executeAsList()
+        val sessions = queries.selectAllSessions(VendorContextProvider.DEFAULT_CONTEXT.vendorId, VendorContextProvider.DEFAULT_CONTEXT.protocolVersion).executeAsList()
 
         return sessions.count { session ->
             val sessionTime = Instant.fromEpochMilliseconds(session.timestamp)
@@ -424,7 +425,7 @@ class SqlDelightGamificationRepository(
      * This is tracked by checking if there was a gap >= breakDays between any two workouts
      */
     private fun hasComebackAfterBreak(breakDays: Int): Boolean {
-        val sessions = queries.selectAllSessions().executeAsList()
+        val sessions = queries.selectAllSessions(VendorContextProvider.DEFAULT_CONTEXT.vendorId, VendorContextProvider.DEFAULT_CONTEXT.protocolVersion).executeAsList()
         if (sessions.size < 2) return false
 
         val sortedSessions = sessions.sortedBy { it.timestamp }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt
@@ -2,6 +2,7 @@ package com.devil.phoenixproject.data.repository
 
 import co.touchlab.kermit.Logger
 import com.devil.phoenixproject.database.VitruvianDatabase
+import com.devil.phoenixproject.data.context.VendorContextProvider
 import com.devil.phoenixproject.data.sync.CustomExerciseSyncDto
 import com.devil.phoenixproject.data.sync.EarnedBadgeSyncDto
 import com.devil.phoenixproject.data.sync.GamificationStatsSyncDto
@@ -268,7 +269,7 @@ class SqlDelightSyncRepository(
                     val localId = existingByServer?.id ?: dto.clientId
 
                     // Preserve local usage stats that the server doesn't track
-                    val existing = queries.selectRoutineById(localId).executeAsOneOrNull()
+                    val existing = queries.selectRoutineById(localId, VendorContextProvider.DEFAULT_CONTEXT.vendorId, VendorContextProvider.DEFAULT_CONTEXT.protocolVersion).executeAsOneOrNull()
 
                     queries.upsertRoutine(
                         id = localId,
@@ -276,7 +277,9 @@ class SqlDelightSyncRepository(
                         description = dto.description,
                         createdAt = dto.createdAt,
                         lastUsed = existing?.lastUsed,
-                        useCount = existing?.useCount ?: 0L
+                        useCount = existing?.useCount ?: 0L,
+                        vendorId = VendorContextProvider.DEFAULT_CONTEXT.vendorId,
+                        protocolVersion = VendorContextProvider.DEFAULT_CONTEXT.protocolVersion
                     )
 
                     // Update sync fields

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightTrainingCycleRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightTrainingCycleRepository.kt
@@ -3,6 +3,7 @@ package com.devil.phoenixproject.data.repository
 import app.cash.sqldelight.coroutines.asFlow
 import app.cash.sqldelight.coroutines.mapToList
 import app.cash.sqldelight.coroutines.mapToOneOrNull
+import com.devil.phoenixproject.data.context.VendorContextProvider
 import com.devil.phoenixproject.database.VitruvianDatabase
 import com.devil.phoenixproject.domain.model.CycleDay
 import com.devil.phoenixproject.domain.model.CycleItem
@@ -19,7 +20,8 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 
 class SqlDelightTrainingCycleRepository(
-    private val db: VitruvianDatabase
+    private val db: VitruvianDatabase,
+    private val vendorContextProvider: VendorContextProvider = VendorContextProvider()
 ) : TrainingCycleRepository {
 
     private val queries = db.vitruvianDatabaseQueries
@@ -618,7 +620,8 @@ class SqlDelightTrainingCycleRepository(
             // Triple: name, exerciseCount, exerciseNames
             val routineInfo = mutableMapOf<String, Triple<String, Int, List<String>>>()
             routineIds.forEach { routineId ->
-                queries.selectRoutineById(routineId).executeAsOneOrNull()?.let { routine ->
+                val context = vendorContextProvider.current()
+                queries.selectRoutineById(routineId, context.vendorId, context.protocolVersion).executeAsOneOrNull()?.let { routine ->
                     val exercises = queries.selectExercisesByRoutine(routineId).executeAsList()
                     routineInfo[routineId] = Triple(
                         routine.name,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepository.kt
@@ -4,6 +4,7 @@ import app.cash.sqldelight.coroutines.asFlow
 import app.cash.sqldelight.coroutines.mapToList
 import app.cash.sqldelight.coroutines.mapToOneOrNull
 import co.touchlab.kermit.Logger
+import com.devil.phoenixproject.data.context.VendorContextProvider
 import com.devil.phoenixproject.database.VitruvianDatabase
 import com.devil.phoenixproject.domain.model.EccentricLoad
 import com.devil.phoenixproject.domain.model.EchoLevel
@@ -27,7 +28,8 @@ import kotlinx.serialization.json.Json
 
 class SqlDelightWorkoutRepository(
     private val db: VitruvianDatabase,
-    private val exerciseRepository: ExerciseRepository
+    private val exerciseRepository: ExerciseRepository,
+    private val vendorContextProvider: VendorContextProvider = VendorContextProvider()
 ) : WorkoutRepository {
 
     private val queries = db.vitruvianDatabaseQueries
@@ -78,6 +80,8 @@ class SqlDelightWorkoutRepository(
         burnoutAvgWeightKg: Double?,
         peakWeightKg: Double?,
         rpe: Long?,
+        vendorId: String,
+        protocolVersion: String,
         // Sync fields (migration 6)
         updatedAt: Long?,
         serverId: String?,
@@ -134,6 +138,8 @@ class SqlDelightWorkoutRepository(
         createdAt: Long,
         lastUsed: Long?,
         useCount: Long,
+        vendorId: String,
+        protocolVersion: String,
         // Sync fields (migration 6)
         updatedAt: Long?,
         serverId: String?,
@@ -351,7 +357,8 @@ class SqlDelightWorkoutRepository(
     }
 
     override fun getAllSessions(): Flow<List<WorkoutSession>> {
-        return queries.selectAllSessions(::mapToSession)
+        val context = vendorContextProvider.current()
+        return queries.selectAllSessions(context.vendorId, context.protocolVersion, ::mapToSession)
             .asFlow()
             .mapToList(Dispatchers.IO)
     }
@@ -398,25 +405,30 @@ class SqlDelightWorkoutRepository(
                 workingAvgWeightKg = session.workingAvgWeightKg?.toDouble(),
                 burnoutAvgWeightKg = session.burnoutAvgWeightKg?.toDouble(),
                 peakWeightKg = session.peakWeightKg?.toDouble(),
-                rpe = session.rpe?.toLong()
+                rpe = session.rpe?.toLong(),
+                vendorId = vendorContextProvider.current().vendorId,
+                protocolVersion = vendorContextProvider.current().protocolVersion
             )
         }
     }
 
     override suspend fun deleteSession(sessionId: String) {
         withContext(Dispatchers.IO) {
-            queries.deleteSession(sessionId)
+            val context = vendorContextProvider.current()
+            queries.deleteSession(sessionId, context.vendorId, context.protocolVersion)
         }
     }
 
     override suspend fun deleteAllSessions() {
         withContext(Dispatchers.IO) {
-            queries.deleteAllSessions()
+            val context = vendorContextProvider.current()
+            queries.deleteAllSessions(context.vendorId, context.protocolVersion)
         }
     }
 
     override fun getAllRoutines(): Flow<List<Routine>> {
-        return queries.selectAllRoutines(::mapToRoutineBasic)
+        val context = vendorContextProvider.current()
+        return queries.selectAllRoutines(context.vendorId, context.protocolVersion, ::mapToRoutineBasic)
             .asFlow()
             .mapToList(Dispatchers.IO)
             .map { basicRoutines ->
@@ -451,7 +463,9 @@ class SqlDelightWorkoutRepository(
                     description = "", // Default empty description
                     createdAt = routine.createdAt,
                     lastUsed = routine.lastUsed,
-                    useCount = routine.useCount.toLong()
+                    useCount = routine.useCount.toLong(),
+                    vendorId = vendorContextProvider.current().vendorId,
+                    protocolVersion = vendorContextProvider.current().protocolVersion
                 )
 
                 // Delete existing supersets and exercises before re-inserting
@@ -533,7 +547,9 @@ class SqlDelightWorkoutRepository(
                 queries.updateRoutineById(
                     name = routine.name,
                     description = "", // Keep description empty for now
-                    id = routineId
+                    id = routineId,
+                    vendorId = vendorContextProvider.current().vendorId,
+                    protocolVersion = vendorContextProvider.current().protocolVersion
                 )
 
                 // Delete existing supersets and exercises, then re-insert
@@ -563,7 +579,7 @@ class SqlDelightWorkoutRepository(
                 // Delete exercises and supersets first (foreign key cascade should handle this, but be explicit)
                 queries.deleteRoutineExercises(routineId)
                 queries.deleteSupersetsByRoutine(routineId)
-                queries.deleteRoutineById(routineId)
+                queries.deleteRoutineById(routineId, vendorContextProvider.current().vendorId, vendorContextProvider.current().protocolVersion)
             }
 
             Logger.d { "Deleted routine $routineId" }
@@ -573,7 +589,7 @@ class SqlDelightWorkoutRepository(
     override suspend fun getRoutineById(routineId: String): Routine? {
         return withContext(Dispatchers.IO) {
             if (routineId.isBlank()) return@withContext null
-            val basicRoutine = queries.selectRoutineById(routineId, ::mapToRoutineBasic).executeAsOneOrNull()
+            val basicRoutine = queries.selectRoutineById(routineId, vendorContextProvider.current().vendorId, vendorContextProvider.current().protocolVersion, ::mapToRoutineBasic).executeAsOneOrNull()
                 ?: return@withContext null
 
             loadRoutineWithExercises(
@@ -694,21 +710,21 @@ class SqlDelightWorkoutRepository(
     // ========== New methods for full parity ==========
 
     override fun getRecentSessions(limit: Int): Flow<List<WorkoutSession>> {
-        return queries.selectRecentSessions(limit.toLong(), ::mapToSession)
+        return queries.selectRecentSessions(vendorContextProvider.current().vendorId, vendorContextProvider.current().protocolVersion, limit.toLong(), ::mapToSession)
             .asFlow()
             .mapToList(Dispatchers.IO)
     }
 
     override suspend fun getSession(sessionId: String): WorkoutSession? {
         return withContext(Dispatchers.IO) {
-            queries.selectSessionById(sessionId, ::mapToSession).executeAsOneOrNull()
+            queries.selectSessionById(sessionId, vendorContextProvider.current().vendorId, vendorContextProvider.current().protocolVersion, ::mapToSession).executeAsOneOrNull()
         }
     }
 
     override suspend fun markRoutineUsed(routineId: String) {
         withContext(Dispatchers.IO) {
             if (routineId.isBlank()) return@withContext
-            queries.updateRoutineLastUsed(currentTimeMillis(), routineId)
+            queries.updateRoutineLastUsed(currentTimeMillis(), routineId, vendorContextProvider.current().vendorId, vendorContextProvider.current().protocolVersion)
             Logger.d { "Marked routine used: $routineId" }
         }
     }
@@ -747,7 +763,7 @@ class SqlDelightWorkoutRepository(
 
     override suspend fun getRecentSessionsSync(limit: Int): List<WorkoutSession> {
         return withContext(Dispatchers.IO) {
-            queries.selectRecentSessions(limit.toLong(), ::mapToSession).executeAsList()
+            queries.selectRecentSessions(vendorContextProvider.current().vendorId, vendorContextProvider.current().protocolVersion, limit.toLong(), ::mapToSession).executeAsList()
         }
     }
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/di/DataModule.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/di/DataModule.kt
@@ -2,6 +2,7 @@ package com.devil.phoenixproject.di
 
 import com.devil.phoenixproject.data.local.DatabaseFactory
 import com.devil.phoenixproject.data.local.ExerciseImporter
+import com.devil.phoenixproject.data.context.VendorContextProvider
 import com.devil.phoenixproject.data.repository.*
 import org.koin.dsl.module
 
@@ -12,18 +13,19 @@ val dataModule = module {
 
     // Data Import
     single { ExerciseImporter(get()) }
+    single { VendorContextProvider() }
 
     // Repositories
     // BleRepository is provided by platformModule
     // Order matters: ExerciseRepository must be created before WorkoutRepository
     single<ExerciseRepository> { SqlDelightExerciseRepository(get(), get()) }
-    single<WorkoutRepository> { SqlDelightWorkoutRepository(get(), get()) }
+    single<WorkoutRepository> { SqlDelightWorkoutRepository(get(), get(), get()) }
     single<PersonalRecordRepository> { SqlDelightPersonalRecordRepository(get()) }
     single<GamificationRepository> { SqlDelightGamificationRepository(get()) }
     single<UserProfileRepository> { SqlDelightUserProfileRepository(get()) }
 
     // Training Cycles Repositories
-    single<TrainingCycleRepository> { SqlDelightTrainingCycleRepository(get()) }
+    single<TrainingCycleRepository> { SqlDelightTrainingCycleRepository(get(), get()) }
     single<CompletedSetRepository> { SqlDelightCompletedSetRepository(get()) }
     single<ProgressionRepository> { SqlDelightProgressionRepository(get()) }
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/DataBackupManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/DataBackupManager.kt
@@ -2,6 +2,7 @@ package com.devil.phoenixproject.util
 
 import co.touchlab.kermit.Logger
 import com.devil.phoenixproject.database.*
+import com.devil.phoenixproject.data.context.VendorContextProvider
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
@@ -371,7 +372,10 @@ abstract class BaseDataBackupManager(
             }
 
             // Get existing IDs for duplicate detection (before transaction)
-            val existingSessionIds = queries.selectAllSessionIds().executeAsList().toSet()
+            val existingSessionIds = queries.selectAllSessionIds(
+                VendorContextProvider.DEFAULT_CONTEXT.vendorId,
+                VendorContextProvider.DEFAULT_CONTEXT.protocolVersion
+            ).executeAsList().toSet()
             val existingRoutineIds = queries.selectAllRoutineIds().executeAsList().toSet()
             val existingSupersetIds = queries.selectAllSupersetIds().executeAsList().toSet()
             val existingPRIds = queries.selectAllPRIds().executeAsList().toSet()
@@ -465,7 +469,9 @@ abstract class BaseDataBackupManager(
                             workingAvgWeightKg = session.workingAvgWeightKg?.toDouble(),
                             burnoutAvgWeightKg = session.burnoutAvgWeightKg?.toDouble(),
                             peakWeightKg = session.peakWeightKg?.toDouble(),
-                            rpe = session.rpe?.toLong()
+                            rpe = session.rpe?.toLong(),
+                            vendorId = VendorContextProvider.DEFAULT_CONTEXT.vendorId,
+                            protocolVersion = VendorContextProvider.DEFAULT_CONTEXT.protocolVersion
                         )
                         sessionsImported++
                     } else {
@@ -506,7 +512,9 @@ abstract class BaseDataBackupManager(
                             description = routine.description,
                             createdAt = routine.createdAt,
                             lastUsed = routine.lastUsed,
-                            useCount = routine.useCount.toLong()
+                            useCount = routine.useCount.toLong(),
+                            vendorId = VendorContextProvider.DEFAULT_CONTEXT.vendorId,
+                            protocolVersion = VendorContextProvider.DEFAULT_CONTEXT.protocolVersion
                         )
                         routinesImported++
                     } else {

--- a/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
+++ b/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
@@ -88,6 +88,8 @@ CREATE TABLE WorkoutSession (
     burnoutAvgWeightKg REAL,
     peakWeightKg REAL,
     rpe INTEGER,
+    vendorId TEXT NOT NULL DEFAULT 'phoenix',
+    protocolVersion TEXT NOT NULL DEFAULT 'v1',
     -- Sync fields (added in migration 6)
     updatedAt INTEGER,
     serverId TEXT,
@@ -139,6 +141,8 @@ CREATE TABLE Routine (
     createdAt INTEGER NOT NULL,
     lastUsed INTEGER,
     useCount INTEGER NOT NULL DEFAULT 0,
+    vendorId TEXT NOT NULL DEFAULT 'phoenix',
+    protocolVersion TEXT NOT NULL DEFAULT 'v1',
     -- Sync fields (added in migration 6)
     updatedAt INTEGER,
     serverId TEXT,
@@ -215,11 +219,14 @@ CREATE TABLE ConnectionLog (
     deviceName TEXT,
     message TEXT NOT NULL,
     details TEXT,
-    metadata TEXT
+    metadata TEXT,
+    vendorId TEXT NOT NULL DEFAULT 'phoenix',
+    protocolVersion TEXT NOT NULL DEFAULT 'v1'
 );
 
 CREATE INDEX idx_connection_log_timestamp ON ConnectionLog(timestamp);
 CREATE INDEX idx_connection_log_device ON ConnectionLog(deviceAddress);
+CREATE INDEX idx_connection_log_vendor_protocol ON ConnectionLog(vendorId, protocolVersion, timestamp DESC);
 
 -- ==================== DIAGNOSTICS HISTORY ====================
 -- Machine diagnostics snapshots for fault tracking
@@ -346,10 +353,12 @@ deleteCustomExercise:
 DELETE FROM Exercise WHERE id = ? AND isCustom = 1;
 
 deleteSession:
-DELETE FROM WorkoutSession WHERE id = ?;
+DELETE FROM WorkoutSession
+WHERE id = ? AND vendorId = :vendorId AND protocolVersion = :protocolVersion;
 
 deleteAllSessions:
-DELETE FROM WorkoutSession;
+DELETE FROM WorkoutSession
+WHERE vendorId = :vendorId AND protocolVersion = :protocolVersion;
 
 -- Exercise Video Queries
 selectVideosByExercise:
@@ -370,10 +379,13 @@ DELETE FROM ExerciseVideo;
 
 -- Workout Session Queries
 selectAllSessions:
-SELECT * FROM WorkoutSession ORDER BY timestamp DESC;
+SELECT * FROM WorkoutSession
+WHERE vendorId = :vendorId AND protocolVersion = :protocolVersion
+ORDER BY timestamp DESC;
 
 selectSessionById:
-SELECT * FROM WorkoutSession WHERE id = ?;
+SELECT * FROM WorkoutSession
+WHERE id = ? AND vendorId = :vendorId AND protocolVersion = :protocolVersion;
 
 -- Sync version for backup
 selectAllSessionsSync:
@@ -381,10 +393,13 @@ SELECT * FROM WorkoutSession;
 
 -- Get all session IDs for duplicate checking during import
 selectAllSessionIds:
-SELECT id FROM WorkoutSession;
+SELECT id FROM WorkoutSession
+WHERE vendorId = :vendorId AND protocolVersion = :protocolVersion;
 
 selectRecentSessions:
-SELECT * FROM WorkoutSession ORDER BY timestamp DESC LIMIT ?;
+SELECT * FROM WorkoutSession
+WHERE vendorId = :vendorId AND protocolVersion = :protocolVersion
+ORDER BY timestamp DESC LIMIT ?;
 
 insertSession:
 INSERT INTO WorkoutSession (
@@ -396,29 +411,30 @@ INSERT INTO WorkoutSession (
     peakForceConcentricA, peakForceConcentricB, peakForceEccentricA, peakForceEccentricB,
     avgForceConcentricA, avgForceConcentricB, avgForceEccentricA, avgForceEccentricB,
     heaviestLiftKg, totalVolumeKg, estimatedCalories,
-    warmupAvgWeightKg, workingAvgWeightKg, burnoutAvgWeightKg, peakWeightKg, rpe
+    warmupAvgWeightKg, workingAvgWeightKg, burnoutAvgWeightKg, peakWeightKg, rpe,
+    vendorId, protocolVersion
 )
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 updateSession:
 UPDATE WorkoutSession 
 SET duration = ?, totalReps = ?, workingReps = ? 
-WHERE id = ?;
+WHERE id = ? AND vendorId = :vendorId AND protocolVersion = :protocolVersion;
 
 updateSessionRoutineName:
 UPDATE WorkoutSession
 SET routineName = ?
-WHERE id = ?;
+WHERE id = ? AND vendorId = :vendorId AND protocolVersion = :protocolVersion;
 
 updateSessionRoutineSessionId:
 UPDATE WorkoutSession
 SET routineSessionId = ?
-WHERE id = ?;
+WHERE id = ? AND vendorId = :vendorId AND protocolVersion = :protocolVersion;
 
 updateSessionRoutineId:
 UPDATE WorkoutSession
 SET routineId = ?
-WHERE id = ?;
+WHERE id = ? AND vendorId = :vendorId AND protocolVersion = :protocolVersion;
 
 -- Metric Queries
 selectMetricsBySession:
@@ -539,21 +555,26 @@ SELECT id FROM PersonalRecord;
 
 -- Routine Queries
 selectAllRoutines:
-SELECT * FROM Routine ORDER BY name ASC;
+SELECT * FROM Routine
+WHERE vendorId = :vendorId AND protocolVersion = :protocolVersion
+ORDER BY name ASC;
 
 selectRoutineById:
-SELECT * FROM Routine WHERE id = ?;
+SELECT * FROM Routine
+WHERE id = ? AND vendorId = :vendorId AND protocolVersion = :protocolVersion;
 
 insertRoutine:
-INSERT INTO Routine (id, name, description, createdAt, lastUsed, useCount) VALUES (?, ?, ?, ?, ?, ?);
+INSERT INTO Routine (id, name, description, createdAt, lastUsed, useCount, vendorId, protocolVersion)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?);
 
 -- Upsert routine (insert or replace) - handles both new and existing routines
 upsertRoutine:
-INSERT OR REPLACE INTO Routine (id, name, description, createdAt, lastUsed, useCount)
-VALUES (?, ?, ?, ?, ?, ?);
+INSERT OR REPLACE INTO Routine (id, name, description, createdAt, lastUsed, useCount, vendorId, protocolVersion)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?);
 
 updateRoutineLastUsed:
-UPDATE Routine SET lastUsed = ?, useCount = useCount + 1 WHERE id = ?;
+UPDATE Routine SET lastUsed = ?, useCount = useCount + 1
+WHERE id = ? AND vendorId = :vendorId AND protocolVersion = :protocolVersion;
 
 -- Sync versions for backup
 selectAllRoutinesSync:
@@ -597,10 +618,12 @@ deleteRoutineExercises:
 DELETE FROM RoutineExercise WHERE routineId = ?;
 
 deleteRoutineById:
-DELETE FROM Routine WHERE id = ?;
+DELETE FROM Routine
+WHERE id = ? AND vendorId = :vendorId AND protocolVersion = :protocolVersion;
 
 updateRoutineById:
-UPDATE Routine SET name = ?, description = ? WHERE id = ?;
+UPDATE Routine SET name = ?, description = ?
+WHERE id = ? AND vendorId = :vendorId AND protocolVersion = :protocolVersion;
 
 -- ==================== SUPERSET QUERIES ====================
 
@@ -652,38 +675,55 @@ SELECT timestamp, totalReps, weightPerCableKg FROM WorkoutSession ORDER BY times
 -- ==================== CONNECTION LOG QUERIES ====================
 
 insertConnectionLog:
-INSERT INTO ConnectionLog (timestamp, eventType, level, deviceAddress, deviceName, message, details, metadata)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?);
+INSERT INTO ConnectionLog (timestamp, eventType, level, deviceAddress, deviceName, message, details, metadata, vendorId, protocolVersion)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 selectAllConnectionLogs:
-SELECT * FROM ConnectionLog ORDER BY timestamp DESC;
+SELECT * FROM ConnectionLog
+WHERE vendorId = :vendorId AND protocolVersion = :protocolVersion
+ORDER BY timestamp DESC;
 
 selectRecentConnectionLogs:
-SELECT * FROM ConnectionLog ORDER BY timestamp DESC LIMIT ?;
+SELECT * FROM ConnectionLog
+WHERE vendorId = :vendorId AND protocolVersion = :protocolVersion
+ORDER BY timestamp DESC LIMIT ?;
 
 selectConnectionLogsByDevice:
-SELECT * FROM ConnectionLog WHERE deviceAddress = ? ORDER BY timestamp DESC;
+SELECT * FROM ConnectionLog
+WHERE deviceAddress = ? AND vendorId = :vendorId AND protocolVersion = :protocolVersion
+ORDER BY timestamp DESC;
 
 selectConnectionLogsByEventType:
-SELECT * FROM ConnectionLog WHERE eventType = ? ORDER BY timestamp DESC;
+SELECT * FROM ConnectionLog
+WHERE eventType = ? AND vendorId = :vendorId AND protocolVersion = :protocolVersion
+ORDER BY timestamp DESC;
 
 selectConnectionLogsByLevel:
-SELECT * FROM ConnectionLog WHERE level = ? ORDER BY timestamp DESC;
+SELECT * FROM ConnectionLog
+WHERE level = ? AND vendorId = :vendorId AND protocolVersion = :protocolVersion
+ORDER BY timestamp DESC;
 
 selectConnectionLogsBetween:
-SELECT * FROM ConnectionLog WHERE timestamp BETWEEN ? AND ? ORDER BY timestamp DESC;
+SELECT * FROM ConnectionLog
+WHERE timestamp BETWEEN ? AND ? AND vendorId = :vendorId AND protocolVersion = :protocolVersion
+ORDER BY timestamp DESC;
 
 countConnectionLogsByLevel:
-SELECT COUNT(*) FROM ConnectionLog WHERE level = ?;
+SELECT COUNT(*) FROM ConnectionLog
+WHERE level = ? AND vendorId = :vendorId AND protocolVersion = :protocolVersion;
 
 deleteConnectionLogsOlderThan:
-DELETE FROM ConnectionLog WHERE timestamp < ?;
+DELETE FROM ConnectionLog
+WHERE timestamp < ? AND vendorId = :vendorId AND protocolVersion = :protocolVersion;
 
 deleteAllConnectionLogs:
-DELETE FROM ConnectionLog;
+DELETE FROM ConnectionLog
+WHERE vendorId = :vendorId AND protocolVersion = :protocolVersion;
 
 selectConnectionLogsForExport:
-SELECT * FROM ConnectionLog ORDER BY timestamp ASC;
+SELECT * FROM ConnectionLog
+WHERE vendorId = :vendorId AND protocolVersion = :protocolVersion
+ORDER BY timestamp ASC;
 
 -- ==================== DIAGNOSTICS HISTORY QUERIES ====================
 

--- a/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/migrations/13.sqm
+++ b/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/migrations/13.sqm
@@ -1,0 +1,27 @@
+-- Migration 13: Add vendor/protocol metadata for multi-vendor data isolation
+-- Default/fallback for legacy Phoenix records uses vendorId='phoenix', protocolVersion='v1'.
+
+ALTER TABLE WorkoutSession ADD COLUMN vendorId TEXT NOT NULL DEFAULT 'phoenix';
+ALTER TABLE WorkoutSession ADD COLUMN protocolVersion TEXT NOT NULL DEFAULT 'v1';
+
+ALTER TABLE Routine ADD COLUMN vendorId TEXT NOT NULL DEFAULT 'phoenix';
+ALTER TABLE Routine ADD COLUMN protocolVersion TEXT NOT NULL DEFAULT 'v1';
+
+ALTER TABLE ConnectionLog ADD COLUMN vendorId TEXT NOT NULL DEFAULT 'phoenix';
+ALTER TABLE ConnectionLog ADD COLUMN protocolVersion TEXT NOT NULL DEFAULT 'v1';
+
+-- Explicit fallback assignment for any pre-existing null/empty values.
+UPDATE WorkoutSession
+SET vendorId = COALESCE(NULLIF(vendorId, ''), 'phoenix'),
+    protocolVersion = COALESCE(NULLIF(protocolVersion, ''), 'v1');
+
+UPDATE Routine
+SET vendorId = COALESCE(NULLIF(vendorId, ''), 'phoenix'),
+    protocolVersion = COALESCE(NULLIF(protocolVersion, ''), 'v1');
+
+UPDATE ConnectionLog
+SET vendorId = COALESCE(NULLIF(vendorId, ''), 'phoenix'),
+    protocolVersion = COALESCE(NULLIF(protocolVersion, ''), 'v1');
+
+CREATE INDEX IF NOT EXISTS idx_connection_log_vendor_protocol
+ON ConnectionLog(vendorId, protocolVersion, timestamp DESC);


### PR DESCRIPTION
### Motivation
- Introduce per-vendor scoping so sessions, routines (templates) and connection logs can be partitioned by `vendorId`/`protocolVersion` and legacy Phoenix rows get a safe default fallback.

### Description
- Add `vendorId` and `protocolVersion` columns (with defaults `'phoenix'` / `'v1'`) to SQLDelight schema for `WorkoutSession`, `Routine`, and `ConnectionLog`, and create an index for log vendor/protocol lookups (`VitruvianDatabase.sq`).
- Add migration `13.sqm` (placed under `shared/src/commonMain/sqldelight/.../migrations/`) that adds the columns and backfills legacy rows to the Phoenix defaults, and bump SQLDelight DB version to `14` (`shared/build.gradle.kts`).
- Introduce `VendorContext` / `VendorContextProvider` and register it in DI so code can read the active vendor context (`shared/src/commonMain/kotlin/com/devil/phoenixproject/data/context/VendorContext.kt`, `DataModule.kt`).
- Update repositories and code paths to honor the active vendor context: `SqlDelightWorkoutRepository` (reads/writes scoped by vendor), `SqlDelightTrainingCycleRepository` (routine lookups), in-memory `ConnectionLogRepository` (tagging/filters), plus related changes in `SqlDelightSyncRepository`, `SqlDelightGamificationRepository`, `DataBackupManager`, `MigrationManager`, and helpers to use the new query signatures and defaults.
- Add migration verification tests and a fixture-based upgrade test (`VendorMigrationTest` + fixture under `shared/src/androidHostTest/resources/migrations/vendor-upgrade-fixture.sql`), and update existing backup/migration tests to use the Phoenix defaults where appropriate.

### Testing
- Compiled the shared metadata successfully with `./gradlew :shared:compileCommonMainKotlinMetadata --no-daemon --no-configuration-cache --console=plain` (build warnings only, compilation succeeded). ✅
- Added unit-style migration verification `VendorMigrationTest` (in-memory SQLite via `JdbcSqliteDriver`) and a fixture upgrade test to validate migration 13 applies defaults to legacy tables; these tests are present under `shared/src/androidHostTest` and the migration SQL is included under `shared/src/commonMain/sqldelight/.../migrations/13.sqm`. ✅
- Attempted `./gradlew :shared:assembleAndroidHostTest` but it cannot complete in this environment because the Android SDK location is not configured (missing `ANDROID_HOME` / `sdk.dir`), so Android host tests were not executed here. ⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2ade02f308322a540e0f926900972)