### PR TITLE
Introduce generic WorkoutIntent and Vitruvian mapping/validation

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/adapter/vitruvian/VitruvianWorkoutIntentMapper.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/adapter/vitruvian/VitruvianWorkoutIntentMapper.kt
@@ -1,0 +1,70 @@
+package com.devil.phoenixproject.adapter.vitruvian
+
+import com.devil.phoenixproject.domain.model.*
+
+/**
+ * Protocol mapping layer: generic [WorkoutIntent] -> Vitruvian mode payload.
+ */
+data class VitruvianModePayload(
+    val programMode: ProgramMode,
+    val echoLevel: EchoLevel,
+    val eccentricLoad: EccentricLoad,
+    val targetReps: Int,
+    val isAmrap: Boolean
+)
+
+object VitruvianProtocolCapabilities {
+    val descriptor = ProtocolCapabilityDescriptor(
+        supportedStrengthProfiles = setOf(
+            StrengthProfile.STANDARD,
+            StrengthProfile.PUMP,
+            StrengthProfile.TIME_UNDER_TENSION,
+            StrengthProfile.TIME_UNDER_TENSION_HIGH,
+            StrengthProfile.ECHO
+        ),
+        supportedTempoProfiles = setOf(TempoProfile.NORMAL),
+        supportsAssistedMode = false,
+        supportsEccentricBias = true,
+        supportsRepTarget = true,
+        supportsTimeTarget = true,
+        supportsRomConstraints = false,
+        maxEccentricPercent = 150
+    )
+}
+
+object VitruvianWorkoutIntentMapper {
+    fun map(intent: WorkoutIntent): VitruvianModePayload {
+        val validationErrors = WorkoutIntentValidator.validate(intent, VitruvianProtocolCapabilities.descriptor)
+        require(validationErrors.isEmpty()) {
+            "Workout intent is not supported by Vitruvian protocol: ${validationErrors.joinToString()}"
+        }
+
+        val mode = when (intent.strengthProfile) {
+            StrengthProfile.STANDARD -> ProgramMode.OldSchool
+            StrengthProfile.PUMP -> ProgramMode.Pump
+            StrengthProfile.TIME_UNDER_TENSION -> ProgramMode.TUT
+            StrengthProfile.TIME_UNDER_TENSION_HIGH -> ProgramMode.TUTBeast
+            StrengthProfile.ECHO -> ProgramMode.Echo
+        }
+
+        val reps = when (val target = intent.target) {
+            is WorkoutTarget.Repetitions -> target.reps
+            is WorkoutTarget.DurationSeconds -> 0
+        }
+
+        val eccentric = when (val bias = intent.eccentricBias) {
+            EccentricBias.NONE -> EccentricLoad.LOAD_100
+            is EccentricBias.Percent -> EccentricLoad.entries
+                .firstOrNull { it.percentage == bias.value }
+                ?: EccentricLoad.LOAD_100
+        }
+
+        return VitruvianModePayload(
+            programMode = mode,
+            echoLevel = EchoLevel.HARD,
+            eccentricLoad = eccentric,
+            targetReps = reps,
+            isAmrap = intent.target is WorkoutTarget.DurationSeconds
+        )
+    }
+}

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/Models.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/Models.kt
@@ -134,8 +134,9 @@ sealed class RoutineFlowState {
 }
 
 /**
- * Program modes used by Phoenix workout setup.
+ * Vitruvian-specific compatibility model for Phoenix workout setup.
  *
+ * Kept for backwards compatibility while the domain layer moves toward generic [WorkoutIntent].
  * Non-Echo modes start with the 96-byte activation/config frame (command 0x04),
  * followed by a START command (0x03). Echo uses its dedicated 0x4E packet.
  */
@@ -259,8 +260,19 @@ data class WorkoutParameters(
     val repCountTiming: RepCountTiming = RepCountTiming.TOP,  // When to count working reps (TOP=concentric peak, BOTTOM=eccentric valley)
     // Echo-specific settings (only used when programMode == ProgramMode.Echo)
     val echoLevel: EchoLevel = EchoLevel.HARD,
-    val eccentricLoad: EccentricLoad = EccentricLoad.LOAD_100
+    val eccentricLoad: EccentricLoad = EccentricLoad.LOAD_100,
+    // Generic domain intent (preferred). When null, callers are using legacy ProgramMode fields.
+    val workoutIntent: WorkoutIntent? = null
 ) {
+    /** Resolve generic intent from either explicit intent or legacy mode fields. */
+    fun resolvedWorkoutIntent(): WorkoutIntent = workoutIntent
+        ?: programMode.toWorkoutIntent(
+            echoLevel = echoLevel,
+            eccentricLoad = eccentricLoad,
+            isAmrap = isAMRAP,
+            reps = reps
+        )
+
     /** True if this is an Echo workout */
     val isEchoMode: Boolean get() = programMode == ProgramMode.Echo
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/WorkoutIntent.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/WorkoutIntent.kt
@@ -1,0 +1,125 @@
+package com.devil.phoenixproject.domain.model
+
+/**
+ * Vendor-agnostic workout intent model.
+ *
+ * This captures what the user wants to train without tying the domain layer
+ * to a specific machine protocol mode id.
+ */
+data class WorkoutIntent(
+    val strengthProfile: StrengthProfile = StrengthProfile.STANDARD,
+    val tempo: TempoProfile = TempoProfile.NORMAL,
+    val assistance: AssistanceProfile = AssistanceProfile.NONE,
+    val eccentricBias: EccentricBias = EccentricBias.NONE,
+    val target: WorkoutTarget = WorkoutTarget.Repetitions(10),
+    val romConstraint: RomConstraint = RomConstraint.Unrestricted
+)
+
+enum class StrengthProfile {
+    STANDARD,
+    PUMP,
+    TIME_UNDER_TENSION,
+    TIME_UNDER_TENSION_HIGH,
+    ECHO
+}
+
+enum class TempoProfile {
+    NORMAL,
+    CONTROLLED,
+    EXPLOSIVE
+}
+
+enum class AssistanceProfile {
+    NONE,
+    ASSISTED
+}
+
+sealed class EccentricBias {
+    data object NONE : EccentricBias()
+    data class Percent(val value: Int) : EccentricBias()
+}
+
+sealed class WorkoutTarget {
+    data class Repetitions(val reps: Int) : WorkoutTarget()
+    data class DurationSeconds(val seconds: Int) : WorkoutTarget()
+}
+
+sealed class RomConstraint {
+    data object Unrestricted : RomConstraint()
+    data class MinRangeMm(val minRangeMm: Int) : RomConstraint()
+}
+
+data class ProtocolCapabilityDescriptor(
+    val supportedStrengthProfiles: Set<StrengthProfile>,
+    val supportedTempoProfiles: Set<TempoProfile>,
+    val supportsAssistedMode: Boolean,
+    val supportsEccentricBias: Boolean,
+    val supportsRepTarget: Boolean,
+    val supportsTimeTarget: Boolean,
+    val supportsRomConstraints: Boolean,
+    val maxEccentricPercent: Int = 150
+)
+
+object WorkoutIntentValidator {
+    fun validate(intent: WorkoutIntent, capability: ProtocolCapabilityDescriptor): List<String> {
+        val errors = mutableListOf<String>()
+        if (intent.strengthProfile !in capability.supportedStrengthProfiles) {
+            errors += "Unsupported strength profile: ${intent.strengthProfile}"
+        }
+        if (intent.tempo !in capability.supportedTempoProfiles) {
+            errors += "Unsupported tempo profile: ${intent.tempo}"
+        }
+        if (intent.assistance == AssistanceProfile.ASSISTED && !capability.supportsAssistedMode) {
+            errors += "Assisted mode is not supported by current protocol"
+        }
+        if (intent.eccentricBias is EccentricBias.Percent) {
+            if (!capability.supportsEccentricBias) {
+                errors += "Eccentric bias is not supported by current protocol"
+            } else if (intent.eccentricBias.value !in 0..capability.maxEccentricPercent) {
+                errors += "Eccentric bias must be between 0 and ${capability.maxEccentricPercent}%"
+            }
+        }
+        when (intent.target) {
+            is WorkoutTarget.Repetitions -> if (!capability.supportsRepTarget) {
+                errors += "Rep-based targets are not supported by current protocol"
+            }
+            is WorkoutTarget.DurationSeconds -> if (!capability.supportsTimeTarget) {
+                errors += "Timed targets are not supported by current protocol"
+            }
+        }
+        if (intent.romConstraint is RomConstraint.MinRangeMm && !capability.supportsRomConstraints) {
+            errors += "ROM constraints are not supported by current protocol"
+        }
+        return errors
+    }
+}
+
+
+fun ProgramMode.toWorkoutIntent(
+    echoLevel: EchoLevel = EchoLevel.HARD,
+    eccentricLoad: EccentricLoad = EccentricLoad.LOAD_100,
+    isAmrap: Boolean = false,
+    reps: Int = 10
+): WorkoutIntent {
+    val profile = when (this) {
+        ProgramMode.OldSchool -> StrengthProfile.STANDARD
+        ProgramMode.Pump -> StrengthProfile.PUMP
+        ProgramMode.TUT -> StrengthProfile.TIME_UNDER_TENSION
+        ProgramMode.TUTBeast -> StrengthProfile.TIME_UNDER_TENSION_HIGH
+        ProgramMode.EccentricOnly -> StrengthProfile.STANDARD
+        ProgramMode.Echo -> StrengthProfile.ECHO
+    }
+
+    val eccentricBias = if (this == ProgramMode.EccentricOnly || this == ProgramMode.Echo) {
+        EccentricBias.Percent(eccentricLoad.percentage)
+    } else {
+        EccentricBias.NONE
+    }
+
+    return WorkoutIntent(
+        strengthProfile = profile,
+        target = if (isAmrap) WorkoutTarget.DurationSeconds(0) else WorkoutTarget.Repetitions(reps),
+        eccentricBias = eccentricBias,
+        tempo = if (echoLevel == EchoLevel.EPIC) TempoProfile.EXPLOSIVE else TempoProfile.NORMAL
+    )
+}

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -12,6 +12,8 @@ import com.devil.phoenixproject.data.repository.CompletedSetRepository
 import com.devil.phoenixproject.data.repository.TrainingCycleRepository
 import com.devil.phoenixproject.data.repository.WorkoutRepository
 import com.devil.phoenixproject.data.sync.SyncTriggerManager
+import com.devil.phoenixproject.adapter.vitruvian.VitruvianProtocolCapabilities
+import com.devil.phoenixproject.adapter.vitruvian.VitruvianWorkoutIntentMapper
 import com.devil.phoenixproject.domain.model.*
 import com.devil.phoenixproject.domain.usecase.RepCounterFromMachine
 import com.devil.phoenixproject.util.BlePacketFactory
@@ -1149,6 +1151,20 @@ class ActiveSessionEngine(
         Logger.d("ActiveSessionEngine") { "LOAD BASELINE: Reset to 0 (disabled)" }
     }
 
+    fun updateWorkoutIntent(intent: WorkoutIntent) {
+        val current = coordinator._workoutParameters.value
+        val mapped = VitruvianWorkoutIntentMapper.map(intent)
+        val updated = current.copy(
+            workoutIntent = intent,
+            programMode = mapped.programMode,
+            reps = if (mapped.targetReps > 0) mapped.targetReps else current.reps,
+            echoLevel = mapped.echoLevel,
+            eccentricLoad = mapped.eccentricLoad,
+            isAMRAP = mapped.isAmrap
+        )
+        updateWorkoutParameters(updated)
+    }
+
     fun updateWorkoutParameters(params: WorkoutParameters) {
         val currentState = coordinator._workoutState.value
         if (currentState is WorkoutState.Idle ||
@@ -1280,11 +1296,33 @@ class ActiveSessionEngine(
             println("Issue188: stopAtTop: ${effectiveParams.stopAtTop}")
             println("Issue188: stallDetection: ${effectiveParams.stallDetectionEnabled}")
 
+            val resolvedIntent = effectiveParams.resolvedWorkoutIntent()
+            val validationErrors = WorkoutIntentValidator.validate(
+                resolvedIntent,
+                VitruvianProtocolCapabilities.descriptor
+            )
+            if (validationErrors.isNotEmpty()) {
+                val message = "Unsupported workout intent: ${validationErrors.joinToString()}"
+                Logger.e { message }
+                coordinator._bleErrorEvents.tryEmit(message)
+                return@launch
+            }
+
+            val mappedPayload = VitruvianWorkoutIntentMapper.map(resolvedIntent)
+            val mappedParams = effectiveParams.copy(
+                workoutIntent = resolvedIntent,
+                programMode = mappedPayload.programMode,
+                reps = if (mappedPayload.targetReps > 0) mappedPayload.targetReps else effectiveParams.reps,
+                echoLevel = mappedPayload.echoLevel,
+                eccentricLoad = mappedPayload.eccentricLoad,
+                isAMRAP = mappedPayload.isAmrap
+            )
+
             val bleParams = if (isTimedCableExercise) {
                 Logger.d { "Duration cable: overriding isAMRAP=true for BLE command (prevents machine rep limit)" }
-                effectiveParams.copy(isAMRAP = true)
+                mappedParams.copy(isAMRAP = true)
             } else {
-                effectiveParams
+                mappedParams
             }
 
             val command = if (bleParams.isEchoMode) {

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/DefaultWorkoutSessionManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/DefaultWorkoutSessionManager.kt
@@ -315,6 +315,7 @@ class DefaultWorkoutSessionManager(
     fun recaptureLoadBaseline() = activeSessionEngine.recaptureLoadBaseline()
     fun resetLoadBaseline() = activeSessionEngine.resetLoadBaseline()
     fun updateWorkoutParameters(params: WorkoutParameters) = activeSessionEngine.updateWorkoutParameters(params)
+    fun updateWorkoutIntent(intent: WorkoutIntent) = activeSessionEngine.updateWorkoutIntent(intent)
     fun startWorkout(skipCountdown: Boolean = false, isJustLiftMode: Boolean = false) = activeSessionEngine.startWorkout(skipCountdown, isJustLiftMode)
     fun skipCountdown() = activeSessionEngine.skipCountdown()
     fun stopWorkout(exitingWorkout: Boolean = false) = activeSessionEngine.stopWorkout(exitingWorkout)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutCoordinator.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutCoordinator.kt
@@ -135,6 +135,7 @@ class WorkoutCoordinator(
         )
     )
     val workoutParameters: StateFlow<WorkoutParameters> = _workoutParameters.asStateFlow()
+    val currentWorkoutIntent: WorkoutIntent get() = _workoutParameters.value.resolvedWorkoutIntent()
 
     // Issue #108: Track if user manually adjusted weight during rest period
     // When true, preserve user's weight instead of reloading from exercise preset

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
@@ -200,6 +200,7 @@ class MainViewModel constructor(
     // ===== Workout Lifecycle Delegation =====
 
     fun updateWorkoutParameters(params: WorkoutParameters) = workoutSessionManager.updateWorkoutParameters(params)
+    fun updateWorkoutIntent(intent: WorkoutIntent) = workoutSessionManager.updateWorkoutIntent(intent)
     fun startWorkout(skipCountdown: Boolean = false, isJustLiftMode: Boolean = false) =
         workoutSessionManager.startWorkout(skipCountdown, isJustLiftMode)
     fun stopWorkout(exitingWorkout: Boolean = false) = workoutSessionManager.stopWorkout(exitingWorkout)

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/WorkoutIntentTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/WorkoutIntentTest.kt
@@ -1,0 +1,42 @@
+package com.devil.phoenixproject.domain.model
+
+import com.devil.phoenixproject.adapter.vitruvian.VitruvianWorkoutIntentMapper
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class WorkoutIntentTest {
+
+    @Test
+    fun validatorRejectsUnsupportedTempo() {
+        val capability = ProtocolCapabilityDescriptor(
+            supportedStrengthProfiles = setOf(StrengthProfile.STANDARD),
+            supportedTempoProfiles = setOf(TempoProfile.NORMAL),
+            supportsAssistedMode = false,
+            supportsEccentricBias = false,
+            supportsRepTarget = true,
+            supportsTimeTarget = false,
+            supportsRomConstraints = false
+        )
+
+        val errors = WorkoutIntentValidator.validate(
+            WorkoutIntent(tempo = TempoProfile.EXPLOSIVE),
+            capability
+        )
+
+        assertTrue(errors.any { it.contains("tempo", ignoreCase = true) })
+    }
+
+    @Test
+    fun mapperMapsPumpToProgramMode() {
+        val intent = WorkoutIntent(
+            strengthProfile = StrengthProfile.PUMP,
+            target = WorkoutTarget.Repetitions(12)
+        )
+
+        val payload = VitruvianWorkoutIntentMapper.map(intent)
+
+        assertEquals(ProgramMode.Pump, payload.programMode)
+        assertEquals(12, payload.targetReps)
+    }
+}


### PR DESCRIPTION
### Motivation
- Decouple workout intent from vendor protocol ids so domain logic can express what the user wants to train (strength/tempo/assistance/eccentric/rep/time/ROM) without tying to `ProgramMode`.
- Provide a per-vendor mapping layer to convert generic intents into protocol-specific payloads and reject unsupported intents using capability descriptors.
- Preserve existing Vitruvian `ProgramMode` as a compatibility model while migrating callers to intent-driven workflows.

### Description
- Added a generic intent model and validator in `domain/model/WorkoutIntent.kt` including `WorkoutIntent`, `ProtocolCapabilityDescriptor`, and `WorkoutIntentValidator` to express intent and validate it against protocol capabilities.
- Implemented a Vitruvian adapter `adapter/vitruvian/VitruvianWorkoutIntentMapper.kt` that validates and maps `WorkoutIntent` → `VitruvianModePayload` (`ProgramMode`/echo/eccentric/targets) and a `VitruvianProtocolCapabilities` descriptor.
- Extended `WorkoutParameters` to carry an optional `workoutIntent` with `resolvedWorkoutIntent()` fallback from legacy `ProgramMode`/echo/eccentric fields for compatibility, and added `ProgramMode.toWorkoutIntent()` conversion helper.
- Added new entry points and plumbing to consume intents: `MainViewModel.updateWorkoutIntent(...)`, `DefaultWorkoutSessionManager.updateWorkoutIntent(...)`, `ActiveSessionEngine.updateWorkoutIntent(...)`, and exposed `WorkoutCoordinator.currentWorkoutIntent`.
- Integrated validation and mapping into the workout start flow in `ActiveSessionEngine.startWorkout()` so unsupported intents are rejected early and mapped params are used to build BLE commands.
- Added unit tests `shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/WorkoutIntentTest.kt` covering validator rejection and Vitruvian mapping behavior.

### Testing
- Compiled shared metadata to verify cross-platform sources with `./gradlew :shared:compileKotlinMetadata --no-configuration-cache --console=plain`, which completed successfully. (✅)
- Attempted to run the new test class with host tests via `./gradlew :shared:testAndroidHostTest --tests "com.devil.phoenixproject.domain.model.WorkoutIntentTest"`, which was blocked by a missing Android SDK (`ANDROID_HOME`) in this environment (environment limitation). (⚠️)
- Added the test file and ensured the project builds locally in CI-like compile steps; the code paths performing validation/mapping are exercised by the new unit tests in supported environments. (partial)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2add5c6c083228dc1570f9722b11b)