### PR TITLE
Add Vitruvian protocol adapters and inject packet routing in KableBleRepository

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/ble/VitruvianProtocolAdapters.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/ble/VitruvianProtocolAdapters.kt
@@ -1,0 +1,101 @@
+package com.devil.phoenixproject.data.ble
+
+import com.devil.phoenixproject.data.repository.RepNotification
+import com.devil.phoenixproject.data.ble.getUInt16BE as parseUInt16BE
+import com.devil.phoenixproject.data.ble.parseDiagnosticPacket as parseDiagnostic
+import com.devil.phoenixproject.data.ble.parseMonitorPacket as parseMonitor
+import com.devil.phoenixproject.data.ble.parseRepPacket as parseReps
+import com.devil.phoenixproject.domain.model.EchoLevel
+import com.devil.phoenixproject.domain.model.ProgramMode
+import com.devil.phoenixproject.domain.model.WorkoutParameters
+import com.devil.phoenixproject.util.BlePacketFactory
+import com.devil.phoenixproject.util.RGBColor
+
+/** Encodes outbound protocol commands for Vitruvian BLE devices. */
+interface CommandEncoder {
+    fun createInitCommand(): ByteArray
+    fun createStartCommand(): ByteArray
+    fun createStopCommand(): ByteArray
+    fun createOfficialStopPacket(): ByteArray
+    fun createResetCommand(): ByteArray
+    fun createWorkoutCommand(programMode: ProgramMode, weightPerCableKg: Float, targetReps: Int): ByteArray
+    fun createProgramParams(params: WorkoutParameters): ByteArray
+    fun createEchoCommand(level: Int, eccentricLoad: Int): ByteArray
+
+    fun createEchoControl(
+        level: EchoLevel,
+        warmupReps: Int = 3,
+        targetReps: Int = 2,
+        isJustLift: Boolean = false,
+        isAMRAP: Boolean = false,
+        eccentricPct: Int = 75
+    ): ByteArray
+
+    fun createColorScheme(brightness: Float, colors: List<RGBColor>): ByteArray
+    fun createColorSchemeCommand(schemeIndex: Int): ByteArray
+}
+
+/** Decodes inbound protocol telemetry streams for Vitruvian BLE devices. */
+interface TelemetryDecoder {
+    fun getUInt16BE(data: ByteArray, offset: Int): Int
+    fun parseRepPacket(data: ByteArray, hasOpcodePrefix: Boolean, timestamp: Long): RepNotification?
+    fun parseMonitorPacket(data: ByteArray): MonitorPacket?
+    fun parseDiagnosticPacket(data: ByteArray): DiagnosticPacket?
+}
+
+/** Describes supported command + telemetry capabilities for a protocol adapter pair. */
+interface ProtocolCapabilityDescriptor {
+    val supportsInitCommands: Boolean
+    val supportsStartStopCommands: Boolean
+    val supportsConfigurationCommands: Boolean
+    val supportsMonitorStream: Boolean
+    val supportsRepStream: Boolean
+    val supportsDiagnosticStream: Boolean
+}
+
+class VitruvianCommandEncoderAdapter : CommandEncoder {
+    override fun createInitCommand(): ByteArray = BlePacketFactory.createInitCommand()
+    override fun createStartCommand(): ByteArray = BlePacketFactory.createStartCommand()
+    override fun createStopCommand(): ByteArray = BlePacketFactory.createStopCommand()
+    override fun createOfficialStopPacket(): ByteArray = BlePacketFactory.createOfficialStopPacket()
+    override fun createResetCommand(): ByteArray = BlePacketFactory.createResetCommand()
+    override fun createWorkoutCommand(programMode: ProgramMode, weightPerCableKg: Float, targetReps: Int): ByteArray =
+        BlePacketFactory.createWorkoutCommand(programMode, weightPerCableKg, targetReps)
+
+    override fun createProgramParams(params: WorkoutParameters): ByteArray = BlePacketFactory.createProgramParams(params)
+    override fun createEchoCommand(level: Int, eccentricLoad: Int): ByteArray = BlePacketFactory.createEchoCommand(level, eccentricLoad)
+
+    override fun createEchoControl(
+        level: EchoLevel,
+        warmupReps: Int,
+        targetReps: Int,
+        isJustLift: Boolean,
+        isAMRAP: Boolean,
+        eccentricPct: Int
+    ): ByteArray = BlePacketFactory.createEchoControl(level, warmupReps, targetReps, isJustLift, isAMRAP, eccentricPct)
+
+    override fun createColorScheme(brightness: Float, colors: List<RGBColor>): ByteArray =
+        BlePacketFactory.createColorScheme(brightness, colors)
+
+    override fun createColorSchemeCommand(schemeIndex: Int): ByteArray = BlePacketFactory.createColorSchemeCommand(schemeIndex)
+}
+
+class VitruvianTelemetryDecoderAdapter : TelemetryDecoder {
+    override fun getUInt16BE(data: ByteArray, offset: Int): Int = parseUInt16BE(data, offset)
+
+    override fun parseRepPacket(data: ByteArray, hasOpcodePrefix: Boolean, timestamp: Long): RepNotification? =
+        parseReps(data, hasOpcodePrefix, timestamp)
+
+    override fun parseMonitorPacket(data: ByteArray): MonitorPacket? = parseMonitor(data)
+
+    override fun parseDiagnosticPacket(data: ByteArray): DiagnosticPacket? = parseDiagnostic(data)
+}
+
+object VitruvianProtocolCapabilityDescriptor : ProtocolCapabilityDescriptor {
+    override val supportsInitCommands: Boolean = true
+    override val supportsStartStopCommands: Boolean = true
+    override val supportsConfigurationCommands: Boolean = true
+    override val supportsMonitorStream: Boolean = true
+    override val supportsRepStream: Boolean = true
+    override val supportsDiagnosticStream: Boolean = true
+}

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/KableBleRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/KableBleRepository.kt
@@ -2,7 +2,6 @@ package com.devil.phoenixproject.data.repository
 
 import com.devil.phoenixproject.domain.model.ConnectionState
 import com.devil.phoenixproject.domain.model.WorkoutMetric
-import com.devil.phoenixproject.util.BlePacketFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -24,8 +23,12 @@ import com.devil.phoenixproject.data.ble.MonitorDataProcessor
 import com.devil.phoenixproject.data.ble.BleOperationQueue
 import com.devil.phoenixproject.data.ble.MetricPollingEngine
 import com.devil.phoenixproject.data.ble.KableBleConnectionManager
-import com.devil.phoenixproject.data.ble.parseRepPacket
-import com.devil.phoenixproject.data.ble.getUInt16BE
+import com.devil.phoenixproject.data.ble.CommandEncoder
+import com.devil.phoenixproject.data.ble.ProtocolCapabilityDescriptor
+import com.devil.phoenixproject.data.ble.TelemetryDecoder
+import com.devil.phoenixproject.data.ble.VitruvianCommandEncoderAdapter
+import com.devil.phoenixproject.data.ble.VitruvianProtocolCapabilityDescriptor
+import com.devil.phoenixproject.data.ble.VitruvianTelemetryDecoderAdapter
 import com.devil.phoenixproject.data.ble.toVitruvianHex
 
 import com.devil.phoenixproject.domain.model.HeuristicStatistics
@@ -35,10 +38,18 @@ import com.devil.phoenixproject.domain.model.WorkoutParameters
  * Thin facade delegating to 6 extracted modules (BleOperationQueue, DiscoMode,
  * HandleStateDetector, MonitorDataProcessor, MetricPollingEngine, KableBleConnectionManager).
  */
-class KableBleRepository : BleRepository {
+class KableBleRepository(
+    private val commandEncoder: CommandEncoder = VitruvianCommandEncoderAdapter(),
+    private val telemetryDecoder: TelemetryDecoder = VitruvianTelemetryDecoderAdapter(),
+    private val protocolCapabilityDescriptor: ProtocolCapabilityDescriptor = VitruvianProtocolCapabilityDescriptor
+) : BleRepository {
 
     private val log = Logger.withTag("KableBleRepository")
     private val logRepo = ConnectionLogRepository.instance
+
+    init {
+        log.i { "Protocol capabilities: init=${protocolCapabilityDescriptor.supportsInitCommands}, startStop=${protocolCapabilityDescriptor.supportsStartStopCommands}, config=${protocolCapabilityDescriptor.supportsConfigurationCommands}, monitor=${protocolCapabilityDescriptor.supportsMonitorStream}, reps=${protocolCapabilityDescriptor.supportsRepStream}, diagnostic=${protocolCapabilityDescriptor.supportsDiagnosticStream}" }
+    }
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     // ===== State flows =====
@@ -144,7 +155,7 @@ class KableBleRepository : BleRepository {
     override suspend fun setColorScheme(schemeIndex: Int): Result<Unit> {
         log.d { "Setting color scheme: $schemeIndex" }
         return try {
-            val command = BlePacketFactory.createColorSchemeCommand(schemeIndex)
+            val command = commandEncoder.createColorSchemeCommand(schemeIndex)
             connectionManager.sendWorkoutCommand(command)
         } catch (e: Exception) {
             log.e { "Failed to set color scheme: ${e.message}" }
@@ -191,7 +202,7 @@ class KableBleRepository : BleRepository {
     override suspend fun stopWorkout(): Result<Unit> {
         log.i { "Stopping workout" }
         return try {
-            val resetCmd = BlePacketFactory.createResetCommand()
+            val resetCmd = commandEncoder.createResetCommand()
             log.d { "Sending RESET command (0x0A)..." }
             sendWorkoutCommand(resetCmd)
             delay(50)
@@ -209,7 +220,7 @@ class KableBleRepository : BleRepository {
     override suspend fun sendStopCommand(): Result<Unit> {
         log.i { "Sending stop command (polling continues)" }
         return try {
-            val stopPacket = BlePacketFactory.createOfficialStopPacket()
+            val stopPacket = commandEncoder.createOfficialStopPacket()
             log.d { "Sending StopPacket (0x50)..." }
             sendWorkoutCommand(stopPacket)
         } catch (e: Exception) {
@@ -275,12 +286,12 @@ class KableBleRepository : BleRepository {
         if (data.size < 16) return
 
         try {
-            val positionARaw = getUInt16BE(data, 2)
-            val positionBRaw = getUInt16BE(data, 4)
-            val loadA = getUInt16BE(data, 6)
-            val loadB = getUInt16BE(data, 8)
-            val velocityA = getUInt16BE(data, 10)
-            val velocityB = getUInt16BE(data, 12)
+            val positionARaw = telemetryDecoder.getUInt16BE(data, 2)
+            val positionBRaw = telemetryDecoder.getUInt16BE(data, 4)
+            val loadA = telemetryDecoder.getUInt16BE(data, 6)
+            val loadB = telemetryDecoder.getUInt16BE(data, 8)
+            val velocityA = telemetryDecoder.getUInt16BE(data, 10)
+            val velocityB = telemetryDecoder.getUInt16BE(data, 12)
 
             val positionA = positionARaw / 10.0f
             val positionB = positionBRaw / 10.0f
@@ -307,7 +318,7 @@ class KableBleRepository : BleRepository {
     private fun parseRepNotification(data: ByteArray) {
         try {
             val currentTime = currentTimeMillis()
-            val notification = parseRepPacket(data, hasOpcodePrefix = true, timestamp = currentTime)
+            val notification = telemetryDecoder.parseRepPacket(data, hasOpcodePrefix = true, timestamp = currentTime)
 
             if (notification == null) {
                 log.w { "Rep notification too short: ${data.size} bytes (minimum 7)" }
@@ -343,7 +354,7 @@ class KableBleRepository : BleRepository {
     private fun parseRepsCharacteristicData(data: ByteArray) {
         try {
             val currentTime = currentTimeMillis()
-            val notification = parseRepPacket(data, hasOpcodePrefix = false, timestamp = currentTime)
+            val notification = telemetryDecoder.parseRepPacket(data, hasOpcodePrefix = false, timestamp = currentTime)
 
             if (notification == null) {
                 log.w { "REPS characteristic data too short: ${data.size} bytes (minimum 6)" }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/ble/ProtocolParserTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/ble/ProtocolParserTest.kt
@@ -15,6 +15,8 @@ import kotlin.test.assertFalse
  */
 class ProtocolParserTest {
 
+    private fun ByteArray.toHexSnapshot(): String = joinToString(" ") { it.toVitruvianHex() }
+
     // ========== getUInt16LE Tests ==========
 
     @Test
@@ -513,4 +515,49 @@ class ProtocolParserTest {
 
         assertNotNull(result)
     }
+
+    @Test
+    fun `golden snapshot parseRepPacket modern format output is stable`() {
+        val data = byteArrayOf(
+            0x0A, 0x00, 0x00, 0x00,
+            0x08, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x96.toByte(), 0x43,
+            0x00, 0x00, 0x00, 0x00,
+            0x03, 0x00,
+            0x05, 0x00,
+            0x07, 0x00,
+            0x0A, 0x00
+        )
+
+        val parsed = parseRepPacket(data, hasOpcodePrefix = false, timestamp = 2000L)
+        assertNotNull(parsed)
+
+        val snapshot = "top=${parsed.topCounter}|complete=${parsed.completeCounter}|rom=${parsed.repsRomCount}/${parsed.repsRomTotal}|set=${parsed.repsSetCount}/${parsed.repsSetTotal}|range=${parsed.rangeTop}/${parsed.rangeBottom}|legacy=${parsed.isLegacyFormat}|raw=${parsed.rawData.toHexSnapshot()}"
+        val golden = "top=10|complete=8|rom=3/5|set=7/10|range=300.0/0.0|legacy=false|raw=0A 00 00 00 08 00 00 00 00 00 96 43 00 00 00 00 03 00 05 00 07 00 0A 00"
+        assertEquals(golden, snapshot)
+    }
+
+    @Test
+    fun `golden snapshot parseDiagnosticPacket output is stable`() {
+        val data = ByteArray(20)
+        data[0] = 0x10
+        data[1] = 0x0E
+        data[6] = 0x01
+        data[12] = 25
+        data[13] = 30
+        data[14] = 35
+        data[15] = 40
+        data[16] = 45
+        data[17] = 50
+        data[18] = 55
+        data[19] = 60
+
+        val parsed = parseDiagnosticPacket(data)
+        assertNotNull(parsed)
+
+        val snapshot = "seconds=${parsed.seconds}|faults=${parsed.faults.joinToString(",")}|temps=${parsed.temps.joinToString(",")}|hasFaults=${parsed.hasFaults}"
+        val golden = "seconds=3600|faults=0,1,0,0|temps=25,30,35,40,45,50,55,60|hasFaults=true"
+        assertEquals(golden, snapshot)
+    }
+
 }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/util/BlePacketFactoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/util/BlePacketFactoryTest.kt
@@ -32,6 +32,11 @@ class BlePacketFactoryTest {
         return value.toShort()
     }
 
+    private fun ByteArray.toHexSnapshot(): String = joinToString(" ") { b ->
+        val v = b.toInt() and 0xFF
+        v.toString(16).padStart(2, '0').uppercase()
+    }
+
     // ========== Init Command Tests ==========
 
     @Test
@@ -541,4 +546,23 @@ class BlePacketFactoryTest {
             assertEquals(0x4E.toByte(), packet[0], "Command should be 0x4E for level $level")
         }
     }
+
+    @Test
+    fun `golden snapshot createInitPreset is stable`() {
+        val packet = BlePacketFactory.createInitPreset()
+        val golden = "11 00 00 00 00 00 00 00 00 00 00 00 CD CC CC 3E FF 00 4C FF 23 8C FF 8C 8C FF 00 4C FF 23 8C FF 8C 8C"
+        assertEquals(golden, packet.toHexSnapshot())
+    }
+
+    @Test
+    fun `golden snapshot createColorScheme with known palette is stable`() {
+        val packet = BlePacketFactory.createColorScheme(
+            brightness = 0.4f,
+            colors = listOf(RGBColor(0xAA, 0xBB, 0xCC), RGBColor(0x11, 0x22, 0x33), RGBColor(0x44, 0x55, 0x66))
+        )
+
+        val golden = "11 00 00 00 00 00 00 00 00 00 00 00 CD CC CC 3E AA BB CC 11 22 33 44 55 66 AA BB CC 11 22 33 44 55 66"
+        assertEquals(golden, packet.toHexSnapshot())
+    }
+
 }


### PR DESCRIPTION
### Motivation
- Introduce a thin, swappable adapter layer for Vitruvian BLE protocol encoding/decoding to allow alternate protocol implementations without changing repository logic.
- Move existing static packet construction and parsing usage behind interfaces to make `KableBleRepository` testable and decoupled from `BlePacketFactory`/`ProtocolParser` internals.
- Preserve existing runtime behavior by providing default Vitruvian adapters that delegate to the current factory/parser implementations.

### Description
- Added three protocol interfaces: `CommandEncoder`, `TelemetryDecoder`, and `ProtocolCapabilityDescriptor` plus concrete `VitruvianCommandEncoderAdapter`, `VitruvianTelemetryDecoderAdapter`, and `VitruvianProtocolCapabilityDescriptor` in `shared/src/commonMain/kotlin/com/devil/phoenixproject/data/ble/VitruvianProtocolAdapters.kt` that delegate to the existing `BlePacketFactory`/parser functions.
- Refactored `KableBleRepository` to accept injectable `commandEncoder`, `telemetryDecoder`, and `protocolCapabilityDescriptor` (with Vitruvian defaults) and routed all packet creation/parsing paths through those interfaces instead of calling static factory/parser functions directly.
- Added golden snapshot-style baseline tests to lock current binary outputs and parser behavior: new assertions in `shared/src/commonTest/kotlin/com/devil/phoenixproject/util/BlePacketFactoryTest.kt` and `shared/src/commonTest/kotlin/com/devil/phoenixproject/data/ble/ProtocolParserTest.kt` for stable hex dumps and parsed snapshots.
- Left behavior unchanged by default because the new Vitruvian adapters simply delegate to the original implementations.

### Testing
- Ran metadata/compile tasks: `./gradlew --no-configuration-cache :shared:compileCommonMainKotlinMetadata :shared:compileKotlinMetadata` completed successfully. (✅)
- Attempted to run the platform unit tests for the modified test classes with Gradle test filters but full Android-hosted test execution failed in this environment due to missing Android SDK (`ANDROID_HOME` / `local.properties` `sdk.dir`). (⚠️)
- Verified the project compiles after the change and the new tests were added to the shared test sources; adapters default to the existing behavior so CI test runs on a correctly provisioned environment should exercise the new golden snapshots. (manual verification via local Gradle compile step)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2add1f1d88322a5fbc5d7ebd32a75)