### PR TITLE
Introduce MachineProfile contract and refactor BLE scanning to use profile-driven matching

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/ble/KableBleConnectionManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/ble/KableBleConnectionManager.kt
@@ -6,6 +6,9 @@ import com.devil.phoenixproject.data.repository.LogEventType
 import com.devil.phoenixproject.data.repository.ReconnectionRequest
 import com.devil.phoenixproject.data.repository.ScannedDevice
 import com.devil.phoenixproject.domain.model.ConnectionState
+import com.devil.phoenixproject.framework.protocol.AdvertisedMachineData
+import com.devil.phoenixproject.framework.protocol.MachineProfile
+import com.devil.phoenixproject.framework.protocol.VitruvianMachineProfile
 import com.devil.phoenixproject.util.BleConstants
 import com.devil.phoenixproject.util.HardwareDetection
 import com.juul.kable.Advertisement
@@ -32,7 +35,6 @@ import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.concurrent.Volatile
 import kotlin.time.Clock
 import kotlin.uuid.ExperimentalUuidApi
-import kotlin.uuid.Uuid
 
 /**
  * Manages the BLE connection lifecycle for Vitruvian machines.
@@ -66,6 +68,7 @@ class KableBleConnectionManager(
     private val pollingEngine: MetricPollingEngine,
     private val discoMode: DiscoMode,
     private val handleDetector: HandleStateDetector,
+    private val machineProfile: MachineProfile = VitruvianMachineProfile,
     // Callbacks for event routing to facade flows
     private val onConnectionStateChanged: (ConnectionState) -> Unit,
     private val onScannedDevicesChanged: (List<ScannedDevice>) -> Unit,
@@ -164,8 +167,8 @@ class KableBleConnectionManager(
     // -------------------------------------------------------------------------
 
     suspend fun startScanning(): Result<Unit> {
-        log.i { "Starting BLE scan for Vitruvian devices" }
-        logRepo.info(LogEventType.SCAN_START, "Starting BLE scan for Vitruvian devices")
+        log.i { "Starting BLE scan for ${machineProfile.displayName} devices" }
+        logRepo.info(LogEventType.SCAN_START, "Starting BLE scan for ${machineProfile.displayName} devices")
 
         return try {
             // Cancel any existing scan job to prevent duplicates
@@ -188,75 +191,28 @@ class KableBleConnectionManager(
                     log.d { "RAW ADV: name=${advertisement.name}, id=${advertisement.identifier}, uuids=${advertisement.uuids}, rssi=${advertisement.rssi}" }
                 }
                 .filter { advertisement ->
-                    // Filter by name if available
-                    val name = advertisement.name
-                    if (name != null) {
-                        val isVitruvian = name.startsWith("Vee_", ignoreCase = true) ||
-                                          name.startsWith("VIT", ignoreCase = true) ||
-                                          name.startsWith("Vitruvian", ignoreCase = true)
-                        if (isVitruvian) {
-                            log.i { "Found Vitruvian by name: $name" }
-                        } else {
-                            log.d { "Ignoring device: $name (not Vitruvian)" }
-                        }
-                        return@filter isVitruvian
-                    }
-
-                    // Check for Vitruvian service UUIDs (mServiceUuids)
-                    val serviceUuids = advertisement.uuids
-                    val hasVitruvianServiceUuid = serviceUuids.any { uuid ->
-                        val uuidStr = uuid.toString().lowercase()
-                        uuidStr.startsWith("0000fef3") ||
-                        uuidStr == BleConstants.NUS_SERVICE_UUID_STRING
-                    }
-
-                    if (hasVitruvianServiceUuid) {
-                        log.i { "Found Vitruvian by service UUID: ${advertisement.identifier}" }
-                        return@filter true
-                    }
-
-                    // CRITICAL: Check for FEF3 service data
-                    // The Vitruvian device advertises FEF3 in serviceData, not serviceUuids!
-                    // In Kable, serviceData is accessed differently - try to get FEF3 directly
-                    val fef3Uuid = try {
-                        Uuid.parse("0000fef3-0000-1000-8000-00805f9b34fb")
-                    } catch (_: Exception) {
-                        null
-                    }
-
-                    val hasVitruvianServiceData = if (fef3Uuid != null) {
-                        // Try to get data for FEF3 service UUID
-                        val fef3Data = advertisement.serviceData(fef3Uuid)
-                        if (fef3Data != null && fef3Data.isNotEmpty()) {
-                            log.i { "Found Vitruvian by FEF3 serviceData: ${advertisement.identifier}, data size: ${fef3Data.size}" }
-                            true
-                        } else {
-                            false
-                        }
+                    val machineData = advertisement.toAdvertisedMachineData()
+                    val match = machineProfile.match(machineData)
+                    if (match.matches) {
+                        log.i { "Found ${machineProfile.displayName} by ${match.reason ?: "profile"}: ${machineProfile.labelFor(machineData)}" }
                     } else {
-                        false
+                        log.d { "Ignoring device: ${machineProfile.labelFor(machineData)} (not ${machineProfile.displayName})" }
                     }
-
-                    hasVitruvianServiceData
+                    match.matches
                 }
                 .onEach { advertisement ->
-                    val identifier = advertisement.identifier.toString()
-                    val advertisedName = advertisement.name
-                    val hasRealName = advertisedName != null &&
-                        (advertisedName.startsWith("Vee_", ignoreCase = true) ||
-                         advertisedName.startsWith("VIT", ignoreCase = true))
+                    val machineData = advertisement.toAdvertisedMachineData()
+                    val identifier = machineData.identifier
+                    val hasRealName = machineProfile.hasPreferredName(machineData.name)
+                    val name = machineProfile.labelFor(machineData)
 
-                    // Use name if available, otherwise use identifier as placeholder
-                    val name = advertisedName ?: "Vitruvian ($identifier)"
-
-                    // Skip devices without a real Vitruvian name if we already have one
+                    // Skip devices without a preferred profile name if we already have one
                     if (!hasRealName) {
                         val alreadyHaveRealDevice = currentScannedDevices.any { existing ->
-                            existing.name.startsWith("Vee_", ignoreCase = true) ||
-                            existing.name.startsWith("VIT", ignoreCase = true)
+                            machineProfile.hasPreferredName(existing.name)
                         }
                         if (alreadyHaveRealDevice) {
-                            log.d { "Skipping nameless device $identifier - already have named Vitruvian device" }
+                            log.d { "Skipping nameless device $identifier - already have named ${machineProfile.displayName} device" }
                             return@onEach
                         }
                     }
@@ -266,7 +222,7 @@ class KableBleConnectionManager(
                         log.d { "Discovered device: $name ($identifier) RSSI: ${advertisement.rssi}" }
                         logRepo.info(
                             LogEventType.DEVICE_FOUND,
-                            "Found Vitruvian device",
+                            "Found ${machineProfile.displayName} device",
                             name,
                             identifier,
                             "RSSI: ${advertisement.rssi} dBm"
@@ -288,8 +244,7 @@ class KableBleConnectionManager(
                     // (same physical device can advertise with different identifiers)
                     if (hasRealName) {
                         devices = devices.filter { existing ->
-                            existing.name.startsWith("Vee_", ignoreCase = true) ||
-                            existing.name.startsWith("VIT", ignoreCase = true) ||
+                            machineProfile.hasPreferredName(existing.name) ||
                             existing.address == identifier  // Keep if same address (will update below)
                         }.toMutableList()
                     }
@@ -329,7 +284,7 @@ class KableBleConnectionManager(
         logRepo.info(
             LogEventType.SCAN_STOP,
             "BLE scan stopped",
-            details = "Found ${discoveredAdvertisements.size} Vitruvian device(s)"
+            details = "Found ${discoveredAdvertisements.size} ${machineProfile.displayName} device(s)"
         )
         scanJob?.cancel()
         scanJob = null
@@ -343,7 +298,7 @@ class KableBleConnectionManager(
     // -------------------------------------------------------------------------
 
     /**
-     * Scan for first Vitruvian device and connect immediately.
+     * Scan for first profile-matching device and connect immediately.
      * This is the simple flow matching parent repo behavior.
      */
     suspend fun scanAndConnect(timeoutMs: Long = 30000L): Result<Unit> {
@@ -356,29 +311,27 @@ class KableBleConnectionManager(
         discoveredAdvertisements.clear()
 
         return try {
-            // Find first Vitruvian device with a real name
+            // Find first matching device with a preferred name
             val advertisement = withTimeoutOrNull(timeoutMs) {
                 Scanner {}
                     .advertisements
                     .filter { adv ->
-                        val name = adv.name
-                        name != null && (
-                            name.startsWith("Vee_", ignoreCase = true) ||
-                            name.startsWith("VIT", ignoreCase = true)
-                        )
+                        val machineData = adv.toAdvertisedMachineData()
+                        machineProfile.match(machineData).matches && machineProfile.hasPreferredName(machineData.name)
                     }
                     .first()
             }
 
             if (advertisement == null) {
-                log.w { "scanAndConnect: No Vitruvian device found within timeout" }
+                log.w { "scanAndConnect: No ${machineProfile.displayName} device found within timeout" }
                 logRepo.error(LogEventType.SCAN_STOP, "No device found", details = "Timeout after ${timeoutMs}ms")
                 reportConnectionState(ConnectionState.Disconnected)
-                return Result.failure(Exception("No Vitruvian device found"))
+                return Result.failure(Exception("No ${machineProfile.displayName} device found"))
             }
 
-            val identifier = advertisement.identifier.toString()
-            val name = advertisement.name ?: "Vitruvian"
+            val machineData = advertisement.toAdvertisedMachineData()
+            val identifier = machineData.identifier
+            val name = machineProfile.labelFor(machineData)
             log.i { "scanAndConnect: Found device $name ($identifier), connecting..." }
 
             // Store for connection
@@ -1101,5 +1054,18 @@ class KableBleConnectionManager(
      */
     private fun currentTimeMillis(): Long {
         return Clock.System.now().toEpochMilliseconds()
+    }
+
+    private fun Advertisement.toAdvertisedMachineData(): AdvertisedMachineData {
+        val serviceData = machineProfile.advertisedDataHints.serviceDataUuids.associateWith { uuid ->
+            serviceData(uuid) ?: byteArrayOf()
+        }
+        return AdvertisedMachineData(
+            name = name,
+            identifier = identifier.toString(),
+            rssi = rssi,
+            serviceUuids = uuids,
+            serviceData = serviceData
+        )
     }
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/framework/protocol/MachineProfile.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/framework/protocol/MachineProfile.kt
@@ -1,0 +1,49 @@
+package com.devil.phoenixproject.framework.protocol
+
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * Contract for machine-specific BLE discovery behavior and device metadata.
+ */
+@OptIn(ExperimentalUuidApi::class)
+interface MachineProfile {
+    val key: String
+    val displayName: String
+    val serviceUuids: Set<Uuid>
+    val nameMatchers: List<Regex>
+    val advertisedDataHints: AdvertisedDataHints
+    val capabilities: Set<MachineCapability>
+
+    fun match(advertisement: AdvertisedMachineData): ProfileMatchResult
+    fun hasPreferredName(advertisedName: String?): Boolean
+    fun labelFor(advertisement: AdvertisedMachineData): String
+}
+
+@OptIn(ExperimentalUuidApi::class)
+data class AdvertisedMachineData(
+    val name: String?,
+    val identifier: String,
+    val rssi: Int,
+    val serviceUuids: List<Uuid>,
+    val serviceData: Map<Uuid, ByteArray>
+)
+
+@OptIn(ExperimentalUuidApi::class)
+data class AdvertisedDataHints(
+    val serviceUuidPrefixes: Set<String> = emptySet(),
+    val serviceDataUuids: Set<Uuid> = emptySet()
+)
+
+enum class MachineCapability {
+    ProprietaryVersionRead,
+    RepsNotifications,
+    MonitorNotifications,
+    HeuristicPolling,
+    DiagnosticPolling
+}
+
+data class ProfileMatchResult(
+    val matches: Boolean,
+    val reason: String? = null
+)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/framework/protocol/VitruvianMachineProfile.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/framework/protocol/VitruvianMachineProfile.kt
@@ -1,0 +1,74 @@
+package com.devil.phoenixproject.framework.protocol
+
+import com.devil.phoenixproject.util.BleConstants
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+@OptIn(ExperimentalUuidApi::class)
+object VitruvianMachineProfile : MachineProfile {
+    override val key: String = "vitruvian"
+    override val displayName: String = "Vitruvian"
+
+    private val fef3Uuid = Uuid.parse("0000fef3-0000-1000-8000-00805f9b34fb")
+
+    override val serviceUuids: Set<Uuid> = setOf(
+        BleConstants.NUS_SERVICE_UUID,
+        fef3Uuid
+    )
+
+    override val nameMatchers: List<Regex> = listOf(
+        Regex("^Vee_.*", RegexOption.IGNORE_CASE),
+        Regex("^VIT.*", RegexOption.IGNORE_CASE),
+        Regex("^Vitruvian.*", RegexOption.IGNORE_CASE)
+    )
+
+    override val advertisedDataHints: AdvertisedDataHints = AdvertisedDataHints(
+        serviceUuidPrefixes = setOf("0000fef3"),
+        serviceDataUuids = setOf(fef3Uuid)
+    )
+
+    override val capabilities: Set<MachineCapability> = setOf(
+        MachineCapability.ProprietaryVersionRead,
+        MachineCapability.RepsNotifications,
+        MachineCapability.MonitorNotifications,
+        MachineCapability.HeuristicPolling,
+        MachineCapability.DiagnosticPolling
+    )
+
+    override fun match(advertisement: AdvertisedMachineData): ProfileMatchResult {
+        val name = advertisement.name
+        if (name != null && nameMatchers.any { it.matches(name) }) {
+            return ProfileMatchResult(matches = true, reason = "name")
+        }
+
+        if (advertisement.serviceUuids.any { matchesServiceUuid(it) }) {
+            return ProfileMatchResult(matches = true, reason = "service_uuid")
+        }
+
+        val hasServiceData = advertisedDataHints.serviceDataUuids.any { uuid ->
+            val data = advertisement.serviceData[uuid]
+            data != null && data.isNotEmpty()
+        }
+        if (hasServiceData) {
+            return ProfileMatchResult(matches = true, reason = "service_data")
+        }
+
+        return ProfileMatchResult(matches = false)
+    }
+
+    override fun hasPreferredName(advertisedName: String?): Boolean {
+        return advertisedName != null && (
+            advertisedName.startsWith("Vee_", ignoreCase = true) ||
+                advertisedName.startsWith("VIT", ignoreCase = true)
+            )
+    }
+
+    override fun labelFor(advertisement: AdvertisedMachineData): String {
+        return advertisement.name ?: "$displayName (${advertisement.identifier})"
+    }
+
+    private fun matchesServiceUuid(uuid: Uuid): Boolean {
+        val uuidString = uuid.toString().lowercase()
+        return uuid in serviceUuids || advertisedDataHints.serviceUuidPrefixes.any { uuidString.startsWith(it) }
+    }
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/framework/protocol/VitruvianMachineProfileTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/framework/protocol/VitruvianMachineProfileTest.kt
@@ -1,0 +1,112 @@
+package com.devil.phoenixproject.framework.protocol
+
+import com.devil.phoenixproject.util.BleConstants
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+@OptIn(ExperimentalUuidApi::class)
+class VitruvianMachineProfileTest {
+
+    private val profile = VitruvianMachineProfile
+    private val fef3Uuid = Uuid.parse("0000fef3-0000-1000-8000-00805f9b34fb")
+
+    private fun advertisement(
+        name: String? = null,
+        identifier: String = "id-1",
+        serviceUuids: List<Uuid> = emptyList(),
+        serviceData: Map<Uuid, ByteArray> = emptyMap()
+    ) = AdvertisedMachineData(
+        name = name,
+        identifier = identifier,
+        rssi = -55,
+        serviceUuids = serviceUuids,
+        serviceData = serviceData
+    )
+
+    @Test
+    fun `match returns true for Vee prefix`() {
+        val match = profile.match(advertisement(name = "Vee_Trainer"))
+        assertTrue(match.matches)
+        assertEquals("name", match.reason)
+    }
+
+    @Test
+    fun `match returns true for VIT prefix`() {
+        val match = profile.match(advertisement(name = "VIT_001"))
+        assertTrue(match.matches)
+        assertEquals("name", match.reason)
+    }
+
+    @Test
+    fun `match returns true for Vitruvian prefix`() {
+        val match = profile.match(advertisement(name = "Vitruvian Trainer"))
+        assertTrue(match.matches)
+        assertEquals("name", match.reason)
+    }
+
+    @Test
+    fun `match returns true for NUS service UUID`() {
+        val match = profile.match(advertisement(serviceUuids = listOf(BleConstants.NUS_SERVICE_UUID)))
+        assertTrue(match.matches)
+        assertEquals("service_uuid", match.reason)
+    }
+
+    @Test
+    fun `match returns true for FEF3 service UUID prefix`() {
+        val match = profile.match(advertisement(serviceUuids = listOf(fef3Uuid)))
+        assertTrue(match.matches)
+        assertEquals("service_uuid", match.reason)
+    }
+
+    @Test
+    fun `match returns true for non-empty FEF3 service data`() {
+        val match = profile.match(advertisement(serviceData = mapOf(fef3Uuid to byteArrayOf(0x01))))
+        assertTrue(match.matches)
+        assertEquals("service_data", match.reason)
+    }
+
+    @Test
+    fun `match returns false for unrelated advertisement`() {
+        val match = profile.match(
+            advertisement(
+                name = "Headphones",
+                serviceUuids = listOf(Uuid.parse("0000180f-0000-1000-8000-00805f9b34fb"))
+            )
+        )
+        assertFalse(match.matches)
+    }
+
+    @Test
+    fun `hasPreferredName only accepts vee and vit prefixes`() {
+        assertTrue(profile.hasPreferredName("Vee_Trainer"))
+        assertTrue(profile.hasPreferredName("VIT_001"))
+        assertFalse(profile.hasPreferredName("Vitruvian Trainer"))
+        assertFalse(profile.hasPreferredName(null))
+    }
+
+    @Test
+    fun `labelFor uses advertised name when present`() {
+        val label = profile.labelFor(advertisement(name = "Vee_Trainer", identifier = "abc"))
+        assertEquals("Vee_Trainer", label)
+    }
+
+    @Test
+    fun `labelFor uses profile display name fallback when name missing`() {
+        val label = profile.labelFor(advertisement(name = null, identifier = "abc"))
+        assertEquals("Vitruvian (abc)", label)
+    }
+
+    @Test
+    fun `profile advertises expected contract fields`() {
+        assertEquals("vitruvian", profile.key)
+        assertEquals("Vitruvian", profile.displayName)
+        assertTrue(profile.serviceUuids.contains(BleConstants.NUS_SERVICE_UUID))
+        assertTrue(profile.advertisedDataHints.serviceDataUuids.contains(fef3Uuid))
+        assertNotNull(profile.capabilities.firstOrNull())
+    }
+}


### PR DESCRIPTION
### Motivation
- Replace hardcoded Vitruvian-specific discovery checks and labels with a reusable profile contract to enable multiple machine types and centralize matching/labeling logic.
- Move Vitruvian-specific heuristics (name prefixes, service UUID/service-data checks, display labels) out of the connection manager to make scanning behavior configurable and testable.

### Description
- Add a new `MachineProfile` contract and supporting types (`AdvertisedMachineData`, `AdvertisedDataHints`, `MachineCapability`, `ProfileMatchResult`) under `framework/protocol` to express discovery identifiers, name matchers, advertised-data hints, capabilities, and labeling APIs.
- Implement `VitruvianMachineProfile` encapsulating the prior Vitruvian matching logic (name matchers, NUS/FEF3 checks, FEF3 service-data detection, preferred-name rules, and label fallback).
- Refactor `KableBleConnectionManager` to accept a `machineProfile: MachineProfile` (defaulting to `VitruvianMachineProfile`) and to drive scan filtering, discovered-device labels, and scan log messages from the profile rather than using literal string/UUID checks and hardcoded “Vitruvian” text.
- Add a helper to normalize `Advertisement` -> `AdvertisedMachineData` and update scan flows to use `profile.match()`, `profile.hasPreferredName()` and `profile.labelFor()`.
- Add `VitruvianMachineProfileTest` unit tests that mirror the discovery/matching and labeling behaviours previously encoded in the manager.

### Testing
- Ran `./gradlew :shared:compileCommonMainKotlinMetadata --no-configuration-cache --console=plain` which completed successfully.
- Ran `./gradlew :shared:compileTestKotlinIosArm64 --no-configuration-cache --console=plain` which completed successfully (test compilation succeeded for iOS target).
- Attempted to run Android-host tests but they could not be executed in this environment due to missing Android SDK (`ANDROID_HOME`/`sdk.dir`) and a separate attempt to run `:shared:commonTest` failed because that task is not present in this project layout; those are environment limitations rather than code failures.
- Added `VitruvianMachineProfileTest` to cover name/service/service-data matching, preferred-name rules, label fallback, and profile contract fields (tests are present but not run against Android-host in this environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2adcce3ec8322879caa1e7e130760)