### PR TITLE
Add regression tests for Just Lift activation packet and Issue #267 lifecycle transition

### DIFF
--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMWorkoutLifecycleTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMWorkoutLifecycleTest.kt
@@ -645,6 +645,46 @@ class DWSMWorkoutLifecycleTest {
     }
 
     @Test
+    fun `Issue #267 Just Lift warmup to working rep transitions without failed stall state`() = runTest {
+        val harness = DWSMTestHarness(this)
+        harness.fakeBleRepo.simulateConnect("Vee_Test")
+
+        harness.dwsm.updateWorkoutParameters(
+            WorkoutParameters(
+                programMode = ProgramMode.OldSchool,
+                reps = 8,
+                warmupReps = 0,
+                weightPerCableKg = 20f,
+                progressionRegressionKg = 0f,
+                stallDetectionEnabled = true,
+                isAMRAP = false,
+                isJustLift = true
+            )
+        )
+        harness.dwsm.startWorkout(skipCountdown = true)
+        advanceUntilIdle()
+        assertIs<WorkoutState.Active>(harness.dwsm.coordinator.workoutState.value)
+
+        completeWarmupReps(harness, warmupTarget = 3, workingTarget = 8)
+        advanceUntilIdle()
+
+        val afterWarmup = harness.dwsm.coordinator.repCount.value
+        assertTrue(afterWarmup.isWarmupComplete)
+        assertEquals(0, afterWarmup.workingReps)
+
+        completeFirstWorkingRep(harness, warmupTarget = 3, workingTarget = 8)
+        advanceUntilIdle()
+
+        val afterWorkingRep = harness.dwsm.coordinator.repCount.value
+        assertEquals(1, afterWorkingRep.workingReps)
+        assertFalse(afterWorkingRep.hasPendingRep)
+        assertEquals(null, harness.dwsm.coordinator.stallStartTime)
+        assertFalse(harness.dwsm.coordinator.isCurrentlyStalled)
+        assertIs<WorkoutState.Active>(harness.dwsm.coordinator.workoutState.value)
+        harness.cleanup()
+    }
+
+    @Test
     fun `set summary volume uses configured load for fixed weight workouts`() = runTest {
         val harness = DWSMTestHarness(this)
 

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/util/BlePacketFactoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/util/BlePacketFactoryTest.kt
@@ -339,6 +339,38 @@ class BlePacketFactoryTest {
     }
 
     @Test
+    fun `Issue #267 Just Lift packet preserves target and activation tail contract`() {
+        val targetWeight = 42.5f
+        val progression = 2.0f
+        val params = WorkoutParameters(
+            programMode = ProgramMode.Pump,
+            reps = 8,
+            warmupReps = 3,
+            weightPerCableKg = targetWeight,
+            progressionRegressionKg = progression,
+            isJustLift = true
+        )
+
+        val packet = BlePacketFactory.createProgramParams(params)
+
+        // Just Lift must carry the actual operating target at 0x58.
+        assertEquals(targetWeight - progression, readFloatLE(packet, 0x58))
+
+        // Protocol force/progression block must remain fully populated.
+        assertEquals(0.0f, readFloatLE(packet, 0x50))
+        assertEquals(targetWeight - progression + 10.0f, readFloatLE(packet, 0x54))
+        assertEquals(targetWeight - progression, readFloatLE(packet, 0x58))
+        assertEquals(progression, readFloatLE(packet, 0x5C))
+
+        // For Just Lift, profile contract is OldSchool and tail bytes 0x48..0x4F are firmware force config.
+        assertEquals(100.0f, readFloatLE(packet, 0x48))
+        assertEquals(progression, readFloatLE(packet, 0x4C))
+        assertEquals((-1300).toShort(), readShortLE(packet, 0x40))
+        assertEquals((-1200).toShort(), readShortLE(packet, 0x42))
+        assertEquals(100.0f, readFloatLE(packet, 0x44))
+    }
+
+    @Test
     fun `createProgramParams zero progression writes zero increment`() {
         val params = WorkoutParameters(
             programMode = ProgramMode.OldSchool,


### PR DESCRIPTION
### Motivation
- Prevent regressions where Just Lift mode incorrectly places softMax or profile bytes into the target weight or activation tail, which caused machines to apply incorrect loads. 
- Guard against a lifecycle failure where a Just Lift warmup → first working rep transition can leave the rep-count stalled in a failed state (reported as Issue #267). 

### Description
- Added a protocol-level regression test `Issue #267 Just Lift packet preserves target and activation tail contract` in `shared/src/commonTest/kotlin/com/devil/phoenixproject/util/BlePacketFactoryTest.kt` that asserts the Just Lift packet writes the adjusted target to `0x58`, populates the force/progression block at `0x50..0x5F`, and preserves expected activation-profile tail bytes at `0x48..0x4F` (firmware-overridden region). 
- Added a lifecycle regression test `Issue #267 Just Lift warmup to working rep transitions without failed stall state` in `shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMWorkoutLifecycleTest.kt` that simulates a Just Lift workout from warmup to first working rep and asserts rep-count moves to working without a pending/stalled failure and stall timers are not set. 
- Tests include discoverable names containing `Issue #267` so the failure mode will be easy to find in future triage. 

### Testing
- Attempted to run targeted tests with Gradle: `./gradlew :shared:test --tests "com.devil.phoenixproject.util.BlePacketFactoryTest" --tests "com.devil.phoenixproject.presentation.manager.DWSMWorkoutLifecycleTest"`, which failed because `:shared:test` is ambiguous in this multiplatform project. 
- Attempted to run Android-host unit tests with `./gradlew :shared:testAndroidHostTest --tests ...`, which failed due to missing Android SDK configuration (`ANDROID_HOME`/`sdk.dir` not set) in this environment. 
- Successfully listed project tasks with `./gradlew :shared:tasks --all` to validate the Gradle configuration and available test targets. 
- Note: these are test-only changes and no production code was modified; the added tests should be executable in a developer environment with a configured Android SDK or by running the appropriate host/test target for the `shared` module.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4419e8f0083229f0c750cf9631670)