### PR TITLE
Split internal workout parameter updates from user edits

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -1165,6 +1165,16 @@ class ActiveSessionEngine(
         coordinator._workoutParameters.value = params
     }
 
+    /**
+     * Internal parameter updates used by manager-driven transitions.
+     *
+     * Unlike [updateWorkoutParameters], this intentionally does NOT mark the
+     * parameters as user-adjusted during rest.
+     */
+    fun setWorkoutParametersInternal(params: WorkoutParameters) {
+        coordinator._workoutParameters.value = params
+    }
+
     fun startWorkout(skipCountdown: Boolean = false, isJustLiftMode: Boolean = false) {
         Logger.d { "startWorkout called: skipCountdown=$skipCountdown, isJustLiftMode=$isJustLiftMode" }
         Logger.d { "startWorkout: loadedRoutine=${coordinator._loadedRoutine.value?.name}, params=${coordinator._workoutParameters.value}" }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/DefaultWorkoutSessionManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/DefaultWorkoutSessionManager.kt
@@ -152,7 +152,7 @@ class DefaultWorkoutSessionManager(
             override fun startWorkout(skipCountdown: Boolean) { this@DefaultWorkoutSessionManager.startWorkout(skipCountdown = skipCountdown) }
             override suspend fun sendStopCommand() { bleRepository.sendStopCommand() }
             override suspend fun stopMachineWorkout() { bleRepository.stopWorkout() }
-            override fun updateWorkoutParameters(params: WorkoutParameters) { this@DefaultWorkoutSessionManager.updateWorkoutParameters(params) }
+            override fun setWorkoutParametersInternal(params: WorkoutParameters) { this@DefaultWorkoutSessionManager.setWorkoutParametersInternal(params) }
         }
     }
 
@@ -315,6 +315,7 @@ class DefaultWorkoutSessionManager(
     fun recaptureLoadBaseline() = activeSessionEngine.recaptureLoadBaseline()
     fun resetLoadBaseline() = activeSessionEngine.resetLoadBaseline()
     fun updateWorkoutParameters(params: WorkoutParameters) = activeSessionEngine.updateWorkoutParameters(params)
+    fun setWorkoutParametersInternal(params: WorkoutParameters) = activeSessionEngine.setWorkoutParametersInternal(params)
     fun startWorkout(skipCountdown: Boolean = false, isJustLiftMode: Boolean = false) = activeSessionEngine.startWorkout(skipCountdown, isJustLiftMode)
     fun skipCountdown() = activeSessionEngine.skipCountdown()
     fun stopWorkout(exitingWorkout: Boolean = false) = activeSessionEngine.stopWorkout(exitingWorkout)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/RoutineFlowManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/RoutineFlowManager.kt
@@ -50,8 +50,8 @@ class RoutineFlowManager(
         suspend fun sendStopCommand()
         /** Send BLE stop/reset to put machine in BASELINE mode */
         suspend fun stopMachineWorkout()
-        /** Update workout parameters (includes side-effect tracking) */
-        fun updateWorkoutParameters(params: WorkoutParameters)
+        /** Update workout parameters for internal manager transitions (no user-adjusted side-effects) */
+        fun setWorkoutParametersInternal(params: WorkoutParameters)
     }
 
     /**
@@ -488,7 +488,7 @@ class RoutineFlowManager(
         println("Issue188-Load: ║   isAMRAP=${params.isAMRAP} (from firstSetReps == null || exercise.isAMRAP)")
         println("Issue188-Load: ║   reps=${params.reps}")
         println("Issue188-Load: ║   progressionRegressionKg=${params.progressionRegressionKg}kg")
-        lifecycleDelegate.updateWorkoutParameters(params)
+        lifecycleDelegate.setWorkoutParametersInternal(params)
     }
 
     fun loadRoutine(routine: Routine) {

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMWorkoutLifecycleTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMWorkoutLifecycleTest.kt
@@ -304,6 +304,122 @@ class DWSMWorkoutLifecycleTest {
         harness.cleanup()
     }
 
+
+    @Test
+    fun `routine next-set weight applies when user did not manually edit`() = runTest {
+        val harness = DWSMTestHarness(this)
+        val base = createTestRoutine(exerciseCount = 1, setsPerExercise = 2)
+        val routine = base.copy(
+            exercises = listOf(
+                base.exercises.first().copy(
+                    setReps = listOf(8, 6),
+                    setWeightsPerCableKg = listOf(20f, 30f),
+                    weightPerCableKg = 20f
+                )
+            )
+        )
+        routine.exercises.forEach { harness.fakeExerciseRepo.addExercise(it.exercise) }
+
+        harness.dwsm.loadRoutine(routine)
+        advanceUntilIdle()
+
+        harness.dwsm.coordinator._workoutState.value = WorkoutState.Resting(
+            restSecondsRemaining = 0,
+            nextExerciseName = "",
+            isLastExercise = true,
+            currentSet = 1,
+            totalSets = 2
+        )
+        harness.dwsm.startNextSet()
+        advanceUntilIdle()
+
+        val params = harness.dwsm.coordinator.workoutParameters.value
+        assertEquals(30f, params.weightPerCableKg)
+        assertEquals(6, params.reps)
+        harness.cleanup()
+    }
+
+    @Test
+    fun `manual rest-screen edits are preserved across transition`() = runTest {
+        val harness = DWSMTestHarness(this)
+        val base = createTestRoutine(exerciseCount = 1, setsPerExercise = 2)
+        val routine = base.copy(
+            exercises = listOf(
+                base.exercises.first().copy(
+                    setReps = listOf(8, 6),
+                    setWeightsPerCableKg = listOf(20f, 30f),
+                    weightPerCableKg = 20f
+                )
+            )
+        )
+        routine.exercises.forEach { harness.fakeExerciseRepo.addExercise(it.exercise) }
+
+        harness.dwsm.loadRoutine(routine)
+        advanceUntilIdle()
+
+        harness.dwsm.coordinator._workoutState.value = WorkoutState.Resting(
+            restSecondsRemaining = 0,
+            nextExerciseName = "",
+            isLastExercise = true,
+            currentSet = 1,
+            totalSets = 2
+        )
+        harness.dwsm.updateWorkoutParameters(
+            harness.dwsm.coordinator.workoutParameters.value.copy(
+                weightPerCableKg = 42f,
+                reps = 11
+            )
+        )
+
+        harness.dwsm.startNextSet()
+        advanceUntilIdle()
+
+        val params = harness.dwsm.coordinator.workoutParameters.value
+        assertEquals(42f, params.weightPerCableKg)
+        assertEquals(11, params.reps)
+        harness.cleanup()
+    }
+
+    @Test
+    fun `previous exercise weight does not leak into next exercise`() = runTest {
+        val harness = DWSMTestHarness(this)
+        val base = createTestRoutine(exerciseCount = 2, setsPerExercise = 1)
+        val routine = base.copy(
+            exercises = listOf(
+                base.exercises[0].copy(
+                    setReps = listOf(8),
+                    setWeightsPerCableKg = listOf(20f),
+                    weightPerCableKg = 20f
+                ),
+                base.exercises[1].copy(
+                    setReps = listOf(10),
+                    setWeightsPerCableKg = listOf(55f),
+                    weightPerCableKg = 55f
+                )
+            )
+        )
+        routine.exercises.forEach { harness.fakeExerciseRepo.addExercise(it.exercise) }
+
+        harness.dwsm.loadRoutine(routine)
+        advanceUntilIdle()
+
+        harness.dwsm.coordinator._workoutState.value = WorkoutState.Resting(
+            restSecondsRemaining = 0,
+            nextExerciseName = routine.exercises[1].exercise.displayName,
+            isLastExercise = false,
+            currentSet = 1,
+            totalSets = 1
+        )
+        harness.dwsm.startNextSet()
+        advanceUntilIdle()
+
+        val params = harness.dwsm.coordinator.workoutParameters.value
+        assertEquals(55f, params.weightPerCableKg)
+        assertEquals(10, params.reps)
+        assertEquals(routine.exercises[1].exercise.id, params.selectedExerciseId)
+        harness.cleanup()
+    }
+
     // ===== E. Auto-stop behavior (indirect) =====
 
     @Test


### PR DESCRIPTION
### Motivation

- Prevent manager-driven transitions (routine load/step changes) from being treated as manual user edits that set `_userAdjustedWeightDuringRest`, so routine-defined set weights apply correctly across transitions. 
- Preserve the existing behavior for explicit UI/manual parameter edits so user adjustments on the rest screen are honored.
- Add focused tests to lock in expected behavior around set/exercise transitions and prevent weight leakage between exercises.

### Description

- Added `fun setWorkoutParametersInternal(params: WorkoutParameters)` to `ActiveSessionEngine` to update `coordinator._workoutParameters` without toggling `_userAdjustedWeightDuringRest`. 
- Updated `RoutineFlowManager.WorkoutLifecycleDelegate` to expose `setWorkoutParametersInternal` and changed the routine-load path to call the internal method so manager-driven loads don’t mark parameters as user-adjusted. 
- Wired `DefaultWorkoutSessionManager` to forward `setWorkoutParametersInternal` to `ActiveSessionEngine` while keeping `updateWorkoutParameters` for UI/manual updates. 
- Added unit tests in `DWSMWorkoutLifecycleTest` to verify routine next-set weights when no manual edit was made, that manual rest-screen edits are preserved, and that previous exercise weights do not leak into the next exercise.

### Testing

- Successfully compiled shared metadata with `./gradlew :shared:compileKotlinMetadata` (Kotlin common compilation succeeded). 
- Attempt to run `:shared:commonTest` invocation failed because the task name `commonTest` is not available in this multi-target setup. 
- Attempt to run `:shared:testAndroidHostTest` failed in the environment due to missing Android SDK / `ANDROID_HOME`, so Android-host unit test execution could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b411efeb948322a87e6381e3170e28)