### PR TITLE
Add firmware-aware activation packet offset layouts

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -1340,6 +1340,14 @@ class ActiveSessionEngine(
                 Logger.i { "CONFIG command sent: ${command.size} bytes for ${effectiveParams.programMode}" }
                 val preview = command.take(16).joinToString(" ") { it.toUByte().toString(16).padStart(2, '0').uppercase() }
                 Logger.d { "Config preview: $preview ..." }
+                if (!effectiveParams.isEchoMode && command.size >= 0x60) {
+                    val activationTailDump = command
+                        .copyOfRange(0x48, 0x60)
+                        .joinToString(" ") { it.toUByte().toString(16).padStart(2, '0').uppercase() }
+                    Logger.w {
+                        "BLE-ACTIVATION-VERIFY (temporary): offsets 0x48..0x5F => $activationTailDump"
+                    }
+                }
             } catch (e: Exception) {
                 Logger.e(e) { "Failed to send config command" }
                 coordinator._bleErrorEvents.tryEmit("Failed to send command: ${e.message}")

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/BleConstants.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/BleConstants.kt
@@ -66,15 +66,16 @@ object BleConstants {
      * Layout:
      * - 0x30-0x3F: concentric activation phase
      * - 0x40-0x4F: eccentric activation phase
-     * - 0x48-0x4B: softMax (overlaps eccentric tail — firmware reads here, write AFTER profile copy)
-     * - 0x4C-0x4F: increment (overlaps eccentric tail — firmware reads here, write AFTER profile copy)
+     * - 0x48-0x4B: legacy softMax for overlap firmware variants (overlaps eccentric tail)
+     * - 0x4C-0x4F: legacy increment for overlap firmware variants (overlaps eccentric tail)
      * - 0x50-0x53: forceMin (0.0f)
      * - 0x54-0x57: forceMax (adjustedWeight + 10.0f — force ceiling)
      * - 0x58-0x5B: target weight (adjustedWeight — actual operating weight)
      * - 0x5C-0x5F: progression (progressionRegressionKg)
      *
-     * Issue #262: Firmware reads softMax at 0x48 and increment at 0x4C, which overlap
-     * the eccentric phase tail. These must be written AFTER copying the mode profile.
+     * Firmware variants differ:
+     * - NON_OVERLAP: keep 0x48-0x4F as profile bytes and use 0x58/0x5C for active weights.
+     * - OVERLAP: write legacy softMax/increment at 0x48/0x4C after profile copy.
      */
     object ActivationPacket {
         const val SIZE = 96

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/BlePacketFactory.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/BlePacketFactory.kt
@@ -13,6 +13,14 @@ import com.devil.phoenixproject.domain.model.WorkoutParameters
  */
 object BlePacketFactory {
 
+    enum class ForceConfigVariant {
+        NON_OVERLAP,
+        OVERLAP
+    }
+
+    @Volatile
+    var defaultForceConfigVariant: ForceConfigVariant = ForceConfigVariant.NON_OVERLAP
+
     // ========== Little-Endian Byte Helpers ==========
 
     private fun putIntLE(buffer: ByteArray, offset: Int, value: Int) {
@@ -124,11 +132,14 @@ object BlePacketFactory {
      * Build the 96-byte activation/program parameters frame.
      *
      * Activation modes serialize a 32-byte mode profile at 0x30-0x4F, followed by
-     * the force config block at 0x50-0x5F. Firmware also reads softMax (0x48) and
-     * increment (0x4C) from offsets that overlap the eccentric phase tail — these
-     * are written AFTER the profile copy so they take priority (Issue #262).
+     * the force config block at 0x50-0x5F.
+     * - NON_OVERLAP keeps 0x48-0x4F untouched so profile bytes are preserved.
+     * - OVERLAP writes legacy softMax/increment at 0x48/0x4C when required.
      */
-    fun createProgramParams(params: WorkoutParameters): ByteArray {
+    fun createProgramParams(
+        params: WorkoutParameters,
+        variant: ForceConfigVariant = defaultForceConfigVariant
+    ): ByteArray {
         val frame = ByteArray(96)
 
         // Header section - Command 0x04 for PROGRAM mode
@@ -185,13 +196,12 @@ object BlePacketFactory {
 
         val effectiveKg = adjustedWeightPerCable + 10.0f
 
-        // Issue #262: Firmware reads softMax at 0x48 and increment at 0x4C.
-        // These overlap the last 8 bytes of the mode profile, but the firmware
-        // interprets them as force config, not mode data. Write them AFTER the
-        // profile copy so they take priority.
         val softMax = if (params.isAMRAP || params.isJustLift) 100.0f else params.weightPerCableKg
-        putFloatLE(frame, BleConstants.ActivationPacket.OFFSET_SOFT_MAX, softMax)
-        putFloatLE(frame, BleConstants.ActivationPacket.OFFSET_INCREMENT, params.progressionRegressionKg)
+
+        if (variant == ForceConfigVariant.OVERLAP) {
+            putFloatLE(frame, BleConstants.ActivationPacket.OFFSET_SOFT_MAX, softMax)
+            putFloatLE(frame, BleConstants.ActivationPacket.OFFSET_INCREMENT, params.progressionRegressionKg)
+        }
 
         // Force config block at 0x50-0x5F
         putFloatLE(frame, BleConstants.ActivationPacket.OFFSET_FORCE_MIN, 0.0f)
@@ -202,10 +212,14 @@ object BlePacketFactory {
         // Diagnostic logging
         println("BLE-ACTIVATION: === MODE: ${params.programMode}, Weight: ${params.weightPerCableKg}kg ===")
         println("BLE-ACTIVATION: adjustedWeight=${adjustedWeightPerCable}kg, effectiveKg=$effectiveKg")
-        println(
-            "BLE-ACTIVATION: softMax[0x48]=${readFloatLE(frame, BleConstants.ActivationPacket.OFFSET_SOFT_MAX)}kg, " +
-                "increment[0x4C]=${readFloatLE(frame, BleConstants.ActivationPacket.OFFSET_INCREMENT)}kg/rep"
-        )
+        if (variant == ForceConfigVariant.OVERLAP) {
+            println(
+                "BLE-ACTIVATION: softMax[0x48]=${readFloatLE(frame, BleConstants.ActivationPacket.OFFSET_SOFT_MAX)}kg, " +
+                    "increment[0x4C]=${readFloatLE(frame, BleConstants.ActivationPacket.OFFSET_INCREMENT)}kg/rep"
+            )
+        } else {
+            println("BLE-ACTIVATION: non-overlap layout active (0x48..0x4F preserved as profile bytes)")
+        }
         println(
             "BLE-ACTIVATION: forceMin[0x50]=${readFloatLE(frame, BleConstants.ActivationPacket.OFFSET_FORCE_MIN)}kg, " +
                 "forceMax[0x54]=${readFloatLE(frame, BleConstants.ActivationPacket.OFFSET_FORCE_MAX)}kg"

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/util/BlePacketFactoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/util/BlePacketFactoryTest.kt
@@ -248,7 +248,10 @@ class BlePacketFactoryTest {
             weightPerCableKg = weight
         )
 
-        val packet = BlePacketFactory.createProgramParams(params)
+        val packet = BlePacketFactory.createProgramParams(
+            params,
+            variant = BlePacketFactory.ForceConfigVariant.OVERLAP
+        )
 
         // Firmware reads softMax from 0x48 (Issue #262)
         assertEquals(weight, readFloatLE(packet, BleConstants.ActivationPacket.OFFSET_SOFT_MAX))
@@ -264,7 +267,10 @@ class BlePacketFactoryTest {
             progressionRegressionKg = progression
         )
 
-        val packet = BlePacketFactory.createProgramParams(params)
+        val packet = BlePacketFactory.createProgramParams(
+            params,
+            variant = BlePacketFactory.ForceConfigVariant.OVERLAP
+        )
 
         // Firmware reads increment from 0x4C (Issue #262)
         assertEquals(progression, readFloatLE(packet, BleConstants.ActivationPacket.OFFSET_INCREMENT))
@@ -302,8 +308,7 @@ class BlePacketFactoryTest {
         // Critical: 0x58 must have the actual weight, NOT softMax (100.0f)
         // This bug caused the machine to apply weight+10kg instead of the set weight
         assertEquals(weight, readFloatLE(packet, BleConstants.ActivationPacket.OFFSET_TARGET_WEIGHT))
-        // softMax goes to 0x48 for firmware
-        assertEquals(100.0f, readFloatLE(packet, BleConstants.ActivationPacket.OFFSET_SOFT_MAX))
+        assertEquals(15.0f, readFloatLE(packet, BleConstants.ActivationPacket.OFFSET_FORCE_MAX))
     }
 
     @Test
@@ -315,7 +320,10 @@ class BlePacketFactoryTest {
             isAMRAP = true
         )
 
-        val packet = BlePacketFactory.createProgramParams(params)
+        val packet = BlePacketFactory.createProgramParams(
+            params,
+            variant = BlePacketFactory.ForceConfigVariant.OVERLAP
+        )
 
         assertEquals(100.0f, readFloatLE(packet, BleConstants.ActivationPacket.OFFSET_SOFT_MAX))
         // Target weight at 0x58 must be the actual weight, not softMax
@@ -331,7 +339,10 @@ class BlePacketFactoryTest {
             isJustLift = true
         )
 
-        val packet = BlePacketFactory.createProgramParams(params)
+        val packet = BlePacketFactory.createProgramParams(
+            params,
+            variant = BlePacketFactory.ForceConfigVariant.OVERLAP
+        )
 
         assertEquals(100.0f, readFloatLE(packet, BleConstants.ActivationPacket.OFFSET_SOFT_MAX))
         // Target weight must be at 0x58, not softMax
@@ -362,7 +373,10 @@ class BlePacketFactoryTest {
             progressionRegressionKg = 3f
         )
 
-        val packet = BlePacketFactory.createProgramParams(params)
+        val packet = BlePacketFactory.createProgramParams(
+            params,
+            variant = BlePacketFactory.ForceConfigVariant.OVERLAP
+        )
 
         // Firmware force config (0x48-0x4F)
         assertEquals(40.0f, readFloatLE(packet, 0x48))  // softMax = weightPerCableKg
@@ -373,6 +387,57 @@ class BlePacketFactoryTest {
         assertEquals(47.0f, readFloatLE(packet, 0x54))   // forceMax = 40-3+10
         assertEquals(37.0f, readFloatLE(packet, 0x58))   // targetWeight = 40-3
         assertEquals(3.0f, readFloatLE(packet, 0x5C))   // progression
+    }
+
+    @Test
+    fun `createProgramParams non-overlap keeps profile tail bytes unchanged`() {
+        val params = WorkoutParameters(
+            programMode = ProgramMode.Pump,
+            reps = 10,
+            weightPerCableKg = 40f,
+            progressionRegressionKg = 3f
+        )
+
+        val packet = BlePacketFactory.createProgramParams(
+            params,
+            variant = BlePacketFactory.ForceConfigVariant.NON_OVERLAP
+        )
+
+        val expectedTail = byteArrayOf(
+            0x9C.toByte(), 0xFF.toByte(),
+            0xCE.toByte(), 0xFF.toByte(),
+            0x00.toByte(), 0x00.toByte(), 0x80.toByte(), 0x3F.toByte()
+        )
+        assertContentEquals(expectedTail, packet.copyOfRange(0x48, 0x50))
+    }
+
+    @Test
+    fun `createProgramParams variant selection yields expected overlap and non-overlap layouts`() {
+        val params = WorkoutParameters(
+            programMode = ProgramMode.Pump,
+            reps = 10,
+            weightPerCableKg = 40f,
+            progressionRegressionKg = 3f
+        )
+
+        val nonOverlapPacket = BlePacketFactory.createProgramParams(
+            params,
+            variant = BlePacketFactory.ForceConfigVariant.NON_OVERLAP
+        )
+        val overlapPacket = BlePacketFactory.createProgramParams(
+            params,
+            variant = BlePacketFactory.ForceConfigVariant.OVERLAP
+        )
+
+        assertEquals(40.0f, readFloatLE(overlapPacket, 0x48))
+        assertEquals(3.0f, readFloatLE(overlapPacket, 0x4C))
+
+        assertEquals(37.0f, readFloatLE(nonOverlapPacket, 0x58))
+        assertEquals(3.0f, readFloatLE(nonOverlapPacket, 0x5C))
+        assertEquals(37.0f, readFloatLE(overlapPacket, 0x58))
+        assertEquals(3.0f, readFloatLE(overlapPacket, 0x5C))
+
+        assertTrue(nonOverlapPacket.copyOfRange(0x48, 0x50).contentEquals(overlapPacket.copyOfRange(0x48, 0x50)).not())
     }
 
     // ========== Echo Mode Tests ==========


### PR DESCRIPTION
### Motivation

- Prevent accidental overwrites of the mode profile tail at `0x48..0x4F` when using the default (non-overlap) firmware layout.
- Provide a firmware-aware strategy so devices that require the legacy overlapping `softMax/increment` offsets can still be supported explicitly.
- Keep the actual operating weight and progression explicit at `0x58` and `0x5C` to avoid regressions (e.g. the Just Lift +10kg bug).
- Add temporary high-signal logging to verify outgoing activation packets in the field while changing layout behaviour.

### Description

- Introduced `ForceConfigVariant` (`NON_OVERLAP`, `OVERLAP`) and a global `defaultForceConfigVariant` to `BlePacketFactory` and extended `createProgramParams` to accept an explicit `variant` parameter (defaulting to the global).
- Changed `createProgramParams` so `OVERLAP` writes legacy `softMax`/`increment` at `0x48`/`0x4C`, while `NON_OVERLAP` preserves bytes `0x48..0x4F` (profile tail) and only writes the protocol force block at `0x50..0x5F` (including `targetWeight` at `0x58` and `progression` at `0x5C`).
- Updated `BleConstants` activation-packet docs to describe both `NON_OVERLAP` and `OVERLAP` layouts and clarify offsets semantics.
- Added temporary high-signal logging in `ActiveSessionEngine` to dump activation packet bytes for `0x48..0x5F` on send to help field verification.
- Added focused tests in `shared/src/commonTest/kotlin/com/devil/phoenixproject/util/BlePacketFactoryTest.kt` that assert:
  - `0x48..0x4F` profile tail preservation in the non-overlap path.
  - Just Lift target-weight (`0x58`) correctness to avoid the +10kg regression and `forceMax` correctness.
  - Variant selection yields the expected byte layouts for both `OVERLAP` and `NON_OVERLAP`.

### Testing

- Ran Gradle task discovery with `./gradlew :shared:tasks --all` which completed successfully to confirm available test targets. (Succeeded)
- Attempted `./gradlew :shared:commonTest --tests "com.devil.phoenixproject.util.BlePacketFactoryTest"` but that Gradle task is not present for this module in the current build configuration. (Failed: task not found)
- Attempted `./gradlew :shared:testAndroidHostTest --tests "com.devil.phoenixproject.util.BlePacketFactoryTest"` to run host tests, but run failed because the Android SDK is not configured in the environment (`ANDROID_HOME`/`local.properties` missing). (Failed: SDK not found)

Notes: tests were added and are runnable in a properly provisioned environment; the `variant` parameter can be used in-code or the `defaultForceConfigVariant` flag can be toggled to select behavior during rollout and field verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b416c05e1c83229f8c3f43b30a992a)