### PR TITLE
Make iOS CompactNumberPicker responsive to window height and font scale

### DIFF
--- a/shared/src/iosMain/kotlin/com/devil/phoenixproject/presentation/components/CompactNumberPicker.ios.kt
+++ b/shared/src/iosMain/kotlin/com/devil/phoenixproject/presentation/components/CompactNumberPicker.ios.kt
@@ -24,17 +24,52 @@ import androidx.compose.ui.focus.onFocusChanged
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.devil.phoenixproject.presentation.util.LocalWindowSizeClass
+import com.devil.phoenixproject.presentation.util.WindowHeightSizeClass
 import kotlinx.coroutines.launch
 import co.touchlab.kermit.Logger
 import kotlin.math.abs
 import kotlin.math.roundToInt
+
+private data class PickerSizing(
+    val itemHeight: Dp,
+    val containerHeight: Dp,
+    val selectedTextStyle: TextStyle,
+    val unselectedTextStyle: TextStyle
+)
+
+@Composable
+private fun rememberPickerSizing(): PickerSizing {
+    val windowSizeClass = LocalWindowSizeClass.current
+    val fontScale = LocalDensity.current.fontScale
+    val typography = MaterialTheme.typography
+    val compactHeightMode =
+        windowSizeClass.heightSizeClass == WindowHeightSizeClass.Compact && fontScale <= 1.05f
+
+    val itemHeight = if (compactHeightMode) 34.dp else 40.dp
+    val selectedTextStyle = when {
+        compactHeightMode -> typography.titleLarge.copy(fontSize = 22.sp, lineHeight = 26.sp)
+        fontScale > 1.15f -> typography.titleLarge
+        else -> typography.headlineMedium
+    }
+
+    return PickerSizing(
+        itemHeight = itemHeight,
+        containerHeight = itemHeight * 3,
+        selectedTextStyle = selectedTextStyle,
+        unselectedTextStyle = if (compactHeightMode) typography.bodyMedium else typography.bodyLarge
+    )
+}
 
 /**
  * iOS implementation using Compose-based scrollable picker.
@@ -98,6 +133,7 @@ actual fun CompactNumberPicker(
     val coroutineScope = rememberCoroutineScope()
     val flingBehavior = rememberSnapFlingBehavior(lazyListState = listState)
     val focusManager = LocalFocusManager.current
+    val pickerSizing = rememberPickerSizing()
 
     // Inline editing state
     var isEditing by remember { mutableStateOf(false) }
@@ -298,9 +334,8 @@ actual fun CompactNumberPicker(
                 )
             }
 
-            // Scrollable picker - Item height is ~40dp (text + padding)
-            val itemHeight = 40.dp
-            val containerHeight = 120.dp
+            val itemHeight = pickerSizing.itemHeight
+            val containerHeight = pickerSizing.containerHeight
             // Center padding pushes first item to middle of container
             val centerPadding = (containerHeight - itemHeight) / 2
 
@@ -348,7 +383,7 @@ actual fun CompactNumberPicker(
                                         value = inputText,
                                         onValueChange = { inputText = it },
                                         textStyle = TextStyle(
-                                            fontSize = MaterialTheme.typography.headlineMedium.fontSize,
+                                            fontSize = pickerSizing.selectedTextStyle.fontSize,
                                             fontWeight = FontWeight.Bold,
                                             color = MaterialTheme.colorScheme.onSurface,
                                             textAlign = TextAlign.Center
@@ -394,9 +429,9 @@ actual fun CompactNumberPicker(
                                 Text(
                                     text = formatValue(floatVal),
                                     style = if (isSelected)
-                                        MaterialTheme.typography.headlineMedium
+                                        pickerSizing.selectedTextStyle
                                     else
-                                        MaterialTheme.typography.bodyLarge,
+                                        pickerSizing.unselectedTextStyle,
                                     fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
                                     color = MaterialTheme.colorScheme.onSurface,
                                     textAlign = TextAlign.Center
@@ -414,7 +449,7 @@ actual fun CompactNumberPicker(
                     }
                     Text(
                         text = formatValue(values[previewIndex]),
-                        style = MaterialTheme.typography.headlineMedium,
+                        style = pickerSizing.selectedTextStyle,
                         fontWeight = FontWeight.Bold,
                         color = MaterialTheme.colorScheme.onSurface,
                         textAlign = TextAlign.Center,
@@ -427,14 +462,14 @@ actual fun CompactNumberPicker(
                 // Selection indicator lines - positioned to frame center item
                 HorizontalDivider(
                     modifier = Modifier
-                        .align(Alignment.TopCenter)
-                        .padding(top = centerPadding - 2.dp),
+                        .align(Alignment.Center)
+                        .offset(y = -(itemHeight / 2)),
                     color = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f)
                 )
                 HorizontalDivider(
                     modifier = Modifier
-                        .align(Alignment.BottomCenter)
-                        .padding(bottom = centerPadding - 2.dp),
+                        .align(Alignment.Center)
+                        .offset(y = itemHeight / 2),
                     color = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f)
                 )
             }


### PR DESCRIPTION
### Motivation
- Improve iOS picker layout so row/container heights and selected text sizing adapt to small portrait phones and large/font-scaled displays to avoid clipping and maintain consistent framing. 

### Description
- Add a local `PickerSizing` helper and `rememberPickerSizing()` that derives `itemHeight`, `containerHeight`, and selected/unselected `TextStyle` from `LocalWindowSizeClass` (height class) and `LocalDensity.current.fontScale`.
- Replace fixed `itemHeight = 40.dp` and `containerHeight = 120.dp` with `pickerSizing.itemHeight` and `pickerSizing.containerHeight` (where `containerHeight = itemHeight * 3`) so the viewport still contains exactly three rows with one centered row.
- Apply the responsive selected text style to the inline edit `BasicTextField`, the centered overlay text, and the selected row rendering, and use a compact-aware unselected style for non-selected rows.
- Reposition the selection dividers to center offsets using `.offset(y = -(itemHeight / 2))` and `.offset(y = itemHeight / 2)` so they continue to frame exactly one row after size changes.

### Testing
- Ran `./gradlew :shared:compileKotlinMetadata` which completed successfully. 
- Attempted `./gradlew :shared:compileKotlinIosArm64` which failed due to a pre-existing, unrelated compilation error in `shared/src/commonMain/kotlin/com/devil/phoenixproject/util/BlePacketFactory.kt` (`Unresolved reference 'Volatile'`), so full iOS compile could not be validated in this environment.
- A browser screenshot attempt against `http://localhost:8080` (Playwright) could not be completed because no web target was available in the environment (`ERR_EMPTY_RESPONSE`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6cdbf06a48322af850fe9e1615d25)