### PR TITLE
fix(test): prevent UncompletedCoroutinesError in weight-leak test

### DIFF
--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMWorkoutLifecycleTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMWorkoutLifecycleTest.kt
@@ -403,6 +403,11 @@ class DWSMWorkoutLifecycleTest {
         harness.dwsm.loadRoutine(routine)
         advanceUntilIdle()
 
+        // Disable autoplay so startNextSet() enters SetReady instead of launching
+        // startWorkout() which creates infinite delay loops (rest timer, metrics, etc.)
+        harness.fakePrefsManager.setSummaryCountdownSeconds(0)
+        advanceUntilIdle()
+
         harness.dwsm.coordinator._workoutState.value = WorkoutState.Resting(
             restSecondsRemaining = 0,
             nextExerciseName = routine.exercises[1].exercise.displayName,


### PR DESCRIPTION
Disable autoplay before startNextSet() so the test enters SetReady state instead of launching startWorkout() which creates infinite delay loops (rest timer, metrics collection). Pre-existing failure on main — not caused by the picker changes.