### PR TITLE
feat(just-lift): replace rest timer slider with chip and dialog

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/RestTimePickerDialog.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/RestTimePickerDialog.kt
@@ -20,21 +20,23 @@ import vitruvianprojectphoenix.shared.generated.resources.Res
 import vitruvianprojectphoenix.shared.generated.resources.*
 
 /**
- * Dialog for selecting superset rest time from fixed options.
- * Options: 0, 5, 10, 15, 20, 25, 30 seconds
+ * Dialog for selecting rest time from chip options.
+ * Default options (superset): 0, 5, 10, 15, 20, 25, 30 seconds.
+ * Override [options], [title], and [formatLabel] for different contexts (e.g. Just Lift).
  */
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun RestTimePickerDialog(
     currentRestSeconds: Int,
     onSelect: (Int) -> Unit,
-    onDismiss: () -> Unit
+    onDismiss: () -> Unit,
+    options: List<Int> = listOf(0, 5, 10, 15, 20, 25, 30),
+    title: String = stringResource(Res.string.rest_between_exercises),
+    formatLabel: (Int) -> String = { "${it}s" }
 ) {
-    val options = listOf(0, 5, 10, 15, 20, 25, 30)
-
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text(stringResource(Res.string.rest_between_exercises)) },
+        title = { Text(title) },
         text = {
             FlowRow(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -51,7 +53,7 @@ fun RestTimePickerDialog(
                             MaterialTheme.colorScheme.surfaceVariant
                     ) {
                         Text(
-                            text = "${seconds}s",
+                            text = formatLabel(seconds),
                             style = MaterialTheme.typography.bodyLarge,
                             fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
                             color = if (isSelected)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/JustLiftScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/JustLiftScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.animation.scaleOut
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -50,9 +51,9 @@ import com.devil.phoenixproject.data.repository.UserProfileRepository
 import com.devil.phoenixproject.domain.model.*
 import com.devil.phoenixproject.presentation.components.AddProfileDialog
 import com.devil.phoenixproject.presentation.components.CompactNumberPicker
-import com.devil.phoenixproject.presentation.components.ExpressiveSlider
 import com.devil.phoenixproject.presentation.components.ProfileSidePanel
 import com.devil.phoenixproject.presentation.components.ProgressionSlider
+import com.devil.phoenixproject.presentation.components.RestTimePickerDialog
 import com.devil.phoenixproject.presentation.navigation.NavigationRoutes
 import com.devil.phoenixproject.presentation.viewmodel.MainViewModel
 import com.devil.phoenixproject.ui.theme.AccessibilityTheme
@@ -577,40 +578,61 @@ fun JustLiftScreen(
                     }
                 }
 
-                // Rest Timer picker
-                Card(
+                // Rest Timer - compact chip + dialog (matches toggle row style)
+                var showRestTimerDialog by remember { mutableStateOf(false) }
+
+                Surface(
                     modifier = Modifier.fillMaxWidth(),
-                    colors = CardDefaults.cardColors(
-                        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
-                    ),
-                    shape = RoundedCornerShape(12.dp)
+                    shape = RoundedCornerShape(12.dp),
+                    color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                    shadowElevation = 2.dp
                 ) {
-                    Column(
+                    Row(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(Spacing.medium),
-                        verticalArrangement = Arrangement.spacedBy(Spacing.small)
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
                     ) {
-                        CompactNumberPicker(
-                            value = restSeconds.toFloat(),
-                            onValueChange = { newValue ->
-                                restSeconds = newValue.toInt()
-                            },
-                            range = 0f..300f,
-                            step = 5f,
-                            label = "Rest Timer",
-                            suffix = if (restSeconds == 0) "Off" else "sec",
-                            modifier = Modifier.fillMaxWidth()
-                        )
-                        Text(
-                            text = if (restSeconds == 0) "No rest between sets"
-                                   else "Rest $restSeconds seconds between sets",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            textAlign = TextAlign.Center,
-                            modifier = Modifier.fillMaxWidth()
-                        )
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = "Rest Timer",
+                                style = MaterialTheme.typography.titleSmall,
+                                fontWeight = FontWeight.Bold,
+                                color = MaterialTheme.colorScheme.onSurface
+                            )
+                            Text(
+                                text = if (restSeconds == 0) "No rest between sets"
+                                       else "Rest $restSeconds seconds between sets",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                        Surface(
+                            modifier = Modifier.clickable { showRestTimerDialog = true },
+                            shape = RoundedCornerShape(16.dp),
+                            color = MaterialTheme.colorScheme.primary.copy(alpha = 0.15f)
+                        ) {
+                            Text(
+                                text = if (restSeconds == 0) "Off" else "${restSeconds}s",
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.primary,
+                                fontWeight = FontWeight.Medium,
+                                modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp)
+                            )
+                        }
                     }
+                }
+
+                if (showRestTimerDialog) {
+                    RestTimePickerDialog(
+                        currentRestSeconds = restSeconds,
+                        onSelect = { restSeconds = it; showRestTimerDialog = false },
+                        onDismiss = { showRestTimerDialog = false },
+                        options = listOf(0, 30, 60, 90, 120),
+                        title = "Rest Between Sets",
+                        formatLabel = { if (it == 0) "Off" else "${it}s" }
+                    )
                 }
 
                 // Active workout status (replaces mode cards when active)
@@ -1079,7 +1101,7 @@ fun AutoStartStopCard(
 private fun JustLiftRestCountdownRow(secondsRemaining: Int) {
     val minutes = secondsRemaining / 60
     val seconds = secondsRemaining % 60
-    val timeText = if (minutes > 0) "%d:%02d".format(minutes, seconds) else "${seconds}s"
+    val timeText = if (minutes > 0) "$minutes:${seconds.toString().padStart(2, '0')}" else "${seconds}s"
 
     Row(
         modifier = Modifier


### PR DESCRIPTION
1. RestTimePickerDialog: refactor to support custom options, titles, and label formatting. This allows reusing the component for both superset rest (0-30s) and set rest (0-120s) contexts.

2. JustLiftScreen: replace the CompactNumberPicker for rest duration with a clickable surface/chip and a RestTimePickerDialog. This matches the toggle row UI style and provides a more consistent selection experience for standard rest intervals (0, 30, 60, 90, 120s).