### PR TITLE
fix(ios): resolve iOS compilation errors on Xcode 26.2/iOS 26 SDK

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -46,6 +46,7 @@ kotlin {
             xcf.add(this)
             // Link system frameworks required by shared module
             linkerOpts("-framework", "HealthKit")
+            linkerOpts("-framework", "Speech")
         }
         binaries.all {
             freeCompilerArgs += listOf("-Xadd-light-debug=enable")

--- a/shared/src/iosMain/kotlin/com/devil/phoenixproject/MainViewController.kt
+++ b/shared/src/iosMain/kotlin/com/devil/phoenixproject/MainViewController.kt
@@ -8,6 +8,7 @@ import coil3.util.DebugLogger
 import androidx.compose.ui.window.ComposeUIViewController
 import com.devil.phoenixproject.presentation.components.RequireBlePermissions
 import platform.Foundation.NSLog
+import kotlin.native.Platform as NativePlatform
 
 /**
  * Creates the main UIViewController for iOS that hosts the Compose Multiplatform UI.
@@ -38,8 +39,8 @@ private fun ensureImageLoader() {
                 add(KtorNetworkFetcherFactory())
             }
             .crossfade(true)
-            // DebugLogger only in debug builds — iOS has no BuildConfig, use Platform.isDebugBinary
-            .apply { if (Platform.isDebugBinary) logger(DebugLogger()) }
+            // DebugLogger only in debug builds — iOS has no BuildConfig, use kotlin.native.Platform
+            .apply { @OptIn(kotlin.experimental.ExperimentalNativeApi::class) if (NativePlatform.isDebugBinary) logger(DebugLogger()) }
             .build()
     }
 }

--- a/shared/src/iosMain/kotlin/com/devil/phoenixproject/domain/voice/SafeWordListener.ios.kt
+++ b/shared/src/iosMain/kotlin/com/devil/phoenixproject/domain/voice/SafeWordListener.ios.kt
@@ -31,8 +31,9 @@ import platform.Speech.SFSpeechRecognitionTask
 import platform.Speech.SFSpeechRecognitionTaskStateCanceling
 import platform.Speech.SFSpeechRecognitionTaskStateCompleted
 import platform.Speech.SFSpeechRecognizer
-import platform.Speech.SFSpeechRecognizerAuthorizationStatusAuthorized
-import platform.Speech.SFSpeechRecognizerAuthorizationStatusNotDetermined
+// Raw values for SFSpeechRecognizerAuthorizationStatus (Xcode 26+ changed enum mapping)
+private const val SPEECH_AUTH_NOT_DETERMINED = 0L
+private const val SPEECH_AUTH_AUTHORIZED = 3L
 import platform.darwin.dispatch_after
 import platform.darwin.dispatch_async
 import platform.darwin.dispatch_get_main_queue
@@ -88,10 +89,10 @@ actual class SafeWordListener(
 
         val authStatus = SFSpeechRecognizer.authorizationStatus()
         when (authStatus) {
-            SFSpeechRecognizerAuthorizationStatusAuthorized -> { /* proceed */ }
-            SFSpeechRecognizerAuthorizationStatusNotDetermined -> {
+            SPEECH_AUTH_AUTHORIZED -> { /* proceed */ }
+            SPEECH_AUTH_NOT_DETERMINED -> {
                 SFSpeechRecognizer.requestAuthorization { newStatus ->
-                    if (newStatus == SFSpeechRecognizerAuthorizationStatusAuthorized) {
+                    if (newStatus == SPEECH_AUTH_AUTHORIZED) {
                         // Re-enter startListening on main thread
                         dispatch_async(dispatch_get_main_queue()) { startListening() }
                     } else {

--- a/shared/src/iosMain/kotlin/com/devil/phoenixproject/util/UriContentReader.ios.kt
+++ b/shared/src/iosMain/kotlin/com/devil/phoenixproject/util/UriContentReader.ios.kt
@@ -1,3 +1,5 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
 package com.devil.phoenixproject.util
 
 import co.touchlab.kermit.Logger


### PR DESCRIPTION
Three compile errors fixed:

1. MainViewController.kt: Platform.isDebugBinary was referencing the project's Platform interface instead of kotlin.native.Platform. Added aliased import.

2. SafeWordListener.ios.kt: SFSpeechRecognizerAuthorizationStatus enum constants unresolved on Xcode 26.2 SDK. Replaced with raw Long value comparisons and added Speech framework to linkerOpts.

3. UriContentReader.ios.kt: Missing @OptIn(ExperimentalForeignApi::class) file annotation for NSString.stringWithContentsOfFile cinterop call.

https://claude.ai/code/session_01HdFwWjABUxP99zpLdBWRGz