### PR TITLE
Replace hardcoded enum values with proper iOS API constants

### DIFF
--- a/shared/src/iosMain/kotlin/com/devil/phoenixproject/domain/voice/SafeWordListener.ios.kt
+++ b/shared/src/iosMain/kotlin/com/devil/phoenixproject/domain/voice/SafeWordListener.ios.kt
@@ -31,9 +31,8 @@ import platform.Speech.SFSpeechRecognitionTask
 import platform.Speech.SFSpeechRecognitionTaskStateCanceling
 import platform.Speech.SFSpeechRecognitionTaskStateCompleted
 import platform.Speech.SFSpeechRecognizer
-// Raw values for SFSpeechRecognizerAuthorizationStatus (Xcode 26+ changed enum mapping)
-private const val SPEECH_AUTH_NOT_DETERMINED = 0L
-private const val SPEECH_AUTH_AUTHORIZED = 3L
+import platform.Speech.SFSpeechRecognizerAuthorizationStatusAuthorized
+import platform.Speech.SFSpeechRecognizerAuthorizationStatusNotDetermined
 import platform.darwin.dispatch_after
 import platform.darwin.dispatch_async
 import platform.darwin.dispatch_get_main_queue
@@ -89,10 +88,10 @@ actual class SafeWordListener(
 
         val authStatus = SFSpeechRecognizer.authorizationStatus()
         when (authStatus) {
-            SPEECH_AUTH_AUTHORIZED -> { /* proceed */ }
-            SPEECH_AUTH_NOT_DETERMINED -> {
+            SFSpeechRecognizerAuthorizationStatusAuthorized -> { /* proceed */ }
+            SFSpeechRecognizerAuthorizationStatusNotDetermined -> {
                 SFSpeechRecognizer.requestAuthorization { newStatus ->
-                    if (newStatus == SPEECH_AUTH_AUTHORIZED) {
+                    if (newStatus == SFSpeechRecognizerAuthorizationStatusAuthorized) {
                         // Re-enter startListening on main thread
                         dispatch_async(dispatch_get_main_queue()) { startListening() }
                     } else {


### PR DESCRIPTION
## Summary
Replaced hardcoded raw values for `SFSpeechRecognizerAuthorizationStatus` with the proper iOS API constants, improving code maintainability and compatibility.

## Key Changes
- Removed hardcoded constants `SPEECH_AUTH_NOT_DETERMINED` (0L) and `SPEECH_AUTH_AUTHORIZED` (3L)
- Added imports for `SFSpeechRecognizerAuthorizationStatusAuthorized` and `SFSpeechRecognizerAuthorizationStatusNotDetermined` from `platform.Speech`
- Updated all enum status comparisons to use the proper API constants instead of raw values

## Implementation Details
This change addresses the issue mentioned in the original comment about Xcode 26+ changing enum mapping. By using the official iOS API constants instead of hardcoded values, the code is now:
- More maintainable and self-documenting
- Less prone to breaking with iOS SDK updates
- Properly aligned with Kotlin/Native's platform bindings for iOS

https://claude.ai/code/session_01UAzhMJbQEdFGweXVSEbSgR