### PR TITLE
Fix iOS build: use Kotlin enum class entries for NS_CLOSED_ENUM

### DIFF
--- a/shared/src/iosMain/kotlin/com/devil/phoenixproject/domain/voice/SafeWordListener.ios.kt
+++ b/shared/src/iosMain/kotlin/com/devil/phoenixproject/domain/voice/SafeWordListener.ios.kt
@@ -31,8 +31,7 @@ import platform.Speech.SFSpeechRecognitionTask
 import platform.Speech.SFSpeechRecognitionTaskStateCanceling
 import platform.Speech.SFSpeechRecognitionTaskStateCompleted
 import platform.Speech.SFSpeechRecognizer
-import platform.Speech.SFSpeechRecognizerAuthorizationStatusAuthorized
-import platform.Speech.SFSpeechRecognizerAuthorizationStatusNotDetermined
+import platform.Speech.SFSpeechRecognizerAuthorizationStatus
 import platform.darwin.dispatch_after
 import platform.darwin.dispatch_async
 import platform.darwin.dispatch_get_main_queue
@@ -88,10 +87,10 @@ actual class SafeWordListener(
 
         val authStatus = SFSpeechRecognizer.authorizationStatus()
         when (authStatus) {
-            SFSpeechRecognizerAuthorizationStatusAuthorized -> { /* proceed */ }
-            SFSpeechRecognizerAuthorizationStatusNotDetermined -> {
+            SFSpeechRecognizerAuthorizationStatus.authorized -> { /* proceed */ }
+            SFSpeechRecognizerAuthorizationStatus.notDetermined -> {
                 SFSpeechRecognizer.requestAuthorization { newStatus ->
-                    if (newStatus == SFSpeechRecognizerAuthorizationStatusAuthorized) {
+                    if (newStatus == SFSpeechRecognizerAuthorizationStatus.authorized) {
                         // Re-enter startListening on main thread
                         dispatch_async(dispatch_get_main_queue()) { startListening() }
                     } else {


### PR DESCRIPTION
Root cause: Xcode 26 changed SFSpeechRecognizerAuthorizationStatus from NS_ENUM to NS_CLOSED_ENUM. Kotlin 2.0+ maps NS_CLOSED_ENUM to a Kotlin enum class with prefix-stripped entry names (e.g. .authorized, .notDetermined) instead of top-level Long constants (SFSpeechRecognizerAuthorizationStatusAuthorized).

SFSpeechRecognitionTaskState remains NS_ENUM and its top-level constants (SFSpeechRecognitionTaskStateCanceling etc.) still resolve correctly.

https://claude.ai/code/session_01UAzhMJbQEdFGweXVSEbSgR