### PR TITLE
Heal legacy RoutineExercise rows by resolving missing/stale exerciseId to fix PR tracking

### DIFF
--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepositoryTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepositoryTest.kt
@@ -1,10 +1,14 @@
 package com.devil.phoenixproject.data.repository
 
 import app.cash.turbine.test
+import com.devil.phoenixproject.domain.model.Exercise
+import com.devil.phoenixproject.domain.model.Routine
+import com.devil.phoenixproject.domain.model.RoutineExercise
 import com.devil.phoenixproject.domain.model.WorkoutSession
 import com.devil.phoenixproject.testutil.FakeExerciseRepository
 import com.devil.phoenixproject.testutil.createTestDatabase
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
@@ -177,6 +181,46 @@ class SqlDelightWorkoutRepositoryTest {
         assertEquals(session.peakForceConcentricA, retrieved.peakForceConcentricA)
         assertEquals(session.peakForceConcentricB, retrieved.peakForceConcentricB)
         assertEquals(session.rpe, retrieved.rpe)
+    }
+
+    @Test
+    fun `getRoutineById heals missing exerciseId by resolving exercise name`() = runTest {
+        val customExercise = Exercise(
+            id = "custom_bayesian_curl",
+            name = "Bayesian Cable Curl",
+            muscleGroup = "Biceps",
+            equipment = "Cable",
+            isCustom = true,
+        )
+        exerciseRepository.addExercise(customExercise)
+
+        val legacyRoutine = Routine(
+            id = "routine-legacy",
+            name = "Legacy Routine",
+            exercises = listOf(
+                RoutineExercise(
+                    id = "re-1",
+                    exercise = Exercise(
+                        id = null,
+                        name = "Bayesian Cable Curl",
+                        muscleGroup = "Biceps",
+                        equipment = "Cable",
+                    ),
+                    orderIndex = 0,
+                    setReps = listOf(10),
+                    weightPerCableKg = 12.5f,
+                ),
+            ),
+        )
+        repository.saveRoutine(legacyRoutine)
+
+        val loaded = repository.getRoutineById("routine-legacy")
+        assertNotNull(loaded)
+        assertEquals("custom_bayesian_curl", loaded.exercises.first().exercise.id)
+
+        // Verify DB self-heal so subsequent loads don't regress to null ID.
+        val healedRow = database.vitruvianDatabaseQueries.selectExercisesByRoutine("routine-legacy").executeAsOne()
+        assertEquals("custom_bayesian_curl", healedRow.exerciseId)
     }
 
     // ========== Helper Methods ==========

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepository.kt
@@ -190,21 +190,29 @@ class SqlDelightWorkoutRepository(private val db: VitruvianDatabase, private val
         val exercises = exerciseRows.mapNotNull { row ->
             try {
                 // Try to get exercise from library, or create from stored data
-                val exercise = row.exerciseId?.let { exerciseId ->
-                    exerciseRepository.getExerciseById(exerciseId) ?: run {
-                        Logger.w { "Exercise not found in database: $exerciseId (${row.exerciseName}), using stored data" }
-                        Exercise(
-                            id = row.exerciseId,
-                            name = row.exerciseName,
-                            muscleGroup = row.exerciseMuscleGroup,
-                            muscleGroups = row.exerciseMuscleGroup,
-                            equipment = row.exerciseEquipment,
-                            isFavorite = false,
-                            isCustom = false,
-                        )
+                val resolvedExercise = row.exerciseId?.let { exerciseId ->
+                    exerciseRepository.getExerciseById(exerciseId)
+                        ?: exerciseRepository.findByName(row.exerciseName)
+                            ?.also { byName ->
+                                Logger.w {
+                                    "Routine exercise had stale exerciseId=$exerciseId; resolved by name '${row.exerciseName}' -> ${byName.id} and healing row ${row.id}"
+                                }
+                                queries.updateRoutineExerciseId(byName.id, row.id)
+                            }
+                } ?: exerciseRepository.findByName(row.exerciseName)
+                    ?.also { byName ->
+                        Logger.i {
+                            "Routine exercise missing exerciseId for '${row.exerciseName}'; resolved to ${byName.id} and healing row ${row.id}"
+                        }
+                        queries.updateRoutineExerciseId(byName.id, row.id)
                     }
-                } ?: run {
-                    Logger.d { "No exerciseId stored for routine exercise ${row.exerciseName}, using stored data" }
+
+                val exercise = resolvedExercise ?: run {
+                    if (row.exerciseId != null) {
+                        Logger.w { "Exercise not found in database: ${row.exerciseId} (${row.exerciseName}), using stored data fallback" }
+                    } else {
+                        Logger.d { "No exerciseId stored for routine exercise ${row.exerciseName}, using stored data fallback" }
+                    }
                     Exercise(
                         id = row.exerciseId,
                         name = row.exerciseName,

--- a/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
+++ b/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
@@ -836,6 +836,12 @@ UPDATE RoutineExercise
 SET supersetId = ?, orderInSuperset = ?
 WHERE id = ?;
 
+-- Heal legacy routine rows that are missing an exerciseId by resolving from exerciseName.
+updateRoutineExerciseId:
+UPDATE RoutineExercise
+SET exerciseId = ?
+WHERE id = ?;
+
 -- Analytics Queries
 selectVolumeHistory:
 SELECT timestamp, totalReps, weightPerCableKg FROM WorkoutSession WHERE profile_id = :profileId ORDER BY timestamp ASC;


### PR DESCRIPTION
### Motivation
- Legacy or migrated `RoutineExercise` rows can have `exerciseId` that is `NULL` or stale, causing routine navigation to load exercises without a valid ID and preventing PR tracking from firing. 
- Workout save / PR-check paths rely on a non-null `selectedExerciseId`, so missing IDs lead to silent no-ops in the PR pipeline. 
- Provide an opportunistic, backwards-compatible self-heal when loading routines so existing data is repaired and PR tracking works for subsequent workouts. 

### Description
- Added a new SQLDelight query `updateRoutineExerciseId` to `VitruvianDatabase.sq` that updates the `exerciseId` for a `RoutineExercise` row. 
- Modified `SqlDelightWorkoutRepository.loadRoutineWithExercises` to resolve missing or stale `exerciseId` by exact name lookup via `exerciseRepository.findByName(...)`, and persist the healed `exerciseId` back to the DB with `queries.updateRoutineExerciseId(...)`. 
- Preserved prior fallback behavior by continuing to use stored-data fallbacks when no deterministic name match exists, and log diagnostics when healing or falling back. 
- Added an android host test `getRoutineById heals missing exerciseId by resolving exercise name` in `SqlDelightWorkoutRepositoryTest` that verifies name-resolution, DB healing, and stable subsequent loads. 

### Testing
- Added a focused regression test in `shared/src/androidHostTest/kotlin/.../SqlDelightWorkoutRepositoryTest.kt` that simulates a legacy routine row with `exerciseId = null` and asserts the row is healed to the expected exercise ID (test code present). 
- Attempted to run host tests with `./gradlew :shared:androidHostTest ...` but the run failed due to missing Supabase credentials in local properties (environment check). 
- Re-ran with `-Pskip.supabase.check=true` and attempted `:shared:testAndroidHostTest`, but the build failed in this environment due to missing Android SDK configuration, so tests could not be executed end-to-end here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ceea81791c8322bed947d9fd33307d)