### PR TITLE
Improve error logging formatting for profileId validation

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightPersonalRecordRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightPersonalRecordRepository.kt
@@ -250,7 +250,8 @@ class SqlDelightPersonalRecordRepository(private val db: VitruvianDatabase) : Pe
     ): List<PRType> {
         // Issue #319: Defensive validation for profileId
         if (profileId.isBlank()) {
-            Logger.e { "PR_SAVE: CRITICAL - profileId is blank for exercise=$exerciseId, using 'default' as fallback. Stack trace: ${Throwable().stackTrace.take(5).joinToString()}" }
+            val stack = Throwable().getStackTrace().take(5).joinToString(separator = "\n")
+            Logger.e { "PR_SAVE: CRITICAL - profileId is blank for exercise=$exerciseId, using 'default' as fallback.\nStack trace:\n$stack" }
         }
         val effectiveProfileId = profileId.ifBlank { "default" }
 


### PR DESCRIPTION
## Summary
Refactored the error logging in the personal record repository to improve readability and maintainability of stack trace output when profileId validation fails.

## Key Changes
- Extracted stack trace generation into a separate variable for better code clarity
- Changed from `stackTrace.take(5).joinToString()` to `getStackTrace().take(5).joinToString(separator = "\n")` for improved formatting
- Updated log message to use multi-line string formatting with explicit newline separators, making the stack trace more readable in logs

## Implementation Details
- The stack trace is now separated by newlines (`\n`) instead of the default comma separator, improving log readability
- The change maintains the same defensive validation logic for blank profileId values (Issue #319)
- The fallback behavior using 'default' as profileId remains unchanged

https://claude.ai/code/session_01M8QkfRh1nVf5dZC4Dc8vDe