### PR TITLE
Fix workout session reset on Android activity recreation

### DIFF
--- a/androidApp/src/androidTest/kotlin/com/devil/phoenixproject/e2e/AppE2ETest.kt
+++ b/androidApp/src/androidTest/kotlin/com/devil/phoenixproject/e2e/AppE2ETest.kt
@@ -1,22 +1,22 @@
 package com.devil.phoenixproject.e2e
 
 import androidx.activity.ComponentActivity
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.hasClickAction
-import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.devil.phoenixproject.App
+import com.devil.phoenixproject.AndroidAppHost
 import com.devil.phoenixproject.data.preferences.PreferencesManager
 import com.devil.phoenixproject.data.repository.BiomechanicsRepository
 import com.devil.phoenixproject.data.repository.BleRepository
 import com.devil.phoenixproject.data.repository.CompletedSetRepository
 import com.devil.phoenixproject.data.repository.ExerciseRepository
 import com.devil.phoenixproject.data.repository.GamificationRepository
-import com.devil.phoenixproject.data.repository.PersonalRecordRepository
 import com.devil.phoenixproject.data.repository.RepMetricRepository
 import com.devil.phoenixproject.data.repository.SyncRepository
 import com.devil.phoenixproject.data.repository.TrainingCycleRepository
@@ -42,8 +42,11 @@ import com.devil.phoenixproject.database.ExerciseSignature
 import com.devil.phoenixproject.database.PhaseStatistics
 import com.devil.phoenixproject.di.appModule
 import com.devil.phoenixproject.di.platformModule
-import com.devil.phoenixproject.domain.model.Routine
+import com.devil.phoenixproject.domain.model.Exercise
+import com.devil.phoenixproject.domain.model.ProgramMode
+import com.devil.phoenixproject.domain.model.WorkoutParameters
 import com.devil.phoenixproject.domain.model.WorkoutSession
+import com.devil.phoenixproject.domain.model.WorkoutState
 import com.devil.phoenixproject.domain.usecase.RepCounterFromMachine
 import com.devil.phoenixproject.domain.usecase.ResolveRoutineWeightsUseCase
 import com.devil.phoenixproject.presentation.viewmodel.EulaViewModel
@@ -71,11 +74,15 @@ import com.devil.phoenixproject.util.DataBackupManager
 import com.russhwolf.settings.MapSettings
 import com.russhwolf.settings.Settings
 import org.junit.After
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.koin.android.ext.koin.androidContext
+import org.koin.compose.viewmodel.koinActivityViewModel
+import org.koin.core.context.GlobalContext
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 import org.koin.dsl.module
@@ -86,6 +93,8 @@ class AppE2ETest : KoinTest {
 
     @get:Rule
     val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    private var resolvedMainViewModel: MainViewModel? = null
 
     @Before
     fun setUp() {
@@ -112,7 +121,7 @@ class AppE2ETest : KoinTest {
 
         composeRule.onNodeWithText("Recent Activity").assertIsDisplayed()
         composeRule.onNodeWithText("Click to Connect").assertIsDisplayed()
-        composeRule.onNodeWithText("PROJECT PHOENIX").assertDoesNotExist()
+        composeRule.onAllNodesWithText("PROJECT PHOENIX").assertCountEquals(0)
     }
 
     @Test
@@ -120,27 +129,130 @@ class AppE2ETest : KoinTest {
         launchApp()
         advancePastSplash()
 
-        composeRule.onNode(hasText("Settings") and hasClickAction()).performClick()
+        composeRule.onNodeWithText("Settings").performClick()
         composeRule.mainClock.advanceTimeBy(500)
         composeRule.waitForIdle()
 
         composeRule.onNodeWithText("Like My Work?").assertIsDisplayed()
     }
 
+    @Test
+    fun activeWorkoutSurvivesActivityRecreationWithoutReplayingSplash() {
+        launchApp()
+        advancePastSplash()
+        startWorkoutAndWaitForActiveState()
+
+        composeRule.activityRule.scenario.recreate()
+        composeRule.mainClock.advanceTimeBy(500)
+        composeRule.waitForIdle()
+
+        val recreatedViewModel = waitForMainViewModel()
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            recreatedViewModel.workoutState.value == WorkoutState.Active
+        }
+        composeRule.mainClock.advanceTimeBy(500)
+        composeRule.waitForIdle()
+
+        composeRule.onAllNodesWithText("PROJECT PHOENIX").assertCountEquals(0)
+        composeRule.onAllNodesWithText("Recent Activity").assertCountEquals(0)
+        assertTrue(recreatedViewModel.workoutState.value == WorkoutState.Active)
+    }
+
+    @Test
+    fun androidScopedDependenciesRemainStableAcrossRecreation() {
+        launchApp()
+        advancePastSplash()
+
+        val initialBleRepository = requireFakeBleRepository()
+        val initialViewModel = waitForMainViewModel()
+
+        composeRule.activityRule.scenario.recreate()
+        composeRule.mainClock.advanceTimeBy(500)
+        composeRule.waitForIdle()
+
+        val recreatedViewModel = requireNotNull(resolvedMainViewModel)
+        val recreatedBleRepository = requireFakeBleRepository()
+
+        assertSame(initialBleRepository, recreatedBleRepository)
+        assertSame(initialViewModel, recreatedViewModel)
+    }
+
     private fun launchApp() {
+        resolvedMainViewModel = null
         composeRule.mainClock.autoAdvance = false
         composeRule.setContent {
-            App()
+            val activityMainViewModel: MainViewModel = koinActivityViewModel()
+            SideEffect {
+                resolvedMainViewModel = activityMainViewModel
+            }
+            AndroidAppHost(mainViewModel = activityMainViewModel)
         }
+        waitForMainViewModel()
     }
 
     private fun advancePastSplash() {
         composeRule.mainClock.advanceTimeBy(SPLASH_DURATION_MS)
         composeRule.waitForIdle()
+        composeRule.onNodeWithText("Recent Activity").assertIsDisplayed()
+        composeRule.onAllNodesWithText("PROJECT PHOENIX").assertCountEquals(0)
     }
 
+    private fun startWorkoutAndWaitForActiveState() {
+        val fakeExerciseRepository = requireFakeExerciseRepository()
+        val fakeBleRepository = requireFakeBleRepository()
+        val mainViewModel = waitForMainViewModel()
+        val exerciseId = "e2e-just-lift-exercise"
+
+        fakeExerciseRepository.addExercise(
+            Exercise(
+                id = exerciseId,
+                name = "E2E Pulldown",
+                muscleGroup = "Back",
+                equipment = "Handles",
+            ),
+        )
+        fakeBleRepository.simulateConnect("Vee_Test")
+
+        composeRule.runOnIdle {
+            mainViewModel.updateWorkoutParameters(
+                WorkoutParameters(
+                    programMode = ProgramMode.OldSchool,
+                    reps = 6,
+                    weightPerCableKg = 20f,
+                    isJustLift = true,
+                    useAutoStart = false,
+                    warmupReps = 0,
+                    selectedExerciseId = exerciseId,
+                ),
+            )
+            mainViewModel.startWorkout(skipCountdown = true, isJustLiftMode = true)
+        }
+
+        composeRule.mainClock.advanceTimeBy(500)
+        composeRule.waitForIdle()
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            mainViewModel.workoutState.value == WorkoutState.Active
+        }
+        composeRule.mainClock.advanceTimeBy(500)
+        composeRule.waitForIdle()
+        composeRule.onAllNodesWithText("Recent Activity").assertCountEquals(0)
+    }
+
+    private fun waitForMainViewModel(): MainViewModel {
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            resolvedMainViewModel != null
+        }
+        return requireNotNull(resolvedMainViewModel)
+    }
+
+    private fun requireFakeBleRepository(): FakeBleRepository =
+        GlobalContext.get().get<BleRepository>() as FakeBleRepository
+
+    private fun requireFakeExerciseRepository(): FakeExerciseRepository =
+        GlobalContext.get().get<ExerciseRepository>() as FakeExerciseRepository
+
     private companion object {
-        const val SPLASH_DURATION_MS = 3000L
+        const val SPLASH_DURATION_MS = 3_000L
     }
 }
 
@@ -150,7 +262,7 @@ private val testModule = module {
     single<BleRepository> { FakeBleRepository() }
     single<WorkoutRepository> { FakeWorkoutRepository() }
     single<ExerciseRepository> { FakeExerciseRepository() }
-    single<PersonalRecordRepository> { FakePersonalRecordRepository() }
+    single<com.devil.phoenixproject.data.repository.PersonalRecordRepository> { com.devil.phoenixproject.testutil.FakePersonalRecordRepository() }
     single<GamificationRepository> { FakeGamificationRepository() }
     single<TrainingCycleRepository> { FakeTrainingCycleRepository() }
     single<UserProfileRepository> { FakeUserProfileRepository() }
@@ -165,7 +277,13 @@ private val testModule = module {
             override suspend fun getBadgesModifiedSince(timestamp: Long, profileId: String): List<EarnedBadgeSyncDto> = emptyList()
             override suspend fun getGamificationStatsForSync(profileId: String): GamificationStatsSyncDto? = null
             override suspend fun getWorkoutSessionsModifiedSince(timestamp: Long, profileId: String): List<WorkoutSession> = emptyList()
-            override suspend fun getFullRoutinesModifiedSince(timestamp: Long, profileId: String): List<Routine> = emptyList()
+            override suspend fun getFullRoutinesModifiedSince(timestamp: Long, profileId: String): List<com.devil.phoenixproject.domain.model.Routine> = emptyList()
+            override suspend fun getFullCyclesForSync(profileId: String): List<PortalSyncAdapter.CycleWithContext> = emptyList()
+            override suspend fun getFullPRsModifiedSince(timestamp: Long, profileId: String): List<com.devil.phoenixproject.domain.model.PersonalRecord> = emptyList()
+            override suspend fun getPhaseStatisticsForSessions(sessionIds: List<String>): List<PhaseStatistics> = emptyList()
+            override suspend fun getAllExerciseSignatures(): List<ExerciseSignature> = emptyList()
+            override suspend fun getAllAssessments(profileId: String): List<AssessmentResult> = emptyList()
+            override suspend fun updateSessionTimestamp(sessionId: String, timestamp: Long) = Unit
             override suspend fun updateServerIds(mappings: IdMappings) = Unit
             override suspend fun mergeSessions(sessions: List<WorkoutSessionSyncDto>) = Unit
             override suspend fun mergePRs(records: List<PersonalRecordSyncDto>) = Unit
@@ -174,14 +292,9 @@ private val testModule = module {
             override suspend fun mergeBadges(badges: List<EarnedBadgeSyncDto>, profileId: String) = Unit
             override suspend fun mergeGamificationStats(stats: GamificationStatsSyncDto?, profileId: String) = Unit
             override suspend fun mergePortalRoutines(routines: List<PullRoutineDto>, lastSync: Long, profileId: String) = Unit
-            override suspend fun getFullCyclesForSync(profileId: String): List<PortalSyncAdapter.CycleWithContext> = emptyList()
-            override suspend fun getFullPRsModifiedSince(timestamp: Long, profileId: String): List<com.devil.phoenixproject.domain.model.PersonalRecord> = emptyList()
-            override suspend fun getPhaseStatisticsForSessions(sessionIds: List<String>): List<PhaseStatistics> = emptyList()
-            override suspend fun getAllExerciseSignatures(): List<ExerciseSignature> = emptyList()
-            override suspend fun getAllAssessments(profileId: String): List<AssessmentResult> = emptyList()
-            override suspend fun updateSessionTimestamp(sessionId: String, timestamp: Long) = Unit
             override suspend fun mergePortalCycles(cycles: List<PullTrainingCycleDto>, profileId: String) = Unit
             override suspend fun mergePortalSessions(sessions: List<WorkoutSession>) = Unit
+            override suspend fun mergePersonalRecords(records: List<PersonalRecordSyncDto>, profileId: String) = Unit
         }
     }
     single { ConnectivityChecker(ApplicationProvider.getApplicationContext()) }
@@ -205,35 +318,41 @@ private val testModule = module {
     single<DataBackupManager> { FakeDataBackupManager() }
     single<com.devil.phoenixproject.data.integration.ExternalActivityRepository> {
         object : com.devil.phoenixproject.data.integration.ExternalActivityRepository {
-            override fun getAll(profileId: String, provider: com.devil.phoenixproject.domain.model.IntegrationProvider?): kotlinx.coroutines.flow.Flow<List<com.devil.phoenixproject.domain.model.ExternalActivity>> = kotlinx.coroutines.flow.flowOf(emptyList())
+            override fun getAll(
+                profileId: String,
+                provider: com.devil.phoenixproject.domain.model.IntegrationProvider?,
+            ) = kotlinx.coroutines.flow.flowOf(emptyList<com.devil.phoenixproject.domain.model.ExternalActivity>())
+
             override suspend fun getUnsyncedActivities(profileId: String): List<com.devil.phoenixproject.domain.model.ExternalActivity> = emptyList()
             override suspend fun upsertActivities(activities: List<com.devil.phoenixproject.domain.model.ExternalActivity>) = Unit
             override suspend fun markSynced(ids: List<String>) = Unit
-            override suspend fun markSyncedBySyncKeys(syncKeys: List<com.devil.phoenixproject.data.integration.ExternalActivitySyncKey>, profileId: String) = Unit
-            override suspend fun deleteActivities(provider: com.devil.phoenixproject.domain.model.IntegrationProvider, profileId: String) = Unit
-            override fun getIntegrationStatus(provider: com.devil.phoenixproject.domain.model.IntegrationProvider, profileId: String): kotlinx.coroutines.flow.Flow<com.devil.phoenixproject.domain.model.IntegrationStatus?> = kotlinx.coroutines.flow.flowOf(null)
-            override fun getAllIntegrationStatuses(profileId: String): kotlinx.coroutines.flow.Flow<List<com.devil.phoenixproject.domain.model.IntegrationStatus>> = kotlinx.coroutines.flow.flowOf(emptyList())
-            override suspend fun updateIntegrationStatus(provider: com.devil.phoenixproject.domain.model.IntegrationProvider, status: com.devil.phoenixproject.domain.model.ConnectionStatus, profileId: String, lastSyncAt: Long?, errorMessage: String?) = Unit
+            override suspend fun markSyncedBySyncKeys(
+                syncKeys: List<com.devil.phoenixproject.data.integration.ExternalActivitySyncKey>,
+                profileId: String,
+            ) = Unit
+
+            override suspend fun deleteActivities(
+                provider: com.devil.phoenixproject.domain.model.IntegrationProvider,
+                profileId: String,
+            ) = Unit
+
+            override fun getIntegrationStatus(
+                provider: com.devil.phoenixproject.domain.model.IntegrationProvider,
+                profileId: String,
+            ) = kotlinx.coroutines.flow.flowOf<com.devil.phoenixproject.domain.model.IntegrationStatus?>(null)
+
+            override fun getAllIntegrationStatuses(
+                profileId: String,
+            ) = kotlinx.coroutines.flow.flowOf(emptyList<com.devil.phoenixproject.domain.model.IntegrationStatus>())
+
+            override suspend fun updateIntegrationStatus(
+                provider: com.devil.phoenixproject.domain.model.IntegrationProvider,
+                status: com.devil.phoenixproject.domain.model.ConnectionStatus,
+                profileId: String,
+                lastSyncAt: Long?,
+                errorMessage: String?,
+            ) = Unit
         }
-    }
-    factory {
-        MainViewModel(
-            bleRepository = get(),
-            workoutRepository = get(),
-            exerciseRepository = get(),
-            personalRecordRepository = get(),
-            repCounter = get(),
-            preferencesManager = get(),
-            gamificationRepository = get(),
-            trainingCycleRepository = get(),
-            completedSetRepository = get(),
-            repMetricRepository = get(),
-            biomechanicsRepository = get(),
-            resolveWeightsUseCase = get(),
-            detectionManager = get(),
-            dataBackupManager = get(),
-            userProfileRepository = get(),
-        )
     }
     single { ThemeViewModel(get()) }
     single { EulaViewModel(get()) }

--- a/androidApp/src/main/kotlin/com/devil/phoenixproject/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/devil/phoenixproject/MainActivity.kt
@@ -25,7 +25,7 @@ class MainActivity : ComponentActivity() {
             // Require BLE permissions before showing the app
             // Permission screens have their own theme, App provides its own theme
             RequireBlePermissions {
-                App()
+                AndroidAppHost()
             }
         }
     }

--- a/shared/src/androidMain/kotlin/com/devil/phoenixproject/AndroidAppHost.kt
+++ b/shared/src/androidMain/kotlin/com/devil/phoenixproject/AndroidAppHost.kt
@@ -1,0 +1,27 @@
+package com.devil.phoenixproject
+
+import androidx.compose.runtime.Composable
+import com.devil.phoenixproject.data.repository.ExerciseRepository
+import com.devil.phoenixproject.data.sync.SyncTriggerManager
+import com.devil.phoenixproject.presentation.viewmodel.EulaViewModel
+import com.devil.phoenixproject.presentation.viewmodel.MainViewModel
+import com.devil.phoenixproject.presentation.viewmodel.ThemeViewModel
+import org.koin.compose.koinInject
+import org.koin.compose.viewmodel.koinActivityViewModel
+
+@Composable
+fun AndroidAppHost(
+    mainViewModel: MainViewModel = koinActivityViewModel(),
+    themeViewModel: ThemeViewModel = koinInject(),
+    eulaViewModel: EulaViewModel = koinInject(),
+    exerciseRepository: ExerciseRepository = koinInject(),
+    syncTriggerManager: SyncTriggerManager = koinInject(),
+) {
+    AppContent(
+        mainViewModel = mainViewModel,
+        themeViewModel = themeViewModel,
+        eulaViewModel = eulaViewModel,
+        exerciseRepository = exerciseRepository,
+        syncTriggerManager = syncTriggerManager,
+    )
+}

--- a/shared/src/androidMain/kotlin/com/devil/phoenixproject/di/PlatformModule.android.kt
+++ b/shared/src/androidMain/kotlin/com/devil/phoenixproject/di/PlatformModule.android.kt
@@ -9,6 +9,7 @@ import com.devil.phoenixproject.data.integration.HealthIntegration
 import com.devil.phoenixproject.data.local.DriverFactory
 import com.devil.phoenixproject.data.repository.BleRepository
 import com.devil.phoenixproject.data.repository.KableBleRepository
+import com.devil.phoenixproject.presentation.viewmodel.MainViewModel
 import com.devil.phoenixproject.domain.voice.AndroidSafeWordListenerFactory
 import com.devil.phoenixproject.domain.voice.SafeWordListenerFactory
 import com.devil.phoenixproject.util.AndroidCsvExporter
@@ -22,6 +23,7 @@ import com.russhwolf.settings.Settings
 import com.russhwolf.settings.SharedPreferencesSettings
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.module.Module
+import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
 
 private const val ENCRYPTED_PREFS_FILE = "vitruvian_secure_preferences"
@@ -52,13 +54,35 @@ actual val platformModule: Module = module {
         SharedPreferencesSettings(encryptedPrefs)
     }
 
-    factory<BleRepository> { KableBleRepository() }
+    single<BleRepository> { KableBleRepository() }
     single<CsvExporter> { AndroidCsvExporter(androidContext()) }
     single<CsvImporter> { AndroidCsvImporter(androidContext(), get()) }
     single<DataBackupManager> { AndroidDataBackupManager(androidContext(), get()) }
     single { ConnectivityChecker(androidContext()) }
     single<SafeWordListenerFactory> { AndroidSafeWordListenerFactory(androidContext()) }
     single { HealthIntegration(androidContext()) }
+    viewModel {
+        MainViewModel(
+            bleRepository = get(),
+            workoutRepository = get(),
+            exerciseRepository = get(),
+            personalRecordRepository = get(),
+            repCounter = get(),
+            preferencesManager = get(),
+            gamificationRepository = get(),
+            trainingCycleRepository = get(),
+            completedSetRepository = get(),
+            syncTriggerManager = get(),
+            repMetricRepository = get(),
+            biomechanicsRepository = get(),
+            resolveWeightsUseCase = get(),
+            detectionManager = get(),
+            dataBackupManager = get(),
+            userProfileRepository = get(),
+            healthIntegration = get(),
+            externalActivityRepository = get(),
+        )
+    }
 }
 
 /**

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/App.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/App.kt
@@ -10,7 +10,15 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -29,19 +37,18 @@ import com.devil.phoenixproject.presentation.viewmodel.EulaViewModel
 import com.devil.phoenixproject.presentation.viewmodel.MainViewModel
 import com.devil.phoenixproject.presentation.viewmodel.ThemeViewModel
 import com.devil.phoenixproject.ui.theme.VitruvianTheme
+import com.devil.phoenixproject.util.KmpUtils
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import org.koin.mp.KoinPlatform
 
-/**
- * Observes app lifecycle and triggers sync on foreground.
- */
+private const val LAUNCH_SPLASH_DURATION_MS = 2500L
+
 @Composable
 private fun AppLifecycleObserver(syncTriggerManager: SyncTriggerManager) {
     val lifecycleOwner = LocalLifecycleOwner.current
     val scope = rememberCoroutineScope()
 
-    DisposableEffect(lifecycleOwner) {
+    DisposableEffect(lifecycleOwner, syncTriggerManager) {
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_RESUME) {
                 scope.launch {
@@ -49,6 +56,7 @@ private fun AppLifecycleObserver(syncTriggerManager: SyncTriggerManager) {
                 }
             }
         }
+
         lifecycleOwner.lifecycle.addObserver(observer)
         onDispose {
             lifecycleOwner.lifecycle.removeObserver(observer)
@@ -56,14 +64,13 @@ private fun AppLifecycleObserver(syncTriggerManager: SyncTriggerManager) {
     }
 }
 
-/**
- * Crash-safe error screen shown when DI resolution fails.
- * Displays the exception details so the user can report them via TestFlight feedback.
- */
 @Composable
-private fun CrashErrorScreen(error: String) {
+internal fun CrashErrorScreen(error: String) {
     Box(
-        modifier = Modifier.fillMaxSize().background(Color(0xFF1A1A2E)).padding(24.dp),
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color(0xFF1A1A2E))
+            .padding(24.dp),
         contentAlignment = Alignment.Center,
     ) {
         Column(
@@ -92,102 +99,63 @@ private fun CrashErrorScreen(error: String) {
 }
 
 @Composable
-fun App() {
-    co.touchlab.kermit.Logger.i { "iOS App: App() composable starting..." }
+fun AppContent(
+    mainViewModel: MainViewModel,
+    themeViewModel: ThemeViewModel,
+    eulaViewModel: EulaViewModel,
+    exerciseRepository: ExerciseRepository,
+    syncTriggerManager: SyncTriggerManager,
+) {
+    val themeMode by themeViewModel.themeMode.collectAsState()
+    val eulaAccepted by eulaViewModel.eulaAccepted.collectAsState()
 
-    // Resolve dependencies via direct Koin access inside remember{} to enable try-catch.
-    // koinViewModel() is @Composable and Compose forbids try-catch around @Composable calls.
-    // Direct koin.get<T>() is a regular function. We cache in remember{} for lifecycle.
-    // On iOS/Kotlin Native, unhandled exceptions during Compose recomposition propagate
-    // through StandaloneCoroutine → propagateExceptionFinalResort → abort().
-    // This catch-and-display approach turns SIGABRT into a visible diagnostic screen.
-    val koin = KoinPlatform.getKoin()
-    val depsResult = remember {
-        runCatching {
-            co.touchlab.kermit.Logger.i { "iOS App: Resolving dependencies via Koin..." }
-            val vm = koin.get<MainViewModel>()
-            co.touchlab.kermit.Logger.i { "iOS App: MainViewModel resolved" }
-            val themeVm = koin.get<ThemeViewModel>()
-            val eulaVm = koin.get<EulaViewModel>()
-            val exRepo = koin.get<ExerciseRepository>()
-            val syncMgr = koin.get<SyncTriggerManager>()
-            co.touchlab.kermit.Logger.i { "iOS App: All dependencies resolved" }
-            listOf<Any>(vm, themeVm, eulaVm, exRepo, syncMgr)
-        }
-    }
+    var launchSplashCompleted by rememberSaveable { mutableStateOf(false) }
+    var launchSplashStartedAtMillis by rememberSaveable { mutableStateOf<Long?>(null) }
 
-    if (depsResult.isFailure) {
-        val e = depsResult.exceptionOrNull()!!
-        // Traverse full cause chain for complete diagnostics
-        val causes = buildString {
-            var current: Throwable? = e
-            var depth = 0
-            while (current != null && depth < 10) {
-                if (depth > 0) append("\n")
-                append("[$depth] ${current::class.simpleName}: ${current.message?.take(200)}")
-                current = current.cause
-                depth++
-            }
-        }
-        co.touchlab.kermit.Logger.e(e) { "FATAL DI resolution:\n$causes" }
-        CrashErrorScreen(causes)
-        return
-    }
-
-    val deps = depsResult.getOrThrow()
-    val vm = deps[0] as MainViewModel
-    val themeVm = deps[1] as ThemeViewModel
-    val eulaVm = deps[2] as EulaViewModel
-    val exRepo = deps[3] as ExerciseRepository
-    val syncMgr = deps[4] as SyncTriggerManager
-
-    // Locale is applied BEFORE composition in platform-specific startup code:
-    // - Android: MainActivity.applyStoredLocaleBeforeComposition() in onCreate()
-    // - iOS: Applied via NSUserDefaults AppleLanguages before Compose entry point
-    // This prevents the first-frame English flicker on non-EN locales.
-
-    // Theme state - persisted via ThemeViewModel
-    val themeMode by themeVm.themeMode.collectAsState()
-
-    // EULA acceptance state
-    val eulaAccepted by eulaVm.eulaAccepted.collectAsState()
-
-    // Splash screen state - only show splash if EULA is already accepted
-    var showSplash by remember { mutableStateOf(eulaAccepted) }
-
-    // Hide splash after animation completes (2500ms for full effect)
-    // Only run if EULA is accepted
     LaunchedEffect(eulaAccepted) {
-        if (eulaAccepted) {
-            showSplash = true
-            delay(2500)
-            showSplash = false
+        if (!eulaAccepted) {
+            launchSplashCompleted = false
+            launchSplashStartedAtMillis = null
+            return@LaunchedEffect
         }
+
+        if (launchSplashCompleted) return@LaunchedEffect
+
+        val startedAt = launchSplashStartedAtMillis ?: KmpUtils.currentTimeMillis().also {
+            launchSplashStartedAtMillis = it
+        }
+        val elapsed = (KmpUtils.currentTimeMillis() - startedAt).coerceAtLeast(0L)
+        val remaining = (LAUNCH_SPLASH_DURATION_MS - elapsed).coerceAtLeast(0L)
+
+        if (remaining > 0L) {
+            delay(remaining)
+        }
+
+        launchSplashCompleted = true
+        launchSplashStartedAtMillis = null
     }
 
-    // Lifecycle observer for foreground sync
-    AppLifecycleObserver(syncMgr)
+    val showLaunchSplash = eulaAccepted && !launchSplashCompleted
+
+    AppLifecycleObserver(syncTriggerManager)
 
     VitruvianTheme(themeMode = themeMode) {
         Box(modifier = Modifier.fillMaxSize()) {
-            // EULA acceptance screen - shown first if not accepted
             if (!eulaAccepted) {
                 EulaScreen(
-                    onAccept = { eulaVm.acceptEula() },
+                    onAccept = { eulaViewModel.acceptEula() },
                 )
             } else {
-                // Main content (only rendered after EULA accepted)
-                if (!showSplash) {
+                if (!showLaunchSplash) {
                     EnhancedMainScreen(
-                        viewModel = vm,
-                        exerciseRepository = exRepo,
+                        viewModel = mainViewModel,
+                        exerciseRepository = exerciseRepository,
                         themeMode = themeMode,
-                        onThemeModeChange = { themeVm.setThemeMode(it) },
+                        onThemeModeChange = themeViewModel::setThemeMode,
                     )
                 }
 
-                // Splash screen overlay with fade animation
-                SplashScreen(visible = showSplash)
+                SplashScreen(visible = showLaunchSplash)
             }
         }
     }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/di/PresentationModule.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/di/PresentationModule.kt
@@ -7,7 +7,6 @@ import com.devil.phoenixproject.presentation.viewmodel.CycleEditorViewModel
 import com.devil.phoenixproject.presentation.viewmodel.EulaViewModel
 import com.devil.phoenixproject.presentation.viewmodel.GamificationViewModel
 import com.devil.phoenixproject.presentation.viewmodel.IntegrationsViewModel
-import com.devil.phoenixproject.presentation.viewmodel.MainViewModel
 import com.devil.phoenixproject.presentation.viewmodel.ThemeViewModel
 import com.devil.phoenixproject.ui.sync.LinkAccountViewModel
 import org.koin.dsl.module
@@ -17,7 +16,6 @@ val presentationModule = module {
     factory { ExerciseDetectionManager(get(), get(), get(), get()) }
 
     // ViewModels
-    factory { MainViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
     factory { ConnectionLogsViewModel() }
     factory { CycleEditorViewModel(get()) }
     factory { GamificationViewModel(get(), get()) }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/EnhancedMainScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/EnhancedMainScreen.kt
@@ -35,6 +35,7 @@ import com.devil.phoenixproject.data.repository.UserProfileRepository
 import com.devil.phoenixproject.data.sync.SyncManager
 import com.devil.phoenixproject.data.sync.SyncState
 import com.devil.phoenixproject.domain.model.ConnectionState
+import com.devil.phoenixproject.domain.model.WorkoutState
 import com.devil.phoenixproject.presentation.components.AddProfileDialog
 import com.devil.phoenixproject.presentation.components.ConnectionLostDialog
 import com.devil.phoenixproject.presentation.components.HapticFeedbackEffect
@@ -71,6 +72,7 @@ fun EnhancedMainScreen(
     val topBarTitle by viewModel.topBarTitle.collectAsState()
     val topBarActions by viewModel.topBarActions.collectAsState()
     val topBarBackAction by viewModel.topBarBackAction.collectAsState()
+    val workoutState by viewModel.workoutState.collectAsState()
 
     // Dynamic title sources
     val loadedRoutine by viewModel.loadedRoutine.collectAsState()
@@ -110,12 +112,23 @@ fun EnhancedMainScreen(
         ThemeMode.DARK -> true
     }
 
-    var currentRoute by remember { mutableStateOf(NavigationRoutes.Home.route) }
+    var currentRoute by remember(navController) {
+        mutableStateOf(navController.currentBackStackEntry?.destination?.route ?: NavigationRoutes.Home.route)
+    }
 
     // Track navigation changes
     LaunchedEffect(navController) {
         navController.currentBackStackEntryFlow.collect { backStackEntry ->
             currentRoute = backStackEntry.destination.route ?: NavigationRoutes.Home.route
+        }
+    }
+
+    LaunchedEffect(currentRoute, workoutState, navController) {
+        if (!shouldResumeActiveWorkout(workoutState)) return@LaunchedEffect
+        if (currentRoute == NavigationRoutes.ActiveWorkout.route) return@LaunchedEffect
+
+        navController.navigate(NavigationRoutes.ActiveWorkout.route) {
+            launchSingleTop = true
         }
     }
 
@@ -477,6 +490,17 @@ fun EnhancedMainScreen(
             }
         } // CompositionLocalProvider
     } // BoxWithConstraints
+}
+
+private fun shouldResumeActiveWorkout(workoutState: WorkoutState): Boolean = when (workoutState) {
+    WorkoutState.Initializing,
+    is WorkoutState.Countdown,
+    WorkoutState.Active,
+    is WorkoutState.Resting,
+    is WorkoutState.SetSummary,
+    -> true
+
+    else -> false
 }
 
 /**

--- a/shared/src/iosMain/kotlin/com/devil/phoenixproject/IosAppHost.kt
+++ b/shared/src/iosMain/kotlin/com/devil/phoenixproject/IosAppHost.kt
@@ -1,0 +1,67 @@
+package com.devil.phoenixproject
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import co.touchlab.kermit.Logger
+import com.devil.phoenixproject.data.repository.ExerciseRepository
+import com.devil.phoenixproject.data.sync.SyncTriggerManager
+import com.devil.phoenixproject.presentation.viewmodel.EulaViewModel
+import com.devil.phoenixproject.presentation.viewmodel.MainViewModel
+import com.devil.phoenixproject.presentation.viewmodel.ThemeViewModel
+import org.koin.mp.KoinPlatform
+
+@Composable
+fun IosAppHost() {
+    Logger.i { "iOS App: IosAppHost() composable starting..." }
+
+    val koin = KoinPlatform.getKoin()
+    val depsResult = remember {
+        runCatching {
+            Logger.i { "iOS App: Resolving app host dependencies via Koin..." }
+            ResolvedIosDependencies(
+                mainViewModel = koin.get(),
+                themeViewModel = koin.get(),
+                eulaViewModel = koin.get(),
+                exerciseRepository = koin.get(),
+                syncTriggerManager = koin.get(),
+            )
+        }
+    }
+
+    if (depsResult.isFailure) {
+        val failure = requireNotNull(depsResult.exceptionOrNull())
+        val error = formatCauseChain(failure)
+        Logger.e(failure) { "FATAL DI resolution:\n$error" }
+        CrashErrorScreen(error)
+        return
+    }
+
+    val deps = depsResult.getOrThrow()
+    AppContent(
+        mainViewModel = deps.mainViewModel,
+        themeViewModel = deps.themeViewModel,
+        eulaViewModel = deps.eulaViewModel,
+        exerciseRepository = deps.exerciseRepository,
+        syncTriggerManager = deps.syncTriggerManager,
+    )
+}
+
+private data class ResolvedIosDependencies(
+    val mainViewModel: MainViewModel,
+    val themeViewModel: ThemeViewModel,
+    val eulaViewModel: EulaViewModel,
+    val exerciseRepository: ExerciseRepository,
+    val syncTriggerManager: SyncTriggerManager,
+)
+
+private fun formatCauseChain(error: Throwable): String = buildString {
+    var current: Throwable? = error
+    var depth = 0
+
+    while (current != null && depth < 10) {
+        if (depth > 0) append('\n')
+        append("[$depth] ${current::class.simpleName}: ${current.message?.take(200)}")
+        current = current.cause
+        depth++
+    }
+}

--- a/shared/src/iosMain/kotlin/com/devil/phoenixproject/MainViewController.kt
+++ b/shared/src/iosMain/kotlin/com/devil/phoenixproject/MainViewController.kt
@@ -20,10 +20,10 @@ fun MainViewController() = run {
         NSLog("iOS UI: ComposeUIViewController content block executing...")
         NSLog("iOS UI: Setting up image loader...")
         ensureImageLoader()
-        NSLog("iOS UI: Image loader ready, loading App()...")
+        NSLog("iOS UI: Image loader ready, loading IosAppHost()...")
         RequireBlePermissions {
-            NSLog("iOS UI: BLE permissions checked, rendering App()...")
-            App()
+            NSLog("iOS UI: BLE permissions checked, rendering IosAppHost()...")
+            IosAppHost()
         }
     }
 }

--- a/shared/src/iosMain/kotlin/com/devil/phoenixproject/di/PlatformModule.ios.kt
+++ b/shared/src/iosMain/kotlin/com/devil/phoenixproject/di/PlatformModule.ios.kt
@@ -7,6 +7,7 @@ import com.devil.phoenixproject.data.repository.KableBleRepository
 import com.devil.phoenixproject.data.sync.SupabaseConfig
 import com.devil.phoenixproject.domain.voice.IosSafeWordListenerFactory
 import com.devil.phoenixproject.domain.voice.SafeWordListenerFactory
+import com.devil.phoenixproject.presentation.viewmodel.MainViewModel
 import com.devil.phoenixproject.util.ConnectivityChecker
 import com.devil.phoenixproject.util.CsvExporter
 import com.devil.phoenixproject.util.CsvImporter
@@ -37,11 +38,33 @@ actual val platformModule: Module = module {
     // iOS apps are sandboxed; use the same Settings for secure storage.
     // Keychain-backed storage is a future enhancement.
     single<Settings>(SecureSettingsQualifier) { get() }
-    factory<BleRepository> { KableBleRepository() }
+    single<BleRepository> { KableBleRepository() }
     single<CsvExporter> { IosCsvExporter() }
     single<CsvImporter> { IosCsvImporter(get()) }
     single<DataBackupManager> { IosDataBackupManager(get()) }
     single { ConnectivityChecker() }
     single<SafeWordListenerFactory> { IosSafeWordListenerFactory() }
     single { HealthIntegration() }
+    single {
+        MainViewModel(
+            bleRepository = get(),
+            workoutRepository = get(),
+            exerciseRepository = get(),
+            personalRecordRepository = get(),
+            repCounter = get(),
+            preferencesManager = get(),
+            gamificationRepository = get(),
+            trainingCycleRepository = get(),
+            completedSetRepository = get(),
+            syncTriggerManager = get(),
+            repMetricRepository = get(),
+            biomechanicsRepository = get(),
+            resolveWeightsUseCase = get(),
+            detectionManager = get(),
+            dataBackupManager = get(),
+            userProfileRepository = get(),
+            healthIntegration = get(),
+            externalActivityRepository = get(),
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- move `MainViewModel` ownership out of the shared root and into platform-specific hosts
- retain Android workout and BLE session state across rotation and other same-process activity recreation
- prevent the launch splash from replaying after recreation and restore navigation to the active workout screen when a session is in progress
- keep iOS startup on a stable app-scoped path with the existing crash-safe DI handling

## Testing
- `:androidApp:compileDebugKotlin`
- `:androidApp:compileDebugAndroidTestKotlin`
- `:shared:testAndroidHostTest --tests com.devil.phoenixproject.di.KoinModuleVerifyTest --tests com.devil.phoenixproject.presentation.viewmodel.MainViewModelTest --tests com.devil.phoenixproject.e2e.WorkoutFlowE2ETest`
- `:androidApp:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.devil.phoenixproject.e2e.AppE2ETest`