### PR TITLE
fix: refine sync timing, harden auth navigation, and disable unimplem…

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,13 +2,13 @@
 gsd_state_version: 1.0
 milestone: v0.8.0
 milestone_name: Beta Readiness
-status: in_progress
-last_updated: "2026-03-23T02:00:00.000Z"
+status: complete
+last_updated: "2026-03-24T00:00:00.000Z"
 progress:
   total_phases: 5
-  completed_phases: 0
+  completed_phases: 5
   total_plans: 15
-  completed_plans: 0
+  completed_plans: 15
 ---
 
 # GSD State: Project Phoenix MP

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/SyncManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/SyncManager.kt
@@ -153,12 +153,12 @@ class SyncManager(
             currentTimeMillis()
         }
 
-        // Pull remote changes using the STORED lastSync (before push), not the push
-        // response time. Using the push response time would ask "what changed since NOW"
-        // which always returns 0 results. The stored lastSync tells the server "give me
-        // everything that changed since my last successful sync."
-        val storedLastSync = tokenStorage.getLastSyncTimestamp()
-        val pullSyncTime = pullRemoteChanges(lastSync = storedLastSync)
+        // Pull remote changes using the PRE-PUSH lastSync, not the current stored value.
+        // The batched push path (line ~428) advances tokenStorage.lastSyncTimestamp after
+        // each batch, so re-reading it here would skip remote changes that arrived between
+        // the original sync checkpoint and the last batch's server timestamp.
+        // Fix for Codex P1: use prePushLastSync captured at line ~97 before any push.
+        val pullSyncTime = pullRemoteChanges(lastSync = prePushLastSync)
         val finalSyncTime = pullSyncTime ?: syncTimeEpoch
 
         tokenStorage.setLastSyncTimestamp(finalSyncTime)
@@ -291,7 +291,7 @@ class SyncManager(
             .groupBy { it.sessionId }
         val signatureDtos = syncRepository.getAllExerciseSignatures()
             .map { PortalSyncAdapter.toPortalExerciseSignature(it) }
-        val assessmentDtos = syncRepository.getAllAssessments()
+        val assessmentDtos = syncRepository.getAllAssessments(activeProfileId)
             .map { PortalSyncAdapter.toPortalAssessmentResult(it) }
 
         // 7. Build portal session + telemetry DTOs (telemetry setIds match generated exercise set IDs)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/AuthScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/AuthScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -60,8 +61,13 @@ import com.devil.phoenixproject.data.repository.AuthRepository
 import com.devil.phoenixproject.data.repository.AuthState
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
-import vitruvianprojectphoenix.shared.generated.resources.*
 import vitruvianprojectphoenix.shared.generated.resources.Res
+import vitruvianprojectphoenix.shared.generated.resources.auth_apple
+import vitruvianprojectphoenix.shared.generated.resources.auth_google
+import vitruvianprojectphoenix.shared.generated.resources.cd_back
+import vitruvianprojectphoenix.shared.generated.resources.label_confirm_password
+import vitruvianprojectphoenix.shared.generated.resources.label_email
+import vitruvianprojectphoenix.shared.generated.resources.label_password
 
 enum class AuthMode {
     SIGN_IN,
@@ -83,11 +89,14 @@ fun AuthScreen(authRepository: AuthRepository, onAuthSuccess: () -> Unit, onBack
     var isLoading by remember { mutableStateOf(false) }
     var errorMessage by remember { mutableStateOf<String?>(null) }
 
-    // Check if already authenticated
-    if (authState is AuthState.Authenticated) {
-        onAuthSuccess()
-        return
+    // Navigate away when already authenticated — wrapped in LaunchedEffect to avoid
+    // calling the navigation side-effect during composition (causes duplicate nav on recomposition).
+    LaunchedEffect(authState) {
+        if (authState is AuthState.Authenticated) {
+            onAuthSuccess()
+        }
     }
+    if (authState is AuthState.Authenticated) return
 
     Scaffold(
         topBar = {
@@ -282,7 +291,8 @@ fun AuthScreen(authRepository: AuthRepository, onAuthSuccess: () -> Unit, onBack
 
             Spacer(modifier = Modifier.height(24.dp))
 
-            // Social login options (placeholders)
+            // Social login options — disabled until platform implementations exist.
+            // signInWithGoogle()/signInWithApple() currently return NotImplementedError.
             Text(
                 text = "Or continue with",
                 style = MaterialTheme.typography.bodySmall,
@@ -293,17 +303,8 @@ fun AuthScreen(authRepository: AuthRepository, onAuthSuccess: () -> Unit, onBack
                 horizontalArrangement = Arrangement.spacedBy(16.dp),
             ) {
                 OutlinedButton(
-                    onClick = {
-                        scope.launch {
-                            isLoading = true
-                            authRepository.signInWithGoogle().fold(
-                                onSuccess = { onAuthSuccess() },
-                                onFailure = { e -> errorMessage = e.message ?: "Google sign-in failed" },
-                            )
-                            isLoading = false
-                        }
-                    },
-                    enabled = !isLoading,
+                    onClick = { /* TODO: Wire platform Google sign-in */ },
+                    enabled = false,
                 ) {
                     GoogleIcon(modifier = Modifier.size(18.dp))
                     Spacer(modifier = Modifier.width(8.dp))
@@ -311,17 +312,8 @@ fun AuthScreen(authRepository: AuthRepository, onAuthSuccess: () -> Unit, onBack
                 }
 
                 OutlinedButton(
-                    onClick = {
-                        scope.launch {
-                            isLoading = true
-                            authRepository.signInWithApple().fold(
-                                onSuccess = { onAuthSuccess() },
-                                onFailure = { e -> errorMessage = e.message ?: "Apple sign-in failed" },
-                            )
-                            isLoading = false
-                        }
-                    },
-                    enabled = !isLoading,
+                    onClick = { /* TODO: Wire platform Apple sign-in */ },
+                    enabled = false,
                 ) {
                     AppleIcon(modifier = Modifier.size(18.dp))
                     Spacer(modifier = Modifier.width(8.dp))

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/util/BlePacketFactoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/util/BlePacketFactoryTest.kt
@@ -1262,7 +1262,7 @@ class BlePacketFactoryTest {
     }
 
     @Test
-    fun `TUTBeast uses default RepConfig (not Eccentric override)`() {
+    fun `TUTBeast uses default RepConfig not Eccentric override`() {
         val packet = BlePacketFactory.createProgramParams(
             WorkoutParameters(ProgramMode.TUTBeast, reps = 6, weightPerCableKg = 70f),
         )


### PR DESCRIPTION
…ented social login

- **Sync**: Fix race condition in `SyncManager` by using `prePushLastSync` for pulling remote changes. This ensures data arriving between a batched push and a pull is not skipped when the local sync timestamp advances.
- **Sync**: Scope `getAllAssessments` query to the `activeProfileId` to prevent cross-profile data leaks during sync.
- **Auth**: Wrap `onAuthSuccess` navigation in a `LaunchedEffect` to prevent illegal side-effects and duplicate navigation events during composition.
- **Auth**: Disable Google and Apple sign-in buttons and remove non-functional repository calls until platform-specific implementations are ready.
- **Tests**: Remove parentheses from `BlePacketFactoryTest` name to improve compatibility/readability.
- **Project**: Mark milestone `v0.8.0` (Beta Readiness) as complete in `STATE.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected synchronization timing to pull remote changes with accurate timestamp reference
  * Enhanced authentication success handling with improved side-effect management
  * Updated assessment data retrieval to be profile-specific

* **Changes**
  * Google and Apple sign-in options are currently unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->