### PR TITLE
feat: implement warm-up sets management in ExerciseConfigViewModel

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseEditBottomSheet.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseEditBottomSheet.kt
@@ -96,6 +96,9 @@ fun ExerciseEditBottomSheet(
     val repCountTiming by viewModel.repCountTiming.collectAsState()
     val stopAtTop by viewModel.stopAtTop.collectAsState()
 
+    // Warm-up sets state (Issue #30)
+    val warmupSets by viewModel.warmupSets.collectAsState()
+
     // PR weight from ViewModel - automatically updates when mode changes
     val currentExercisePR by viewModel.currentExercisePR.collectAsState()
 
@@ -493,6 +496,22 @@ fun ExerciseEditBottomSheet(
                             )
                         }
                     }
+                }
+
+                // Warm-up Sets Configuration (Issue #30)
+                // Only show for standard exercises (not bodyweight)
+                if (exerciseType == ExerciseType.STANDARD) {
+                    WarmupSetsConfiguration(
+                        warmupSets = warmupSets,
+                        workingWeight = sets.firstOrNull()?.weightPerCable ?: 0f,
+                        weightSuffix = weightSuffix,
+                        onAddWarmupSet = viewModel::addWarmupSet,
+                        onRemoveWarmupSet = viewModel::removeWarmupSet,
+                        onUpdateReps = viewModel::updateWarmupSetReps,
+                        onUpdatePercent = viewModel::updateWarmupSetPercent,
+                        onApplyPreset = viewModel::applyClassicWarmupPreset,
+                        onClearAll = viewModel::clearWarmupSets,
+                    )
                 }
 
                 // Sets Configuration
@@ -1248,6 +1267,294 @@ fun WeightConfigurationCard(
                         )
                     }
                 }
+            }
+        }
+    }
+}
+
+/**
+ * Warm-up Sets Configuration Card (Issue #30)
+ * Allows users to configure variable warm-up sets before working sets.
+ * Each warm-up set has a number of reps and a percentage of the working weight.
+ */
+@Composable
+fun WarmupSetsConfiguration(
+    warmupSets: List<WarmupSet>,
+    workingWeight: Float,
+    weightSuffix: String,
+    onAddWarmupSet: () -> Unit,
+    onRemoveWarmupSet: (Int) -> Unit,
+    onUpdateReps: (Int, Int) -> Unit,
+    onUpdatePercent: (Int, Int) -> Unit,
+    onApplyPreset: () -> Unit,
+    onClearAll: () -> Unit,
+) {
+    var expanded by remember { mutableStateOf(warmupSets.isNotEmpty()) }
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHighest),
+        shape = RoundedCornerShape(20.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 8.dp),
+        border = BorderStroke(
+            2.dp,
+            if (warmupSets.isNotEmpty()) {
+                MaterialTheme.colorScheme.tertiary.copy(alpha = 0.5f)
+            } else {
+                MaterialTheme.colorScheme.outlineVariant
+            },
+        ),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(Spacing.medium),
+        ) {
+            // Header with toggle
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        "Warm-up Sets",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = if (warmupSets.isNotEmpty()) {
+                            MaterialTheme.colorScheme.tertiary
+                        } else {
+                            MaterialTheme.colorScheme.onSurface
+                        },
+                    )
+                    Text(
+                        if (warmupSets.isEmpty()) {
+                            "Add warm-up sets before working sets"
+                        } else {
+                            "${warmupSets.size} warm-up set${if (warmupSets.size > 1) "s" else ""} configured"
+                        },
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                IconButton(onClick = { expanded = !expanded }) {
+                    Icon(
+                        imageVector = if (expanded) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
+                        contentDescription = if (expanded) "Collapse" else "Expand",
+                    )
+                }
+            }
+
+            // Expanded content
+            if (expanded) {
+                Spacer(modifier = Modifier.height(Spacing.medium))
+
+                // Quick preset button
+                if (warmupSets.isEmpty()) {
+                    Button(
+                        onClick = onApplyPreset,
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+                            contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+                        ),
+                    ) {
+                        Text("Apply 12-8-4 Preset (50%/70%/85%)")
+                    }
+                    Spacer(modifier = Modifier.height(Spacing.small))
+                }
+
+                // Warm-up sets list
+                warmupSets.forEachIndexed { index, warmupSet ->
+                    WarmupSetRow(
+                        index = index,
+                        warmupSet = warmupSet,
+                        workingWeight = workingWeight,
+                        weightSuffix = weightSuffix,
+                        onUpdateReps = { reps -> onUpdateReps(index, reps) },
+                        onUpdatePercent = { percent -> onUpdatePercent(index, percent) },
+                        onRemove = { onRemoveWarmupSet(index) },
+                    )
+                    if (index < warmupSets.lastIndex) {
+                        Spacer(modifier = Modifier.height(Spacing.small))
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(Spacing.small))
+
+                // Add/Clear buttons
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(Spacing.small),
+                ) {
+                    OutlinedButton(
+                        onClick = onAddWarmupSet,
+                        modifier = Modifier.weight(1f),
+                    ) {
+                        Icon(Icons.Default.Add, contentDescription = null, modifier = Modifier.size(18.dp))
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text("Add Warm-up")
+                    }
+                    if (warmupSets.isNotEmpty()) {
+                        TextButton(
+                            onClick = onClearAll,
+                            colors = ButtonDefaults.textButtonColors(
+                                contentColor = MaterialTheme.colorScheme.error,
+                            ),
+                        ) {
+                            Text("Clear All")
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Individual warm-up set row with reps picker, percentage picker, and calculated weight preview.
+ */
+@Composable
+private fun WarmupSetRow(
+    index: Int,
+    warmupSet: WarmupSet,
+    workingWeight: Float,
+    weightSuffix: String,
+    onUpdateReps: (Int) -> Unit,
+    onUpdatePercent: (Int) -> Unit,
+    onRemove: () -> Unit,
+) {
+    val calculatedWeight = (workingWeight * warmupSet.percentOfWorking / 100f)
+        .let { (it * 2).roundToInt() / 2f } // Round to 0.5
+
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(12.dp),
+        color = MaterialTheme.colorScheme.surface,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(Spacing.small),
+            horizontalArrangement = Arrangement.spacedBy(Spacing.small),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            // Warm-up number label
+            Text(
+                "W${index + 1}",
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.tertiary,
+                modifier = Modifier.width(28.dp),
+            )
+
+            // Reps picker
+            Column(
+                modifier = Modifier.weight(1f),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    "Reps",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    IconButton(
+                        onClick = { onUpdateReps(warmupSet.reps - 1) },
+                        modifier = Modifier.size(32.dp),
+                        enabled = warmupSet.reps > 1,
+                    ) {
+                        Text("-", fontWeight = FontWeight.Bold)
+                    }
+                    Text(
+                        "${warmupSet.reps}",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                    )
+                    IconButton(
+                        onClick = { onUpdateReps(warmupSet.reps + 1) },
+                        modifier = Modifier.size(32.dp),
+                        enabled = warmupSet.reps < 20,
+                    ) {
+                        Text("+", fontWeight = FontWeight.Bold)
+                    }
+                }
+            }
+
+            // Percentage picker
+            Column(
+                modifier = Modifier.weight(1f),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    "% of Working",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    IconButton(
+                        onClick = { onUpdatePercent(warmupSet.percentOfWorking - 5) },
+                        modifier = Modifier.size(32.dp),
+                        enabled = warmupSet.percentOfWorking > 10,
+                    ) {
+                        Text("-", fontWeight = FontWeight.Bold)
+                    }
+                    Text(
+                        "${warmupSet.percentOfWorking}%",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.tertiary,
+                    )
+                    IconButton(
+                        onClick = { onUpdatePercent(warmupSet.percentOfWorking + 5) },
+                        modifier = Modifier.size(32.dp),
+                        enabled = warmupSet.percentOfWorking < 100,
+                    ) {
+                        Text("+", fontWeight = FontWeight.Bold)
+                    }
+                }
+            }
+
+            // Calculated weight preview
+            Column(
+                modifier = Modifier.weight(1f),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    "Weight",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(
+                    "$calculatedWeight",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                )
+                Text(
+                    weightSuffix,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            // Delete button
+            IconButton(
+                onClick = onRemove,
+                modifier = Modifier.size(36.dp),
+            ) {
+                Icon(
+                    Icons.Default.Delete,
+                    contentDescription = "Remove warm-up set",
+                    tint = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.size(20.dp),
+                )
             }
         }
     }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModel.kt
@@ -10,6 +10,7 @@ import com.devil.phoenixproject.domain.model.PRType
 import com.devil.phoenixproject.domain.model.PersonalRecord
 import com.devil.phoenixproject.domain.model.RepCountTiming
 import com.devil.phoenixproject.domain.model.RoutineExercise
+import com.devil.phoenixproject.domain.model.WarmupSet
 import com.devil.phoenixproject.domain.model.WeightUnit
 import com.devil.phoenixproject.domain.model.WorkoutMode
 import com.devil.phoenixproject.domain.model.toWorkoutMode
@@ -107,6 +108,10 @@ class ExerciseConfigViewModel constructor(
 
     private val _prTypeForScaling = MutableStateFlow(PRType.MAX_WEIGHT)
     val prTypeForScaling: StateFlow<PRType> = _prTypeForScaling.asStateFlow()
+
+    // Warm-up sets state (Issue #30)
+    private val _warmupSets = MutableStateFlow<List<WarmupSet>>(emptyList())
+    val warmupSets: StateFlow<List<WarmupSet>> = _warmupSets.asStateFlow()
 
     init {
     }
@@ -209,6 +214,9 @@ class ExerciseConfigViewModel constructor(
         _weightPercentOfPR.value = exercise.weightPercentOfPR
         _prTypeForScaling.value = exercise.prTypeForScaling
 
+        // Warm-up sets (Issue #30)
+        _warmupSets.value = exercise.warmupSets
+
         // Load PR for the current exercise and mode
         exercise.exercise.id?.let { exerciseId ->
             loadPRForExercise(exerciseId, _selectedMode.value.displayName)
@@ -310,6 +318,74 @@ class ExerciseConfigViewModel constructor(
 
     fun onPRTypeForScalingChange(prType: PRType) {
         _prTypeForScaling.value = prType
+    }
+
+    // Warm-up set handlers (Issue #30)
+
+    /**
+     * Add a new warm-up set with default values.
+     * Defaults to 12 reps @ 50% for first set, then 8 @ 70%, then 4 @ 85%.
+     */
+    fun addWarmupSet() {
+        val current = _warmupSets.value
+        val newSet = when (current.size) {
+            0 -> WarmupSet(reps = 12, percentOfWorking = 50)
+            1 -> WarmupSet(reps = 8, percentOfWorking = 70)
+            2 -> WarmupSet(reps = 4, percentOfWorking = 85)
+            else -> WarmupSet(reps = 4, percentOfWorking = 90) // Additional sets default to 4 @ 90%
+        }
+        _warmupSets.value = current + newSet
+    }
+
+    /**
+     * Remove a warm-up set by index.
+     */
+    fun removeWarmupSet(index: Int) {
+        val current = _warmupSets.value
+        if (index in current.indices) {
+            _warmupSets.value = current.filterIndexed { i, _ -> i != index }
+        }
+    }
+
+    /**
+     * Update the reps for a warm-up set.
+     */
+    fun updateWarmupSetReps(index: Int, reps: Int) {
+        val current = _warmupSets.value.toMutableList()
+        if (index in current.indices) {
+            current[index] = current[index].copy(reps = reps.coerceIn(1, 20))
+            _warmupSets.value = current
+        }
+    }
+
+    /**
+     * Update the percentage for a warm-up set.
+     */
+    fun updateWarmupSetPercent(index: Int, percent: Int) {
+        val current = _warmupSets.value.toMutableList()
+        if (index in current.indices) {
+            current[index] = current[index].copy(percentOfWorking = percent.coerceIn(10, 100))
+            _warmupSets.value = current
+        }
+    }
+
+    /**
+     * Clear all warm-up sets.
+     */
+    fun clearWarmupSets() {
+        _warmupSets.value = emptyList()
+    }
+
+    /**
+     * Apply the classic 12-8-4 warm-up preset (Issue #30 suggestion).
+     * 12 reps @ 50%, 8 reps @ 70%, 4 reps @ 85%.
+     */
+    fun applyClassicWarmupPreset() {
+        _warmupSets.value = listOf(
+            WarmupSet(reps = 12, percentOfWorking = 50),
+            WarmupSet(reps = 8, percentOfWorking = 70),
+            WarmupSet(reps = 4, percentOfWorking = 85),
+        )
     }
 
     /**
@@ -434,6 +510,8 @@ class ExerciseConfigViewModel constructor(
             weightPercentOfPR = _weightPercentOfPR.value,
             prTypeForScaling = _prTypeForScaling.value,
             setWeightsPercentOfPR = resolvedSetWeightsPercentOfPR,
+            // Warm-up sets (Issue #30)
+            warmupSets = _warmupSets.value,
         )
 
         logDebug("Updated exercise to save:")


### PR DESCRIPTION
Introduces state and handlers for managing warm-up sets within the exercise configuration flow (Issue #30).

- Add `warmupSets` MutableStateFlow to track warm-up configurations
- Implement `addWarmupSet()` with intelligent defaults:
    - 1st set: 12 reps @ 50%
    - 2nd set: 8 reps @ 70%
    - 3rd set: 4 reps @ 85%
    - Subsequent: 4 reps @ 90%
- Add `applyClassicWarmupPreset()` to quickly apply the 12-8-4 (50/70/85%) scheme
- Add CRUD handlers: `removeWarmupSet`, `updateWarmupSetReps`, `updateWarmupSetPercent`, and `clearWarmupSets`
- Persist warm-up sets into the `RoutineExercise` model during the save flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added warm-up set configuration for exercises in the editor
* Users can now add, edit, and remove warm-up sets with customizable repetitions and weight percentages
* Introduced a preset warm-up option with automatically suggested values
* Live weight preview displays calculated warm-up loads based on working weight

<!-- end of auto-generated comment: release notes by coderabbit.ai -->