### PR TITLE
Fix navigation loop when completing workout routine

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/DefaultWorkoutSessionManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/DefaultWorkoutSessionManager.kt
@@ -620,6 +620,12 @@ class DefaultWorkoutSessionManager(
                 if (nextStep == null) {
                     Logger.d { "proceedFromSummary: No more steps - showing routine complete" }
                     showRoutineComplete()
+                    // Issue #355: Clear workoutState so EnhancedMainScreen's resume-active-workout
+                    // guard does not bounce the user back to ActiveWorkout after navigation to
+                    // RoutineComplete. Leaving workoutState at SetSummary caused a navigation
+                    // ping-pong with ActiveWorkoutScreen's Complete observer. Mirrors the reset
+                    // performed in ActiveSessionEngine.startNextSetOrExercise() (Path B).
+                    coordinator._workoutState.value = WorkoutState.Idle
                     return@launch
                 }
 


### PR DESCRIPTION
## Summary
Fixed a navigation issue where users were bounced back to the ActiveWorkout screen after completing a routine, caused by the workout state not being properly cleared upon routine completion.

## Key Changes
- Clear `workoutState` to `Idle` when no more steps remain after summary in `DefaultWorkoutSessionManager.proceedFromSummary()`
- This prevents `EnhancedMainScreen`'s resume-active-workout guard from redirecting users back to ActiveWorkout after navigating to RoutineComplete
- Aligns the cleanup behavior with the reset performed in `ActiveSessionEngine.startNextSetOrExercise()` (Path B)

## Implementation Details
The issue occurred because leaving `workoutState` at `SetSummary` caused a navigation ping-pong between ActiveWorkoutScreen's Complete observer and the resume-active-workout navigation guard. By explicitly resetting the state to `Idle` when the routine completes, we ensure the user can successfully navigate to and remain on the RoutineComplete screen.

Fixes #355

https://claude.ai/code/session_01GzG1vtqipZh8yWHHgpxpkV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where the app state was not properly reset after completing a workout routine, which could cause unexpected behavior when starting a new session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->