### PR TITLE
feat(mobile): SQLDelight LWW pull merge for WorkoutSession (Phase 3.3)

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt
@@ -1753,6 +1753,87 @@ class SqlDelightSyncRepository(
      * either INSERT OR REPLACE or skip. Wrapped in a single transaction so
      * the read+write pair is atomic per row.
      */
+    /**
+     * Phase 3.3 (audit item #1): replace the legacy INSERT OR IGNORE pull
+     * merge with `updatedAt`-gated LWW. SQLite 3.18 does not support
+     * `INSERT ... ON CONFLICT DO UPDATE WHERE`, so the gate lives here:
+     * SELECT existing.updatedAt → compare to incoming → INSERT OR REPLACE
+     * iff incoming wins. Wrapped in a single transaction so the read+write
+     * pair is atomic per row.
+     *
+     * `updatedAtBySessionId` keys on the per-exercise WorkoutSession.id
+     * (== portal exercise id; one portal session expands to N mobile rows
+     * in PortalPullAdapter.toWorkoutSessionsWithLookup). Missing entries
+     * default to "older" so first-time pulls always write.
+     */
+    override suspend fun mergeSessionsLww(
+        sessions: List<WorkoutSession>,
+        updatedAtBySessionId: Map<String, Long>,
+    ) = withContext(Dispatchers.IO) {
+        if (sessions.isEmpty()) return@withContext
+        db.transaction {
+            for (session in sessions) {
+                val existingTs = queries.selectSessionUpdatedAt(session.id)
+                    .executeAsOneOrNull()
+                    ?.updatedAt
+                val incomingTs = updatedAtBySessionId[session.id] ?: 0L
+                val accept = existingTs == null || incomingTs >= existingTs
+                if (!accept) continue
+
+                queries.mergeSessionLww(
+                    id = session.id,
+                    timestamp = session.timestamp,
+                    mode = session.mode,
+                    targetReps = session.reps.toLong(),
+                    weightPerCableKg = session.weightPerCableKg.toDouble(),
+                    progressionKg = session.progressionKg.toDouble(),
+                    duration = session.duration,
+                    totalReps = session.totalReps.toLong(),
+                    warmupReps = session.warmupReps.toLong(),
+                    workingReps = session.workingReps.toLong(),
+                    isJustLift = if (session.isJustLift) 1L else 0L,
+                    stopAtTop = if (session.stopAtTop) 1L else 0L,
+                    eccentricLoad = session.eccentricLoad.toLong(),
+                    echoLevel = session.echoLevel.toLong(),
+                    exerciseId = session.exerciseId,
+                    exerciseName = session.exerciseName,
+                    routineSessionId = session.routineSessionId,
+                    routineName = session.routineName,
+                    routineId = session.routineId,
+                    safetyFlags = session.safetyFlags.toLong(),
+                    deloadWarningCount = session.deloadWarningCount.toLong(),
+                    romViolationCount = session.romViolationCount.toLong(),
+                    spotterActivations = session.spotterActivations.toLong(),
+                    peakForceConcentricA = session.peakForceConcentricA?.toDouble(),
+                    peakForceConcentricB = session.peakForceConcentricB?.toDouble(),
+                    peakForceEccentricA = session.peakForceEccentricA?.toDouble(),
+                    peakForceEccentricB = session.peakForceEccentricB?.toDouble(),
+                    avgForceConcentricA = session.avgForceConcentricA?.toDouble(),
+                    avgForceConcentricB = session.avgForceConcentricB?.toDouble(),
+                    avgForceEccentricA = session.avgForceEccentricA?.toDouble(),
+                    avgForceEccentricB = session.avgForceEccentricB?.toDouble(),
+                    heaviestLiftKg = session.heaviestLiftKg?.toDouble(),
+                    totalVolumeKg = session.totalVolumeKg?.toDouble(),
+                    cableCount = session.cableCount?.toLong(),
+                    estimatedCalories = session.estimatedCalories?.toDouble(),
+                    warmupAvgWeightKg = session.warmupAvgWeightKg?.toDouble(),
+                    workingAvgWeightKg = session.workingAvgWeightKg?.toDouble(),
+                    burnoutAvgWeightKg = session.burnoutAvgWeightKg?.toDouble(),
+                    peakWeightKg = session.peakWeightKg?.toDouble(),
+                    rpe = session.rpe?.toLong(),
+                    avgMcvMmS = session.avgMcvMmS?.toDouble(),
+                    avgAsymmetryPercent = session.avgAsymmetryPercent?.toDouble(),
+                    totalVelocityLossPercent = session.totalVelocityLossPercent?.toDouble(),
+                    dominantSide = session.dominantSide,
+                    strengthProfile = session.strengthProfile,
+                    formScore = session.formScore?.toLong(),
+                    updatedAt = incomingTs,
+                    profile_id = session.profileId,
+                )
+            }
+        }
+    }
+
     override suspend fun mergeSessionNotes(
         notes: Map<String, SessionNotesEntry>,
     ) = withContext(Dispatchers.IO) {

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SyncRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SyncRepository.kt
@@ -259,6 +259,31 @@ interface SyncRepository {
     ) {
         // Default no-op for fakes / older implementations.
     }
+
+    /**
+     * Phase 3.3 (audit item #1): LWW pull merge for WorkoutSession rows.
+     *
+     * Replaces the legacy INSERT OR IGNORE behavior (`mergeAllPullData`)
+     * which silently dropped server-newer rows. For each session, the
+     * implementation reads the existing local `updatedAt`, compares to
+     * `updatedAtBySessionId[session.id]`, and overwrites only when the
+     * incoming timestamp is newer-or-equal. NULL existing or absent map
+     * entry is treated as older (accept incoming) so first-time pulls
+     * always write.
+     *
+     * `updatedAtBySessionId` is the authoritative server timestamp that
+     * portal-sync-pull returns on `PullWorkoutSessionDto.updatedAt`. It
+     * is keyed on the per-exercise WorkoutSession.id (which equals the
+     * portal exercise id; one portal session expands to N mobile rows).
+     *
+     * Default no-op so unrelated test fakes do not need to implement.
+     */
+    suspend fun mergeSessionsLww(
+        sessions: List<WorkoutSession>,
+        updatedAtBySessionId: Map<String, Long>,
+    ) {
+        // Default no-op for fakes / older implementations.
+    }
 }
 
 /** Side-table entry for session notes (Phase 3.5). */

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncDtos.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncDtos.kt
@@ -607,16 +607,19 @@ data class PullWorkoutSessionDto(
     val workoutMode: String? = null,
     val routineSessionId: String? = null,
     /**
-     * Session-level notes from portal. Added 2026-04-19 (audit item #2).
-     *
-     * Wire contract only — mobile does not yet persist session-level notes
-     * locally because the mobile WorkoutSession model is per-exercise (portal
-     * session → N mobile rows grouped by routineSessionId). A SessionNotes
-     * table keyed on routineSessionId is the planned persistence surface and
-     * ships with the Phase 3 LWW migration; until then, this field round-trips
-     * through the wire but is ignored when merging into SQLDelight.
+     * Session-level notes from portal. Persisted by mobile via the
+     * SessionNotes side-table (migration 26.sqm) keyed on `routineSessionId`.
+     * Resolves audit item #2.
      */
     val notes: String? = null,
+    /**
+     * Server-canonical last-write timestamp (ISO 8601). Mobile uses this as
+     * the LWW gate when merging the pull row into the local WorkoutSession
+     * table. Optional for backward compat with Edge Function responses
+     * that pre-date Phase 3.3 — when null, mobile falls back to the
+     * legacy INSERT OR IGNORE path. Resolves audit item #1 mobile half.
+     */
+    val updatedAt: String? = null,
     val exercises: List<PullExerciseDto> = emptyList(),
 )
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/SyncManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/SyncManager.kt
@@ -1041,18 +1041,53 @@ class SyncManager(
                     )
                 }
 
-        // 3. Execute atomic merge (all or nothing)
+        // Phase 3.3 (audit item #1): build per-session updatedAt map keyed
+        // on the per-exercise WorkoutSession.id (== portal exercise id).
+        // Each portal session's updatedAt applies to all child mobile rows.
+        val sessionUpdatedAtById: Map<String, Long> = pullResponse.sessions
+            .flatMap { ps ->
+                val ts = ps.updatedAt?.let { iso ->
+                    runCatching { kotlin.time.Instant.parse(iso).toEpochMilliseconds() }
+                        .getOrNull()
+                } ?: 0L
+                ps.exercises.map { ex -> ex.id to ts }
+            }
+            .toMap()
+
+        // 3. Execute atomic merge (all or nothing). Sessions are merged via
+        // the LWW path (mergeSessionsLww) when SYNC_LWW_ENABLED is implicit
+        // through the presence of incoming updatedAt; falls back to the
+        // legacy INSERT OR IGNORE behavior when the map has no entries
+        // (older Edge Function payloads pre-Phase-3.2).
+        val sessionsHaveUpdatedAt = sessionUpdatedAtById.values.any { it > 0L }
         try {
-            syncRepository.mergeAllPullData(
-                sessions = mobileSessions,
-                routines = pullResponse.routines,
-                cycles = pullResponse.cycles,
-                badges = badgeDtos,
-                gamificationStats = gamificationStatsDto,
-                personalRecords = prDtos,
-                lastSync = lastSync,
-                profileId = mergeProfileId,
-            )
+            if (sessionsHaveUpdatedAt) {
+                syncRepository.mergeSessionsLww(mobileSessions, sessionUpdatedAtById)
+                // Routines/cycles/badges/stats/PRs still go through the atomic
+                // path. Pass an empty session list to skip the legacy
+                // INSERT OR IGNORE branch (already handled by LWW).
+                syncRepository.mergeAllPullData(
+                    sessions = emptyList(),
+                    routines = pullResponse.routines,
+                    cycles = pullResponse.cycles,
+                    badges = badgeDtos,
+                    gamificationStats = gamificationStatsDto,
+                    personalRecords = prDtos,
+                    lastSync = lastSync,
+                    profileId = mergeProfileId,
+                )
+            } else {
+                syncRepository.mergeAllPullData(
+                    sessions = mobileSessions,
+                    routines = pullResponse.routines,
+                    cycles = pullResponse.cycles,
+                    badges = badgeDtos,
+                    gamificationStats = gamificationStatsDto,
+                    personalRecords = prDtos,
+                    lastSync = lastSync,
+                    profileId = mergeProfileId,
+                )
+            }
 
             // Phase 3.5: persist session-level notes after the atomic merge
             // succeeds. Kept outside the main transaction so a notes-table

--- a/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
+++ b/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
@@ -518,6 +518,13 @@ SELECT * FROM WorkoutSession WHERE profile_id = :profileId ORDER BY timestamp DE
 selectSessionById:
 SELECT * FROM WorkoutSession WHERE id = ?;
 
+-- Phase 3.3 (audit item #1): cheap LWW-gate read. Returns just the
+-- existing updatedAt for a given session id so the repository can
+-- decide whether to accept an incoming pull row without loading the
+-- full row body.
+selectSessionUpdatedAt:
+SELECT updatedAt FROM WorkoutSession WHERE id = ?;
+
 -- Sync version for backup
 selectAllSessionsSync:
 SELECT * FROM WorkoutSession;
@@ -550,6 +557,29 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 
 -- Includes updatedAt to prevent re-push (selectSessionsModifiedSince picks up updatedAt IS NULL).
 insertSessionIgnore:
 INSERT OR IGNORE INTO WorkoutSession (
+    id, timestamp, mode, targetReps, weightPerCableKg, progressionKg,
+    duration, totalReps, warmupReps, workingReps,
+    isJustLift, stopAtTop, eccentricLoad, echoLevel,
+    exerciseId, exerciseName, routineSessionId, routineName, routineId,
+    safetyFlags, deloadWarningCount, romViolationCount, spotterActivations,
+    peakForceConcentricA, peakForceConcentricB, peakForceEccentricA, peakForceEccentricB,
+    avgForceConcentricA, avgForceConcentricB, avgForceEccentricA, avgForceEccentricB,
+    heaviestLiftKg, totalVolumeKg, cableCount, estimatedCalories,
+    warmupAvgWeightKg, workingAvgWeightKg, burnoutAvgWeightKg, peakWeightKg, rpe,
+    avgMcvMmS, avgAsymmetryPercent, totalVelocityLossPercent, dominantSide, strengthProfile,
+    formScore,
+    updatedAt,
+    profile_id
+)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+
+-- Phase 3.3 (audit item #1): LWW write — overwrite existing row whose
+-- id matches. The repository gates this with a prior selectSessionUpdatedAt
+-- comparison so stale incoming rows never reach the REPLACE. SQLite 3.18
+-- does not support `INSERT ... ON CONFLICT DO UPDATE WHERE`, hence the
+-- LWW gate lives in Kotlin.
+mergeSessionLww:
+INSERT OR REPLACE INTO WorkoutSession (
     id, timestamp, mode, targetReps, weightPerCableKg, progressionKg,
     duration, totalReps, warmupReps, workingReps,
     isJustLift, stopAtTop, eccentricLoad, echoLevel,


### PR DESCRIPTION
## Summary

Resolves the mobile half of audit item #1 (asymmetric merge). Server-side LWW shipped in Phase 3.1 + 3.2; this completes the pull-side gate so the contract is symmetric.

### Changes

**Schema (\`VitruvianDatabase.sq\`)**:
- \`selectSessionUpdatedAt\`: cheap LWW-gate read
- \`mergeSessionLww\`: INSERT OR REPLACE variant gated by repository-side comparison (sqlite_3_18 dialect doesn't support \`ON CONFLICT DO UPDATE WHERE\`, so the gate lives in Kotlin — same pattern as Phase 3.5 SessionNotes)

**Repository (\`SyncRepository\` + \`SqlDelightSyncRepository\`)**:
- New \`mergeSessionsLww(sessions, updatedAtBySessionId)\` overload with default no-op for test fakes
- Implementation runs SELECT existing + compare per row in single transaction. Missing map entries default to "older" so first-time pulls always write.

**DTO (\`PullWorkoutSessionDto\`)**:
- Added \`updatedAt: String?\` (ISO 8601). Nullable for backward compat with pre-Phase-3.3 Edge Function payloads.

**Wire (\`SyncManager.runPullPage\`)**:
- Build \`sessionUpdatedAtById: Map<String, Long>\` keyed on per-exercise WorkoutSession.id
- Route through \`mergeSessionsLww\` when any incoming row carries \`updatedAt\`; fall through to legacy INSERT OR IGNORE otherwise (full backward compat)

## Companion PR

\`9thLevelSoftware/phoenix-portal\` branch \`cursor/dto-drift-phase-3-3\` adds the matching server-side projection.

## Test plan
- [ ] \`./gradlew :shared:testDebugUnitTest\` passes
- [ ] \`./gradlew :shared:allTests\` passes
- [ ] CI green
- [ ] Manual: 2-device convergence test — Device A edits session at T2, Device B pulls → SessionLwwMerge returns true, local row updated to T2 state

🤖 Generated with [Claude Code](https://claude.com/claude-code)