### PR TITLE
chore: gitignore .gradle-local-test/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,4 @@ repomix-output.xml
 bugreport-*.zip
 .codex_tmp/
 /.gradle-local/
+/.gradle-local-test/


### PR DESCRIPTION
## Summary

One-line .gitignore addition. Mirrors existing \`/.gradle-local/\` entry to also cover \`/.gradle-local-test/\` produced by the schema-validation gradle task in \`shared/build.gradle.kts\`.

Trivial — no code/CI impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)