### PR TITLE
fix(ci): bump Kotlin/Native heap to 12g to fix iOS release link OOM

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,8 +3,12 @@
 # JVM arguments for the Gradle daemon
 org.gradle.jvmargs=-Xmx8g -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:MaxMetaspaceSize=2g -XX:ReservedCodeCacheSize=512m
 
-# Kotlin/Native memory settings (needs extra for DevirtualizationAnalysis)
-kotlin.native.jvmArgs=-Xmx8g
+# Kotlin/Native memory settings (needs extra for DevirtualizationAnalysis).
+# Release framework link on iosArm64 runs a whole-program call-graph pass that
+# OOMed at 8g (java.lang.OutOfMemoryError in LongHashSet.grow during
+# DevirtualizationAnalysis.CondensationBuilder.mergeEdges). macos-26 runners
+# provide ~14g RAM so 12g is safe.
+kotlin.native.jvmArgs=-Xmx12g
 # Note: SQLite JDBC VerifyMigrationTask may fail on Windows if java.io.tmpdir resolves
 # to a protected directory (e.g., C:\Windows). The task runs correctly in CI (Linux).
 # If needed locally, set GRADLE_OPTS=-Djava.io.tmpdir=%TEMP% before running.


### PR DESCRIPTION
## Summary

The `build-and-attach` job in [iOS Release IPA #117](https://github.com/9thLevelSoftware/Project-Phoenix-MP/actions/runs/24645923385/job/72058472257) failed at `:shared:linkReleaseFrameworkIosArm64`. The underlying error in the Kotlin/Native compiler log:

```
e: Compilation failed: Java heap space
e: java.lang.OutOfMemoryError: Java heap space
    at org.jetbrains.kotlin.backend.konan.util.LongHashSet.grow(LongHashSet.kt:66)
    at org.jetbrains.kotlin.backend.konan.util.LongHashSet.add(LongHashSet.kt:49)
    at ...DevirtualizationAnalysis$DevirtualizationAnalysisImpl$CondensationBuilder.mergeEdges
    at ...DevirtualizationAnalysis$DevirtualizationAnalysisImpl.analyze
    ...
```

`DevirtualizationAnalysis` is a whole-program call-graph / escape-analysis pass that only runs for release framework builds (debug links skip it), which is why `compileKotlinIosArm64` and the Android build passed but the TestFlight/Release IPA workflow blew up after 6m 43s.

## Fix

Bump `kotlin.native.jvmArgs` from `-Xmx8g` to `-Xmx12g` in `gradle.properties`.

- The `macos-26` Apple Silicon runner provides ~14 GB RAM, so 12g leaves ~2 GB for the Gradle daemon + OS.
- Debug builds (which skip DevirtualizationAnalysis) are unaffected — they use a fraction of that ceiling.
- `org.gradle.jvmargs` is unchanged (daemon stays at 8g); only the K/N compiler subprocess gets the extra headroom.

## Test plan

- [ ] Re-run `iOS Release IPA` workflow manually (`workflow_dispatch`) and confirm `:shared:linkReleaseFrameworkIosArm64` completes.
- [ ] Re-run `iOS TestFlight` and `iOS TestFlight (Internal Only)` workflows likewise — both use the same gradle.properties so this fix covers all three.
- [ ] Android + unit-test workflows remain green (they don't hit this path but sanity check).

If 12g still isn't enough (unlikely given the error is mid-analysis rather than end-of-heap), follow-up options are (a) bump to 14g and reduce Gradle daemon to 4g, or (b) pass `-Xdisable-phases=Devirtualization` to the K/N compiler to skip the pass at a small release-performance cost.