### PR TITLE
fix(sync): telemetry-aware push batching to clear 10k rep_telemetry cap

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/SyncManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/SyncManager.kt
@@ -447,7 +447,7 @@ class SyncManager(
         sessions: List<PortalWorkoutSessionDto>,
         telemetryCountBySessionId: Map<String, Int>,
     ): List<List<PortalWorkoutSessionDto>> {
-        if (sessions.isEmpty()) return listOf(emptyList())
+        if (sessions.isEmpty()) return listOf(emptyList<PortalWorkoutSessionDto>())
         val batches = mutableListOf<List<PortalWorkoutSessionDto>>()
         var current = mutableListOf<PortalWorkoutSessionDto>()
         var currentTelemetry = 0
@@ -465,7 +465,7 @@ class SyncManager(
                 currentTelemetry + sessionTelemetry > SyncConfig.MAX_TELEMETRY_PER_BATCH
             if (current.isNotEmpty() && (wouldExceedSessions || wouldExceedTelemetry)) {
                 batches.add(current)
-                current = mutableListOf()
+                current = mutableListOf<PortalWorkoutSessionDto>()
                 currentTelemetry = 0
             }
             current.add(session)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/SyncManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/SyncManager.kt
@@ -428,6 +428,53 @@ class SyncManager(
 
     // === Private Helpers ===
 
+    /**
+     * Builds push batches that respect BOTH the per-batch session cap
+     * ([SYNC_BATCH_SIZE]) and the per-batch telemetry cap
+     * ([SyncConfig.MAX_TELEMETRY_PER_BATCH]).
+     *
+     * A fixed chunk of 50 sessions can still blow past the server's rep_telemetry
+     * array cap (10_000) when sessions carry heavy force-curve telemetry — the
+     * client self-check then rejects the batch and sync gets stuck. This greedy
+     * planner closes a batch early whenever adding another session would exceed
+     * either cap.
+     *
+     * A single session whose own telemetry exceeds the cap is still placed
+     * alone in its batch and logged as a warning. PortalApiClient will still
+     * reject it, but batches around it continue to flow normally.
+     */
+    internal fun planSessionBatches(
+        sessions: List<PortalWorkoutSessionDto>,
+        telemetryCountBySessionId: Map<String, Int>,
+    ): List<List<PortalWorkoutSessionDto>> {
+        if (sessions.isEmpty()) return listOf(emptyList())
+        val batches = mutableListOf<List<PortalWorkoutSessionDto>>()
+        var current = mutableListOf<PortalWorkoutSessionDto>()
+        var currentTelemetry = 0
+        for (session in sessions) {
+            val sessionTelemetry = telemetryCountBySessionId[session.id] ?: 0
+            if (sessionTelemetry > SyncConfig.MAX_TELEMETRY_PER_BATCH) {
+                Logger.w("SyncManager") {
+                    "Session ${session.id} has $sessionTelemetry telemetry points, " +
+                        "exceeding per-batch cap ${SyncConfig.MAX_TELEMETRY_PER_BATCH}. " +
+                        "Batch will likely be rejected by the server until telemetry is trimmed."
+                }
+            }
+            val wouldExceedSessions = current.size + 1 > SYNC_BATCH_SIZE
+            val wouldExceedTelemetry =
+                currentTelemetry + sessionTelemetry > SyncConfig.MAX_TELEMETRY_PER_BATCH
+            if (current.isNotEmpty() && (wouldExceedSessions || wouldExceedTelemetry)) {
+                batches.add(current)
+                current = mutableListOf()
+                currentTelemetry = 0
+            }
+            current.add(session)
+            currentTelemetry += sessionTelemetry
+        }
+        if (current.isNotEmpty()) batches.add(current)
+        return batches
+    }
+
     private suspend fun pushLocalChanges(): Result<PortalSyncPushResponse> {
         val userId = tokenStorage.currentUser.value?.id
             ?: return Result.failure(PortalApiException("Not authenticated", null, 401))
@@ -590,18 +637,22 @@ class SyncManager(
         }
         val profileDtos = allProfiles.map { LocalProfileDto(it.id, it.name, it.colorIndex) }
 
-        // 8. Chunked push -- batch sessions to stay under Edge Function body limit (~1 MB).
+        // 8. Chunked push -- batch sessions to stay under Edge Function body limit (~1 MB)
+        //    AND under the server-side rep_telemetry array cap (MAX_TELEMETRY_PER_BATCH).
         //    Non-session data (routines, cycles, badges, RPG, gamification, signatures, assessments)
         //    is included only in the final batch to avoid duplicate upserts.
         //    IMPORTANT: We do NOT update lastSync until ALL batches succeed. This prevents
         //    data consistency gaps where a partial batch sequence leaves the timestamp
         //    advanced but later batches uncommitted (audit 4.1 fix).
         val allSessions = buildResult.sessions
-        val totalBatches = if (allSessions.size > SYNC_BATCH_SIZE) {
-            (allSessions.size + SYNC_BATCH_SIZE - 1) / SYNC_BATCH_SIZE
-        } else {
-            1
+        val telemetryCountBySessionId = allSessions.associate { session ->
+            val count = (sessionSetIds[session.id] ?: emptySet()).sumOf { setId ->
+                telemetryBySetId[setId]?.size ?: 0
+            }
+            session.id to count
         }
+        val batchPlan = planSessionBatches(allSessions, telemetryCountBySessionId)
+        val totalBatches = batchPlan.size.coerceAtLeast(1)
 
         Logger.d("SyncManager") {
             "Pushing portal payload: ${allSessions.size} sessions ($totalBatches batch(es)), " +
@@ -614,7 +665,7 @@ class SyncManager(
 
         var lastResponse: PortalSyncPushResponse? = null
 
-        if (allSessions.size <= SYNC_BATCH_SIZE) {
+        if (batchPlan.size <= 1) {
             // --- Single-push fast path (most common case) ---
             val payload = PortalSyncPayload(
                 deviceId = deviceId,
@@ -643,7 +694,7 @@ class SyncManager(
             lastFailedBatchHash = null
         } else {
             // --- Batched push for large history syncs ---
-            val batches = allSessions.chunked(SYNC_BATCH_SIZE)
+            val batches = batchPlan
             batches.forEachIndexed { index, batchSessions ->
                 val isLastBatch = index == batches.lastIndex
                 Logger.i("SyncManager") {

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/SyncManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/SyncManager.kt
@@ -428,53 +428,6 @@ class SyncManager(
 
     // === Private Helpers ===
 
-    /**
-     * Builds push batches that respect BOTH the per-batch session cap
-     * ([SYNC_BATCH_SIZE]) and the per-batch telemetry cap
-     * ([SyncConfig.MAX_TELEMETRY_PER_BATCH]).
-     *
-     * A fixed chunk of 50 sessions can still blow past the server's rep_telemetry
-     * array cap (10_000) when sessions carry heavy force-curve telemetry — the
-     * client self-check then rejects the batch and sync gets stuck. This greedy
-     * planner closes a batch early whenever adding another session would exceed
-     * either cap.
-     *
-     * A single session whose own telemetry exceeds the cap is still placed
-     * alone in its batch and logged as a warning. PortalApiClient will still
-     * reject it, but batches around it continue to flow normally.
-     */
-    internal fun planSessionBatches(
-        sessions: List<PortalWorkoutSessionDto>,
-        telemetryCountBySessionId: Map<String, Int>,
-    ): List<List<PortalWorkoutSessionDto>> {
-        if (sessions.isEmpty()) return listOf(emptyList<PortalWorkoutSessionDto>())
-        val batches = mutableListOf<List<PortalWorkoutSessionDto>>()
-        var current = mutableListOf<PortalWorkoutSessionDto>()
-        var currentTelemetry = 0
-        for (session in sessions) {
-            val sessionTelemetry = telemetryCountBySessionId[session.id] ?: 0
-            if (sessionTelemetry > SyncConfig.MAX_TELEMETRY_PER_BATCH) {
-                Logger.w("SyncManager") {
-                    "Session ${session.id} has $sessionTelemetry telemetry points, " +
-                        "exceeding per-batch cap ${SyncConfig.MAX_TELEMETRY_PER_BATCH}. " +
-                        "Batch will likely be rejected by the server until telemetry is trimmed."
-                }
-            }
-            val wouldExceedSessions = current.size + 1 > SYNC_BATCH_SIZE
-            val wouldExceedTelemetry =
-                currentTelemetry + sessionTelemetry > SyncConfig.MAX_TELEMETRY_PER_BATCH
-            if (current.isNotEmpty() && (wouldExceedSessions || wouldExceedTelemetry)) {
-                batches.add(current)
-                current = mutableListOf<PortalWorkoutSessionDto>()
-                currentTelemetry = 0
-            }
-            current.add(session)
-            currentTelemetry += sessionTelemetry
-        }
-        if (current.isNotEmpty()) batches.add(current)
-        return batches
-    }
-
     private suspend fun pushLocalChanges(): Result<PortalSyncPushResponse> {
         val userId = tokenStorage.currentUser.value?.id
             ?: return Result.failure(PortalApiException("Not authenticated", null, 401))
@@ -1239,4 +1192,51 @@ class SyncManager(
             else -> platformName
         }
     }
+}
+
+/**
+ * Builds push batches that respect BOTH the per-batch session cap
+ * ([SyncManager.SYNC_BATCH_SIZE]) and the per-batch telemetry cap
+ * ([SyncConfig.MAX_TELEMETRY_PER_BATCH]).
+ *
+ * A fixed chunk of 50 sessions can still blow past the server's rep_telemetry
+ * array cap (10_000) when sessions carry heavy force-curve telemetry — the
+ * client self-check then rejects the batch and sync gets stuck. This greedy
+ * planner closes a batch early whenever adding another session would exceed
+ * either cap.
+ *
+ * A single session whose own telemetry exceeds the cap is still placed
+ * alone in its batch and logged as a warning. PortalApiClient will still
+ * reject it, but batches around it continue to flow normally.
+ */
+internal fun planSessionBatches(
+    sessions: List<PortalWorkoutSessionDto>,
+    telemetryCountBySessionId: Map<String, Int>,
+): List<List<PortalWorkoutSessionDto>> {
+    if (sessions.isEmpty()) return listOf(emptyList<PortalWorkoutSessionDto>())
+    val batches = mutableListOf<List<PortalWorkoutSessionDto>>()
+    var current = mutableListOf<PortalWorkoutSessionDto>()
+    var currentTelemetry = 0
+    for (session in sessions) {
+        val sessionTelemetry = telemetryCountBySessionId[session.id] ?: 0
+        if (sessionTelemetry > SyncConfig.MAX_TELEMETRY_PER_BATCH) {
+            Logger.w("SyncManager") {
+                "Session ${session.id} has $sessionTelemetry telemetry points, " +
+                    "exceeding per-batch cap ${SyncConfig.MAX_TELEMETRY_PER_BATCH}. " +
+                    "Batch will likely be rejected by the server until telemetry is trimmed."
+            }
+        }
+        val wouldExceedSessions = current.size + 1 > SyncManager.SYNC_BATCH_SIZE
+        val wouldExceedTelemetry =
+            currentTelemetry + sessionTelemetry > SyncConfig.MAX_TELEMETRY_PER_BATCH
+        if (current.isNotEmpty() && (wouldExceedSessions || wouldExceedTelemetry)) {
+            batches.add(current)
+            current = mutableListOf<PortalWorkoutSessionDto>()
+            currentTelemetry = 0
+        }
+        current.add(session)
+        currentTelemetry += sessionTelemetry
+    }
+    if (current.isNotEmpty()) batches.add(current)
+    return batches
 }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/PortalPushLimitsTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/PortalPushLimitsTest.kt
@@ -378,13 +378,12 @@ class PortalPushLimitsTest {
      */
     @Test
     fun planSessionBatchesSplitsWhenCumulativeTelemetryExceedsCap() {
-        val manager = createManager()
         val sessions = (0 until 50).map { stubPortalSession("sess-$it") }
         // Each session carries 800 telemetry points → 50 * 800 = 40_000, well past the
         // 10_000 cap. Should split into at least 5 batches (ceil(40_000 / 10_000)).
         val telemetryCounts = sessions.associate { it.id to 800 }
 
-        val batches = manager.planSessionBatches(sessions, telemetryCounts)
+        val batches = planSessionBatches(sessions, telemetryCounts)
 
         assertTrue(
             batches.size >= 4,
@@ -408,11 +407,10 @@ class PortalPushLimitsTest {
     /** Sessions with zero telemetry should batch identically to the old 50-per-batch chunker. */
     @Test
     fun planSessionBatchesPreservesLegacyChunkingWhenTelemetryIsEmpty() {
-        val manager = createManager()
         val sessions = (0 until 73).map { stubPortalSession("sess-$it") }
         val telemetryCounts = sessions.associate { it.id to 0 }
 
-        val batches = manager.planSessionBatches(sessions, telemetryCounts)
+        val batches = planSessionBatches(sessions, telemetryCounts)
 
         assertEquals(listOf(50, 23), batches.map { it.size })
     }
@@ -425,7 +423,6 @@ class PortalPushLimitsTest {
      */
     @Test
     fun planSessionBatchesIsolatesSingleSessionTelemetryOverflow() {
-        val manager = createManager()
         val small1 = stubPortalSession("small-1")
         val giant = stubPortalSession("giant")
         val small2 = stubPortalSession("small-2")
@@ -435,7 +432,7 @@ class PortalPushLimitsTest {
             small2.id to 100,
         )
 
-        val batches = manager.planSessionBatches(listOf(small1, giant, small2), telemetryCounts)
+        val batches = planSessionBatches(listOf(small1, giant, small2), telemetryCounts)
 
         // Expect 3 batches: [small1], [giant], [small2]
         assertEquals(3, batches.size, "Giant session must be isolated in its own batch")
@@ -446,8 +443,7 @@ class PortalPushLimitsTest {
 
     @Test
     fun planSessionBatchesHandlesEmptyInput() {
-        val manager = createManager()
-        val batches = manager.planSessionBatches(emptyList(), emptyMap())
+        val batches = planSessionBatches(emptyList(), emptyMap())
         assertEquals(1, batches.size)
         assertTrue(batches[0].isEmpty())
     }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/PortalPushLimitsTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/PortalPushLimitsTest.kt
@@ -368,6 +368,96 @@ class PortalPushLimitsTest {
         )
     }
 
+    // ==================== Telemetry-Aware Batching (audit: 36_852 point rejection) ====================
+
+    /**
+     * Sessions that individually fit under SYNC_BATCH_SIZE can still push a single
+     * batch past the server-side rep_telemetry array cap when force-curve data is
+     * heavy. The planner must close a batch early whenever the next session would
+     * push cumulative telemetry past MAX_TELEMETRY_PER_BATCH.
+     */
+    @Test
+    fun planSessionBatchesSplitsWhenCumulativeTelemetryExceedsCap() {
+        val manager = createManager()
+        val sessions = (0 until 50).map { stubPortalSession("sess-$it") }
+        // Each session carries 800 telemetry points → 50 * 800 = 40_000, well past the
+        // 10_000 cap. Should split into at least 5 batches (ceil(40_000 / 10_000)).
+        val telemetryCounts = sessions.associate { it.id to 800 }
+
+        val batches = manager.planSessionBatches(sessions, telemetryCounts)
+
+        assertTrue(
+            batches.size >= 4,
+            "40_000 telemetry points must split into multiple batches; got ${batches.size}",
+        )
+        batches.forEach { batch ->
+            val tel = batch.sumOf { telemetryCounts[it.id] ?: 0 }
+            assertTrue(
+                tel <= SyncConfig.MAX_TELEMETRY_PER_BATCH,
+                "Batch telemetry $tel must not exceed ${SyncConfig.MAX_TELEMETRY_PER_BATCH}",
+            )
+            assertTrue(
+                batch.size <= SyncManager.SYNC_BATCH_SIZE,
+                "Batch size ${batch.size} must not exceed SYNC_BATCH_SIZE",
+            )
+        }
+        // No sessions lost or duplicated.
+        assertEquals(sessions.size, batches.sumOf { it.size })
+    }
+
+    /** Sessions with zero telemetry should batch identically to the old 50-per-batch chunker. */
+    @Test
+    fun planSessionBatchesPreservesLegacyChunkingWhenTelemetryIsEmpty() {
+        val manager = createManager()
+        val sessions = (0 until 73).map { stubPortalSession("sess-$it") }
+        val telemetryCounts = sessions.associate { it.id to 0 }
+
+        val batches = manager.planSessionBatches(sessions, telemetryCounts)
+
+        assertEquals(listOf(50, 23), batches.map { it.size })
+    }
+
+    /**
+     * A single session whose telemetry alone exceeds MAX_TELEMETRY_PER_BATCH should be
+     * emitted in its own batch so surrounding batches still succeed. The oversized
+     * batch will still be rejected by PortalApiClient's self-check, but that's isolated
+     * to one session instead of poisoning a whole 50-session chunk.
+     */
+    @Test
+    fun planSessionBatchesIsolatesSingleSessionTelemetryOverflow() {
+        val manager = createManager()
+        val small1 = stubPortalSession("small-1")
+        val giant = stubPortalSession("giant")
+        val small2 = stubPortalSession("small-2")
+        val telemetryCounts = mapOf(
+            small1.id to 100,
+            giant.id to SyncConfig.MAX_TELEMETRY_PER_BATCH + 5_000,
+            small2.id to 100,
+        )
+
+        val batches = manager.planSessionBatches(listOf(small1, giant, small2), telemetryCounts)
+
+        // Expect 3 batches: [small1], [giant], [small2]
+        assertEquals(3, batches.size, "Giant session must be isolated in its own batch")
+        assertEquals(listOf(small1.id), batches[0].map { it.id })
+        assertEquals(listOf(giant.id), batches[1].map { it.id })
+        assertEquals(listOf(small2.id), batches[2].map { it.id })
+    }
+
+    @Test
+    fun planSessionBatchesHandlesEmptyInput() {
+        val manager = createManager()
+        val batches = manager.planSessionBatches(emptyList(), emptyMap())
+        assertEquals(1, batches.size)
+        assertTrue(batches[0].isEmpty())
+    }
+
+    private fun stubPortalSession(id: String) = PortalWorkoutSessionDto(
+        id = id,
+        userId = "user-123",
+        startedAt = "2026-03-02T12:00:00Z",
+    )
+
     @Test
     fun pushPayloadCapturesDeviceIdAndPlatform() = runTest {
         authenticate()


### PR DESCRIPTION
## Summary
- Portal push batched by session count only (50/batch), but the server's `rep_telemetry` array cap (10,000) is a separate limit. Heavy force-curve sessions pushed a single 50-session chunk past the cap, so `PortalApiClient` aborted with `Push payload has 36852 telemetry points; cap is 10000` and sync was stuck after three retries (see screenshot).
- Replace the fixed `chunked(SYNC_BATCH_SIZE)` with a new `planSessionBatches` greedy planner that closes a batch as soon as the next session would exceed either `SYNC_BATCH_SIZE` (50 sessions) or `SyncConfig.MAX_TELEMETRY_PER_BATCH` (10,000 telemetry points).
- A single session whose own telemetry exceeds the cap is isolated in its own batch and logged, so it can't poison neighbouring sessions. Smaller batches should also reduce Edge Function processing time and help with the 60s `mobile-sync-push` request timeouts also reported by this user.

## Behaviour
- Sessions with no telemetry continue to chunk exactly like the old logic (73 → `[50, 23]`).
- Sessions with heavy telemetry split earlier; no batch exceeds either cap.
- Existing `PortalPushLimitsTest` expectations are unchanged (their stub sessions carry 0 telemetry).

## Test plan
- [x] Added `planSessionBatchesSplitsWhenCumulativeTelemetryExceedsCap`
- [x] Added `planSessionBatchesPreservesLegacyChunkingWhenTelemetryIsEmpty`
- [x] Added `planSessionBatchesIsolatesSingleSessionTelemetryOverflow`
- [x] Added `planSessionBatchesHandlesEmptyInput`
- [ ] `./gradlew :shared:commonTest` (blocked locally — sandbox can't download gradle 9.3.1; verify in CI)
- [ ] Smoke test on TestFlight build: "Force Full Resync" for the account that originally hit `36852 telemetry points` and confirm all 6 batches succeed.

https://claude.ai/code/session_015s4VWimBdbtk7gUYK5NMn6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced sync operation batching to intelligently manage telemetry data volume constraints, ensuring more reliable batch processing.

* **Tests**
  * Added comprehensive test coverage for telemetry-aware batching behavior and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->