### PR TITLE
fix(ios): drop platform.CommonCrypto dep, use pure-Kotlin SHA-256

### DIFF
--- a/shared/src/androidMain/kotlin/com/devil/phoenixproject/data/auth/OAuth.android.kt
+++ b/shared/src/androidMain/kotlin/com/devil/phoenixproject/data/auth/OAuth.android.kt
@@ -8,7 +8,6 @@ import android.net.Uri
 import android.os.Bundle
 import co.touchlab.kermit.Logger
 import kotlinx.coroutines.CompletableDeferred
-import java.security.MessageDigest
 import java.security.SecureRandom
 
 private val log = Logger.withTag("OAuthLauncher")
@@ -18,9 +17,6 @@ internal actual fun generateSecureRandomBytes(size: Int): ByteArray {
     SecureRandom().nextBytes(bytes)
     return bytes
 }
-
-internal actual fun sha256(input: ByteArray): ByteArray =
-    MessageDigest.getInstance("SHA-256").digest(input)
 
 /**
  * Android OAuth launcher. Opens the authorize URL in whatever browser the

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/auth/OAuth.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/auth/OAuth.kt
@@ -39,9 +39,89 @@ enum class OAuthProvider(val wireName: String, val scopes: String) {
 /** A PKCE verifier/challenge pair per RFC 7636. */
 data class OAuthPkce(val verifier: String, val challenge: String)
 
-/** Platform-backed cryptographic primitives for PKCE. Implemented per-target. */
+/** Platform-backed secure random. Hash is implemented in common code below. */
 internal expect fun generateSecureRandomBytes(size: Int): ByteArray
-internal expect fun sha256(input: ByteArray): ByteArray
+
+/**
+ * Pure-Kotlin SHA-256 (FIPS 180-4). Used only for the PKCE S256 challenge,
+ * which hashes a short verifier string — performance is irrelevant and the
+ * output is not a secret. Avoiding `platform.CommonCrypto` keeps the iOS
+ * build green across Kotlin/Native platform-library regressions (the K/N
+ * 2.3.20 Apple platform libs do not expose `platform.CommonCrypto`).
+ */
+internal fun sha256(input: ByteArray): ByteArray {
+    val k = intArrayOf(
+        0x428a2f98.toInt(), 0x71374491, -0x4a3f0431, -0x164a245b,
+        0x3956c25b, 0x59f111f1, -0x6dc07d5c, -0x54e3a12b,
+        -0x27f85568, 0x12835b01, 0x243185be, 0x550c7dc3,
+        0x72be5d74, -0x7f214e02, -0x6423f959, -0x3e640e8c,
+        -0x1b64963f, -0x1041b87a, 0x0fc19dc6, 0x240ca1cc,
+        0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+        -0x67c1aeae, -0x57ce3993, -0x4ffcd838, -0x40a68039,
+        -0x391ff40d, -0x2a586eb9, 0x06ca6351, 0x14292967,
+        0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+        0x650a7354, 0x766a0abb, -0x7e3d36d2, -0x6d8dd37b,
+        -0x5d40175f, -0x57e599b5, -0x3db47490, -0x3893ae5d,
+        -0x2e6d17e7, -0x2966f9dc, -0xbf1ca7b, 0x106aa070,
+        0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5,
+        0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+        0x748f82ee, 0x78a5636f, -0x7b3787ec, -0x7338fdf8,
+        -0x6f410006, -0x5baf9315, -0x41065c09, -0x398e870e,
+    )
+    val h = intArrayOf(
+        0x6a09e667, -0x4498517b, 0x3c6ef372, -0x5ab00ac6,
+        0x510e527f, -0x64fa9774, 0x1f83d9ab, 0x5be0cd19,
+    )
+    val bitLen = input.size.toLong() * 8L
+    val padLen = ((56 - (input.size + 1) % 64) + 64) % 64
+    val padded = ByteArray(input.size + 1 + padLen + 8)
+    input.copyInto(padded)
+    padded[input.size] = 0x80.toByte()
+    for (i in 0 until 8) {
+        padded[padded.size - 1 - i] = (bitLen ushr (i * 8)).toByte()
+    }
+
+    val w = IntArray(64)
+    var chunkStart = 0
+    while (chunkStart < padded.size) {
+        for (i in 0 until 16) {
+            val j = chunkStart + i * 4
+            w[i] = (padded[j].toInt() and 0xff shl 24) or
+                (padded[j + 1].toInt() and 0xff shl 16) or
+                (padded[j + 2].toInt() and 0xff shl 8) or
+                (padded[j + 3].toInt() and 0xff)
+        }
+        for (i in 16 until 64) {
+            val s0 = w[i - 15].rotateRight(7) xor w[i - 15].rotateRight(18) xor (w[i - 15] ushr 3)
+            val s1 = w[i - 2].rotateRight(17) xor w[i - 2].rotateRight(19) xor (w[i - 2] ushr 10)
+            w[i] = w[i - 16] + s0 + w[i - 7] + s1
+        }
+        var a = h[0]; var b = h[1]; var c = h[2]; var d = h[3]
+        var e = h[4]; var f = h[5]; var g = h[6]; var hh = h[7]
+        for (i in 0 until 64) {
+            val s1 = e.rotateRight(6) xor e.rotateRight(11) xor e.rotateRight(25)
+            val ch = (e and f) xor (e.inv() and g)
+            val t1 = hh + s1 + ch + k[i] + w[i]
+            val s0 = a.rotateRight(2) xor a.rotateRight(13) xor a.rotateRight(22)
+            val maj = (a and b) xor (a and c) xor (b and c)
+            val t2 = s0 + maj
+            hh = g; g = f; f = e; e = d + t1
+            d = c; c = b; b = a; a = t1 + t2
+        }
+        h[0] += a; h[1] += b; h[2] += c; h[3] += d
+        h[4] += e; h[5] += f; h[6] += g; h[7] += hh
+        chunkStart += 64
+    }
+
+    val out = ByteArray(32)
+    for (i in 0 until 8) {
+        out[i * 4] = (h[i] ushr 24).toByte()
+        out[i * 4 + 1] = (h[i] ushr 16).toByte()
+        out[i * 4 + 2] = (h[i] ushr 8).toByte()
+        out[i * 4 + 3] = h[i].toByte()
+    }
+    return out
+}
 
 /**
  * Base64URL encoding without padding (RFC 4648 §5). PKCE requires the `=`

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/auth/OAuthPkceTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/auth/OAuthPkceTest.kt
@@ -1,0 +1,47 @@
+package com.devil.phoenixproject.data.auth
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class OAuthPkceTest {
+
+    @Test
+    fun sha256_emptyInput_matchesFipsTestVector() {
+        assertEquals(
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            sha256(ByteArray(0)).toHex(),
+        )
+    }
+
+    @Test
+    fun sha256_abc_matchesFipsTestVector() {
+        assertEquals(
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+            sha256("abc".encodeToByteArray()).toHex(),
+        )
+    }
+
+    @Test
+    fun sha256_longInput_matchesFipsTestVector() {
+        val input = (
+            "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"
+            ).encodeToByteArray()
+        assertEquals(
+            "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1",
+            sha256(input).toHex(),
+        )
+    }
+
+    @Test
+    fun sha256_rfc7636_pkceTestVector() {
+        // RFC 7636 Appendix B: S256 example. Verifier hashed to challenge.
+        val verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+        assertEquals(
+            "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+            sha256(verifier.encodeToByteArray()).toBase64UrlNoPad(),
+        )
+    }
+
+    private fun ByteArray.toHex(): String =
+        joinToString("") { (it.toInt() and 0xff).toString(16).padStart(2, '0') }
+}

--- a/shared/src/iosMain/kotlin/com/devil/phoenixproject/data/auth/OAuth.ios.kt
+++ b/shared/src/iosMain/kotlin/com/devil/phoenixproject/data/auth/OAuth.ios.kt
@@ -4,13 +4,10 @@ import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.convert
-import kotlinx.cinterop.reinterpret
 import kotlinx.cinterop.usePinned
 import kotlinx.coroutines.suspendCancellableCoroutine
 import platform.AuthenticationServices.ASWebAuthenticationPresentationContextProvidingProtocol
 import platform.AuthenticationServices.ASWebAuthenticationSession
-import platform.CommonCrypto.CC_SHA256
-import platform.CommonCrypto.CC_SHA256_DIGEST_LENGTH
 import platform.Foundation.NSError
 import platform.Foundation.NSURL
 import platform.Security.SecRandomCopyBytes
@@ -38,29 +35,6 @@ internal actual fun generateSecureRandomBytes(size: Int): ByteArray {
         check(status == 0) { "SecRandomCopyBytes failed with status=$status" }
     }
     return bytes
-}
-
-@OptIn(ExperimentalForeignApi::class)
-internal actual fun sha256(input: ByteArray): ByteArray {
-    // CC_SHA256_DIGEST_LENGTH comes from CommonCrypto as Long in Kotlin/Native
-    // 2.3.x platform libs; ByteArray(size: Int) needs the explicit narrowing.
-    val digest = ByteArray(CC_SHA256_DIGEST_LENGTH.toInt())
-    if (input.isEmpty()) {
-        digest.usePinned { digestPinned ->
-            CC_SHA256(null, 0u, digestPinned.addressOf(0).reinterpret())
-        }
-        return digest
-    }
-    input.usePinned { inputPinned ->
-        digest.usePinned { digestPinned ->
-            CC_SHA256(
-                inputPinned.addressOf(0),
-                input.size.convert(),
-                digestPinned.addressOf(0).reinterpret(),
-            )
-        }
-    }
-    return digest
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fixes iOS Release IPA and TestFlight workflows failing at `:shared:compileKotlinIosArm64` with `Unresolved reference 'CommonCrypto'` under Kotlin 2.3.20. The Apple platform libraries in K/N 2.3.20 no longer expose `platform.CommonCrypto`, so `CC_SHA256` / `CC_SHA256_DIGEST_LENGTH` imports no longer resolve.
- Replaces the iOS-only `CC_SHA256` call with a self-contained FIPS 180-4 SHA-256 implementation in `commonMain`. The hash is only used for the PKCE S256 challenge over a short verifier string — performance is irrelevant and the output is not a secret, so pure Kotlin is a clean fit. No cinterop def file or build-config change required.
- Drops the `expect fun sha256` + per-platform actuals (CommonCrypto on iOS, `MessageDigest` on Android). `generateSecureRandomBytes` stays expect/actual so each platform keeps using its native CSPRNG (`SecRandomCopyBytes` / `SecureRandom`).

## Test plan
- [x] SHA-256 implementation verified against the FIPS 180-4 empty-string, `"abc"`, and 56-byte test vectors, plus the RFC 7636 Appendix B PKCE example, via a Python transliteration cross-checked against `hashlib.sha256`.
- [x] `./gradlew :shared:compileCommonMainKotlinMetadata -Pskip.supabase.check=true` succeeds locally.
- [ ] Re-run the **iOS Release IPA** workflow and confirm `:shared:compileKotlinIosArm64` completes and the IPA is produced.
- [ ] Re-run the **iOS TestFlight** workflow (same compile step) and confirm it uploads.
- [ ] On a device build, confirm Google / Apple OAuth sign-in still succeeds (PKCE challenge matches what Supabase expects).

https://claude.ai/code/session_013cThWPXC8BTgRYGfyGJ6xt