### PR TITLE
chore: bump version to 0.7.0

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -59,7 +59,7 @@ android {
         targetSdk = 36
         // Fail fast if CI injects an invalid version code instead of silently shipping a default.
         versionCode = injectedVersionCode ?: 5
-        versionName = "0.6.5"
+        versionName = "0.7.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/iosApp/VitruvianPhoenix/VitruvianPhoenix.xcodeproj/project.pbxproj
+++ b/iosApp/VitruvianPhoenix/VitruvianPhoenix.xcodeproj/project.pbxproj
@@ -367,7 +367,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.6.5;
+				MARKETING_VERSION = 0.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.devil.phoenixproject.projectphoenix;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -412,7 +412,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.6.5;
+				MARKETING_VERSION = 0.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.devil.phoenixproject.projectphoenix;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/Constants.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/Constants.kt
@@ -5,7 +5,7 @@ package com.devil.phoenixproject.util
  */
 object Constants {
     // App version
-    const val APP_VERSION = "0.6.5"
+    const val APP_VERSION = "0.7.0"
 
     // EULA version - increment when EULA text changes materially
     // Users must re-accept when this version increases


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Bumps `versionName` to `0.7.0` in `androidApp/build.gradle.kts`
- Bumps `MARKETING_VERSION` to `0.7.0` in both Debug and Release configurations in `iosApp/VitruvianPhoenix/VitruvianPhoenix.xcodeproj/project.pbxproj`
- Bumps `APP_VERSION` constant to `0.7.0` in `shared/src/commonMain/kotlin/com/devil/phoenixproject/util/Constants.kt`

## Test plan

- [ ] Verify Settings screen displays `0.7.0` on Android
- [ ] Verify Settings screen displays `0.7.0` on iOS

https://claude.ai/code/session_01A4rgN2f9KTkwvKZnFMaqnr
EOF
)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.7.0 across all platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->