### PR TITLE
feat(linkaccount): add Google/Apple OAuth buttons to Link Portal Account

### DIFF
--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -138,6 +138,9 @@
     <!-- ==================== Auth ==================== -->
     <string name="auth_google">Google</string>
     <string name="auth_apple">Apple</string>
+    <string name="auth_or_continue_with">Or continue with</string>
+    <string name="auth_google_failed">Google sign-in failed</string>
+    <string name="auth_apple_failed">Apple sign-in failed</string>
 
     <!-- ==================== Link Account / Sync ==================== -->
     <string name="phoenix_portal">Phoenix Portal</string>

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/SyncManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/SyncManager.kt
@@ -283,6 +283,21 @@ class SyncManager(
     }
 
     /**
+     * Resets [_syncState] to [SyncState.Idle] without performing a sync.
+     *
+     * Use this after an out-of-band sign-in (OAuth, deep-link, etc.) that
+     * bypasses [login] but still needs to clear a stale
+     * [SyncState.NotAuthenticated] left over from a prior [logout]. Otherwise
+     * the UI continues to show "Authentication failed — please sign out and
+     * sign back in" even though the new session is valid.
+     */
+    suspend fun resetSyncStateToIdle() {
+        syncMutex.withLock {
+            _syncState.value = SyncState.Idle
+        }
+    }
+
+    /**
      * Refreshes [PortalUser.isPremium] from the server subscription endpoint.
      * Prefer this on app foreground; do not infer entitlement from sync HTTP status alone.
      */

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/di/PresentationModule.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/di/PresentationModule.kt
@@ -27,5 +27,5 @@ val presentationModule = module {
     single { EulaViewModel(get()) }
 
     // Sync UI
-    factory { LinkAccountViewModel(get()) }
+    factory { LinkAccountViewModel(get(), get()) }
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/OAuthProviderIcons.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/OAuthProviderIcons.kt
@@ -1,0 +1,93 @@
+package com.devil.phoenixproject.presentation.components
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+
+/**
+ * Google "G" logo drawn with Canvas primitives so we don't have to ship a
+ * raster or SVG asset. Uses Google's brand blue regardless of theme — the
+ * logo is trademarked and we render it as Google publishes it.
+ */
+@Composable
+fun GoogleIcon(modifier: Modifier = Modifier) {
+    Canvas(modifier = modifier) {
+        val side = size.minDimension
+        val strokeWidth = side * 0.15f
+        val radius = side * 0.4f
+        val center = Offset(side / 2, side / 2)
+
+        drawArc(
+            color = Color(0xFF4285F4),
+            startAngle = 45f,
+            sweepAngle = 270f,
+            useCenter = false,
+            topLeft = Offset(center.x - radius, center.y - radius),
+            size = Size(radius * 2, radius * 2),
+            style = Stroke(width = strokeWidth, cap = StrokeCap.Round),
+        )
+
+        drawLine(
+            color = Color(0xFF4285F4),
+            start = Offset(center.x, center.y),
+            end = Offset(center.x + radius, center.y),
+            strokeWidth = strokeWidth,
+            cap = StrokeCap.Round,
+        )
+    }
+}
+
+/**
+ * Apple logo drawn with Canvas primitives. Uses the ambient
+ * [LocalContentColor] so the icon stays readable on both light and dark
+ * `OutlinedButton` surfaces — hardcoded black disappears in dark mode.
+ */
+@Composable
+fun AppleIcon(modifier: Modifier = Modifier) {
+    val iconColor = LocalContentColor.current
+    Canvas(modifier = modifier) {
+        val side = size.minDimension
+        val centerX = side / 2
+
+        val path = Path().apply {
+            moveTo(centerX, side * 0.15f)
+            cubicTo(
+                centerX + side * 0.5f,
+                side * 0.2f,
+                centerX + side * 0.4f,
+                side * 0.7f,
+                centerX,
+                side * 0.95f,
+            )
+            cubicTo(
+                centerX - side * 0.4f,
+                side * 0.7f,
+                centerX - side * 0.5f,
+                side * 0.2f,
+                centerX,
+                side * 0.15f,
+            )
+            close()
+        }
+
+        drawPath(
+            path = path,
+            color = iconColor,
+        )
+
+        drawLine(
+            color = iconColor,
+            start = Offset(centerX + side * 0.05f, side * 0.15f),
+            end = Offset(centerX + side * 0.15f, side * 0.02f),
+            strokeWidth = side * 0.08f,
+            cap = StrokeCap.Round,
+        )
+    }
+}

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/AuthScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/AuthScreen.kt
@@ -1,6 +1,5 @@
 package com.devil.phoenixproject.presentation.screen
 
-import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -26,7 +25,6 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
@@ -45,12 +43,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Path
-import androidx.compose.ui.graphics.StrokeCap
-import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
@@ -60,6 +52,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.devil.phoenixproject.data.repository.AuthRepository
 import com.devil.phoenixproject.data.repository.AuthState
+import com.devil.phoenixproject.presentation.components.AppleIcon
+import com.devil.phoenixproject.presentation.components.GoogleIcon
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 import vitruvianprojectphoenix.shared.generated.resources.Res
@@ -351,77 +345,6 @@ fun AuthScreen(authRepository: AuthRepository, onAuthSuccess: () -> Unit, onBack
     }
 }
 
-/** Google "G" logo drawn with Canvas primitives (no network-fetched asset). */
-@Composable
-private fun GoogleIcon(modifier: Modifier = Modifier) {
-    Canvas(modifier = modifier) {
-        val side = size.minDimension
-        val strokeWidth = side * 0.15f
-        val radius = side * 0.4f
-        val center = Offset(side / 2, side / 2)
-
-        drawArc(
-            color = Color(0xFF4285F4),
-            startAngle = 45f,
-            sweepAngle = 270f,
-            useCenter = false,
-            topLeft = Offset(center.x - radius, center.y - radius),
-            size = Size(radius * 2, radius * 2),
-            style = Stroke(width = strokeWidth, cap = StrokeCap.Round),
-        )
-
-        drawLine(
-            color = Color(0xFF4285F4),
-            start = Offset(center.x, center.y),
-            end = Offset(center.x + radius, center.y),
-            strokeWidth = strokeWidth,
-            cap = StrokeCap.Round,
-        )
-    }
-}
-
-/** Apple logo drawn with Canvas primitives. */
-@Composable
-private fun AppleIcon(modifier: Modifier = Modifier) {
-    // Theme-aware color so the icon stays readable on both light + dark
-    // OutlinedButton surfaces. Hardcoded black would disappear in dark mode.
-    val iconColor = LocalContentColor.current
-    Canvas(modifier = modifier) {
-        val side = size.minDimension
-        val centerX = side / 2
-
-        val path = Path().apply {
-            moveTo(centerX, side * 0.15f)
-            cubicTo(
-                centerX + side * 0.5f,
-                side * 0.2f,
-                centerX + side * 0.4f,
-                side * 0.7f,
-                centerX,
-                side * 0.95f,
-            )
-            cubicTo(
-                centerX - side * 0.4f,
-                side * 0.7f,
-                centerX - side * 0.5f,
-                side * 0.2f,
-                centerX,
-                side * 0.15f,
-            )
-            close()
-        }
-
-        drawPath(
-            path = path,
-            color = iconColor,
-        )
-
-        drawLine(
-            color = iconColor,
-            start = Offset(centerX + side * 0.05f, side * 0.15f),
-            end = Offset(centerX + side * 0.15f, side * 0.02f),
-            strokeWidth = side * 0.08f,
-            cap = StrokeCap.Round,
-        )
-    }
-}
+// GoogleIcon / AppleIcon now live in
+// com.devil.phoenixproject.presentation.components.OAuthProviderIcons so the
+// LinkAccount surface can reuse them. Imports above point to that file.

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/LinkAccountScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/LinkAccountScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -48,6 +49,8 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import com.devil.phoenixproject.data.sync.AuthEvent
 import com.devil.phoenixproject.data.sync.SyncState
+import com.devil.phoenixproject.presentation.components.AppleIcon
+import com.devil.phoenixproject.presentation.components.GoogleIcon
 import com.devil.phoenixproject.ui.sync.LinkAccountUiState
 import com.devil.phoenixproject.ui.sync.LinkAccountViewModel
 import com.devil.phoenixproject.util.KmpUtils
@@ -55,6 +58,8 @@ import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
 import vitruvianprojectphoenix.shared.generated.resources.Res
 import vitruvianprojectphoenix.shared.generated.resources.action_login
+import vitruvianprojectphoenix.shared.generated.resources.auth_apple
+import vitruvianprojectphoenix.shared.generated.resources.auth_google
 import vitruvianprojectphoenix.shared.generated.resources.cd_back
 import vitruvianprojectphoenix.shared.generated.resources.label_email
 import vitruvianprojectphoenix.shared.generated.resources.label_password
@@ -156,6 +161,8 @@ fun LinkAccountScreen(onNavigateBack: () -> Unit) {
                 LoginForm(
                     uiState = uiState,
                     onLogin = { email, password -> viewModel.login(email, password) },
+                    onGoogleLogin = { viewModel.loginWithGoogle() },
+                    onAppleLogin = { viewModel.loginWithApple() },
                     onClearError = { viewModel.clearError() },
                 )
             }
@@ -291,7 +298,13 @@ private fun LinkedAccountContent(
 }
 
 @Composable
-private fun LoginForm(uiState: LinkAccountUiState, onLogin: (String, String) -> Unit, onClearError: () -> Unit) {
+private fun LoginForm(
+    uiState: LinkAccountUiState,
+    onLogin: (String, String) -> Unit,
+    onGoogleLogin: () -> Unit,
+    onAppleLogin: () -> Unit,
+    onClearError: () -> Unit,
+) {
     var email by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
     var showPassword by remember { mutableStateOf(false) }
@@ -368,6 +381,43 @@ private fun LoginForm(uiState: LinkAccountUiState, onLogin: (String, String) -> 
                     )
                 } else {
                     Text(stringResource(Res.string.action_login))
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // OAuth sign-in. Reuses the same Supabase GoTrue backend the web
+            // portal uses, so a user who signed up on the portal via Google /
+            // Apple lands in the same account here — no separate provisioning.
+            // Sign-up stays on the web, so this surface is sign-in-only.
+            Text(
+                text = "Or continue with",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.align(Alignment.CenterHorizontally),
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterHorizontally),
+            ) {
+                OutlinedButton(
+                    onClick = onGoogleLogin,
+                    enabled = uiState !is LinkAccountUiState.Loading,
+                ) {
+                    GoogleIcon(modifier = Modifier.size(18.dp))
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(stringResource(Res.string.auth_google))
+                }
+                OutlinedButton(
+                    onClick = onAppleLogin,
+                    enabled = uiState !is LinkAccountUiState.Loading,
+                ) {
+                    AppleIcon(modifier = Modifier.size(18.dp))
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(stringResource(Res.string.auth_apple))
                 }
             }
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/LinkAccountScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/LinkAccountScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
+import com.devil.phoenixproject.data.auth.OAuthProvider
 import com.devil.phoenixproject.data.sync.AuthEvent
 import com.devil.phoenixproject.data.sync.SyncState
 import com.devil.phoenixproject.presentation.components.AppleIcon
@@ -59,7 +60,10 @@ import org.koin.compose.koinInject
 import vitruvianprojectphoenix.shared.generated.resources.Res
 import vitruvianprojectphoenix.shared.generated.resources.action_login
 import vitruvianprojectphoenix.shared.generated.resources.auth_apple
+import vitruvianprojectphoenix.shared.generated.resources.auth_apple_failed
 import vitruvianprojectphoenix.shared.generated.resources.auth_google
+import vitruvianprojectphoenix.shared.generated.resources.auth_google_failed
+import vitruvianprojectphoenix.shared.generated.resources.auth_or_continue_with
 import vitruvianprojectphoenix.shared.generated.resources.cd_back
 import vitruvianprojectphoenix.shared.generated.resources.label_email
 import vitruvianprojectphoenix.shared.generated.resources.label_password
@@ -157,12 +161,17 @@ fun LinkAccountScreen(onNavigateBack: () -> Unit) {
                     onLogout = { viewModel.logout() },
                 )
             } else {
-                // Login form (sign up happens via Phoenix Portal)
+                // Login form (sign up happens via Phoenix Portal). Strings
+                // are read here so they can be passed to the ViewModel as
+                // localized fallbacks — VMs in this project don't have
+                // direct access to compose-resources.
+                val googleFailedFallback = stringResource(Res.string.auth_google_failed)
+                val appleFailedFallback = stringResource(Res.string.auth_apple_failed)
                 LoginForm(
                     uiState = uiState,
                     onLogin = { email, password -> viewModel.login(email, password) },
-                    onGoogleLogin = { viewModel.loginWithGoogle() },
-                    onAppleLogin = { viewModel.loginWithApple() },
+                    onGoogleLogin = { viewModel.loginWithGoogle(googleFailedFallback) },
+                    onAppleLogin = { viewModel.loginWithApple(appleFailedFallback) },
                     onClearError = { viewModel.clearError() },
                 )
             }
@@ -391,7 +400,7 @@ private fun LoginForm(
             // Apple lands in the same account here — no separate provisioning.
             // Sign-up stays on the web, so this surface is sign-in-only.
             Text(
-                text = "Or continue with",
+                text = stringResource(Res.string.auth_or_continue_with),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.align(Alignment.CenterHorizontally),
@@ -399,23 +408,44 @@ private fun LoginForm(
 
             Spacer(modifier = Modifier.height(8.dp))
 
+            // Track which provider (if any) initiated the active load so we
+            // can render an inline spinner inside that specific button —
+            // otherwise the user sees three dimmed buttons with no feedback
+            // while the system browser warms up.
+            val loadingProvider = (uiState as? LinkAccountUiState.Loading)?.provider
+            val anyLoading = uiState is LinkAccountUiState.Loading
+
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterHorizontally),
             ) {
                 OutlinedButton(
                     onClick = onGoogleLogin,
-                    enabled = uiState !is LinkAccountUiState.Loading,
+                    enabled = !anyLoading,
                 ) {
-                    GoogleIcon(modifier = Modifier.size(18.dp))
+                    if (loadingProvider == OAuthProvider.GOOGLE) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(18.dp),
+                            strokeWidth = 2.dp,
+                        )
+                    } else {
+                        GoogleIcon(modifier = Modifier.size(18.dp))
+                    }
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(stringResource(Res.string.auth_google))
                 }
                 OutlinedButton(
                     onClick = onAppleLogin,
-                    enabled = uiState !is LinkAccountUiState.Loading,
+                    enabled = !anyLoading,
                 ) {
-                    AppleIcon(modifier = Modifier.size(18.dp))
+                    if (loadingProvider == OAuthProvider.APPLE) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(18.dp),
+                            strokeWidth = 2.dp,
+                        )
+                    } else {
+                        AppleIcon(modifier = Modifier.size(18.dp))
+                    }
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(stringResource(Res.string.auth_apple))
                 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/ui/sync/LinkAccountViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/ui/sync/LinkAccountViewModel.kt
@@ -1,5 +1,6 @@
 package com.devil.phoenixproject.ui.sync
 
+import com.devil.phoenixproject.data.repository.AuthRepository
 import com.devil.phoenixproject.data.sync.PortalUser
 import com.devil.phoenixproject.data.sync.SyncManager
 import com.devil.phoenixproject.data.sync.SyncState
@@ -43,7 +44,10 @@ sealed class LinkAccountUiState {
  * .onDisappear { viewModel.clear() }
  * ```
  */
-class LinkAccountViewModel(private val syncManager: SyncManager) {
+class LinkAccountViewModel(
+    private val syncManager: SyncManager,
+    private val authRepository: AuthRepository,
+) {
     private val job = SupervisorJob()
     private val scope = CoroutineScope(Dispatchers.Main + job)
 
@@ -80,6 +84,70 @@ class LinkAccountViewModel(private val syncManager: SyncManager) {
                 // Coroutine cancelled during clear() - preserve original cancellation
                 throw e
             }
+        }
+    }
+
+    /**
+     * Link the portal account by signing in with Google OAuth.
+     *
+     * The flow runs against the same Supabase GoTrue backend the portal uses,
+     * so a user who signed up on the web portal with Google lands in the
+     * exact same account here — no separate provisioning required. After the
+     * OAuth session is saved, we refresh premium/tier from the server so the
+     * UI reflects the actual subscription state instead of defaulting to
+     * free.
+     */
+    fun loginWithGoogle() {
+        scope.launch {
+            try {
+                _uiState.value = LinkAccountUiState.Loading
+                authRepository.signInWithGoogle()
+                    .onSuccess { finishOAuthLink() }
+                    .onFailure { error ->
+                        _uiState.value = LinkAccountUiState.Error(
+                            error.message ?: "Google sign-in failed",
+                        )
+                    }
+            } catch (e: CancellationException) {
+                throw e
+            }
+        }
+    }
+
+    /**
+     * Link the portal account by signing in with Apple OAuth. Same
+     * contract as [loginWithGoogle] — same GoTrue backend, same post-sign-in
+     * premium/tier refresh.
+     */
+    fun loginWithApple() {
+        scope.launch {
+            try {
+                _uiState.value = LinkAccountUiState.Loading
+                authRepository.signInWithApple()
+                    .onSuccess { finishOAuthLink() }
+                    .onFailure { error ->
+                        _uiState.value = LinkAccountUiState.Error(
+                            error.message ?: "Apple sign-in failed",
+                        )
+                    }
+            } catch (e: CancellationException) {
+                throw e
+            }
+        }
+    }
+
+    /**
+     * Shared post-OAuth tail: pull premium + tier from the server so the
+     * PortalUser exposed by [currentUser] reflects the real entitlement
+     * rather than the default-false values `saveGoTrueAuth` writes.
+     */
+    private suspend fun finishOAuthLink() {
+        syncManager.refreshPremiumStatusFromServer()
+        val user = syncManager.currentUser.value
+        _uiState.value = if (user != null) {
+            LinkAccountUiState.Success(user)
+        } else {
+            LinkAccountUiState.Error("Signed in but user session is missing")
         }
     }
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/ui/sync/LinkAccountViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/ui/sync/LinkAccountViewModel.kt
@@ -1,5 +1,7 @@
 package com.devil.phoenixproject.ui.sync
 
+import co.touchlab.kermit.Logger
+import com.devil.phoenixproject.data.auth.OAuthProvider
 import com.devil.phoenixproject.data.repository.AuthRepository
 import com.devil.phoenixproject.data.sync.PortalUser
 import com.devil.phoenixproject.data.sync.SyncManager
@@ -15,7 +17,15 @@ import kotlinx.coroutines.launch
 
 sealed class LinkAccountUiState {
     object Initial : LinkAccountUiState()
-    object Loading : LinkAccountUiState()
+
+    /**
+     * Loading state. [provider] identifies which OAuth provider triggered the
+     * flow, or `null` for the email/password path. The UI uses this to render
+     * a spinner inside the specific button the user tapped instead of just
+     * dimming all three.
+     */
+    data class Loading(val provider: OAuthProvider? = null) : LinkAccountUiState()
+
     data class Success(val user: PortalUser) : LinkAccountUiState()
     data class Error(val message: String) : LinkAccountUiState()
 }
@@ -69,7 +79,7 @@ class LinkAccountViewModel(
     fun login(email: String, password: String) {
         scope.launch {
             try {
-                _uiState.value = LinkAccountUiState.Loading
+                _uiState.value = LinkAccountUiState.Loading(provider = null)
 
                 syncManager.login(email, password)
                     .onSuccess { user ->
@@ -96,21 +106,13 @@ class LinkAccountViewModel(
      * OAuth session is saved, we refresh premium/tier from the server so the
      * UI reflects the actual subscription state instead of defaulting to
      * free.
+     *
+     * @param fallbackErrorMessage localized error string used when the
+     *        underlying provider didn't surface its own message.
      */
-    fun loginWithGoogle() {
-        scope.launch {
-            try {
-                _uiState.value = LinkAccountUiState.Loading
-                authRepository.signInWithGoogle()
-                    .onSuccess { finishOAuthLink() }
-                    .onFailure { error ->
-                        _uiState.value = LinkAccountUiState.Error(
-                            error.message ?: "Google sign-in failed",
-                        )
-                    }
-            } catch (e: CancellationException) {
-                throw e
-            }
+    fun loginWithGoogle(fallbackErrorMessage: String) {
+        runOAuth(OAuthProvider.GOOGLE, fallbackErrorMessage) {
+            authRepository.signInWithGoogle()
         }
     }
 
@@ -119,15 +121,25 @@ class LinkAccountViewModel(
      * contract as [loginWithGoogle] — same GoTrue backend, same post-sign-in
      * premium/tier refresh.
      */
-    fun loginWithApple() {
+    fun loginWithApple(fallbackErrorMessage: String) {
+        runOAuth(OAuthProvider.APPLE, fallbackErrorMessage) {
+            authRepository.signInWithApple()
+        }
+    }
+
+    private fun runOAuth(
+        provider: OAuthProvider,
+        fallbackErrorMessage: String,
+        block: suspend () -> Result<*>,
+    ) {
         scope.launch {
             try {
-                _uiState.value = LinkAccountUiState.Loading
-                authRepository.signInWithApple()
+                _uiState.value = LinkAccountUiState.Loading(provider = provider)
+                block()
                     .onSuccess { finishOAuthLink() }
                     .onFailure { error ->
                         _uiState.value = LinkAccountUiState.Error(
-                            error.message ?: "Apple sign-in failed",
+                            error.message ?: fallbackErrorMessage,
                         )
                     }
             } catch (e: CancellationException) {
@@ -137,12 +149,29 @@ class LinkAccountViewModel(
     }
 
     /**
-     * Shared post-OAuth tail: pull premium + tier from the server so the
-     * PortalUser exposed by [currentUser] reflects the real entitlement
-     * rather than the default-false values `saveGoTrueAuth` writes.
+     * Shared post-OAuth tail. Two responsibilities:
+     *
+     * 1. Reset [SyncState.NotAuthenticated] left over from a prior
+     *    [SyncManager.logout]. OAuth bypasses [SyncManager.login], which is
+     *    where that reset normally happens, so without this the screen will
+     *    render "Authentication failed" right after a successful sign-in.
+     * 2. Pull premium + tier from the server so the PortalUser exposed by
+     *    [currentUser] reflects real entitlement instead of the
+     *    default-false values `saveGoTrueAuth` writes.
+     *
+     * The premium refresh is best-effort: a network failure here must NOT
+     * leave the UI stuck at Loading or invalidate the sign-in itself —
+     * the GoTrue session was already persisted. Wrap in `runCatching` and
+     * always advance to Success/Error.
      */
     private suspend fun finishOAuthLink() {
-        syncManager.refreshPremiumStatusFromServer()
+        syncManager.resetSyncStateToIdle()
+        runCatching { syncManager.refreshPremiumStatusFromServer() }
+            .onFailure { e ->
+                Logger.w("LinkAccountViewModel") {
+                    "OAuth premium refresh failed (sign-in still succeeded): ${e.message}"
+                }
+            }
         val user = syncManager.currentUser.value
         _uiState.value = if (user != null) {
             LinkAccountUiState.Success(user)
@@ -154,7 +183,7 @@ class LinkAccountViewModel(
     fun signup(email: String, password: String, displayName: String) {
         scope.launch {
             try {
-                _uiState.value = LinkAccountUiState.Loading
+                _uiState.value = LinkAccountUiState.Loading(provider = null)
 
                 syncManager.signup(email, password, displayName)
                     .onSuccess { user ->


### PR DESCRIPTION
## Summary

PR #374 restored Google/Apple OAuth sign-in to the legacy `AuthScreen`, but the **Link Portal Account** surface (the one actually reachable from Settings in the current UI) still only accepted email/password. A user who signed up on the web portal with Google therefore couldn't link the mobile app to their portal account at all.

This PR mirrors the OAuth UX to that screen so portal users can actually use the mobile app.

## Flow

1. Tap "Continue with Google" (or Apple) in Settings → Link Portal Account
2. `LinkAccountViewModel.loginWithGoogle/Apple()` delegates to `AuthRepository.signInWith{Google,Apple}()` — the same Supabase GoTrue PKCE flow shipped in #374
3. GoTrue session saved via the existing token pipeline
4. `SyncManager.refreshPremiumStatusFromServer()` pulls real premium/tier (otherwise the UI would show free because `saveGoTrueAuth` writes default-false)
5. UI flips to the `LinkedAccountContent` card with the live user

Because GoTrue is the same backend the portal uses, a user created on the web with Google maps to the exact same GoTrue user ID on mobile — no separate provisioning.

## Changes

- `LinkAccountViewModel` gains `loginWithGoogle()` / `loginWithApple()` + an `AuthRepository` constructor param
- `LinkAccountScreen.LoginForm` gains "Or continue with" + Google/Apple buttons (sign-in only — sign-up still on the web)
- `GoogleIcon` / `AppleIcon` canvas composables moved from `AuthScreen.kt` into a shared `presentation/components/OAuthProviderIcons.kt` so both screens render identically and the icons survive the planned removal of the legacy AuthScreen
- `PresentationModule` factory updated for the new `LinkAccountViewModel` constructor param

## Test plan

- [ ] Portal user signed up with Google on the web → Settings → Link Portal Account → Continue with Google → session returns, premium/tier resolved, screen flips to LinkedAccountContent
- [ ] Same flow for Apple
- [ ] Existing email/password login path still works
- [ ] Cancelling the browser mid-flow surfaces a clear error, screen stays on LoginForm
- [ ] Android + iOS builds

## Config (already done for #374, still required)

- Supabase **Auth → URL Configuration → Redirect URLs** must include `com.devil.phoenixproject://auth-callback`
- Google + Apple providers enabled on the Supabase project

https://claude.ai/code/session_01PjJrB41Y5Fvpy2DoSdr4Dx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Google and Apple OAuth sign-in options to the account linking screen, enabling users to authenticate with their existing accounts from these providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->