### PR TITLE
fix(ui): preserve quarter kilogram picker values

### DIFF
--- a/shared/src/androidMain/kotlin/com/devil/phoenixproject/presentation/components/CompactNumberPicker.android.kt
+++ b/shared/src/androidMain/kotlin/com/devil/phoenixproject/presentation/components/CompactNumberPicker.android.kt
@@ -103,15 +103,9 @@ actual fun CompactNumberPicker(
                         this.value = currentIndex.coerceIn(0, values.size - 1)
                         wrapSelectorWheel = false
 
-                        // Format displayed values with proper decimal precision
+                        // Format displayed values with precision matching the picker step.
                         val displayValues = values.map {
-                            val formatted = if (step >= 1.0f && it % 1.0f == 0f) {
-                                // Show as integer if step is 1.0 and value is whole number
-                                it.toInt().toString()
-                            } else {
-                                // Show with one decimal place for fractional values
-                                "%.1f".format(it)
-                            }
+                            val formatted = formatCompactNumberPickerValue(it, step)
                             if (suffix.isNotEmpty()) "$formatted $suffix" else formatted
                         }.toTypedArray()
                         this.displayedValues = displayValues

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/CompactNumberPicker.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/CompactNumberPicker.kt
@@ -2,6 +2,9 @@ package com.devil.phoenixproject.presentation.components
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import com.devil.phoenixproject.util.KmpUtils
+import kotlin.math.abs
+import kotlin.math.roundToInt
 
 /**
  * Compact Number Picker - Platform-specific number picker
@@ -43,3 +46,32 @@ expect fun CompactNumberPicker(
     label: String = "",
     suffix: String = "",
 )
+
+internal fun formatCompactNumberPickerValue(value: Float, step: Float): String {
+    val decimals = decimalPlacesForStep(step)
+    val formatted = if (decimals <= 0) {
+        if (value % 1.0f == 0f) {
+            value.toInt().toString()
+        } else {
+            KmpUtils.formatFloat(value, 2).trimEnd('0').trimEnd('.')
+        }
+    } else {
+        KmpUtils.formatFloat(value, decimals).trimEnd('0').trimEnd('.')
+    }
+
+    return if (formatted == "-0") "0" else formatted
+}
+
+private fun decimalPlacesForStep(step: Float): Int {
+    if (step <= 0f) return 0
+
+    var scaled = step
+    for (decimals in 0..4) {
+        if (abs(scaled.roundToInt() - scaled) < 0.0001f) {
+            return decimals
+        }
+        scaled *= 10f
+    }
+
+    return 4
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/components/CompactNumberPickerFormatTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/components/CompactNumberPickerFormatTest.kt
@@ -1,0 +1,21 @@
+package com.devil.phoenixproject.presentation.components
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CompactNumberPickerFormatTest {
+
+    @Test
+    fun formatCompactNumberPickerValue_quarterKgStep_preservesQuarterValues() {
+        assertEquals("10", formatCompactNumberPickerValue(10f, 0.25f))
+        assertEquals("10.25", formatCompactNumberPickerValue(10.25f, 0.25f))
+        assertEquals("10.5", formatCompactNumberPickerValue(10.5f, 0.25f))
+        assertEquals("10.75", formatCompactNumberPickerValue(10.75f, 0.25f))
+    }
+
+    @Test
+    fun formatCompactNumberPickerValue_halfStep_usesSingleDecimalWhenNeeded() {
+        assertEquals("10", formatCompactNumberPickerValue(10f, 0.5f))
+        assertEquals("10.5", formatCompactNumberPickerValue(10.5f, 0.5f))
+    }
+}

--- a/shared/src/iosMain/kotlin/com/devil/phoenixproject/presentation/components/CompactNumberPicker.ios.kt
+++ b/shared/src/iosMain/kotlin/com/devil/phoenixproject/presentation/components/CompactNumberPicker.ios.kt
@@ -174,13 +174,7 @@ actual fun CompactNumberPicker(
 
     // Format a value for display
     fun formatValue(floatVal: Float): String {
-        val formatted = if (step >= 1.0f && floatVal % 1.0f == 0f) {
-            floatVal.toInt().toString()
-        } else {
-            val intPart = floatVal.toInt()
-            val decPart = ((floatVal - intPart) * 10).toInt().let { if (floatVal < 0 && it < 0) -it else abs(it) }
-            "$intPart.$decPart"
-        }
+        val formatted = formatCompactNumberPickerValue(floatVal, step)
         return if (suffix.isNotEmpty()) "$formatted $suffix" else formatted
     }
 
@@ -271,13 +265,7 @@ actual fun CompactNumberPicker(
     }
 
     // Format value for editing (without suffix)
-    fun formatValueForEdit(floatVal: Float): String = if (step >= 1.0f && floatVal % 1.0f == 0f) {
-        floatVal.toInt().toString()
-    } else {
-        val intPart = floatVal.toInt()
-        val decPart = ((floatVal - intPart) * 10).toInt().let { if (floatVal < 0 && it < 0) -it else abs(it) }
-        "$intPart.$decPart"
-    }
+    fun formatValueForEdit(floatVal: Float): String = formatCompactNumberPickerValue(floatVal, step)
 
     fun formatOverlayValue(floatVal: Float, useCompactOverlay: Boolean): String = if (useCompactOverlay) formatValueForEdit(floatVal) else formatValue(floatVal)
 


### PR DESCRIPTION
## Issue

The UI rounded `.25kg` picker steps to the closest single decimal place, so values like `10.25kg` and `10.75kg` were displayed incorrectly (`10.3kg` and `10.8kg` respectively).

## Solution

Added shared `CompactNumberPicker` formatting that derives decimal precision from the picker step, then reused it across Android and iOS picker display/edit paths. This preserves quarter-kilogram values while still showing whole and half-step values cleanly.

## Testing Done

- Added common tests for quarter-step and half-step formatting
- Ran `ANDROID_HOME=/home/baron/Android/Sdk ./gradlew :shared:allTests --console=plain -Pskip.supabase.check=true`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numeric formatting in the number picker component to consistently adapt decimal precision based on the configured step value across Android and iOS platforms.

* **Tests**
  * Added comprehensive test coverage validating number picker value formatting for various step configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->