### PR TITLE
fix: resolve workout navigation races, session tracking, and profile …

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/UserProfileRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/UserProfileRepository.kt
@@ -168,6 +168,9 @@ class SqlDelightUserProfileRepository(private val database: VitruvianDatabase) :
         }
 
         refreshProfilesSync()
+        // Returns true because the profile itself was deleted successfully.
+        // Gamification recompute failure above is best-effort and non-critical;
+        // stats will self-heal on next workout or app restart.
         return true
     }
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/UserProfileRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/UserProfileRepository.kt
@@ -161,6 +161,8 @@ class SqlDelightUserProfileRepository(private val database: VitruvianDatabase) :
             gamificationRepository.updateStats(targetProfileId)
             val rpgInput = gamificationRepository.getRpgInput(targetProfileId)
             gamificationRepository.saveRpgProfile(RpgAttributeEngine.computeProfile(rpgInput), targetProfileId)
+        } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+            throw e
         } catch (e: Exception) {
             Logger.e(e) { "PROFILE_DELETE: Gamification recompute failed for profile '$targetProfileId' after deleting '$id'" }
         }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/UserProfileRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/UserProfileRepository.kt
@@ -153,9 +153,17 @@ class SqlDelightUserProfileRepository(private val database: VitruvianDatabase) :
             queries.setActiveProfile("default")
         }
 
-        gamificationRepository.updateStats(targetProfileId)
-        val rpgInput = gamificationRepository.getRpgInput(targetProfileId)
-        gamificationRepository.saveRpgProfile(RpgAttributeEngine.computeProfile(rpgInput), targetProfileId)
+        // Issue #393: Wrap post-deletion gamification recompute in try-catch.
+        // getRpgInput() has no internal error handling; if it throws (e.g., missing
+        // data after cascade reassignment), the whole deleteProfile call propagates
+        // the exception to the UI, which on iOS causes SIGABRT.
+        try {
+            gamificationRepository.updateStats(targetProfileId)
+            val rpgInput = gamificationRepository.getRpgInput(targetProfileId)
+            gamificationRepository.saveRpgProfile(RpgAttributeEngine.computeProfile(rpgInput), targetProfileId)
+        } catch (e: Exception) {
+            Logger.e(e) { "PROFILE_DELETE: Gamification recompute failed for profile '$targetProfileId' after deleting '$id'" }
+        }
 
         refreshProfilesSync()
         return true

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapter.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapter.kt
@@ -232,7 +232,9 @@ object PortalSyncAdapter {
      */
     private fun buildPortalExerciseWithTelemetry(swr: SessionWithReps, portalSessionId: String, orderIndex: Int): ExerciseWithTelemetry {
         val session = swr.session
-        val exerciseId = generateUUID()
+        // Use stable mobile session ID as exercise ID so repeated syncs
+        // upsert the same row instead of creating duplicates (issue #33).
+        val exerciseId = session.id
         val setId = generateUUID()
 
         // Build rep summaries from RepMetricData + RepBiomechanics

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/DeleteProfileDialog.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/DeleteProfileDialog.kt
@@ -37,13 +37,17 @@ fun DeleteProfileDialog(profile: UserProfile, profileRepository: UserProfileRepo
                         // SIGABRT on iOS (Kotlin/Native abort() on uncaught exception).
                         try {
                             profileRepository.deleteProfile(profile.id)
+                            onDismiss()
                         } catch (e: kotlin.coroutines.cancellation.CancellationException) {
                             throw e
                         } catch (e: Exception) {
                             Logger.e(e) { "PROFILE_DELETE: Failed to delete profile '${profile.name}' (id=${profile.id})" }
+                            // Still dismiss on failure — profile list will refresh and
+                            // the error is logged. Keeping dialog open with no user-visible
+                            // feedback would be confusing.
+                            onDismiss()
                         }
                     }
-                    onDismiss()
                 },
                 colors = ButtonDefaults.textButtonColors(
                     contentColor = MaterialTheme.colorScheme.error,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/DeleteProfileDialog.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/DeleteProfileDialog.kt
@@ -1,14 +1,22 @@
 package com.devil.phoenixproject.presentation.components
 
-import androidx.compose.material3.*
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import co.touchlab.kermit.Logger
 import com.devil.phoenixproject.data.repository.UserProfile
 import com.devil.phoenixproject.data.repository.UserProfileRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
-import vitruvianprojectphoenix.shared.generated.resources.*
 import vitruvianprojectphoenix.shared.generated.resources.Res
+import vitruvianprojectphoenix.shared.generated.resources.action_cancel
+import vitruvianprojectphoenix.shared.generated.resources.action_delete
+import vitruvianprojectphoenix.shared.generated.resources.delete_profile
+import vitruvianprojectphoenix.shared.generated.resources.delete_profile_message
 
 /**
  * Confirmation dialog for deleting a user profile.
@@ -25,7 +33,13 @@ fun DeleteProfileDialog(profile: UserProfile, profileRepository: UserProfileRepo
             TextButton(
                 onClick = {
                     scope.launch {
-                        profileRepository.deleteProfile(profile.id)
+                        // Issue #393: Unhandled exceptions in profile deletion caused
+                        // SIGABRT on iOS (Kotlin/Native abort() on uncaught exception).
+                        try {
+                            profileRepository.deleteProfile(profile.id)
+                        } catch (e: Exception) {
+                            Logger.e(e) { "PROFILE_DELETE: Failed to delete profile '${profile.name}' (id=${profile.id})" }
+                        }
                     }
                     onDismiss()
                 },

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/DeleteProfileDialog.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/DeleteProfileDialog.kt
@@ -36,16 +36,17 @@ fun DeleteProfileDialog(profile: UserProfile, profileRepository: UserProfileRepo
                         // Issue #393: Unhandled exceptions in profile deletion caused
                         // SIGABRT on iOS (Kotlin/Native abort() on uncaught exception).
                         try {
-                            profileRepository.deleteProfile(profile.id)
-                            onDismiss()
+                            val deleted = profileRepository.deleteProfile(profile.id)
+                            if (deleted) {
+                                onDismiss()
+                            } else {
+                                // Protected profile (e.g. "default") — keep dialog open
+                                Logger.w { "PROFILE_DELETE: Refused to delete protected profile '${profile.name}' (id=${profile.id})" }
+                            }
                         } catch (e: kotlin.coroutines.cancellation.CancellationException) {
                             throw e
                         } catch (e: Exception) {
                             Logger.e(e) { "PROFILE_DELETE: Failed to delete profile '${profile.name}' (id=${profile.id})" }
-                            // Still dismiss on failure — profile list will refresh and
-                            // the error is logged. Keeping dialog open with no user-visible
-                            // feedback would be confusing.
-                            onDismiss()
                         }
                     }
                 },

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/DeleteProfileDialog.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/DeleteProfileDialog.kt
@@ -37,6 +37,8 @@ fun DeleteProfileDialog(profile: UserProfile, profileRepository: UserProfileRepo
                         // SIGABRT on iOS (Kotlin/Native abort() on uncaught exception).
                         try {
                             profileRepository.deleteProfile(profile.id)
+                        } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+                            throw e
                         } catch (e: Exception) {
                             Logger.e(e) { "PROFILE_DELETE: Failed to delete profile '${profile.name}' (id=${profile.id})" }
                         }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -2231,7 +2231,13 @@ class ActiveSessionEngine(
             return
         }
 
-        if (coordinator.currentRoutineSessionId.isNullOrBlank()) {
+        // Issue #392: Generate new session ID when routine changes OR when no ID exists.
+        // Previously only checked isNullOrBlank, so switching from Routine A → B without
+        // going through the natural "routine complete" path reused Routine A's session ID,
+        // merging both routines into one history entry.
+        if (coordinator.currentRoutineSessionId.isNullOrBlank() ||
+            coordinator.currentRoutineId != loadedRoutine.id
+        ) {
             coordinator.currentRoutineSessionId = KmpUtils.randomUUID()
         }
         coordinator.currentRoutineName = loadedRoutine.name
@@ -2464,6 +2470,10 @@ class ActiveSessionEngine(
                 coordinator._routineFlowState.value = RoutineFlowState.NotInRoutine
                 coordinator._loadedRoutine.value = null
                 coordinator.routineStartTime = 0
+                // Issue #392: Clear routine session context on exit
+                coordinator.currentRoutineSessionId = null
+                coordinator.currentRoutineName = null
+                coordinator.currentRoutineId = null
             } else {
                 coordinator._workoutState.value = summary
             }
@@ -3600,8 +3610,11 @@ class ActiveSessionEngine(
             startWorkoutOrSetReady()
         } else {
             Logger.d { "startNextSetOrExercise: No more steps - showing routine complete" }
-            flowDelegate?.showRoutineComplete()
+            // Issue #393: Set Idle BEFORE showRoutineComplete() to prevent race where
+            // routineFlowState=Complete + workoutState=SetSummary causes navigation ping-pong
+            // between EnhancedMainScreen and ActiveWorkoutScreen.
             coordinator._workoutState.value = WorkoutState.Idle
+            flowDelegate?.showRoutineComplete()
             coordinator._currentSetIndex.value = 0
             coordinator._currentExerciseIndex.value = 0
             coordinator.currentRoutineSessionId = null

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/DefaultWorkoutSessionManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/DefaultWorkoutSessionManager.kt
@@ -619,13 +619,17 @@ class DefaultWorkoutSessionManager(
                 // If no more steps in the entire routine, show completion screen
                 if (nextStep == null) {
                     Logger.d { "proceedFromSummary: No more steps - showing routine complete" }
-                    showRoutineComplete()
-                    // Issue #355: Clear workoutState so EnhancedMainScreen's resume-active-workout
-                    // guard does not bounce the user back to ActiveWorkout after navigation to
-                    // RoutineComplete. Leaving workoutState at SetSummary caused a navigation
-                    // ping-pong with ActiveWorkoutScreen's Complete observer. Mirrors the reset
-                    // performed in ActiveSessionEngine.startNextSetOrExercise() (Path B).
+                    // Issue #393: Set workoutState to Idle BEFORE showing routine complete.
+                    // Previously, showRoutineComplete() set routineFlowState=Complete while
+                    // workoutState was still SetSummary. This created a race window where:
+                    //   1. ActiveWorkoutScreen sees Complete → navigates to RoutineComplete
+                    //   2. EnhancedMainScreen sees SetSummary → force-navigates back to ActiveWorkout
+                    //   3. New ActiveWorkoutScreen sees Complete → navigates again
+                    // Result: multiple overlapping RoutineComplete screens (visible as garbled UI).
+                    // Setting Idle first ensures shouldResumeActiveWorkout() returns false before
+                    // the Complete navigation fires.
                     coordinator._workoutState.value = WorkoutState.Idle
+                    showRoutineComplete()
                     return@launch
                 }
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/DefaultWorkoutSessionManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/DefaultWorkoutSessionManager.kt
@@ -630,6 +630,10 @@ class DefaultWorkoutSessionManager(
                     // the Complete navigation fires.
                     coordinator._workoutState.value = WorkoutState.Idle
                     showRoutineComplete()
+                    // Clear routine session context so stale IDs don't leak into next routine
+                    coordinator.currentRoutineSessionId = null
+                    coordinator.currentRoutineName = null
+                    coordinator.currentRoutineId = null
                     return@launch
                 }
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/HistoryManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/HistoryManager.kt
@@ -76,7 +76,7 @@ class HistoryManager(
                     sortedSessions.maxOfOrNull { it.timestamp + it.duration } ?: firstStart
                 GroupedRoutineHistoryItem(
                     routineSessionId = id,
-                    routineName = sessionList.first().routineName ?: "Unnamed Routine",
+                    routineName = sortedSessions.first().routineName ?: "Unnamed Routine",
                     sessions = sortedSessions,
                     // Use elapsed span (first set start -> last set end) so inter-set rest is included.
                     totalDuration = (lastEnd - firstStart).coerceAtLeast(0L),

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/RoutineFlowManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/RoutineFlowManager.kt
@@ -956,6 +956,10 @@ class RoutineFlowManager(
         coordinator._loadedRoutine.value = null
         coordinator._workoutState.value = WorkoutState.Idle
         coordinator.routineStartTime = 0
+        // Issue #392: Clear routine session context so next routine gets fresh ID
+        coordinator.currentRoutineSessionId = null
+        coordinator.currentRoutineName = null
+        coordinator.currentRoutineId = null
     }
 
     /**
@@ -987,6 +991,10 @@ class RoutineFlowManager(
         coordinator._loadedRoutine.value = null
         clearCycleContext()
         coordinator.routineStartTime = 0
+        // Issue #392: Clear routine session context so next routine gets fresh ID
+        coordinator.currentRoutineSessionId = null
+        coordinator.currentRoutineName = null
+        coordinator.currentRoutineId = null
     }
 
     // ===== Exercise Navigation =====

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ActiveWorkoutScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ActiveWorkoutScreen.kt
@@ -308,12 +308,19 @@ fun ActiveWorkoutScreen(navController: NavController, viewModel: MainViewModel, 
             }
 
             is RoutineFlowState.Complete -> {
-                Logger.d {
-                    "ActiveWorkoutScreen: RoutineFlowState.Complete - navigating to RoutineComplete"
-                }
-                hasNavigatedAway = true
-                navController.navigate(NavigationRoutes.RoutineComplete.route) {
-                    popUpTo(NavigationRoutes.RoutineOverview.route) { inclusive = false }
+                // Issue #393: Guard against navigating while workoutState is still active.
+                // Without this, the Complete navigation fires while workoutState is SetSummary,
+                // allowing EnhancedMainScreen's shouldResumeActiveWorkout guard to bounce back,
+                // creating duplicate RoutineComplete screens (visible as overlapping garbled UI).
+                if (!isWorkoutActive) {
+                    Logger.d {
+                        "ActiveWorkoutScreen: RoutineFlowState.Complete + Idle - navigating to RoutineComplete"
+                    }
+                    hasNavigatedAway = true
+                    navController.navigate(NavigationRoutes.RoutineComplete.route) {
+                        popUpTo(NavigationRoutes.RoutineOverview.route) { inclusive = false }
+                        launchSingleTop = true
+                    }
                 }
             }
 


### PR DESCRIPTION
…deletion crashes

- **Workout Session Management**: Prevent "navigation ping-pong" and duplicate routine completion screens by setting `workoutState` to `Idle` before triggering `showRoutineComplete`. This ensures background guards do not force-navigate back to the active workout during the transition.
- **Session ID Logic**: Ensure a fresh session ID is generated when switching routines mid-session and clear session context (ID, Name, Routine ID) upon completion or exit to prevent history merging.
- **Stability**: Wrap profile deletion and post-deletion gamification recomputes in try-catch blocks to prevent uncaught exceptions from causing SIGABRT crashes on iOS.
- **Sync**: Use stable mobile session IDs as exercise IDs in `PortalSyncAdapter` to ensure upsert behavior and prevent duplicate rows during repeated syncs.
- **History**: Fix `HistoryManager` to correctly derive the routine name from the sorted session list.
- **UI**: Added `launchSingleTop = true` to the routine completion navigation to prevent multiple instances of the completion screen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Profile deletion now retries gamification recompute as best-effort, logs failures, and preserves cancellation semantics.
  * Delete confirmation dialog only dismisses when deletion succeeds; failures are logged and left open.
  * Sync uses the stable session identifier for exercises to avoid spurious upserts.
  * Routine/session IDs are cleared when leaving flows; completion sets workout to Idle before showing completion and navigates conditionally (single-top).
  * Routine history now derives the name from the earliest session.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->