### PR TITLE
fix(ble): force NON_OVERLAP variant for EccentricOnly mode

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/BlePacketFactory.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/BlePacketFactory.kt
@@ -125,15 +125,31 @@ object BlePacketFactory {
      * (per-rep progression) at 0x4C. These offsets fall within the mode profile
      * block (0x30-0x4F), so we overwrite the last 8 bytes of the eccentric phase
      * with the correct force config values after copying the profile.
+     *
+     * Variant override: when the profile actually copied into the packet is
+     * [ProgramMode.EccentricOnly], the [variant] argument is forced to
+     * [ForceConfigVariant.NON_OVERLAP] to preserve the eccentric-up ramp bytes
+     * at 0x48-0x4F. The override keys off the resolved profile, not
+     * `params.programMode`, so Just Lift / Echo selections (which always use
+     * the OldSchool profile) continue to honor the requested variant.
      */
     fun createProgramParams(params: WorkoutParameters, variant: ForceConfigVariant = defaultForceConfigVariant): ByteArray {
+        // Resolve the profile up front so the variant decision can key off it.
+        val profileMode = if (params.isJustLift || params.isEchoMode) {
+            ProgramMode.OldSchool
+        } else {
+            params.programMode
+        }
+
         // EccentricOnly relies on the eccentric-up ramp bytes at 0x48-0x4F
         // (minMmS=-100, maxMmS=-50, ramp=20.0f). The OVERLAP variant overwrites
         // those bytes with softMax/increment, which leaves the firmware unable
         // to apply weight during the eccentric phase (reps count, but the
         // chosen weight is never engaged). The official app preserves the
-        // profile tail for this mode.
-        val effectiveVariant = if (params.programMode is ProgramMode.EccentricOnly) {
+        // profile tail for this mode. Gate on the resolved profile, not the
+        // requested mode, so Just Lift packets (which use the OldSchool
+        // profile) keep the OVERLAP overwrites they were designed for.
+        val effectiveVariant = if (profileMode is ProgramMode.EccentricOnly) {
             ForceConfigVariant.NON_OVERLAP
         } else {
             variant
@@ -195,13 +211,6 @@ object BlePacketFactory {
         frame[0x2f] = 0x00
 
         // Get the mode profile block (32 bytes for offsets 0x30-0x4F)
-        val profileMode = if (params.isJustLift ||
-            params.isEchoMode
-        ) {
-            ProgramMode.OldSchool
-        } else {
-            params.programMode
-        }
         val profile = getActivationPhases(profileMode)
         profile.copyInto(frame, 0x30)
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/BlePacketFactory.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/BlePacketFactory.kt
@@ -127,6 +127,17 @@ object BlePacketFactory {
      * with the correct force config values after copying the profile.
      */
     fun createProgramParams(params: WorkoutParameters, variant: ForceConfigVariant = defaultForceConfigVariant): ByteArray {
+        // EccentricOnly relies on the eccentric-up ramp bytes at 0x48-0x4F
+        // (minMmS=-100, maxMmS=-50, ramp=20.0f). The OVERLAP variant overwrites
+        // those bytes with softMax/increment, which leaves the firmware unable
+        // to apply weight during the eccentric phase (reps count, but the
+        // chosen weight is never engaged). The official app preserves the
+        // profile tail for this mode.
+        val effectiveVariant = if (params.programMode is ProgramMode.EccentricOnly) {
+            ForceConfigVariant.NON_OVERLAP
+        } else {
+            variant
+        }
         val frame = ByteArray(96)
 
         // Header section - Command 0x04 for PROGRAM mode
@@ -205,7 +216,7 @@ object BlePacketFactory {
 
         val softMax = if (params.isAMRAP || params.isJustLift) 100.0f else params.weightPerCableKg
 
-        if (variant == ForceConfigVariant.OVERLAP) {
+        if (effectiveVariant == ForceConfigVariant.OVERLAP) {
             // Issue #262: Firmware reads softMax at 0x48 and increment at 0x4C.
             // These overlap the last 8 bytes of the mode profile, but the firmware
             // interprets them as force config, not mode data. Write them AFTER the
@@ -239,7 +250,7 @@ object BlePacketFactory {
         Logger.d("BlePacket") {
             "adjustedWeight=${adjustedWeightPerCable}kg, effectiveKg=$effectiveKg"
         }
-        if (variant == ForceConfigVariant.OVERLAP) {
+        if (effectiveVariant == ForceConfigVariant.OVERLAP) {
             Logger.d("BlePacket") {
                 "softMax[0x48]=${readFloatLE(
                     frame,

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/util/BlePacketFactoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/util/BlePacketFactoryTest.kt
@@ -1151,6 +1151,52 @@ class BlePacketFactoryTest {
         assertEquals(0.0f, readFloatLE(packet, 0x5C), "increment (=progression)")
     }
 
+    @Test
+    fun `EccentricOnly preserves profile tail even when OVERLAP variant is requested`() {
+        // Regression guard: createProgramParams must override the caller-provided
+        // variant for EccentricOnly so the eccentric-up ramp at 0x48-0x4F survives.
+        // If this ever regresses the firmware stops applying weight during the
+        // eccentric phase (reps still count, but the cables go slack).
+        val params = WorkoutParameters(
+            programMode = ProgramMode.EccentricOnly,
+            reps = 6,
+            weightPerCableKg = 60f,
+        )
+        val packet = BlePacketFactory.createProgramParams(
+            params,
+            variant = BlePacketFactory.ForceConfigVariant.OVERLAP,
+        )
+
+        assertEquals((-100).toShort(), readShortLE(packet, 0x48), "ecc.up.minMmS preserved")
+        assertEquals((-50).toShort(), readShortLE(packet, 0x4A), "ecc.up.maxMmS preserved")
+        assertEquals(20.0f, readFloatLE(packet, 0x4C), "ecc.up.ramp preserved")
+
+        // Force config block at 0x50-0x5F still carries the active weight.
+        assertEquals(60.0f, readFloatLE(packet, 0x58), "targetWeight at 0x58")
+    }
+
+    @Test
+    fun `JustLift with EccentricOnly programMode honors OVERLAP variant`() {
+        // Just Lift always copies the OldSchool profile, so its 0x48-0x4F bytes
+        // are not the eccentric-up ramp. The variant override must key off the
+        // resolved profile (not params.programMode) or this configuration would
+        // silently lose its softMax/increment writes.
+        val params = WorkoutParameters(
+            programMode = ProgramMode.EccentricOnly,
+            reps = 0,
+            weightPerCableKg = 40f,
+            isJustLift = true,
+        )
+        val packet = BlePacketFactory.createProgramParams(
+            params,
+            variant = BlePacketFactory.ForceConfigVariant.OVERLAP,
+        )
+
+        // Just Lift forces softMax to 100.0f at 0x48 and increment to 0 at 0x4C.
+        assertEquals(100.0f, readFloatLE(packet, 0x48), "Just Lift softMax at 0x48")
+        assertEquals(0.0f, readFloatLE(packet, 0x4C), "Just Lift increment at 0x4C")
+    }
+
     // ========== Cross-Mode Regression Tests ==========
 
     @Test


### PR DESCRIPTION
## Summary

Fixes Eccentric Only mode no longer engaging the chosen weight (reps count, but the cables stay slack).

## Root cause

Commit afc1d9c (`fix: resolve weight calculation bugs and improve UI accessibility`) flipped the default `ForceConfigVariant` from `NON_OVERLAP` to `OVERLAP`. In OVERLAP layout, `BlePacketFactory.createProgramParams` writes `softMax` at 0x48 and `increment` at 0x4C **after** copying the mode profile, deliberately clobbering the last 8 bytes of the eccentric phase block. For most modes this is harmless because the firmware reads weight from the force config block at 0x50–0x5F.

For `EccentricOnly` it isn't harmless. That mode's profile places the eccentric-up velocity ramp at exactly those bytes:

| Offset | EccentricOnly profile value | Overwritten by OVERLAP |
| --- | --- | --- |
| 0x48 (short LE) | `-100` (ecc.up.minMmS) | `softMax` (weight ceiling, float) |
| 0x4A (short LE) | `-50` (ecc.up.maxMmS) | (high half of softMax) |
| 0x4C (float LE) | `20.0f` (ecc.up.ramp) | `increment` (per-rep progression) |

Without those ramp parameters, the firmware can't drive force during the eccentric phase, which is exactly what the user observed: rep notifications fire but no weight is applied. The companion test `EccentricOnly packet matches official app mode profile` already documents this — it explicitly requests `NON_OVERLAP` because the official app preserves the profile tail for this mode.

## Fix

`createProgramParams` now overrides the variant to `NON_OVERLAP` whenever `params.programMode is ProgramMode.EccentricOnly`, regardless of the global default or the explicit `variant` argument. Weight still flows through the force config block at 0x50–0x5F, which existing tests cover.

## Test plan

- [ ] `:shared:testAndroidHostTest --tests *BlePacketFactoryTest*` — existing eccentric tests should remain green (the force-config test asserts only 0x50–0x5F; the profile test already requested NON_OVERLAP).
- [ ] On-device: start an Eccentric Only set on a Vee_*-named V-Form trainer with a non-zero weight and confirm the cables actually load against the chosen weight during the eccentric phase.
- [ ] Smoke-test one non-eccentric mode (e.g. OldSchool) to confirm the OVERLAP path is unchanged for everything else.

https://claude.ai/code/session_01A3qK5EqRymjBRuFyQxvBgL

---
_Generated by [Claude Code](https://claude.ai/code/session_01A3qK5EqRymjBRuFyQxvBgL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Eccentric-only profiles now preserve their specific ramp/limit settings when overlap configuration is applied; variant selection uses the resolved profile to determine overlap behavior.
* **Tests**
  * Added tests validating overlap vs non-overlap behavior for eccentric-only and Just Lift scenarios to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->