### PR TITLE
Refresh Smart Insights timestamp at data fetch time

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SmartInsightsTab.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SmartInsightsTab.kt
@@ -108,7 +108,7 @@ private fun SmartInsightsContent(modifier: Modifier = Modifier) {
     val activeProfile by userProfileRepository.activeProfile.collectAsState()
     val profileId = activeProfile?.id ?: "default"
 
-    val nowMs = remember { currentTimeMillis() }
+    var nowMs by remember { mutableStateOf(currentTimeMillis()) }
     val twentyEightDaysMs = 28L * 24 * 60 * 60 * 1000
 
     var isLoading by remember { mutableStateOf(true) }
@@ -117,6 +117,7 @@ private fun SmartInsightsContent(modifier: Modifier = Modifier) {
     var weightHistory by remember { mutableStateOf<List<SessionSummary>>(emptyList()) }
 
     LaunchedEffect(profileId) {
+        nowMs = currentTimeMillis()
         withContext(Dispatchers.IO) {
             sessionSummaries =
                 repository.getSessionSummariesSince(nowMs - twentyEightDaysMs, profileId)
@@ -137,13 +138,13 @@ private fun SmartInsightsContent(modifier: Modifier = Modifier) {
     }
 
     // Compute all insights
-    val weeklyVolume = remember(sessionSummaries) {
+    val weeklyVolume = remember(sessionSummaries, nowMs) {
         SmartSuggestionsEngine.computeWeeklyVolume(sessionSummaries, nowMs)
     }
-    val balanceAnalysis = remember(sessionSummaries) {
+    val balanceAnalysis = remember(sessionSummaries, nowMs) {
         SmartSuggestionsEngine.analyzeBalance(sessionSummaries, nowMs)
     }
-    val neglectedExercises = remember(exerciseLastPerformed) {
+    val neglectedExercises = remember(exerciseLastPerformed, nowMs) {
         SmartSuggestionsEngine.findNeglectedExercises(exerciseLastPerformed, nowMs)
     }
     val plateaus = remember(weightHistory) {
@@ -203,7 +204,7 @@ private fun SmartInsightsContent(modifier: Modifier = Modifier) {
 
         // Section F: Training Readiness / ACWR (ACWR-01)
         item {
-            val readiness = remember(sessionSummaries) {
+            val readiness = remember(sessionSummaries, nowMs) {
                 ReadinessEngine.computeReadiness(sessionSummaries, nowMs)
             }
             ReadinessBriefingCard(readinessResult = readiness)


### PR DESCRIPTION
### Motivation
- Ensure all SmartSuggestions and Readiness cutoffs use a timestamp that reflects the moment data is fetched so week/day windows stay aligned with the latest refresh cycle. 
- Prevent stale `nowMs` values from causing inconsistent insight calculations after background refreshes or profile changes.

### Description
- Replace the immutable remembered timestamp with mutable state via `var nowMs by remember { mutableStateOf(currentTimeMillis()) }` in `SmartInsightsContent`. 
- Capture a fresh timestamp at fetch time by setting `nowMs = currentTimeMillis()` at the start of the `LaunchedEffect(profileId)` fetch flow. 
- Use the refreshed `nowMs` when calling repository functions (fetch window) and include `nowMs` in memoization keys for `remember` on `weeklyVolume`, `balanceAnalysis`, `neglectedExercises`, and `readiness` so downstream `SmartSuggestionsEngine` and `ReadinessEngine` computations align with the latest refresh. 

### Testing
- Ran `./gradlew :shared:compileKotlinMetadata`, which failed in this environment due to missing Supabase credentials required by the build configuration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa927196e48322a54914ce28d5ca1c)

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/9thLevelSoftware/Project-Phoenix-MP/412)
<!-- GitContextEnd -->