### PR TITLE
Align SmartInsights query and weekly-volume computation to shared nowMs (Option A)

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/premium/SmartSuggestionsEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/premium/SmartSuggestionsEngine.kt
@@ -40,6 +40,10 @@ object SmartSuggestionsEngine {
      * SUGG-01: Compute weekly volume per muscle group.
      * Filters sessions from current 7-day window (nowMs - 7 days to nowMs).
      * totalKg = sum of (weightPerCableKg * cableMultiplier * workingReps) per session.
+     *
+     * NOTE: Callers should pass the same effective nowMs used to fetch sessions from storage.
+     * In SmartInsightsTab we intentionally use Option A (single 28-day fetch + shared nowMs),
+     * then derive the weekly window here to keep query and computation aligned.
      */
     fun computeWeeklyVolume(sessions: List<SessionSummary>, nowMs: Long): WeeklyVolumeReport {
         val weekStart = nowMs - SEVEN_DAYS_MS

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SmartInsightsTab.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SmartInsightsTab.kt
@@ -108,7 +108,7 @@ private fun SmartInsightsContent(modifier: Modifier = Modifier) {
     val activeProfile by userProfileRepository.activeProfile.collectAsState()
     val profileId = activeProfile?.id ?: "default"
 
-    var nowMs by remember { mutableStateOf(currentTimeMillis()) }
+    var insightsAnchorNowMs by remember { mutableStateOf<Long?>(null) }
     val twentyEightDaysMs = 28L * 24 * 60 * 60 * 1000
 
     var isLoading by remember { mutableStateOf(true) }
@@ -120,8 +120,9 @@ private fun SmartInsightsContent(modifier: Modifier = Modifier) {
         // Option A: fetch a broad 28-day slice once, then compute every card's time window from
         // the exact same anchor timestamp. This avoids drift where query and computation use
         // slightly different "now" values.
+        isLoading = true
         val snapshotNowMs = currentTimeMillis()
-        nowMs = snapshotNowMs
+        insightsAnchorNowMs = snapshotNowMs
         withContext(Dispatchers.IO) {
             sessionSummaries =
                 repository.getSessionSummariesSince(snapshotNowMs - twentyEightDaysMs, profileId)
@@ -141,15 +142,17 @@ private fun SmartInsightsContent(modifier: Modifier = Modifier) {
         return
     }
 
-    // Compute all insights
-    val weeklyVolume = remember(sessionSummaries, nowMs) {
-        SmartSuggestionsEngine.computeWeeklyVolume(sessionSummaries, nowMs)
+    val anchorNowMs = insightsAnchorNowMs ?: return
+
+    // Compute all insights from the same fetch anchor timestamp (Option A).
+    val weeklyVolume = remember(sessionSummaries, anchorNowMs) {
+        SmartSuggestionsEngine.computeWeeklyVolume(sessionSummaries, anchorNowMs)
     }
-    val balanceAnalysis = remember(sessionSummaries, nowMs) {
-        SmartSuggestionsEngine.analyzeBalance(sessionSummaries, nowMs)
+    val balanceAnalysis = remember(sessionSummaries, anchorNowMs) {
+        SmartSuggestionsEngine.analyzeBalance(sessionSummaries, anchorNowMs)
     }
-    val neglectedExercises = remember(exerciseLastPerformed, nowMs) {
-        SmartSuggestionsEngine.findNeglectedExercises(exerciseLastPerformed, nowMs)
+    val neglectedExercises = remember(exerciseLastPerformed, anchorNowMs) {
+        SmartSuggestionsEngine.findNeglectedExercises(exerciseLastPerformed, anchorNowMs)
     }
     val plateaus = remember(weightHistory) {
         SmartSuggestionsEngine.detectPlateaus(weightHistory)
@@ -208,8 +211,8 @@ private fun SmartInsightsContent(modifier: Modifier = Modifier) {
 
         // Section F: Training Readiness / ACWR (ACWR-01)
         item {
-            val readiness = remember(sessionSummaries, nowMs) {
-                ReadinessEngine.computeReadiness(sessionSummaries, nowMs)
+            val readiness = remember(sessionSummaries, anchorNowMs) {
+                ReadinessEngine.computeReadiness(sessionSummaries, anchorNowMs)
             }
             ReadinessBriefingCard(readinessResult = readiness)
         }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SmartInsightsTab.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SmartInsightsTab.kt
@@ -117,10 +117,14 @@ private fun SmartInsightsContent(modifier: Modifier = Modifier) {
     var weightHistory by remember { mutableStateOf<List<SessionSummary>>(emptyList()) }
 
     LaunchedEffect(profileId) {
-        nowMs = currentTimeMillis()
+        // Option A: fetch a broad 28-day slice once, then compute every card's time window from
+        // the exact same anchor timestamp. This avoids drift where query and computation use
+        // slightly different "now" values.
+        val snapshotNowMs = currentTimeMillis()
+        nowMs = snapshotNowMs
         withContext(Dispatchers.IO) {
             sessionSummaries =
-                repository.getSessionSummariesSince(nowMs - twentyEightDaysMs, profileId)
+                repository.getSessionSummariesSince(snapshotNowMs - twentyEightDaysMs, profileId)
             exerciseLastPerformed = repository.getExerciseLastPerformed(profileId)
             weightHistory = repository.getExerciseWeightHistory(profileId)
         }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SmartInsightsTab.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SmartInsightsTab.kt
@@ -132,7 +132,8 @@ private fun SmartInsightsContent(modifier: Modifier = Modifier) {
         isLoading = false
     }
 
-    if (isLoading) {
+    val anchorNowMs = insightsAnchorNowMs
+    if (isLoading || anchorNowMs == null) {
         Box(
             modifier = modifier.fillMaxSize(),
             contentAlignment = Alignment.Center,
@@ -141,8 +142,6 @@ private fun SmartInsightsContent(modifier: Modifier = Modifier) {
         }
         return
     }
-
-    val anchorNowMs = insightsAnchorNowMs ?: return
 
     // Compute all insights from the same fetch anchor timestamp (Option A).
     val weeklyVolume = remember(sessionSummaries, anchorNowMs) {

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SmartInsightsTab.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SmartInsightsTab.kt
@@ -121,6 +121,7 @@ private fun SmartInsightsContent(modifier: Modifier = Modifier) {
         // the exact same anchor timestamp. This avoids drift where query and computation use
         // slightly different "now" values.
         isLoading = true
+        insightsAnchorNowMs = null
         val snapshotNowMs = currentTimeMillis()
         insightsAnchorNowMs = snapshotNowMs
         withContext(Dispatchers.IO) {


### PR DESCRIPTION
### Motivation
- Prevent subtle timing drift between repository queries and windowed computations by ensuring both use the same effective `nowMs` anchor.
- Prefer a single snapshot fetch to keep downstream functions (e.g., weekly volume) deterministic relative to the same timestamp.

### Description
- Implemented Option A in `SmartInsightsTab`: capture `snapshotNowMs` once inside `LaunchedEffect(profileId)` and assign it to `nowMs` before doing data fetches, and use `snapshotNowMs` when calling `getSessionSummariesSince(...)`.
- Updated calls that compute insights to continue using the shared `nowMs` state so all cards derive their windows from the same anchor.
- Added documentation next to the repository fetch in `SmartInsightsTab` explaining the Option A rationale and why it avoids query/computation drift.
- Added a doc note above `SmartSuggestionsEngine.computeWeeklyVolume(...)` explaining that callers should pass the same effective `nowMs` used for data fetches and referencing the Option A pattern used in `SmartInsightsTab`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa950d826c8322a5e0bfbd5e2ba4c3)

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/9thLevelSoftware/Project-Phoenix-MP/413)
<!-- GitContextEnd -->