### PR TITLE
Use average intensity for Time-of-Day insights with confidence gating

### DIFF
--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -362,7 +362,7 @@
     <string name="insights_legs">Legs</string>
     <string name="insights_well_balanced">Dein Training ist gut ausbalanciert</string>
     <string name="insights_days_ago">Vor %1$d Tagen</string>
-    <string name="insights_need_more_sessions">Mindestens 3 Sessions an 2+ Tagen pro Zeitfenster nötig</string>
+    <string name="insights_need_more_sessions">Mehr Sessions an unterschiedlichen Tagen nötig, um dein bestes Zeitfenster zu erkennen</string>
     <string name="insights_perform_best_in">Deine höchste durchschnittliche Intensität ist am</string>
 
     <!-- ==================== Issue 3: ExerciseConfigModal ==================== -->

--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -352,7 +352,7 @@
     <string name="insights_training_balance">Trainingsbalance</string>
     <string name="insights_exercise_variety">Übungsvielfalt</string>
     <string name="insights_plateau_alert">Plateau-Warnung</string>
-    <string name="insights_best_window">Bestes Trainingsfenster</string>
+    <string name="insights_best_window">Fenster mit höchster durchschnittlicher Intensität</string>
     <string name="insights_col_muscle_group">Muskelgruppe</string>
     <string name="insights_col_sets">Sets</string>
     <string name="insights_col_reps">Reps</string>
@@ -363,7 +363,7 @@
     <string name="insights_well_balanced">Dein Training ist gut ausbalanciert</string>
     <string name="insights_days_ago">Vor %1$d Tagen</string>
     <string name="insights_need_more_sessions">Train more to unlock time insights (need 10+ sessions)</string>
-    <string name="insights_perform_best_in">Du trainierst am besten am</string>
+    <string name="insights_perform_best_in">Deine höchste durchschnittliche Intensität ist am</string>
 
     <!-- ==================== Issue 3: ExerciseConfigModal ==================== -->
     <string name="config_beast_mode">BEAST MODE</string>

--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -362,7 +362,7 @@
     <string name="insights_legs">Legs</string>
     <string name="insights_well_balanced">Dein Training ist gut ausbalanciert</string>
     <string name="insights_days_ago">Vor %1$d Tagen</string>
-    <string name="insights_need_more_sessions">Train more to unlock time insights (need 10+ sessions)</string>
+    <string name="insights_need_more_sessions">Mindestens 3 Sessions an 2+ Tagen pro Zeitfenster nötig</string>
     <string name="insights_perform_best_in">Deine höchste durchschnittliche Intensität ist am</string>
 
     <!-- ==================== Issue 3: ExerciseConfigModal ==================== -->

--- a/shared/src/commonMain/composeResources/values-es/strings.xml
+++ b/shared/src/commonMain/composeResources/values-es/strings.xml
@@ -362,7 +362,7 @@
     <string name="insights_legs">Legs</string>
     <string name="insights_well_balanced">Tu entrenamiento está bien equilibrado</string>
     <string name="insights_days_ago">Hace %1$d días</string>
-    <string name="insights_need_more_sessions">Se necesitan al menos 3 sesiones en 2+ días por franja</string>
+    <string name="insights_need_more_sessions">Se necesitan más sesiones en distintos días para identificar tu mejor franja</string>
     <string name="insights_perform_best_in">Tu mayor intensidad promedio está en la</string>
 
     <!-- ==================== Issue 3: ExerciseConfigModal ==================== -->

--- a/shared/src/commonMain/composeResources/values-es/strings.xml
+++ b/shared/src/commonMain/composeResources/values-es/strings.xml
@@ -352,7 +352,7 @@
     <string name="insights_training_balance">Balance de entrenamiento</string>
     <string name="insights_exercise_variety">Variedad de ejercicios</string>
     <string name="insights_plateau_alert">Alerta de meseta</string>
-    <string name="insights_best_window">Mejor ventana de entrenamiento</string>
+    <string name="insights_best_window">Ventana con mayor intensidad promedio</string>
     <string name="insights_col_muscle_group">Grupo muscular</string>
     <string name="insights_col_sets">Sets</string>
     <string name="insights_col_reps">Reps</string>
@@ -363,7 +363,7 @@
     <string name="insights_well_balanced">Tu entrenamiento está bien equilibrado</string>
     <string name="insights_days_ago">Hace %1$d días</string>
     <string name="insights_need_more_sessions">Train more to unlock time insights (need 10+ sessions)</string>
-    <string name="insights_perform_best_in">Rindes mejor en la</string>
+    <string name="insights_perform_best_in">Tu mayor intensidad promedio está en la</string>
 
     <!-- ==================== Issue 3: ExerciseConfigModal ==================== -->
     <string name="config_beast_mode">BEAST MODE</string>

--- a/shared/src/commonMain/composeResources/values-es/strings.xml
+++ b/shared/src/commonMain/composeResources/values-es/strings.xml
@@ -362,7 +362,7 @@
     <string name="insights_legs">Legs</string>
     <string name="insights_well_balanced">Tu entrenamiento está bien equilibrado</string>
     <string name="insights_days_ago">Hace %1$d días</string>
-    <string name="insights_need_more_sessions">Train more to unlock time insights (need 10+ sessions)</string>
+    <string name="insights_need_more_sessions">Se necesitan al menos 3 sesiones en 2+ días por franja</string>
     <string name="insights_perform_best_in">Tu mayor intensidad promedio está en la</string>
 
     <!-- ==================== Issue 3: ExerciseConfigModal ==================== -->

--- a/shared/src/commonMain/composeResources/values-fr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fr/strings.xml
@@ -362,7 +362,7 @@
     <string name="insights_legs">Legs</string>
     <string name="insights_well_balanced">Votre entraînement est bien équilibré</string>
     <string name="insights_days_ago">Il y a %1$d jours</string>
-    <string name="insights_need_more_sessions">Train more to unlock time insights (need 10+ sessions)</string>
+    <string name="insights_need_more_sessions">Au moins 3 séances sur 2+ jours par créneau sont nécessaires</string>
     <string name="insights_perform_best_in">Votre intensité moyenne la plus élevée est le</string>
 
     <!-- ==================== Issue 3: ExerciseConfigModal ==================== -->

--- a/shared/src/commonMain/composeResources/values-fr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fr/strings.xml
@@ -352,7 +352,7 @@
     <string name="insights_training_balance">Équilibre d'entraînement</string>
     <string name="insights_exercise_variety">Variété des exercices</string>
     <string name="insights_plateau_alert">Alerte de plateau</string>
-    <string name="insights_best_window">Meilleure fenêtre</string>
+    <string name="insights_best_window">Fenêtre d'intensité moyenne la plus élevée</string>
     <string name="insights_col_muscle_group">Groupe musculaire</string>
     <string name="insights_col_sets">Sets</string>
     <string name="insights_col_reps">Reps</string>
@@ -363,7 +363,7 @@
     <string name="insights_well_balanced">Votre entraînement est bien équilibré</string>
     <string name="insights_days_ago">Il y a %1$d jours</string>
     <string name="insights_need_more_sessions">Train more to unlock time insights (need 10+ sessions)</string>
-    <string name="insights_perform_best_in">Vous performez le mieux le</string>
+    <string name="insights_perform_best_in">Votre intensité moyenne la plus élevée est le</string>
 
     <!-- ==================== Issue 3: ExerciseConfigModal ==================== -->
     <string name="config_beast_mode">BEAST MODE</string>

--- a/shared/src/commonMain/composeResources/values-fr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fr/strings.xml
@@ -362,7 +362,7 @@
     <string name="insights_legs">Legs</string>
     <string name="insights_well_balanced">Votre entraînement est bien équilibré</string>
     <string name="insights_days_ago">Il y a %1$d jours</string>
-    <string name="insights_need_more_sessions">Au moins 3 séances sur 2+ jours par créneau sont nécessaires</string>
+    <string name="insights_need_more_sessions">Plus de séances sur des jours différents sont nécessaires pour identifier votre meilleur créneau</string>
     <string name="insights_perform_best_in">Votre intensité moyenne la plus élevée est le</string>
 
     <!-- ==================== Issue 3: ExerciseConfigModal ==================== -->

--- a/shared/src/commonMain/composeResources/values-nl/strings.xml
+++ b/shared/src/commonMain/composeResources/values-nl/strings.xml
@@ -354,7 +354,7 @@
     <string name="insights_training_balance">Trainingsbalans</string>
     <string name="insights_exercise_variety">Oefeningsvariatie</string>
     <string name="insights_plateau_alert">Plateau-waarschuwing</string>
-    <string name="insights_best_window">Beste trainingsmoment</string>
+    <string name="insights_best_window">Moment met hoogste gemiddelde intensiteit</string>
     <string name="insights_col_muscle_group">Spiergroep</string>
     <string name="insights_col_sets">Series</string>
     <string name="insights_col_reps">Herhalingen</string>
@@ -365,7 +365,7 @@
     <string name="insights_well_balanced">Je training is goed gebalanceerd</string>
     <string name="insights_days_ago">%1$d dagen geleden</string>
     <string name="insights_need_more_sessions">Train meer om tijdinzichten te ontgrendelen (10+ sessies nodig)</string>
-    <string name="insights_perform_best_in">Je presteert het best in de</string>
+    <string name="insights_perform_best_in">Je hoogste gemiddelde intensiteit is in de</string>
 
     <!-- Issue 3: ExerciseConfigModal -->
     <string name="config_beast_mode">BEAST MODE</string>

--- a/shared/src/commonMain/composeResources/values-nl/strings.xml
+++ b/shared/src/commonMain/composeResources/values-nl/strings.xml
@@ -364,7 +364,7 @@
     <string name="insights_legs">Benen</string>
     <string name="insights_well_balanced">Je training is goed gebalanceerd</string>
     <string name="insights_days_ago">%1$d dagen geleden</string>
-    <string name="insights_need_more_sessions">Minimaal 3 sessies op 2+ dagen per tijdvenster nodig</string>
+    <string name="insights_need_more_sessions">Meer sessies op verschillende dagen nodig om je beste tijdvenster te bepalen</string>
     <string name="insights_perform_best_in">Je hoogste gemiddelde intensiteit is in de</string>
 
     <!-- Issue 3: ExerciseConfigModal -->

--- a/shared/src/commonMain/composeResources/values-nl/strings.xml
+++ b/shared/src/commonMain/composeResources/values-nl/strings.xml
@@ -364,7 +364,7 @@
     <string name="insights_legs">Benen</string>
     <string name="insights_well_balanced">Je training is goed gebalanceerd</string>
     <string name="insights_days_ago">%1$d dagen geleden</string>
-    <string name="insights_need_more_sessions">Train meer om tijdinzichten te ontgrendelen (10+ sessies nodig)</string>
+    <string name="insights_need_more_sessions">Minimaal 3 sessies op 2+ dagen per tijdvenster nodig</string>
     <string name="insights_perform_best_in">Je hoogste gemiddelde intensiteit is in de</string>
 
     <!-- Issue 3: ExerciseConfigModal -->

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -400,7 +400,7 @@
     <string name="insights_legs">Legs</string>
     <string name="insights_well_balanced">Your training is well-balanced</string>
     <string name="insights_days_ago">%1$d days ago</string>
-    <string name="insights_need_more_sessions">Train more to unlock time insights (need 10+ sessions)</string>
+    <string name="insights_need_more_sessions">Need at least 3 sessions across 2+ days in a time window</string>
     <string name="insights_perform_best_in">Your highest average intensity is in the</string>
 
     <!-- ==================== Issue 3: ExerciseConfigModal ==================== -->

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -390,7 +390,7 @@
     <string name="insights_training_balance">Training Balance</string>
     <string name="insights_exercise_variety">Exercise Variety</string>
     <string name="insights_plateau_alert">Plateau Alert</string>
-    <string name="insights_best_window">Best Training Window</string>
+    <string name="insights_best_window">Highest Average Intensity Window</string>
     <string name="insights_col_muscle_group">Muscle Group</string>
     <string name="insights_col_sets">Sets</string>
     <string name="insights_col_reps">Reps</string>
@@ -401,7 +401,7 @@
     <string name="insights_well_balanced">Your training is well-balanced</string>
     <string name="insights_days_ago">%1$d days ago</string>
     <string name="insights_need_more_sessions">Train more to unlock time insights (need 10+ sessions)</string>
-    <string name="insights_perform_best_in">You perform best in the</string>
+    <string name="insights_perform_best_in">Your highest average intensity is in the</string>
 
     <!-- ==================== Issue 3: ExerciseConfigModal ==================== -->
     <string name="config_beast_mode">BEAST MODE</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -400,7 +400,7 @@
     <string name="insights_legs">Legs</string>
     <string name="insights_well_balanced">Your training is well-balanced</string>
     <string name="insights_days_ago">%1$d days ago</string>
-    <string name="insights_need_more_sessions">Need at least 3 sessions across 2+ days in a time window</string>
+    <string name="insights_need_more_sessions">Need more sessions across different days to identify your best window</string>
     <string name="insights_perform_best_in">Your highest average intensity is in the</string>
 
     <!-- ==================== Issue 3: ExerciseConfigModal ==================== -->

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/premium/SmartSuggestionsEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/premium/SmartSuggestionsEngine.kt
@@ -35,6 +35,7 @@ object SmartSuggestionsEngine {
     private const val PLATEAU_WEIGHT_TOLERANCE = 0.5f
 
     private const val MIN_SESSIONS_FOR_OPTIMAL = 3
+    private const val MIN_DISTINCT_DAYS_FOR_OPTIMAL = 2
 
     /**
      * SUGG-01: Compute weekly volume per muscle group.
@@ -251,31 +252,47 @@ object SmartSuggestionsEngine {
         val byWindow = sessions.groupBy { classifyTimeWindow(it.timestamp, timeZone) }
 
         val windowCounts = mutableMapOf<TimeWindow, Int>()
-        val windowAvgVolumes = mutableMapOf<TimeWindow, Float>()
+        val windowAvgIntensity = mutableMapOf<TimeWindow, Float>()
+        val windowDistinctDays = mutableMapOf<TimeWindow, Int>()
 
         for ((window, windowSessions) in byWindow) {
             windowCounts[window] = windowSessions.size
             val totalVolume = windowSessions.sumOf {
                 (it.weightPerCableKg * it.cableMultiplier * it.workingReps).toDouble()
             }.toFloat()
-            windowAvgVolumes[window] = totalVolume / windowSessions.size
+            val totalWorkingReps = windowSessions.sumOf { it.workingReps }
+            val averageIntensity = if (totalWorkingReps > 0) {
+                totalVolume / totalWorkingReps
+            } else {
+                0f
+            }
+            windowAvgIntensity[window] = averageIntensity
+
+            val distinctDays = windowSessions
+                .map { Instant.fromEpochMilliseconds(it.timestamp).toLocalDateTime(timeZone).date }
+                .toSet()
+                .size
+            windowDistinctDays[window] = distinctDays
         }
 
-        // Find optimal: window with highest avg volume, minimum 3 sessions
-        val optimal = windowAvgVolumes
-            .filter { (window, _) -> (windowCounts[window] ?: 0) >= MIN_SESSIONS_FOR_OPTIMAL }
+        // Find optimal: window with highest average intensity, with confidence gating.
+        val optimal = windowAvgIntensity
+            .filter { (window, _) ->
+                (windowCounts[window] ?: 0) >= MIN_SESSIONS_FOR_OPTIMAL &&
+                    (windowDistinctDays[window] ?: 0) >= MIN_DISTINCT_DAYS_FOR_OPTIMAL
+            }
             .maxByOrNull { it.value }
             ?.key
 
         val suggestion = if (optimal != null) {
-            "Your best performance is during ${formatTimeWindow(optimal)} sessions. " +
+            "Your highest average intensity is during ${formatTimeWindow(optimal)} sessions. " +
                 "Try to schedule your key workouts during this time."
         } else {
-            "Train at more consistent times to identify your optimal training window."
+            "Train at consistent times with more sessions across different days to identify your highest-intensity window."
         }
 
         return TimeOfDayAnalysis(
-            windowVolumes = windowAvgVolumes,
+            windowVolumes = windowAvgIntensity,
             windowCounts = windowCounts,
             optimalWindow = optimal,
             suggestion = suggestion,

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/premium/SmartSuggestionsEngineTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/premium/SmartSuggestionsEngineTest.kt
@@ -354,12 +354,12 @@ class SmartSuggestionsEngineTest {
     fun timeOfDayMixedWithClearWinner() {
         val baseTime = NOW - (NOW % ONE_DAY_MS)
         val sessions = listOf(
-            // 4 evening sessions (high volume)
+            // 4 evening sessions (high intensity)
             session(timestamp = baseTime + 17 * ONE_HOUR_MS, weightPerCableKg = 80f),
             session(timestamp = baseTime - ONE_DAY_MS + 17 * ONE_HOUR_MS, weightPerCableKg = 80f),
             session(timestamp = baseTime - 2 * ONE_DAY_MS + 17 * ONE_HOUR_MS, weightPerCableKg = 80f),
             session(timestamp = baseTime - 3 * ONE_DAY_MS + 17 * ONE_HOUR_MS, weightPerCableKg = 80f),
-            // 1 morning session (lower volume)
+            // 1 morning session (lower intensity)
             session(timestamp = baseTime + 8 * ONE_HOUR_MS, weightPerCableKg = 40f),
         )
         val analysis = SmartSuggestionsEngine.analyzeTimeOfDay(sessions, TimeZone.UTC)
@@ -379,8 +379,44 @@ class SmartSuggestionsEngineTest {
             session(timestamp = baseTime - 2 * ONE_DAY_MS + 17 * ONE_HOUR_MS, weightPerCableKg = 40f),
         )
         val analysis = SmartSuggestionsEngine.analyzeTimeOfDay(sessions, TimeZone.UTC)
-        // Morning has higher volume per session but only 2 sessions -> not eligible
+        // Morning has higher intensity but only 2 sessions -> not eligible
         // Evening has 3 sessions -> eligible
+        assertEquals(TimeWindow.EVENING, analysis.optimalWindow)
+    }
+
+    @Test
+    fun timeOfDayRequiresDistinctDaysNotJustSessionCount() {
+        val baseTime = NOW - (NOW % ONE_DAY_MS)
+        val sessions = listOf(
+            // 3 morning sessions all on the same day (fails distinct-day gate)
+            session(timestamp = baseTime + 7 * ONE_HOUR_MS, weightPerCableKg = 90f),
+            session(timestamp = baseTime + 8 * ONE_HOUR_MS, weightPerCableKg = 90f),
+            session(timestamp = baseTime + 9 * ONE_HOUR_MS, weightPerCableKg = 90f),
+            // 3 evening sessions across 3 days (passes gates)
+            session(timestamp = baseTime + 17 * ONE_HOUR_MS, weightPerCableKg = 60f),
+            session(timestamp = baseTime - ONE_DAY_MS + 17 * ONE_HOUR_MS, weightPerCableKg = 60f),
+            session(timestamp = baseTime - 2 * ONE_DAY_MS + 17 * ONE_HOUR_MS, weightPerCableKg = 60f),
+        )
+
+        val analysis = SmartSuggestionsEngine.analyzeTimeOfDay(sessions, TimeZone.UTC)
+        assertEquals(TimeWindow.EVENING, analysis.optimalWindow)
+    }
+
+    @Test
+    fun timeOfDayUsesIntensityInsteadOfRawVolume() {
+        val baseTime = NOW - (NOW % ONE_DAY_MS)
+        val sessions = listOf(
+            // Morning: more total volume from reps, but lower intensity (20kg/rep)
+            session(timestamp = baseTime + 8 * ONE_HOUR_MS, weightPerCableKg = 20f, workingReps = 20),
+            session(timestamp = baseTime - ONE_DAY_MS + 8 * ONE_HOUR_MS, weightPerCableKg = 20f, workingReps = 20),
+            session(timestamp = baseTime - 2 * ONE_DAY_MS + 8 * ONE_HOUR_MS, weightPerCableKg = 20f, workingReps = 20),
+            // Evening: lower total volume, higher intensity (40kg/rep)
+            session(timestamp = baseTime + 17 * ONE_HOUR_MS, weightPerCableKg = 40f, workingReps = 5),
+            session(timestamp = baseTime - ONE_DAY_MS + 17 * ONE_HOUR_MS, weightPerCableKg = 40f, workingReps = 5),
+            session(timestamp = baseTime - 2 * ONE_DAY_MS + 17 * ONE_HOUR_MS, weightPerCableKg = 40f, workingReps = 5),
+        )
+
+        val analysis = SmartSuggestionsEngine.analyzeTimeOfDay(sessions, TimeZone.UTC)
         assertEquals(TimeWindow.EVENING, analysis.optimalWindow)
     }
 


### PR DESCRIPTION
### Motivation
- Replace the previous window scoring based on average total volume with a normalized metric so time-of-day recommendations reflect per-rep intensity rather than raw volume. 
- Improve confidence in the detected optimal window by requiring a minimum number of sessions and a minimum number of distinct workout days per window. 
- Update UI wording so the insight text and labels accurately describe the new metric (average intensity).

### Description
- Updated `SmartSuggestionsEngine.analyzeTimeOfDay` to compute `averageIntensity = totalVolume / totalWorkingReps` per `TimeWindow` and keep `windowCounts` for display. 
- Added `MIN_DISTINCT_DAYS_FOR_OPTIMAL` and computed `windowDistinctDays` to gate `optimalWindow` selection using both `MIN_SESSIONS_FOR_OPTIMAL` and `MIN_DISTINCT_DAYS_FOR_OPTIMAL`. 
- Switched the selected metric from average total volume to average intensity when choosing the optimal window and updated suggestion copy to say "highest average intensity". 
- Updated localized UI strings in `shared/src/commonMain/composeResources/values/strings.xml` and `values-de/values-es/values-fr/values-nl` so the Time-of-Day card labels match the new definition.

### Testing
- Attempted `./gradlew :shared:compileKotlinMetadata` which fails in this environment due to project Supabase credential checks. 
- Successfully validated the shared module compile step using `./gradlew :shared:compileKotlinMetadata -Pskip.supabase.check=true`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa950fbc608322b5243a004adc7a40)

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/9thLevelSoftware/Project-Phoenix-MP/414)
<!-- GitContextEnd -->