### PR TITLE
Standardize inclusive cutoff policy (>=) in ReadinessEngine and add boundary tests

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/premium/ReadinessEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/premium/ReadinessEngine.kt
@@ -12,8 +12,8 @@ import com.devil.phoenixproject.domain.model.cableMultiplier
  *
  * Follows the SmartSuggestionsEngine pattern exactly:
  * - Volume formula: weightPerCableKg * cableMultiplier * workingReps
- * - Acute window: last 7 days
- * - Chronic window: last 28 days (divided by 4 for weekly average)
+ * - Acute window: last 7 days (inclusive cutoff: timestamp >= now - 7 days)
+ * - Chronic window: last 28 days (inclusive cutoff: timestamp >= now - 28 days, divided by 4 for weekly average)
  * - ACWR = acute / chronic weekly average
  */
 object ReadinessEngine {
@@ -32,7 +32,7 @@ object ReadinessEngine {
      * Returns [ReadinessResult.InsufficientData] when:
      * - Session list is empty
      * - Training history spans less than 28 days
-     * - Fewer than 3 sessions exist in the last 14 days
+     * - Fewer than 3 sessions exist in the last 14 days (inclusive cutoff: timestamp >= now - 14 days)
      * - Chronic weekly volume is zero
      *
      * Returns [ReadinessResult.Ready] with score (0-100), status (GREEN/YELLOW/RED),
@@ -49,20 +49,20 @@ object ReadinessEngine {
 
         // Guard: need 3+ sessions in last 14 days
         val fourteenDaysAgo = nowMs - FOURTEEN_DAYS_MS
-        val recentCount = sessions.count { it.timestamp > fourteenDaysAgo }
+        val recentCount = sessions.count { it.timestamp >= fourteenDaysAgo }
         if (recentCount < MIN_RECENT_SESSIONS) return ReadinessResult.InsufficientData
 
         // Compute acute load (last 7 days volume)
         val sevenDaysAgo = nowMs - SEVEN_DAYS_MS
         val acuteVolume = sessions
-            .filter { it.timestamp > sevenDaysAgo }
+            .filter { it.timestamp >= sevenDaysAgo }
             .sumOf { (it.weightPerCableKg * it.cableMultiplier * it.workingReps).toDouble() }
             .toFloat()
 
         // Compute chronic load (28-day total volume, divided by 4 for weekly average)
         val twentyEightDaysAgo = nowMs - TWENTY_EIGHT_DAYS_MS
         val chronicTotalVolume = sessions
-            .filter { it.timestamp > twentyEightDaysAgo }
+            .filter { it.timestamp >= twentyEightDaysAgo }
             .sumOf { (it.weightPerCableKg * it.cableMultiplier * it.workingReps).toDouble() }
             .toFloat()
         val chronicWeeklyAvg = chronicTotalVolume / 4f

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/premium/ReadinessEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/premium/ReadinessEngine.kt
@@ -26,6 +26,13 @@ object ReadinessEngine {
     private const val MIN_HISTORY_DAYS = 28
     private const val MIN_RECENT_SESSIONS = 3
 
+
+    /**
+     * Inclusive cutoff policy for readiness time windows.
+     * A session is in-window when timestamp >= cutoffMs.
+     */
+    private fun isInWindow(timestamp: Long, cutoffMs: Long): Boolean = timestamp >= cutoffMs
+
     /**
      * Compute readiness from training session history.
      *
@@ -49,20 +56,20 @@ object ReadinessEngine {
 
         // Guard: need 3+ sessions in last 14 days
         val fourteenDaysAgo = nowMs - FOURTEEN_DAYS_MS
-        val recentCount = sessions.count { it.timestamp >= fourteenDaysAgo }
+        val recentCount = sessions.count { isInWindow(it.timestamp, fourteenDaysAgo) }
         if (recentCount < MIN_RECENT_SESSIONS) return ReadinessResult.InsufficientData
 
         // Compute acute load (last 7 days volume)
         val sevenDaysAgo = nowMs - SEVEN_DAYS_MS
         val acuteVolume = sessions
-            .filter { it.timestamp >= sevenDaysAgo }
+            .filter { isInWindow(it.timestamp, sevenDaysAgo) }
             .sumOf { (it.weightPerCableKg * it.cableMultiplier * it.workingReps).toDouble() }
             .toFloat()
 
         // Compute chronic load (28-day total volume, divided by 4 for weekly average)
         val twentyEightDaysAgo = nowMs - TWENTY_EIGHT_DAYS_MS
         val chronicTotalVolume = sessions
-            .filter { it.timestamp >= twentyEightDaysAgo }
+            .filter { isInWindow(it.timestamp, twentyEightDaysAgo) }
             .sumOf { (it.weightPerCableKg * it.cableMultiplier * it.workingReps).toDouble() }
             .toFloat()
         val chronicWeeklyAvg = chronicTotalVolume / 4f

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/premium/ReadinessEngineTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/premium/ReadinessEngineTest.kt
@@ -36,6 +36,9 @@ class ReadinessEngineTest {
         cableCount = cableCount,
     )
 
+    private fun volume(session: SessionSummary): Float =
+        (session.weightPerCableKg * session.cableMultiplier * session.workingReps)
+
     /**
      * Creates a set of sessions spread over the given number of days,
      * all within the last [days] days from NOW. Useful for setting up
@@ -110,7 +113,6 @@ class ReadinessEngineTest {
         assertIs<ReadinessResult.InsufficientData>(result)
     }
 
-
     @Test
     fun fourteenDayBoundaryIsInclusiveForRecentSessionCount() {
         val sessions = listOf(
@@ -143,19 +145,42 @@ class ReadinessEngineTest {
         val result = ReadinessEngine.computeReadiness(sessions, NOW)
         assertIs<ReadinessResult.Ready>(result)
 
-        val expectedAcuteVolume = listOf(
-            session(timestamp = NOW - 7 * ONE_DAY_MS, weightPerCableKg = 30f, workingReps = 8),
-            session(timestamp = NOW - 3 * ONE_DAY_MS, weightPerCableKg = 25f, workingReps = 7),
-            session(timestamp = NOW - 1 * ONE_DAY_MS, weightPerCableKg = 25f, workingReps = 7),
-        ).sumOf { (it.weightPerCableKg * it.cableMultiplier * it.workingReps).toDouble() }.toFloat()
+        val chronicBoundarySession = sessions[1]
+        val fourteenDaySession = sessions[2]
+        val acuteBoundarySession = sessions[3]
+        val recentSessionA = sessions[4]
+        val recentSessionB = sessions[5]
 
-        val expectedChronicTotal = listOf(
-            session(timestamp = NOW - 28 * ONE_DAY_MS, weightPerCableKg = 20f, workingReps = 10),
+        val expectedAcuteVolume =
+            volume(acuteBoundarySession) + volume(recentSessionA) + volume(recentSessionB)
+
+        val expectedChronicTotal =
+            volume(chronicBoundarySession) + volume(fourteenDaySession) +
+                volume(acuteBoundarySession) + volume(recentSessionA) + volume(recentSessionB)
+
+        assertEquals(expectedAcuteVolume, result.acuteVolumeKg)
+        assertEquals(expectedChronicTotal / 4f, result.chronicWeeklyAvgKg)
+    }
+
+    @Test
+    fun sessionsBeforeBoundariesAreExcludedFromAcuteAndChronicWindows() {
+        val sessions = listOf(
+            session(timestamp = NOW - 35 * ONE_DAY_MS, weightPerCableKg = 10f, workingReps = 5),
+            // 1 ms before 28-day cutoff (excluded from chronic)
+            session(timestamp = NOW - 28 * ONE_DAY_MS - 1, weightPerCableKg = 90f, workingReps = 12),
             session(timestamp = NOW - 14 * ONE_DAY_MS, weightPerCableKg = 15f, workingReps = 6),
-            session(timestamp = NOW - 7 * ONE_DAY_MS, weightPerCableKg = 30f, workingReps = 8),
+            // 1 ms before 7-day cutoff (excluded from acute, included in chronic)
+            session(timestamp = NOW - 7 * ONE_DAY_MS - 1, weightPerCableKg = 80f, workingReps = 10),
             session(timestamp = NOW - 3 * ONE_DAY_MS, weightPerCableKg = 25f, workingReps = 7),
-            session(timestamp = NOW - 1 * ONE_DAY_MS, weightPerCableKg = 25f, workingReps = 7),
-        ).sumOf { (it.weightPerCableKg * it.cableMultiplier * it.workingReps).toDouble() }.toFloat()
+            session(timestamp = NOW - ONE_DAY_MS, weightPerCableKg = 25f, workingReps = 7),
+        )
+
+        val result = ReadinessEngine.computeReadiness(sessions, NOW)
+        assertIs<ReadinessResult.Ready>(result)
+
+        val expectedAcuteVolume = volume(sessions[4]) + volume(sessions[5])
+        val expectedChronicTotal =
+            volume(sessions[2]) + volume(sessions[3]) + volume(sessions[4]) + volume(sessions[5])
 
         assertEquals(expectedAcuteVolume, result.acuteVolumeKg)
         assertEquals(expectedChronicTotal / 4f, result.chronicWeeklyAvgKg)

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/premium/ReadinessEngineTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/premium/ReadinessEngineTest.kt
@@ -1,6 +1,9 @@
 package com.devil.phoenixproject.domain.premium
 
-import com.devil.phoenixproject.domain.model.*
+import com.devil.phoenixproject.domain.model.ReadinessResult
+import com.devil.phoenixproject.domain.model.ReadinessStatus
+import com.devil.phoenixproject.domain.model.SessionSummary
+import com.devil.phoenixproject.domain.model.cableMultiplier
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/premium/ReadinessEngineTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/premium/ReadinessEngineTest.kt
@@ -110,6 +110,57 @@ class ReadinessEngineTest {
         assertIs<ReadinessResult.InsufficientData>(result)
     }
 
+
+    @Test
+    fun fourteenDayBoundaryIsInclusiveForRecentSessionCount() {
+        val sessions = listOf(
+            session(timestamp = NOW - 35 * ONE_DAY_MS),
+            session(timestamp = NOW - 30 * ONE_DAY_MS),
+            session(timestamp = NOW - 20 * ONE_DAY_MS),
+            // Exactly at 14-day cutoff; should count as recent under inclusive policy
+            session(timestamp = NOW - 14 * ONE_DAY_MS),
+            session(timestamp = NOW - 10 * ONE_DAY_MS),
+            session(timestamp = NOW - 1 * ONE_DAY_MS),
+        )
+        val result = ReadinessEngine.computeReadiness(sessions, NOW)
+        assertIs<ReadinessResult.Ready>(result)
+    }
+
+    @Test
+    fun sevenAndTwentyEightDayBoundariesAreInclusiveForLoadWindows() {
+        val sessions = listOf(
+            // Ensure history span >= 28 days
+            session(timestamp = NOW - 35 * ONE_DAY_MS, weightPerCableKg = 10f, workingReps = 5),
+            // Exactly at chronic window boundary; must be included in chronic volume
+            session(timestamp = NOW - 28 * ONE_DAY_MS, weightPerCableKg = 20f, workingReps = 10),
+            session(timestamp = NOW - 14 * ONE_DAY_MS, weightPerCableKg = 15f, workingReps = 6),
+            // Exactly at acute boundary; must be included in acute and chronic volume
+            session(timestamp = NOW - 7 * ONE_DAY_MS, weightPerCableKg = 30f, workingReps = 8),
+            session(timestamp = NOW - 3 * ONE_DAY_MS, weightPerCableKg = 25f, workingReps = 7),
+            session(timestamp = NOW - 1 * ONE_DAY_MS, weightPerCableKg = 25f, workingReps = 7),
+        )
+
+        val result = ReadinessEngine.computeReadiness(sessions, NOW)
+        assertIs<ReadinessResult.Ready>(result)
+
+        val expectedAcuteVolume = listOf(
+            session(timestamp = NOW - 7 * ONE_DAY_MS, weightPerCableKg = 30f, workingReps = 8),
+            session(timestamp = NOW - 3 * ONE_DAY_MS, weightPerCableKg = 25f, workingReps = 7),
+            session(timestamp = NOW - 1 * ONE_DAY_MS, weightPerCableKg = 25f, workingReps = 7),
+        ).sumOf { (it.weightPerCableKg * it.cableMultiplier * it.workingReps).toDouble() }.toFloat()
+
+        val expectedChronicTotal = listOf(
+            session(timestamp = NOW - 28 * ONE_DAY_MS, weightPerCableKg = 20f, workingReps = 10),
+            session(timestamp = NOW - 14 * ONE_DAY_MS, weightPerCableKg = 15f, workingReps = 6),
+            session(timestamp = NOW - 7 * ONE_DAY_MS, weightPerCableKg = 30f, workingReps = 8),
+            session(timestamp = NOW - 3 * ONE_DAY_MS, weightPerCableKg = 25f, workingReps = 7),
+            session(timestamp = NOW - 1 * ONE_DAY_MS, weightPerCableKg = 25f, workingReps = 7),
+        ).sumOf { (it.weightPerCableKg * it.cableMultiplier * it.workingReps).toDouble() }.toFloat()
+
+        assertEquals(expectedAcuteVolume, result.acuteVolumeKg)
+        assertEquals(expectedChronicTotal / 4f, result.chronicWeeklyAvgKg)
+    }
+
     // ==========================================================
     // ACWR Sweet Spot (0.8-1.3) -> HIGH readiness (70-100)
     // ==========================================================


### PR DESCRIPTION
### Motivation
- Remove ambiguity and off-by-one behavior by choosing a single inclusive cutoff policy (`timestamp >= now - window`) for readiness windows. 
- Ensure predictable behavior for sessions that land exactly on 7-, 14- and 28-day boundaries so production logic and downstream consumers can rely on deterministic inclusion. 

### Description
- Update KDoc in `ReadinessEngine` to document inclusive semantics for the acute (7-day) and chronic (28-day) windows and the 14-day recent-session sufficiency check. 
- Change runtime logic in `ReadinessEngine.computeReadiness` to use `>=` for all three window checks: recent-session count (14 days), acute filter (7 days), and chronic filter (28 days). 
- Add two regression tests in `ReadinessEngineTest`: `fourteenDayBoundaryIsInclusiveForRecentSessionCount` to assert the 14-day inclusion for sufficiency, and `sevenAndTwentyEightDayBoundariesAreInclusiveForLoadWindows` to assert exact-boundary inclusion in acute and chronic volume calculations (with explicit expected volume assertions). 

### Testing
- Added unit tests `ReadinessEngineTest.fourteenDayBoundaryIsInclusiveForRecentSessionCount` and `ReadinessEngineTest.sevenAndTwentyEightDayBoundariesAreInclusiveForLoadWindows` (no test failures asserted here because CI/local environment required). 
- Attempted to run tests locally with `./gradlew :shared:compileTestKotlinMetadata :shared:allTests --tests "com.devil.phoenixproject.domain.premium.ReadinessEngineTest"` which failed due to Supabase credential checks in the build configuration. 
- Re-ran targeted test attempts with `-Pskip.supabase.check=true` and `:shared:testAndroidHostTest --tests "com.devil.phoenixproject.domain.premium.ReadinessEngineTest"`, both of which failed in this environment because either the Gradle task did not accept `--tests` or the Android SDK/`ANDROID_HOME` was not available; these failures are environment configuration issues and not related to the new logic itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa9511f1488322ae3fc2a0a9ff80fa)

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/9thLevelSoftware/Project-Phoenix-MP/416)
<!-- GitContextEnd -->