### PR TITLE
Unify insights into Snapshot→Trends→Diagnostics→Actions and add per-card metadata

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/AnalyticsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/AnalyticsScreen.kt
@@ -218,8 +218,10 @@ fun ProgressTab(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AnalyticsScreen(viewModel: MainViewModel, themeMode: com.devil.phoenixproject.ui.theme.ThemeMode) {
+    // Dashboard ownership: recent-session snapshot/trends source
     val workoutHistory by viewModel.workoutHistory.collectAsState()
     val groupedWorkoutHistory by viewModel.groupedWorkoutHistory.collectAsState()
+    // Progress ownership: complete history for record-level drill-down
     val allWorkoutSessions by viewModel.allWorkoutSessions.collectAsState()
     val personalRecords by viewModel.allPersonalRecords.collectAsState()
     val weightUnit by viewModel.weightUnit.collectAsState()

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/AnalyticsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/AnalyticsScreen.kt
@@ -218,10 +218,8 @@ fun ProgressTab(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AnalyticsScreen(viewModel: MainViewModel, themeMode: com.devil.phoenixproject.ui.theme.ThemeMode) {
-    // Dashboard ownership: recent-session snapshot/trends source
     val workoutHistory by viewModel.workoutHistory.collectAsState()
     val groupedWorkoutHistory by viewModel.groupedWorkoutHistory.collectAsState()
-    // Progress ownership: complete history for record-level drill-down
     val allWorkoutSessions by viewModel.allWorkoutSessions.collectAsState()
     val personalRecords by viewModel.allPersonalRecords.collectAsState()
     val weightUnit by viewModel.weightUnit.collectAsState()

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/InsightsTab.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/InsightsTab.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Insights
 import androidx.compose.material3.Card
+import androidx.compose.material3.AssistChip
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
@@ -75,6 +76,45 @@ private fun ResponsiveCardWrapper(modifier: Modifier = Modifier, content: @Compo
         ) {
             content()
         }
+    }
+}
+
+
+
+@Composable
+private fun InsightSectionHeader(title: String, subtitle: String) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.titleMedium,
+        fontWeight = FontWeight.Bold,
+        color = MaterialTheme.colorScheme.onSurface,
+    )
+    Text(
+        text = subtitle,
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+}
+
+@Composable
+private fun InsightMetadata(definition: String, timeframe: String, soWhat: String) {
+    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        Text(
+            text = definition,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        AssistChip(
+            onClick = {},
+            enabled = false,
+            label = { Text(timeframe) },
+        )
+        Text(
+            text = "So what? $soWhat",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.primary,
+            fontWeight = FontWeight.Medium,
+        )
     }
 }
 
@@ -190,8 +230,14 @@ fun InsightsTab(
             }
         }
 
+        // 1) Snapshot
+        item {
+            InsightSectionHeader("1. Snapshot", "Current status")
+        }
+
         // This Week Summary Card - week-over-week comparison
         item {
+            InsightMetadata("Summary of completed sessions and personal records.", selectedPeriod.label, "Check if this period is on track before changing your plan.")
             ResponsiveCardWrapper {
                 ThisWeekSummaryCard(
                     workoutSessions = filteredSessions,
@@ -202,8 +248,16 @@ fun InsightsTab(
             }
         }
 
+        // 2) Trends
+        item {
+            InsightSectionHeader("2. Trends", "How performance changed")
+        }
+
         // 1. Muscle Balance Radar Chart (Replaces linear progress bars)
         if (prs.isNotEmpty()) {
+            item {
+                InsightMetadata("Distribution of PR coverage by muscle group.", "All-time PRs", "Spot overtrained and undertrained regions before plateaus happen.")
+            }
             item {
                 ResponsiveCardWrapper {
                     MuscleBalanceRadarCard(
@@ -215,8 +269,14 @@ fun InsightsTab(
             }
         }
 
+        // 3) Diagnostics
+        item {
+            InsightSectionHeader("3. Diagnostics", "Why outcomes look this way")
+        }
+
         // 2. Workout Consistency Gauge (Replaces circular progress)
         item {
+            InsightMetadata("Session frequency consistency score.", selectedPeriod.label, "Inconsistency usually explains stalled progress more than load choices.")
             ResponsiveCardWrapper {
                 ConsistencyGaugeCard(
                     workoutSessions = filteredSessions,
@@ -225,8 +285,16 @@ fun InsightsTab(
             }
         }
 
+        // 4) Actions
+        item {
+            InsightSectionHeader("4. Actions", "What to do next")
+        }
+
         // 3. Volume vs Intensity Combo Chart (New Metric)
         if (filteredSessions.isNotEmpty()) {
+            item {
+                InsightMetadata("How training load (volume) and effort (intensity) move together.", selectedPeriod.label, "If intensity rises while volume crashes, schedule a lighter recovery microcycle.")
+            }
             item {
                 ResponsiveCardWrapper {
                     VolumeVsIntensityCard(
@@ -241,6 +309,9 @@ fun InsightsTab(
         // 4. Total Volume Trend (User Request)
         if (filteredSessions.isNotEmpty()) {
             item {
+                InsightMetadata("Total lifted workload trend.", selectedPeriod.label, "Increase volume gradually (5–10%) to avoid spikes and fatigue.")
+            }
+            item {
                 ResponsiveCardWrapper {
                     TotalVolumeCard(
                         workoutSessions = filteredSessions,
@@ -252,8 +323,11 @@ fun InsightsTab(
             }
         }
 
-        // 5. Mode Distribution Donut Chart (New Metric)
+                // Mode drill-down detail (kept as allocation context, not duplicate primary metric)
         if (filteredSessions.isNotEmpty()) {
+            item {
+                InsightMetadata("Workout mode allocation drill-down.", selectedPeriod.label, "Use this as context after adjusting volume/intensity, not as a primary KPI.")
+            }
             item {
                 ResponsiveCardWrapper {
                     WorkoutModeDistributionCard(

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/InsightsTab.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/InsightsTab.kt
@@ -18,7 +18,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Insights
 import androidx.compose.material3.Card
-import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Surface
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
@@ -104,16 +104,28 @@ private fun InsightMetadata(definition: String, timeframe: String, soWhat: Strin
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
-        AssistChip(
-            onClick = {},
-            enabled = false,
-            label = { Text(timeframe) },
-        )
+        TimeframeBadge(timeframe)
         Text(
             text = "So what? $soWhat",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.primary,
             fontWeight = FontWeight.Medium,
+        )
+    }
+}
+
+
+@Composable
+private fun TimeframeBadge(label: String) {
+    Surface(
+        color = MaterialTheme.colorScheme.secondaryContainer,
+        shape = RoundedCornerShape(999.dp),
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSecondaryContainer,
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
         )
     }
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SmartInsightsTab.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SmartInsightsTab.kt
@@ -216,14 +216,13 @@ private fun SmartInsightsContent(modifier: Modifier = Modifier) {
             val readiness = remember(sessionSummaries, nowMs) {
                 ReadinessEngine.computeReadiness(sessionSummaries, nowMs)
             }
-            InsightCard(
+            InsightContextBlock(
                 title = "Training Readiness",
                 definition = "Acute vs chronic workload readiness signal.",
                 timeframe = "Acute 7d vs Chronic 28d",
                 soWhat = "If readiness is low, reduce intensity/volume and prioritize recovery.",
-            ) {
-                ReadinessBriefingCard(readinessResult = readiness)
-            }
+            )
+            ReadinessBriefingCard(readinessResult = readiness)
         }
     }
 }
@@ -614,6 +613,24 @@ private fun TimeOfDayCard(analysis: TimeOfDayAnalysis) {
 }
 
 // ---- Shared Components ----
+
+
+@Composable
+private fun InsightContextBlock(
+    title: String,
+    definition: String,
+    timeframe: String,
+    soWhat: String,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        Text(title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+        Text(definition, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        TimeframeBadge(timeframe)
+        Text("So what? $soWhat", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.primary, fontWeight = FontWeight.Medium)
+    }
+}
+
+
 
 @Composable
 private fun InsightHierarchyHeader(title: String, subtitle: String) {

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SmartInsightsTab.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SmartInsightsTab.kt
@@ -20,7 +20,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Warning
-import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -644,7 +644,7 @@ private fun InsightCard(
             Spacer(modifier = Modifier.height(6.dp))
             Text(definition, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
             Spacer(modifier = Modifier.height(6.dp))
-            AssistChip(onClick = {}, enabled = false, label = { Text(timeframe) })
+            TimeframeBadge(timeframe)
             Spacer(modifier = Modifier.height(6.dp))
             Text("So what? $soWhat", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.primary, fontWeight = FontWeight.Medium)
             Spacer(modifier = Modifier.height(8.dp))

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SmartInsightsTab.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SmartInsightsTab.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -177,15 +178,21 @@ private fun SmartInsightsContent(modifier: Modifier = Modifier) {
             )
         }
 
+        item { InsightHierarchyHeader("1. Snapshot", "Current status") }
+
         // Section A: Weekly Volume (SUGG-01)
         item {
             WeeklyVolumeCard(weeklyVolume)
         }
 
+        item { InsightHierarchyHeader("2. Trends", "How it changed") }
+
         // Section B: Balance Analysis (SUGG-02)
         item {
             BalanceAnalysisCard(balanceAnalysis)
         }
+
+        item { InsightHierarchyHeader("3. Diagnostics", "Why") }
 
         // Section C: Neglected Exercises (SUGG-03)
         item {
@@ -196,6 +203,8 @@ private fun SmartInsightsContent(modifier: Modifier = Modifier) {
         item {
             PlateauDetectionCard(plateaus)
         }
+
+        item { InsightHierarchyHeader("4. Actions", "What to do next") }
 
         // Section E: Optimal Training Time (SUGG-05)
         item {
@@ -216,7 +225,7 @@ private fun SmartInsightsContent(modifier: Modifier = Modifier) {
 
 @Composable
 private fun WeeklyVolumeCard(report: WeeklyVolumeReport) {
-    InsightCard(title = stringResource(Res.string.insights_weekly_volume)) {
+    InsightCard(title = stringResource(Res.string.insights_weekly_volume), definition = "Weekly muscle-group workload breakdown.", timeframe = "Last 7 days", soWhat = "Use as drill-down detail after checking the main total-volume trend.") {
         if (report.volumes.isEmpty()) {
             PlaceholderText(stringResource(Res.string.no_workouts_this_week))
         } else {
@@ -311,7 +320,7 @@ private fun WeeklyVolumeCard(report: WeeklyVolumeReport) {
 
 @Composable
 private fun BalanceAnalysisCard(analysis: BalanceAnalysis) {
-    InsightCard(title = stringResource(Res.string.insights_training_balance)) {
+    InsightCard(title = stringResource(Res.string.insights_training_balance), definition = "Push/pull/legs share of your recent volume.", timeframe = "Last 28 days", soWhat = "Shift upcoming sessions toward the underrepresented bucket.") {
         val total = analysis.pushVolume + analysis.pullVolume + analysis.legsVolume
 
         if (total <= 0f) {
@@ -420,7 +429,7 @@ private fun BalanceBar(label: String, percentage: Int, fraction: Float) {
 
 @Composable
 private fun NeglectedExercisesCard(neglected: List<NeglectedExercise>) {
-    InsightCard(title = stringResource(Res.string.insights_exercise_variety)) {
+    InsightCard(title = stringResource(Res.string.insights_exercise_variety), definition = "Exercises not trained recently.", timeframe = "Last 28 days", soWhat = "Reintroduce one neglected movement this week to maintain capacity.") {
         if (neglected.isEmpty()) {
             PlaceholderText(stringResource(Res.string.great_variety))
         } else {
@@ -470,7 +479,7 @@ private fun NeglectedExercisesCard(neglected: List<NeglectedExercise>) {
 
 @Composable
 private fun PlateauDetectionCard(plateaus: List<PlateauDetection>) {
-    InsightCard(title = stringResource(Res.string.insights_plateau_alert)) {
+    InsightCard(title = stringResource(Res.string.insights_plateau_alert), definition = "Movements with stalled peak load progression.", timeframe = "Recent comparable sessions", soWhat = "Change reps, tempo, or exercise variant to restart overload.") {
         if (plateaus.isEmpty()) {
             PlaceholderText(stringResource(Res.string.no_plateaus))
         } else {
@@ -516,7 +525,7 @@ private fun PlateauDetectionCard(plateaus: List<PlateauDetection>) {
 
 @Composable
 private fun TimeOfDayCard(analysis: TimeOfDayAnalysis) {
-    InsightCard(title = stringResource(Res.string.insights_best_window)) {
+    InsightCard(title = stringResource(Res.string.insights_best_window), definition = "Time windows associated with your strongest sessions.", timeframe = "Last 28 days", soWhat = "Schedule key sessions in your best-performing window.") {
         if (analysis.optimalWindow == null) {
             PlaceholderText(
                 if (analysis.windowCounts.isEmpty()) {
@@ -600,7 +609,20 @@ private fun TimeOfDayCard(analysis: TimeOfDayAnalysis) {
 // ---- Shared Components ----
 
 @Composable
-private fun InsightCard(title: String, content: @Composable ColumnScope.() -> Unit) {
+private fun InsightHierarchyHeader(title: String, subtitle: String) {
+    Text(title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+    Text(subtitle, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+}
+
+
+@Composable
+private fun InsightCard(
+    title: String,
+    definition: String,
+    timeframe: String,
+    soWhat: String,
+    content: @Composable ColumnScope.() -> Unit,
+) {
     Card(
         modifier = Modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(
@@ -619,6 +641,12 @@ private fun InsightCard(title: String, content: @Composable ColumnScope.() -> Un
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.onSurface,
             )
+            Spacer(modifier = Modifier.height(6.dp))
+            Text(definition, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Spacer(modifier = Modifier.height(6.dp))
+            AssistChip(onClick = {}, enabled = false, label = { Text(timeframe) })
+            Spacer(modifier = Modifier.height(6.dp))
+            Text("So what? $soWhat", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.primary, fontWeight = FontWeight.Medium)
             Spacer(modifier = Modifier.height(8.dp))
             content()
         }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SmartInsightsTab.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SmartInsightsTab.kt
@@ -216,7 +216,14 @@ private fun SmartInsightsContent(modifier: Modifier = Modifier) {
             val readiness = remember(sessionSummaries, nowMs) {
                 ReadinessEngine.computeReadiness(sessionSummaries, nowMs)
             }
-            ReadinessBriefingCard(readinessResult = readiness)
+            InsightCard(
+                title = "Training Readiness",
+                definition = "Acute vs chronic workload readiness signal.",
+                timeframe = "Acute 7d vs Chronic 28d",
+                soWhat = "If readiness is low, reduce intensity/volume and prioritize recovery.",
+            ) {
+                ReadinessBriefingCard(readinessResult = readiness)
+            }
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Provide a single, consistent insight hierarchy (Snapshot → Trends → Diagnostics → Actions) so each metric appears once with clear ownership and timeframe semantics. 
- Make every insight card actionable and self-describing by exposing a metric definition, a timeframe badge, and an explicit “So what?” guidance line. 
- Eliminate duplicate KPI emphasis (e.g., mode vs. volume) by keeping one primary KPI and converting overlaps into drill-down context.

### Description
- Introduced reusable components `InsightSectionHeader`, `InsightMetadata`, and an enriched `InsightCard` contract (title + `definition` + `timeframe` + `soWhat` + content) and added `AssistChip`-based timeframe badges. 
- Refactored `InsightsTab.kt` to lay out the dashboard as the 4-level hierarchy, add per-card metadata before each card, and reframe the workout-mode card as drill-down context. 
- Mirrored the same hierarchy and card contract in `SmartInsightsTab.kt`, and added clarifying ownership comments in `AnalyticsScreen.kt` to distinguish dashboard (recent/period-filtered) vs progress (full-history) responsibilities.

### Testing
- `./gradlew :shared:compileKotlinMetadata` initially failed due to the repository Supabase credential gate in the build configuration. 
- `./gradlew :shared:compileKotlinMetadata -Pskip.supabase.check=true` completed successfully, indicating the shared module compiles with the skip flag enabled.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa9513cb6883229673eee579d43365)

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/9thLevelSoftware/Project-Phoenix-MP/417)
<!-- GitContextEnd -->