### PR TITLE
fix(rep-counter): avoid firmware warmup sync when local warmup disabled

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/RepCounterFromMachine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/RepCounterFromMachine.kt
@@ -280,7 +280,7 @@ class RepCounterFromMachine {
     ) {
         // Issue #210: Sync warmupTarget with machine's repsRomTotal if provided and different
         // This ensures our warmup tracking matches the machine's expectation
-        if (!isLegacyFormat && repsRomTotal > 0 && repsRomTotal != warmupTarget) {
+        if (!isLegacyFormat && warmupTarget > 0 && repsRomTotal > 0 && repsRomTotal != warmupTarget) {
             logDebug("⚠️ WARMUP SYNC: Machine's repsRomTotal=$repsRomTotal differs from our warmupTarget=$warmupTarget - syncing")
             warmupTarget = repsRomTotal
         }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/RepCounterFromMachineTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/RepCounterFromMachineTest.kt
@@ -567,6 +567,27 @@ class RepCounterFromMachineTest {
         assertFalse(capturedEvents.any { it.type == RepType.WORKOUT_COMPLETE }, "WORKOUT_COMPLETE should NOT fire")
     }
 
+    @Test
+    fun `variable warmup sets ignore machine repsRomTotal warmup sync`() {
+        // Issue #411: Variable warm-up sets send warmupTarget=0 intentionally.
+        // Some firmware still reports repsRomTotal=3; this must NOT re-enable firmware warmup gating.
+        repCounter.configure(warmupTarget = 0, workingTarget = 12, isJustLift = false, stopAtTop = false)
+
+        repCounter.process(
+            repsRomCount = 0,
+            repsRomTotal = 3,
+            repsSetCount = 1,
+            repsSetTotal = 12,
+            up = 1,
+            down = 1,
+        )
+
+        val count = repCounter.getRepCount()
+        assertEquals(0, count.warmupReps)
+        assertEquals(1, count.workingReps, "First rep should count as working rep, not hidden warmup")
+        assertTrue(count.isWarmupComplete, "Warmup gate should stay open when warmupTarget=0")
+    }
+
     // ========== Position Range Tests ==========
 
     @Test


### PR DESCRIPTION
### Motivation
- Variable warm-up sets intentionally run with `warmupTarget=0`, but some firmware still reports `repsRomTotal` (commonly `3`) which was being adopted unconditionally and re-enabled a hidden warmup gate that cut warm-up sets short.

### Description
- Change `RepCounterFromMachine.process` so `repsRomTotal` only overrides the local `warmupTarget` when local warmup tracking is enabled (`warmupTarget > 0`).
- Add a regression unit test `variable warmup sets ignore machine repsRomTotal warmup sync` in `shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/RepCounterFromMachineTest.kt` that verifies a packet with `repsRomTotal=3` does not re-enable firmware warmup when `warmupTarget=0`.
- Updated source file `shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/RepCounterFromMachine.kt` and the corresponding test file.

### Testing
- Added the regression test `variable warmup sets ignore machine repsRomTotal warmup sync`, but targeted test execution in this environment failed to run to completion.
- Attempted `./gradlew :shared:testDebugUnitTest` which could not find the task in this project configuration, and attempts with `-Pskip.supabase.check=true` still did not resolve the task name.
- Attempted `./gradlew :shared:testAndroidHostTest` which failed due to missing Android SDK configuration (`ANDROID_HOME`/`sdk.dir`), so full automated verification must run in CI or on a machine with proper Android/Gradle credentials and SDK installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb5796854c8322b2b06453bcd842c8)

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/9thLevelSoftware/Project-Phoenix-MP/422)
<!-- GitContextEnd -->