### PR TITLE
Request transient duck audio focus for Android workout cues

### DIFF
--- a/shared/src/androidMain/kotlin/com/devil/phoenixproject/presentation/components/HapticFeedbackEffect.android.kt
+++ b/shared/src/androidMain/kotlin/com/devil/phoenixproject/presentation/components/HapticFeedbackEffect.android.kt
@@ -260,7 +260,7 @@ private fun playSound(
         return
     }
 
-    val audioFocusSession = requestTransientDuckAudioFocus(context)
+    val audioFocusSession = requestTransientDuckAudioFocus(context, AudioAttributes.USAGE_GAME)
 
     try {
         val streamId = soundPool.play(
@@ -319,19 +319,18 @@ private fun playWithMediaPlayer(event: HapticEvent, context: Context) {
     }
     if (resId == 0) return
 
-    val audioFocusSession = requestTransientDuckAudioFocus(context)
+    val playbackUsage = if (DeviceInfo.isFireOS()) {
+        AudioAttributes.USAGE_MEDIA
+    } else {
+        AudioAttributes.USAGE_GAME
+    }
+    val audioFocusSession = requestTransientDuckAudioFocus(context, playbackUsage)
 
     try {
         // Fire OS: Use USAGE_MEDIA to work around SoundPool volume bug
         // Standard Android: Use USAGE_GAME to mix with music without interrupting
         val audioAttributes = AudioAttributes.Builder()
-            .setUsage(
-                if (DeviceInfo.isFireOS()) {
-                    AudioAttributes.USAGE_MEDIA
-                } else {
-                    AudioAttributes.USAGE_GAME
-                },
-            )
+            .setUsage(playbackUsage)
             .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
             .build()
 
@@ -363,7 +362,10 @@ private interface AudioFocusSession {
     fun abandon()
 }
 
-private fun requestTransientDuckAudioFocus(context: Context): AudioFocusSession {
+private fun requestTransientDuckAudioFocus(
+    context: Context,
+    playbackUsage: Int,
+): AudioFocusSession {
     val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as? AudioManager
         ?: return object : AudioFocusSession {
             override fun abandon() = Unit
@@ -374,7 +376,7 @@ private fun requestTransientDuckAudioFocus(context: Context): AudioFocusSession 
             val request = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK)
                 .setAudioAttributes(
                     AudioAttributes.Builder()
-                        .setUsage(AudioAttributes.USAGE_ASSISTANCE_SONIFICATION)
+                        .setUsage(playbackUsage)
                         .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
                         .build(),
                 )

--- a/shared/src/androidMain/kotlin/com/devil/phoenixproject/presentation/components/HapticFeedbackEffect.android.kt
+++ b/shared/src/androidMain/kotlin/com/devil/phoenixproject/presentation/components/HapticFeedbackEffect.android.kt
@@ -366,6 +366,9 @@ private fun requestTransientDuckAudioFocus(
     context: Context,
     playbackUsage: Int,
 ): AudioFocusSession {
+    val focusChangeListener = AudioManager.OnAudioFocusChangeListener {
+        // No-op listener used as a unique identity token for each focus request session.
+    }
     val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as? AudioManager
         ?: return object : AudioFocusSession {
             override fun abandon() = Unit
@@ -380,6 +383,7 @@ private fun requestTransientDuckAudioFocus(
                         .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
                         .build(),
                 )
+                .setOnAudioFocusChangeListener(focusChangeListener)
                 .setAcceptsDelayedFocusGain(false)
                 .setWillPauseWhenDucked(false)
                 .build()
@@ -401,14 +405,14 @@ private fun requestTransientDuckAudioFocus(
     } else {
         @Suppress("DEPRECATION")
         audioManager.requestAudioFocus(
-            null,
+            focusChangeListener,
             AudioManager.STREAM_MUSIC,
             AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK,
         )
         object : AudioFocusSession {
             override fun abandon() {
                 @Suppress("DEPRECATION")
-                audioManager.abandonAudioFocus(null)
+                audioManager.abandonAudioFocus(focusChangeListener)
             }
         }
     }

--- a/shared/src/androidMain/kotlin/com/devil/phoenixproject/presentation/components/HapticFeedbackEffect.android.kt
+++ b/shared/src/androidMain/kotlin/com/devil/phoenixproject/presentation/components/HapticFeedbackEffect.android.kt
@@ -277,7 +277,7 @@ private fun playSound(
             audioFocusSession.abandon()
             playWithMediaPlayer(event, context)
         } else {
-            audioFocusSession.abandonAfterDelay(focusHoldDurationMs(event))
+            audioFocusSession.abandonAfterDelay(focusHoldDurationMs(context, event))
         }
     } catch (e: Exception) {
         Logger.w(e) { "SoundPool.play threw for $event — MediaPlayer fallback" }
@@ -352,14 +352,54 @@ private fun playWithMediaPlayer(event: HapticEvent, context: Context) {
 }
 
 
-private fun focusHoldDurationMs(event: HapticEvent): Long = when (event) {
-    is HapticEvent.BADGE_EARNED,
-    is HapticEvent.PERSONAL_RECORD,
-    is HapticEvent.DISCO_MODE_UNLOCKED -> 5000L
+private val soundDurationCacheMs = mutableMapOf<String, Long>()
 
-    is HapticEvent.REP_COUNT_ANNOUNCED -> 2500L
+private fun focusHoldDurationMs(context: Context, event: HapticEvent): Long {
+    val candidateSoundNames = when (event) {
+        is HapticEvent.BADGE_EARNED -> getBadgeSoundNames()
+        is HapticEvent.PERSONAL_RECORD -> getPRSoundNames()
+        is HapticEvent.DISCO_MODE_UNLOCKED -> listOf("discomode")
+        is HapticEvent.REP_COUNT_ANNOUNCED -> listOf("rep_%02d".format(event.repNumber))
+        is HapticEvent.REST_ENDING -> listOf("restover")
+        else -> emptyList()
+    }
 
-    else -> 1500L
+    val maxDurationMs = candidateSoundNames.maxOfOrNull { getSoundDurationMs(context, it) } ?: 0L
+    val fallbackMs = 1500L
+    val safetyBufferMs = 250L
+    return maxOf(fallbackMs, maxDurationMs + safetyBufferMs)
+}
+
+private fun getSoundDurationMs(context: Context, soundName: String): Long {
+    soundDurationCacheMs[soundName]?.let { return it }
+
+    val packageName = context.packageName.removeSuffix(".debug")
+    var resId = context.resources.getIdentifier(soundName, "raw", packageName)
+    if (resId == 0) {
+        resId = context.resources.getIdentifier(soundName, "raw", context.packageName)
+    }
+    if (resId == 0) return 0L
+
+    val durationMs = try {
+        MediaPlayer.create(context, resId)?.useDurationOrZero() ?: 0L
+    } catch (_: Exception) {
+        0L
+    }
+
+    soundDurationCacheMs[soundName] = durationMs
+    return durationMs
+}
+
+private fun MediaPlayer.useDurationOrZero(): Long = try {
+    duration.toLong()
+} catch (_: Exception) {
+    0L
+} finally {
+    try {
+        release()
+    } catch (_: Exception) {
+        // Best effort cleanup
+    }
 }
 
 private fun AudioFocusSession.abandonAfterDelay(delayMs: Long = 1500L) {
@@ -428,22 +468,27 @@ private fun requestTransientDuckAudioFocus(
     }
 }
 
+private fun getBadgeSoundNames(): List<String> = listOf(
+    "absolute_domination", "absolute_unit", "another_milestone_crushed",
+    "beast_mode", "insane_performance", "maxed_out", "new_peak_achieved",
+    "new_record_secured", "no_ones_stopping_you_now", "power", "pr",
+    "pressure_create_greatness", "record", "shattered", "strenght_unlocked",
+    "that_bar_never_stood_a_chance", "that_was_a_demolition", "that_was_god_mode",
+    "that_was_monster_level", "that_was_next_tier_strenght", "that_was_pure_savagery",
+    "the_grind_continues", "the_grind_is_real", "this_is_what_champions_are_made",
+    "unchained_power", "unstoppable", "victory", "you_crushed_that",
+    "you_dominated_that_set", "you_just_broke_your_limits", "you_just_destroyed_that_weight",
+    "you_just_levelled_up", "you_went_full_throttle",
+)
+
+private fun getPRSoundNames(): List<String> = listOf("new_personal_record", "new_personal_record_2")
+
+
 /**
  * Get a random badge celebration sound name.
  */
 private fun getRandomBadgeSound(): String {
-    val badgeSoundNames = listOf(
-        "absolute_domination", "absolute_unit", "another_milestone_crushed",
-        "beast_mode", "insane_performance", "maxed_out", "new_peak_achieved",
-        "new_record_secured", "no_ones_stopping_you_now", "power", "pr",
-        "pressure_create_greatness", "record", "shattered", "strenght_unlocked",
-        "that_bar_never_stood_a_chance", "that_was_a_demolition", "that_was_god_mode",
-        "that_was_monster_level", "that_was_next_tier_strenght", "that_was_pure_savagery",
-        "the_grind_continues", "the_grind_is_real", "this_is_what_champions_are_made",
-        "unchained_power", "unstoppable", "victory", "you_crushed_that",
-        "you_dominated_that_set", "you_just_broke_your_limits", "you_just_destroyed_that_weight",
-        "you_just_levelled_up", "you_went_full_throttle",
-    )
+    val badgeSoundNames = getBadgeSoundNames()
     return badgeSoundNames[Random.nextInt(badgeSoundNames.size)]
 }
 
@@ -451,9 +496,10 @@ private fun getRandomBadgeSound(): String {
  * Get a random PR celebration sound name.
  */
 private fun getRandomPRSound(): String {
-    val prSoundNames = listOf("new_personal_record", "new_personal_record_2")
+    val prSoundNames = getPRSoundNames()
     return prSoundNames[Random.nextInt(prSoundNames.size)]
 }
+
 
 @SuppressLint("MissingPermission")
 private fun playHapticFeedback(vibrator: Vibrator, event: HapticEvent) {

--- a/shared/src/androidMain/kotlin/com/devil/phoenixproject/presentation/components/HapticFeedbackEffect.android.kt
+++ b/shared/src/androidMain/kotlin/com/devil/phoenixproject/presentation/components/HapticFeedbackEffect.android.kt
@@ -8,6 +8,8 @@ import android.media.AudioManager
 import android.media.MediaPlayer
 import android.media.SoundPool
 import android.os.Build
+import android.os.Handler
+import android.os.Looper
 import android.os.VibrationEffect
 import android.os.Vibrator
 import android.os.VibratorManager
@@ -272,13 +274,15 @@ private fun playSound(
         // If SoundPool fails, try MediaPlayer fallback
         if (streamId == 0) {
             Logger.d { "SoundPool.play returned 0 for $event (soundId=$soundId) — MediaPlayer fallback" }
+            audioFocusSession.abandon()
             playWithMediaPlayer(event, context)
+        } else {
+            audioFocusSession.abandonAfterDelay()
         }
     } catch (e: Exception) {
         Logger.w(e) { "SoundPool.play threw for $event — MediaPlayer fallback" }
-        playWithMediaPlayer(event, context)
-    } finally {
         audioFocusSession.abandon()
+        playWithMediaPlayer(event, context)
     }
 }
 
@@ -331,7 +335,11 @@ private fun playWithMediaPlayer(event: HapticEvent, context: Context) {
             .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
             .build()
 
-        val mediaPlayer = MediaPlayer.create(context, resId, audioAttributes, 0) ?: return
+        val mediaPlayer = MediaPlayer.create(context, resId, audioAttributes, 0)
+        if (mediaPlayer == null) {
+            audioFocusSession.abandon()
+            return
+        }
         mediaPlayer.setVolume(1.0f, 1.0f)
         mediaPlayer.setOnCompletionListener {
             it.release()
@@ -342,6 +350,13 @@ private fun playWithMediaPlayer(event: HapticEvent, context: Context) {
         // Silently fail - sound is not critical
         audioFocusSession.abandon()
     }
+}
+
+
+private fun AudioFocusSession.abandonAfterDelay(delayMs: Long = 1500L) {
+    Handler(Looper.getMainLooper()).postDelayed({
+        abandon()
+    }, delayMs)
 }
 
 private interface AudioFocusSession {

--- a/shared/src/androidMain/kotlin/com/devil/phoenixproject/presentation/components/HapticFeedbackEffect.android.kt
+++ b/shared/src/androidMain/kotlin/com/devil/phoenixproject/presentation/components/HapticFeedbackEffect.android.kt
@@ -3,6 +3,7 @@ package com.devil.phoenixproject.presentation.components
 import android.annotation.SuppressLint
 import android.content.Context
 import android.media.AudioAttributes
+import android.media.AudioFocusRequest
 import android.media.AudioManager
 import android.media.MediaPlayer
 import android.media.SoundPool
@@ -257,6 +258,8 @@ private fun playSound(
         return
     }
 
+    val audioFocusSession = requestTransientDuckAudioFocus(context)
+
     try {
         val streamId = soundPool.play(
             soundId,
@@ -274,6 +277,8 @@ private fun playSound(
     } catch (e: Exception) {
         Logger.w(e) { "SoundPool.play threw for $event — MediaPlayer fallback" }
         playWithMediaPlayer(event, context)
+    } finally {
+        audioFocusSession.abandon()
     }
 }
 
@@ -310,6 +315,8 @@ private fun playWithMediaPlayer(event: HapticEvent, context: Context) {
     }
     if (resId == 0) return
 
+    val audioFocusSession = requestTransientDuckAudioFocus(context)
+
     try {
         // Fire OS: Use USAGE_MEDIA to work around SoundPool volume bug
         // Standard Android: Use USAGE_GAME to mix with music without interrupting
@@ -326,10 +333,67 @@ private fun playWithMediaPlayer(event: HapticEvent, context: Context) {
 
         val mediaPlayer = MediaPlayer.create(context, resId, audioAttributes, 0) ?: return
         mediaPlayer.setVolume(1.0f, 1.0f)
-        mediaPlayer.setOnCompletionListener { it.release() }
+        mediaPlayer.setOnCompletionListener {
+            it.release()
+            audioFocusSession.abandon()
+        }
         mediaPlayer.start()
     } catch (_: Exception) {
         // Silently fail - sound is not critical
+        audioFocusSession.abandon()
+    }
+}
+
+private interface AudioFocusSession {
+    fun abandon()
+}
+
+private fun requestTransientDuckAudioFocus(context: Context): AudioFocusSession {
+    val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as? AudioManager
+        ?: return object : AudioFocusSession {
+            override fun abandon() = Unit
+        }
+
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        try {
+            val request = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK)
+                .setAudioAttributes(
+                    AudioAttributes.Builder()
+                        .setUsage(AudioAttributes.USAGE_ASSISTANCE_SONIFICATION)
+                        .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                        .build(),
+                )
+                .setAcceptsDelayedFocusGain(false)
+                .setWillPauseWhenDucked(false)
+                .build()
+            audioManager.requestAudioFocus(request)
+            object : AudioFocusSession {
+                override fun abandon() {
+                    try {
+                        audioManager.abandonAudioFocusRequest(request)
+                    } catch (_: Exception) {
+                        // Best effort
+                    }
+                }
+            }
+        } catch (_: Exception) {
+            object : AudioFocusSession {
+                override fun abandon() = Unit
+            }
+        }
+    } else {
+        @Suppress("DEPRECATION")
+        audioManager.requestAudioFocus(
+            null,
+            AudioManager.STREAM_MUSIC,
+            AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK,
+        )
+        object : AudioFocusSession {
+            override fun abandon() {
+                @Suppress("DEPRECATION")
+                audioManager.abandonAudioFocus(null)
+            }
+        }
     }
 }
 

--- a/shared/src/androidMain/kotlin/com/devil/phoenixproject/presentation/components/HapticFeedbackEffect.android.kt
+++ b/shared/src/androidMain/kotlin/com/devil/phoenixproject/presentation/components/HapticFeedbackEffect.android.kt
@@ -277,7 +277,7 @@ private fun playSound(
             audioFocusSession.abandon()
             playWithMediaPlayer(event, context)
         } else {
-            audioFocusSession.abandonAfterDelay()
+            audioFocusSession.abandonAfterDelay(focusHoldDurationMs(event))
         }
     } catch (e: Exception) {
         Logger.w(e) { "SoundPool.play threw for $event — MediaPlayer fallback" }
@@ -351,6 +351,16 @@ private fun playWithMediaPlayer(event: HapticEvent, context: Context) {
     }
 }
 
+
+private fun focusHoldDurationMs(event: HapticEvent): Long = when (event) {
+    is HapticEvent.BADGE_EARNED,
+    is HapticEvent.PERSONAL_RECORD,
+    is HapticEvent.DISCO_MODE_UNLOCKED -> 5000L
+
+    is HapticEvent.REP_COUNT_ANNOUNCED -> 2500L
+
+    else -> 1500L
+}
 
 private fun AudioFocusSession.abandonAfterDelay(delayMs: Long = 1500L) {
     Handler(Looper.getMainLooper()).postDelayed({


### PR DESCRIPTION
### Motivation
- Workout audio cues could be masked by background music because playback used `USAGE_GAME` but did not request transient audio focus to duck other audio. 
- The change ensures short cues take audio precedence (ducking) so they remain audible across devices and OS versions.

### Description
- Added `AudioFocusRequest` import and a small `AudioFocusSession` helper with `requestTransientDuckAudioFocus` to request and abandon `AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK` when playing cues. 
- Wrapped SoundPool playback in `playSound` with a transient ducking focus request and ensured focus is abandoned in a `finally` block. 
- Applied the same focus request to the `MediaPlayer` fallback in `playWithMediaPlayer` and abandoned focus on completion or on exception. 
- Kept existing routing and Fire OS logic intact and modified `shared/src/androidMain/kotlin/com/devil/phoenixproject/presentation/components/HapticFeedbackEffect.android.kt` only. 

### Testing
- Ran `./gradlew :shared:compileDebugKotlinAndroid -q` which failed due to Supabase credential gating in the environment. 
- Ran `./gradlew :shared:compileAndroidMain -Pskip.supabase.check=true -q` which failed because the container lacks an Android SDK (`ANDROID_HOME`/`local.properties`). 
- Inspected Gradle tasks with `./gradlew :shared:tasks --all -Pskip.supabase.check=true` to determine available compile targets; no successful builds completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb57a2b8c8832292e9229989f121e3)

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/9thLevelSoftware/Project-Phoenix-MP/423)
<!-- GitContextEnd -->