### PR TITLE
Address PR #429 review feedback: route workout cues to STREAM_MUSIC

### DIFF
--- a/androidApp/src/main/kotlin/com/devil/phoenixproject/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/devil/phoenixproject/MainActivity.kt
@@ -21,8 +21,10 @@ class MainActivity : ComponentActivity() {
         // Compose ViewModel pipeline (which fires after the first frame).
         applyStoredLocaleBeforeComposition()
 
-        // Issue #409: Keep hardware volume buttons on media while users are in
-        // the workout UI, especially when background music is playing.
+        // Issue #409: Route hardware volume buttons to media stream for the
+        // entire activity lifetime so workout cues (SoundPool/MediaPlayer with
+        // USAGE_MEDIA → STREAM_MUSIC) stay adjustable, even when background
+        // music is playing.
         volumeControlStream = AudioManager.STREAM_MUSIC
 
         enableEdgeToEdge()

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/components/HapticFeedbackAudioRoutingGuardTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/components/HapticFeedbackAudioRoutingGuardTest.kt
@@ -8,39 +8,60 @@ import kotlin.test.assertTrue
 /**
  * Structural guards for Android workout cue playback.
  *
- * These protect the v0.7.x known-good audio path: short workout cues should be
- * classified as assistance sonification, while Fire OS keeps the explicit media fallback.
+ * Workout cues must use USAGE_MEDIA so they route to STREAM_MUSIC, matching
+ * MainActivity's volumeControlStream contract. Fire OS keeps the same usage
+ * to work around its SoundPool volume bug via the MediaPlayer fallback.
  */
 class HapticFeedbackAudioRoutingGuardTest {
 
     private val projectRoot: File by lazy {
         var dir = File(System.getProperty("user.dir") ?: ".")
         while (!File(dir, "shared/src/androidMain").exists()) {
-            dir = dir.parentFile ?: break
+            val parent = dir.parentFile ?: break
+            dir = parent
+        }
+        check(File(dir, "shared/src/androidMain").exists()) {
+            "Could not locate project root containing shared/src/androidMain " +
+                "starting from ${System.getProperty("user.dir")}. " +
+                "Verify the working directory used by the test runner."
         }
         dir
     }
 
     private val hapticSourceFile: File
-        get() = File(
-            projectRoot,
-            "shared/src/androidMain/kotlin/com/devil/phoenixproject/presentation/components/HapticFeedbackEffect.android.kt",
-        )
+        get() {
+            val file = File(
+                projectRoot,
+                "shared/src/androidMain/kotlin/com/devil/phoenixproject/presentation/components/HapticFeedbackEffect.android.kt",
+            )
+            check(file.isFile) {
+                "HapticFeedbackEffect.android.kt not found at ${file.absolutePath}. " +
+                    "The audio routing guard cannot run without the source file."
+            }
+            return file
+        }
 
     private val rawResourceDir: File
-        get() = File(projectRoot, "androidApp/src/main/res/raw")
+        get() {
+            val dir = File(projectRoot, "androidApp/src/main/res/raw")
+            check(dir.isDirectory) {
+                "Expected raw resource directory at ${dir.absolutePath} but it is missing or not a directory."
+            }
+            return dir
+        }
 
     @Test
-    fun `standard Android cue playback uses assistance sonification`() {
+    fun `standard Android cue playback uses media usage`() {
         val source = hapticSourceFile.readText()
 
         assertTrue(
-            source.contains("STANDARD_ANDROID_CUE_USAGE = AudioAttributes.USAGE_ASSISTANCE_SONIFICATION"),
-            "Standard Android cues must use assistance sonification, matching the v0.7.x playback path.",
+            source.contains("STANDARD_ANDROID_CUE_USAGE = AudioAttributes.USAGE_MEDIA"),
+            "Standard Android cues must use USAGE_MEDIA so they route to STREAM_MUSIC " +
+                "(matching MainActivity.volumeControlStream).",
         )
         assertTrue(
             source.contains("FIRE_OS_CUE_USAGE = AudioAttributes.USAGE_MEDIA"),
-            "Fire OS must keep the media fallback for its SoundPool volume issue.",
+            "Fire OS must keep USAGE_MEDIA to work around its SoundPool volume bug.",
         )
         assertTrue(
             source.contains("buildCueAudioAttributes(STANDARD_ANDROID_CUE_USAGE)"),
@@ -49,6 +70,11 @@ class HapticFeedbackAudioRoutingGuardTest {
         assertFalse(
             source.contains("AudioAttributes.USAGE_GAME"),
             "Workout cues must not be classified as game audio; that was the v0.9.0 sweep regression.",
+        )
+        assertFalse(
+            source.contains("AudioAttributes.USAGE_ASSISTANCE_SONIFICATION"),
+            "Workout cues must not use USAGE_ASSISTANCE_SONIFICATION; it routes to STREAM_SYSTEM " +
+                "and breaks the volumeControlStream = STREAM_MUSIC contract.",
         )
     }
 
@@ -64,11 +90,11 @@ class HapticFeedbackAudioRoutingGuardTest {
     @Test
     fun `referenced raw cue resources exist`() {
         val source = hapticSourceFile.readText()
-        val availableRawNames = rawResourceDir
-            .listFiles()
-            ?.map { it.nameWithoutExtension }
-            ?.toSet()
-            ?: emptySet()
+        val rawFiles = rawResourceDir.listFiles()
+        check(rawFiles != null) {
+            "Failed to list ${rawResourceDir.absolutePath}: listFiles() returned null."
+        }
+        val availableRawNames = rawFiles.map { it.nameWithoutExtension }.toSet()
 
         val loadSoundNames = Regex("""loadSoundByName\(context, soundPool, "([a-z0-9_]+)"\)""")
             .findAll(source)

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/components/HapticFeedbackAudioRoutingGuardTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/components/HapticFeedbackAudioRoutingGuardTest.kt
@@ -104,7 +104,7 @@ class HapticFeedbackAudioRoutingGuardTest {
         val constantSoundNames = soundNamesInConstantList(source, "BADGE_SOUND_NAMES") +
             soundNamesInConstantList(source, "PR_SOUND_NAMES")
 
-        val repCountNames = (1..25).map { "rep_%02d".format(it) }
+        val repCountNames = repCountSoundNames(source)
         val expectedNames = loadSoundNames + constantSoundNames + repCountNames
         val missing = expectedNames.sorted().filterNot { it in availableRawNames }
 
@@ -118,14 +118,27 @@ class HapticFeedbackAudioRoutingGuardTest {
         val start = source.indexOf("private val $listName = listOf(")
         if (start < 0) return emptySet()
 
-        val lineEnd = source.indexOf('\n', start)
-        val singleLine = lineEnd > start && source.substring(start, lineEnd).contains(")")
-        val end = if (singleLine) lineEnd else source.indexOf("\n)", start)
+        // Sound names only contain [a-z0-9_], so the next `)` after `start`
+        // is reliably the closing paren of `listOf(...)`, regardless of how
+        // the list is formatted (single-line, multi-line, indented `)`, etc.).
+        val end = source.indexOf(")", start)
         if (end < 0) return emptySet()
 
         return Regex("\"([a-z0-9_]+)\"")
             .findAll(source.substring(start, end))
             .map { it.groupValues[1] }
             .toSet()
+    }
+
+    private fun repCountSoundNames(source: String): Set<String> {
+        // Mirror the rep-count range in HapticFeedbackEffect.android.kt so the
+        // guard stays in sync if the upper bound changes.
+        val match = Regex("""\(1\.\.(\d+)\)\.mapNotNull""").find(source)
+        check(match != null) {
+            "Could not locate the rep-count range '(1..N).mapNotNull' in HapticFeedbackEffect.android.kt; " +
+                "update repCountSoundNames if the loop shape has changed."
+        }
+        val upper = match.groupValues[1].toInt()
+        return (1..upper).map { "rep_%02d".format(it) }.toSet()
     }
 }

--- a/shared/src/androidMain/kotlin/com/devil/phoenixproject/presentation/components/HapticFeedbackEffect.android.kt
+++ b/shared/src/androidMain/kotlin/com/devil/phoenixproject/presentation/components/HapticFeedbackEffect.android.kt
@@ -21,7 +21,12 @@ import com.devil.phoenixproject.util.DeviceInfo
 import kotlinx.coroutines.flow.SharedFlow
 import kotlin.random.Random
 
-private val STANDARD_ANDROID_CUE_USAGE = AudioAttributes.USAGE_ASSISTANCE_SONIFICATION
+// Both standard Android and Fire OS classify workout cues as USAGE_MEDIA so
+// playback is bound to STREAM_MUSIC. This matches MainActivity's
+// volumeControlStream = STREAM_MUSIC contract: hardware volume buttons control
+// the same stream the cues are played on, and cues mix with background music
+// without interrupting it.
+private val STANDARD_ANDROID_CUE_USAGE = AudioAttributes.USAGE_MEDIA
 private val FIRE_OS_CUE_USAGE = AudioAttributes.USAGE_MEDIA
 
 @Composable
@@ -42,9 +47,10 @@ actual fun HapticFeedbackEffect(hapticEvents: SharedFlow<HapticEvent>) {
     // Track which sounds are loaded and ready to play
     val loadedSounds = remember { mutableSetOf<Int>() }
 
-    // Create SoundPool for audio feedback.
-    // v0.7.x used assistance sonification for short workout cues; keep that
-    // classification so UI-like cues are routed as sound effects, not game audio.
+    // Create SoundPool for audio feedback. USAGE_MEDIA routes to STREAM_MUSIC
+    // so hardware volume keys (forced to STREAM_MUSIC by MainActivity) actually
+    // control cue loudness, and cues stay audible through DND while mixing with
+    // background music.
     val soundPool = remember {
         SoundPool.Builder()
             .setMaxStreams(3)
@@ -150,8 +156,9 @@ private fun loadSoundByName(context: Context, soundPool: SoundPool, name: String
 
 /**
  * Issue #409: Check media volume and log warning if muted.
- * Retained because Fire OS uses media playback and some Android policies still
- * route short sound effects through media volume.
+ * Cues use USAGE_MEDIA which routes to STREAM_MUSIC; if media volume is 0, all
+ * sounds are inaudible. MainActivity forces hardware volume buttons to
+ * STREAM_MUSIC so users can adjust this directly.
  */
 private fun warnIfMediaVolumeMuted(context: Context) {
     try {
@@ -161,7 +168,7 @@ private fun warnIfMediaVolumeMuted(context: Context) {
             val maxVolume = audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC)
             Logger.w {
                 "Issue #409: Media volume is 0/$maxVolume — workout sounds will be inaudible. " +
-                    "Raise media volume if audio cues are silent."
+                    "Cues use USAGE_MEDIA (STREAM_MUSIC). Raise media volume to hear audio cues."
             }
         }
     } catch (_: Exception) {
@@ -262,8 +269,8 @@ private fun playSound(
 
 /**
  * Fallback sound playback using MediaPlayer for when SoundPool fails or on Fire OS.
- * Fire OS: Uses USAGE_MEDIA to work around SoundPool volume bug.
- * Standard Android: Uses USAGE_ASSISTANCE_SONIFICATION to match the known-good v0.7.x cue path.
+ * Both standard Android and Fire OS use USAGE_MEDIA so cues route to STREAM_MUSIC,
+ * matching MainActivity's volumeControlStream contract.
  */
 private fun playWithMediaPlayer(event: HapticEvent, context: Context) {
     val soundName = when (event) {


### PR DESCRIPTION
## Summary

Resolves the review feedback on #429. That PR moved standard Android
workout cues to `USAGE_ASSISTANCE_SONIFICATION`, which routes to
`STREAM_SYSTEM` and breaks the existing `volumeControlStream = STREAM_MUSIC`
contract enforced in `MainActivity` — hardware volume buttons would no
longer adjust cue loudness, and the media-volume mute warning would
trigger spuriously.

This PR keeps the cue refactor (helper functions and constants) but
points both standard Android and Fire OS at `USAGE_MEDIA` so cues route
through `STREAM_MUSIC` consistently with the activity's volume control.

### Review issues addressed

- **P1 / high (chatgpt-codex-connector, gemini-code-assist on
  `HapticFeedbackEffect.android.kt`)** — `STANDARD_ANDROID_CUE_USAGE`
  is now `USAGE_MEDIA`, restoring `STREAM_MUSIC` routing so hardware
  volume keys actually control cue loudness.
- **High (gemini-code-assist on `HapticFeedbackEffect.android.kt`
  line 164)** — the `warnIfMediaVolumeMuted` comment and log message
  are updated to describe `USAGE_MEDIA → STREAM_MUSIC`; the warning's
  use of `STREAM_MUSIC` is now correct, not contradictory.
- **High (gemini-code-assist on `MainActivity.kt`)** — the activity's
  comment now reflects that cues use `USAGE_MEDIA` routed to
  `STREAM_MUSIC`, matching the implementation.
- **Copilot on `MainActivity.kt` line 25** — comment now describes the
  actual scope (entire activity lifetime, not "while in the workout
  UI"), since `volumeControlStream` is set unconditionally.
- **Copilot on `HapticFeedbackAudioRoutingGuardTest.kt` line 22** —
  `projectRoot` now `check`s that the discovered directory contains
  `shared/src/androidMain` and fails with an actionable message
  instead of bubbling up a `FileNotFoundException`.
- **Copilot on `HapticFeedbackAudioRoutingGuardTest.kt` line 72** —
  `rawResourceDir.listFiles()` returning `null` (and the directory
  not existing) now produces an explicit failure message instead of
  reporting every cue as missing.
- **Medium (gemini-code-assist on `HapticFeedbackAudioRoutingGuardTest.kt`)** —
  the structural test now also guards against `USAGE_ASSISTANCE_SONIFICATION`
  to prevent the regression resurfacing. (The string-matching strategy is
  intentionally retained as a lightweight host-side guard; a unit test that
  loads `AudioAttributes` would require an Android instrumentation test.)

## Test plan

- [ ] `./gradlew :shared:androidHostTestDebugUnitTest` (host-side
  structural guard)
- [ ] `./gradlew :androidApp:assembleDebug`
- [ ] Manual: install on an Android device, start a workout, verify
  hardware volume keys adjust cue loudness in real time, with and
  without background music playing.
- [ ] Manual on Fire OS (or `DeviceInfo.isFireOS()` mock): verify cue
  audio still plays via the `MediaPlayer` fallback path.

https://claude.ai/code/session_01DTjZ8oNQtgbwiFTJCPqAvz

---
_Generated by [Claude Code](https://claude.ai/code/session_01DTjZ8oNQtgbwiFTJCPqAvz)_

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/9thLevelSoftware/Project-Phoenix-MP/430)
<!-- GitContextEnd -->