### PR TITLE
Harden Compose layouts for iOS accessibility scaling

### DIFF
--- a/shared/src/androidMain/kotlin/com/devil/phoenixproject/presentation/util/PlatformAccessibilitySettings.android.kt
+++ b/shared/src/androidMain/kotlin/com/devil/phoenixproject/presentation/util/PlatformAccessibilitySettings.android.kt
@@ -1,0 +1,9 @@
+package com.devil.phoenixproject.presentation.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+
+@Composable
+actual fun rememberPlatformAccessibilitySettings(): PlatformAccessibilitySettings {
+    return remember { PlatformAccessibilitySettings(boldTextEnabled = false) }
+}

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/AnimatedActionButton.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/AnimatedActionButton.kt
@@ -197,7 +197,7 @@ fun AnimatedActionButton(
     val windowSizeClass = LocalWindowSizeClass.current
     val useCompactAccessibility = isCompactAccessibilityLayout()
     val buttonHeight = if (useCompactAccessibility) {
-        72.dp
+        88.dp
     } else {
         when (windowSizeClass.widthSizeClass) {
             WindowWidthSizeClass.Expanded -> 80.dp
@@ -341,9 +341,10 @@ fun AnimatedActionButton(
                             text = label,
                             color = Color.White,
                             style = labelStyle,
-                            maxLines = 1,
+                            maxLines = if (useCompactAccessibility) 2 else 1,
                             overflow = TextOverflow.Ellipsis,
                             textAlign = TextAlign.Center,
+                            modifier = Modifier.padding(horizontal = 8.dp),
                         )
                     }
                 }
@@ -375,6 +376,7 @@ fun AnimatedActionButton(
                         maxLines = if (useCompactAccessibility) 2 else 1,
                         overflow = TextOverflow.Ellipsis,
                         textAlign = TextAlign.Center,
+                        modifier = Modifier.padding(horizontal = 4.dp),
                     )
                 },
             )
@@ -395,6 +397,7 @@ fun AnimatedActionButton(
                         maxLines = if (useCompactAccessibility) 2 else 1,
                         overflow = TextOverflow.Ellipsis,
                         textAlign = TextAlign.Center,
+                        modifier = Modifier.padding(horizontal = 4.dp),
                     )
                 },
             )

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/ExercisePicker.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/ExercisePicker.kt
@@ -68,6 +68,7 @@ import com.devil.phoenixproject.domain.model.Exercise
 import com.devil.phoenixproject.presentation.components.exercisepicker.ExerciseFilterShelf
 import com.devil.phoenixproject.presentation.components.exercisepicker.ExerciseListEmptyState
 import com.devil.phoenixproject.presentation.components.exercisepicker.GroupedExerciseList
+import com.devil.phoenixproject.presentation.util.isCompactAccessibilityLayout
 import com.devil.phoenixproject.ui.theme.PhoenixOrangeDark
 import com.devil.phoenixproject.ui.theme.PhoenixOrangeLight
 import com.devil.phoenixproject.ui.theme.ThemeMode
@@ -410,6 +411,7 @@ fun ExercisePickerContent(
     var videoDialogVideos by remember { mutableStateOf<List<ExerciseVideoEntity>>(emptyList()) }
     val listState = rememberLazyListState()
     val focusManager = LocalFocusManager.current
+    val useCompactAccessibility = isCompactAccessibilityLayout()
 
     val hasActiveFilters = searchQuery.isNotBlank() ||
         showFavoritesOnly ||
@@ -442,8 +444,9 @@ fun ExercisePickerContent(
         Column(
             modifier = Modifier.fillMaxSize(),
         ) {
-            // Title (only in bottom sheet mode)
-            if (!fullScreen) {
+            // Title (only in bottom sheet mode). Omit it in compact accessibility
+            // mode so search results keep usable space above the iOS keyboard.
+            if (!fullScreen && !useCompactAccessibility) {
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -529,7 +532,7 @@ fun ExercisePickerContent(
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(
                         text = createButtonLabel,
-                        maxLines = 1,
+                        maxLines = if (useCompactAccessibility) 2 else 1,
                         overflow = TextOverflow.Ellipsis,
                     )
                 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/AnalyticsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/AnalyticsScreen.kt
@@ -25,7 +25,9 @@ import com.devil.phoenixproject.domain.model.WorkoutSession
 import com.devil.phoenixproject.presentation.components.*
 import com.devil.phoenixproject.presentation.util.LocalWindowSizeClass
 import com.devil.phoenixproject.presentation.util.WeightDisplayFormatter
+import com.devil.phoenixproject.presentation.util.WindowHeightSizeClass
 import com.devil.phoenixproject.presentation.util.WindowWidthSizeClass
+import com.devil.phoenixproject.presentation.util.isCompactAccessibilityLayout
 import com.devil.phoenixproject.presentation.viewmodel.MainViewModel
 import com.devil.phoenixproject.ui.theme.Spacing
 import com.devil.phoenixproject.util.CsvExporter
@@ -230,10 +232,16 @@ fun AnalyticsScreen(viewModel: MainViewModel, themeMode: com.devil.phoenixprojec
 
     // Responsive sizing based on window size class
     val windowSizeClass = LocalWindowSizeClass.current
-    val tabIndicatorHeight = when (windowSizeClass.widthSizeClass) {
-        WindowWidthSizeClass.Expanded -> 12.dp
-        WindowWidthSizeClass.Medium -> 10.dp
-        WindowWidthSizeClass.Compact -> 8.dp
+    val useCompactTabs = isCompactAccessibilityLayout() ||
+        windowSizeClass.heightSizeClass == WindowHeightSizeClass.Compact
+    val tabIndicatorHeight = if (useCompactTabs) {
+        4.dp
+    } else {
+        when (windowSizeClass.widthSizeClass) {
+            WindowWidthSizeClass.Expanded -> 12.dp
+            WindowWidthSizeClass.Medium -> 10.dp
+            WindowWidthSizeClass.Compact -> 8.dp
+        }
     }
     val fabIconSize = when (windowSizeClass.widthSizeClass) {
         WindowWidthSizeClass.Expanded -> 36.dp
@@ -311,17 +319,19 @@ fun AnalyticsScreen(viewModel: MainViewModel, themeMode: com.devil.phoenixprojec
                 Tab(
                     selected = pagerState.currentPage == 0,
                     onClick = { scope.launch { pagerState.animateScrollToPage(0) } },
-                    text = {
-                        Text(
-                            stringResource(Res.string.analytics_dashboard),
-                            style = MaterialTheme.typography.labelSmall,
-                            maxLines = 1,
-                            color = if (pagerState.currentPage == 0) {
-                                MaterialTheme.colorScheme.primary
-                            } else {
-                                MaterialTheme.colorScheme.onSurfaceVariant
-                            },
-                        )
+                    text = if (useCompactTabs) null else {
+                        {
+                            Text(
+                                stringResource(Res.string.analytics_dashboard),
+                                style = MaterialTheme.typography.labelSmall,
+                                maxLines = 1,
+                                color = if (pagerState.currentPage == 0) {
+                                    MaterialTheme.colorScheme.primary
+                                } else {
+                                    MaterialTheme.colorScheme.onSurfaceVariant
+                                },
+                            )
+                        }
                     },
                     icon = {
                         Icon(
@@ -338,17 +348,19 @@ fun AnalyticsScreen(viewModel: MainViewModel, themeMode: com.devil.phoenixprojec
                 Tab(
                     selected = pagerState.currentPage == 1,
                     onClick = { scope.launch { pagerState.animateScrollToPage(1) } },
-                    text = {
-                        Text(
-                            stringResource(Res.string.analytics_progress),
-                            style = MaterialTheme.typography.labelSmall,
-                            maxLines = 1,
-                            color = if (pagerState.currentPage == 1) {
-                                MaterialTheme.colorScheme.primary
-                            } else {
-                                MaterialTheme.colorScheme.onSurfaceVariant
-                            },
-                        )
+                    text = if (useCompactTabs) null else {
+                        {
+                            Text(
+                                stringResource(Res.string.analytics_progress),
+                                style = MaterialTheme.typography.labelSmall,
+                                maxLines = 1,
+                                color = if (pagerState.currentPage == 1) {
+                                    MaterialTheme.colorScheme.primary
+                                } else {
+                                    MaterialTheme.colorScheme.onSurfaceVariant
+                                },
+                            )
+                        }
                     },
                     icon = {
                         Icon(
@@ -365,17 +377,19 @@ fun AnalyticsScreen(viewModel: MainViewModel, themeMode: com.devil.phoenixprojec
                 Tab(
                     selected = pagerState.currentPage == 2,
                     onClick = { scope.launch { pagerState.animateScrollToPage(2) } },
-                    text = {
-                        Text(
-                            stringResource(Res.string.analytics_history),
-                            style = MaterialTheme.typography.labelSmall,
-                            maxLines = 1,
-                            color = if (pagerState.currentPage == 2) {
-                                MaterialTheme.colorScheme.primary
-                            } else {
-                                MaterialTheme.colorScheme.onSurfaceVariant
-                            },
-                        )
+                    text = if (useCompactTabs) null else {
+                        {
+                            Text(
+                                stringResource(Res.string.analytics_history),
+                                style = MaterialTheme.typography.labelSmall,
+                                maxLines = 1,
+                                color = if (pagerState.currentPage == 2) {
+                                    MaterialTheme.colorScheme.primary
+                                } else {
+                                    MaterialTheme.colorScheme.onSurfaceVariant
+                                },
+                            )
+                        }
                     },
                     icon = {
                         Icon(

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ConnectionLogsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ConnectionLogsScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -68,6 +69,7 @@ import com.devil.phoenixproject.data.local.ConnectionLogEntity
 import com.devil.phoenixproject.data.repository.LogLevel
 import com.devil.phoenixproject.presentation.viewmodel.ConnectionLogsViewModel
 import com.devil.phoenixproject.presentation.viewmodel.MainViewModel
+import com.devil.phoenixproject.presentation.util.isCompactAccessibilityLayout
 import com.devil.phoenixproject.ui.theme.AccessibilityTheme
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
@@ -104,6 +106,7 @@ fun ConnectionLogsScreen(
     val filter by logsViewModel.filter.collectAsState()
     val isAutoScrollEnabled by logsViewModel.isAutoScrollEnabled.collectAsState()
     val isLoggingEnabled by logsViewModel.isLoggingEnabled.collectAsState()
+    val useCompactAccessibility = isCompactAccessibilityLayout()
 
     val listState = rememberLazyListState()
 
@@ -174,99 +177,191 @@ fun ConnectionLogsScreen(
                 keyboardActions = KeyboardActions(onSearch = { focusManager.clearFocus() }),
             )
 
-            // Filter chips — scrollable to prevent overflow with Bold Text / accessibility
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .horizontalScroll(rememberScrollState())
-                    .padding(horizontal = 16.dp, vertical = 4.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                LogLevelFilterChip(
-                    level = LogLevel.DEBUG,
-                    selected = filter.showDebug,
-                    count = logs.count { it.level == LogLevel.DEBUG.name },
-                    onClick = { logsViewModel.toggleLevel(LogLevel.DEBUG) },
-                )
-                LogLevelFilterChip(
-                    level = LogLevel.INFO,
-                    selected = filter.showInfo,
-                    count = logs.count { it.level == LogLevel.INFO.name },
-                    onClick = { logsViewModel.toggleLevel(LogLevel.INFO) },
-                )
-                LogLevelFilterChip(
-                    level = LogLevel.WARNING,
-                    selected = filter.showWarning,
-                    count = logs.count { it.level == LogLevel.WARNING.name },
-                    onClick = { logsViewModel.toggleLevel(LogLevel.WARNING) },
-                )
-                LogLevelFilterChip(
-                    level = LogLevel.ERROR,
-                    selected = filter.showError,
-                    count = logs.count { it.level == LogLevel.ERROR.name },
-                    onClick = { logsViewModel.toggleLevel(LogLevel.ERROR) },
-                )
+            // Critical filter chips wrap under iOS Bold Text so every level remains visible.
+            if (useCompactAccessibility) {
+                FlowRow(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 4.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    LogLevelFilterChip(
+                        level = LogLevel.DEBUG,
+                        selected = filter.showDebug,
+                        count = logs.count { it.level == LogLevel.DEBUG.name },
+                        onClick = { logsViewModel.toggleLevel(LogLevel.DEBUG) },
+                    )
+                    LogLevelFilterChip(
+                        level = LogLevel.INFO,
+                        selected = filter.showInfo,
+                        count = logs.count { it.level == LogLevel.INFO.name },
+                        onClick = { logsViewModel.toggleLevel(LogLevel.INFO) },
+                    )
+                    LogLevelFilterChip(
+                        level = LogLevel.WARNING,
+                        selected = filter.showWarning,
+                        count = logs.count { it.level == LogLevel.WARNING.name },
+                        onClick = { logsViewModel.toggleLevel(LogLevel.WARNING) },
+                    )
+                    LogLevelFilterChip(
+                        level = LogLevel.ERROR,
+                        selected = filter.showError,
+                        count = logs.count { it.level == LogLevel.ERROR.name },
+                        onClick = { logsViewModel.toggleLevel(LogLevel.ERROR) },
+                    )
+                }
+            } else {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .horizontalScroll(rememberScrollState())
+                        .padding(horizontal = 16.dp, vertical = 4.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    LogLevelFilterChip(
+                        level = LogLevel.DEBUG,
+                        selected = filter.showDebug,
+                        count = logs.count { it.level == LogLevel.DEBUG.name },
+                        onClick = { logsViewModel.toggleLevel(LogLevel.DEBUG) },
+                    )
+                    LogLevelFilterChip(
+                        level = LogLevel.INFO,
+                        selected = filter.showInfo,
+                        count = logs.count { it.level == LogLevel.INFO.name },
+                        onClick = { logsViewModel.toggleLevel(LogLevel.INFO) },
+                    )
+                    LogLevelFilterChip(
+                        level = LogLevel.WARNING,
+                        selected = filter.showWarning,
+                        count = logs.count { it.level == LogLevel.WARNING.name },
+                        onClick = { logsViewModel.toggleLevel(LogLevel.WARNING) },
+                    )
+                    LogLevelFilterChip(
+                        level = LogLevel.ERROR,
+                        selected = filter.showError,
+                        count = logs.count { it.level == LogLevel.ERROR.name },
+                        onClick = { logsViewModel.toggleLevel(LogLevel.ERROR) },
+                    )
+                }
             }
 
             // Action bar
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 8.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Text(
-                    text = "${logs.size} logs",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(end = 8.dp),
-                )
-
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+            if (useCompactAccessibility) {
+                Column(
                     modifier = Modifier
-                        .weight(1f, fill = false)
-                        .horizontalScroll(rememberScrollState()),
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
                 ) {
-                    // Auto-scroll toggle
-                    FilterChip(
-                        selected = isAutoScrollEnabled,
-                        onClick = { logsViewModel.toggleAutoScroll() },
-                        label = { Text(stringResource(Res.string.auto_scroll)) },
-                        leadingIcon = {
+                    Text(
+                        text = "${logs.size} logs",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+
+                    FlowRow(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalArrangement = Arrangement.spacedBy(4.dp),
+                    ) {
+                        FilterChip(
+                            selected = isAutoScrollEnabled,
+                            onClick = { logsViewModel.toggleAutoScroll() },
+                            label = { Text(stringResource(Res.string.auto_scroll)) },
+                            leadingIcon = {
+                                Icon(
+                                    Icons.Default.KeyboardArrowDown,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(18.dp),
+                                )
+                            },
+                        )
+
+                        FilterChip(
+                            selected = isLoggingEnabled,
+                            onClick = { logsViewModel.setLoggingEnabled(!isLoggingEnabled) },
+                            label = { Text(if (isLoggingEnabled) "Logging ON" else "Logging OFF") },
+                        )
+
+                        IconButton(onClick = {
+                            exportContent = logsViewModel.exportLogsAsText()
+                            showExportDialog = true
+                        }) {
                             Icon(
-                                Icons.Default.KeyboardArrowDown,
-                                contentDescription = null,
-                                modifier = Modifier.size(18.dp),
+                                Icons.Default.Share,
+                                contentDescription = stringResource(Res.string.cd_export_logs),
                             )
-                        },
-                    )
+                        }
 
-                    // Logging toggle
-                    FilterChip(
-                        selected = isLoggingEnabled,
-                        onClick = { logsViewModel.setLoggingEnabled(!isLoggingEnabled) },
-                        label = { Text(if (isLoggingEnabled) "Logging ON" else "Logging OFF") },
-                    )
-
-                    // Export button
-                    IconButton(onClick = {
-                        exportContent = logsViewModel.exportLogsAsText()
-                        showExportDialog = true
-                    }) {
-                        Icon(
-                            Icons.Default.Share,
-                            contentDescription = stringResource(Res.string.cd_export_logs),
-                        )
+                        IconButton(onClick = { showClearDialog = true }) {
+                            Icon(
+                                Icons.Default.Delete,
+                                contentDescription = stringResource(Res.string.cd_clear_logs),
+                            )
+                        }
                     }
+                }
+            } else {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = "${logs.size} logs",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(end = 8.dp),
+                    )
 
-                    // Clear button
-                    IconButton(onClick = { showClearDialog = true }) {
-                        Icon(
-                            Icons.Default.Delete,
-                            contentDescription = stringResource(Res.string.cd_clear_logs),
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        modifier = Modifier
+                            .weight(1f, fill = false)
+                            .horizontalScroll(rememberScrollState()),
+                    ) {
+                        // Auto-scroll toggle
+                        FilterChip(
+                            selected = isAutoScrollEnabled,
+                            onClick = { logsViewModel.toggleAutoScroll() },
+                            label = { Text(stringResource(Res.string.auto_scroll)) },
+                            leadingIcon = {
+                                Icon(
+                                    Icons.Default.KeyboardArrowDown,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(18.dp),
+                                )
+                            },
                         )
+
+                        // Logging toggle
+                        FilterChip(
+                            selected = isLoggingEnabled,
+                            onClick = { logsViewModel.setLoggingEnabled(!isLoggingEnabled) },
+                            label = { Text(if (isLoggingEnabled) "Logging ON" else "Logging OFF") },
+                        )
+
+                        // Export button
+                        IconButton(onClick = {
+                            exportContent = logsViewModel.exportLogsAsText()
+                            showExportDialog = true
+                        }) {
+                            Icon(
+                                Icons.Default.Share,
+                                contentDescription = stringResource(Res.string.cd_export_logs),
+                            )
+                        }
+
+                        // Clear button
+                        IconButton(onClick = { showClearDialog = true }) {
+                            Icon(
+                                Icons.Default.Delete,
+                                contentDescription = stringResource(Res.string.cd_clear_logs),
+                            )
+                        }
                     }
                 }
             }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/EnhancedMainScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/EnhancedMainScreen.kt
@@ -81,10 +81,12 @@ import com.devil.phoenixproject.presentation.components.HapticFeedbackEffect
 import com.devil.phoenixproject.presentation.components.ProfileSidePanel
 import com.devil.phoenixproject.presentation.navigation.NavGraph
 import com.devil.phoenixproject.presentation.navigation.NavigationRoutes
-import com.devil.phoenixproject.presentation.util.WindowHeightSizeClass
+import com.devil.phoenixproject.presentation.util.LocalPlatformAccessibilitySettings
 import com.devil.phoenixproject.presentation.util.LocalWindowSizeClass
+import com.devil.phoenixproject.presentation.util.WindowHeightSizeClass
 import com.devil.phoenixproject.presentation.util.calculateWindowSizeClass
 import com.devil.phoenixproject.presentation.util.isCompactAccessibilityLayout
+import com.devil.phoenixproject.presentation.util.rememberPlatformAccessibilitySettings
 import com.devil.phoenixproject.presentation.viewmodel.MainViewModel
 import com.devil.phoenixproject.ui.theme.AccessibilityTheme
 import com.devil.phoenixproject.ui.theme.ThemeMode
@@ -233,8 +235,12 @@ fun EnhancedMainScreen(
 
     BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
         val windowSizeClass = calculateWindowSizeClass(maxWidth, maxHeight)
+        val platformAccessibilitySettings = rememberPlatformAccessibilitySettings()
 
-        CompositionLocalProvider(LocalWindowSizeClass provides windowSizeClass) {
+        CompositionLocalProvider(
+            LocalWindowSizeClass provides windowSizeClass,
+            LocalPlatformAccessibilitySettings provides platformAccessibilitySettings,
+        ) {
             val useCompactTopBar = isCompactAccessibilityLayout() ||
                 windowSizeClass.heightSizeClass == WindowHeightSizeClass.Compact
             val fullTopBarTitle = if (topBarTitle.isNotEmpty()) {

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/EnhancedMainScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/EnhancedMainScreen.kt
@@ -81,6 +81,7 @@ import com.devil.phoenixproject.presentation.components.HapticFeedbackEffect
 import com.devil.phoenixproject.presentation.components.ProfileSidePanel
 import com.devil.phoenixproject.presentation.navigation.NavGraph
 import com.devil.phoenixproject.presentation.navigation.NavigationRoutes
+import com.devil.phoenixproject.presentation.util.WindowHeightSizeClass
 import com.devil.phoenixproject.presentation.util.LocalWindowSizeClass
 import com.devil.phoenixproject.presentation.util.calculateWindowSizeClass
 import com.devil.phoenixproject.presentation.util.isCompactAccessibilityLayout
@@ -234,7 +235,8 @@ fun EnhancedMainScreen(
         val windowSizeClass = calculateWindowSizeClass(maxWidth, maxHeight)
 
         CompositionLocalProvider(LocalWindowSizeClass provides windowSizeClass) {
-            val useCompactTopBar = isCompactAccessibilityLayout()
+            val useCompactTopBar = isCompactAccessibilityLayout() ||
+                windowSizeClass.heightSizeClass == WindowHeightSizeClass.Compact
             val fullTopBarTitle = if (topBarTitle.isNotEmpty()) {
                 topBarTitle
             } else {
@@ -386,7 +388,10 @@ fun EnhancedMainScreen(
                                         contentDescription = stringResource(Res.string.cd_analytics),
                                     )
                                 },
-                                label = { Text(stringResource(Res.string.nav_analytics)) },
+                                label = if (useCompactTopBar) null else {
+                                    { Text(stringResource(Res.string.nav_analytics)) }
+                                },
+                                alwaysShowLabel = !useCompactTopBar,
                                 selected = currentRoute == NavigationRoutes.Analytics.route,
                                 onClick = {
                                     if (currentRoute != NavigationRoutes.Analytics.route) {
@@ -414,7 +419,10 @@ fun EnhancedMainScreen(
                                         contentDescription = stringResource(Res.string.cd_workouts),
                                     )
                                 },
-                                label = { Text(stringResource(Res.string.nav_workouts)) },
+                                label = if (useCompactTopBar) null else {
+                                    { Text(stringResource(Res.string.nav_workouts)) }
+                                },
+                                alwaysShowLabel = !useCompactTopBar,
                                 selected = isWorkoutsRoute,
                                 onClick = {
                                     if (currentRoute != NavigationRoutes.Home.route) {
@@ -441,7 +449,10 @@ fun EnhancedMainScreen(
                                         contentDescription = "Insights",
                                     )
                                 },
-                                label = { Text("Insights") },
+                                label = if (useCompactTopBar) null else {
+                                    { Text("Insights") }
+                                },
+                                alwaysShowLabel = !useCompactTopBar,
                                 selected = currentRoute == NavigationRoutes.SmartInsights.route,
                                 onClick = {
                                     if (currentRoute != NavigationRoutes.SmartInsights.route) {
@@ -469,7 +480,10 @@ fun EnhancedMainScreen(
                                         contentDescription = stringResource(Res.string.cd_settings),
                                     )
                                 },
-                                label = { Text(stringResource(Res.string.nav_settings)) },
+                                label = if (useCompactTopBar) null else {
+                                    { Text(stringResource(Res.string.nav_settings)) }
+                                },
+                                alwaysShowLabel = !useCompactTopBar,
                                 selected = currentRoute == NavigationRoutes.Settings.route,
                                 onClick = {
                                     if (currentRoute != NavigationRoutes.Settings.route) {

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/HomeScreen.kt
@@ -227,64 +227,27 @@ fun HomeScreen(navController: NavController, viewModel: MainViewModel, themeMode
                     RecentActivitySummary(recentSessions, weightUnit)
                 }
 
-                // Spacer for FABs clearance
-                item(key = "fab-spacer") {
-                    Spacer(modifier = Modifier.height(fabSpacerHeight))
+                if (useCompactAccessibility) {
+                    item(key = "action-grid") {
+                        HomeActionGrid(navController = navController)
+                    }
+                } else {
+                    // Spacer for FABs clearance
+                    item(key = "fab-spacer") {
+                        Spacer(modifier = Modifier.height(fabSpacerHeight))
+                    }
                 }
             }
 
-            // Bottom FAB Grid: 2 columns, equal width - positioned directly above the navbar
-            Row(
-                modifier = Modifier
-                    .align(Alignment.BottomCenter)
-                    .fillMaxWidth()
-                    .padding(horizontal = 12.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                // Left column: Cycles & Routines
-                Column(
-                    modifier = Modifier.weight(1f),
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
-                ) {
-                    AnimatedActionButton(
-                        label = "Cycles",
-                        icon = Icons.Default.Loop,
-                        onClick = { navController.navigate(NavigationRoutes.TrainingCycles.route) },
-                        isPrimary = false,
-                        iconAnimation = IconAnimation.ROTATE,
-                    )
-                    AnimatedActionButton(
-                        label = "Routines",
-                        icon = Icons.AutoMirrored.Filled.FormatListBulleted,
-                        onClick = { navController.navigate(NavigationRoutes.DailyRoutines.route) },
-                        isPrimary = false,
-                        iconAnimation = IconAnimation.NONE,
-                    )
-                }
-
-                // Right column: Single Exercise & Just Lift
-                Column(
-                    modifier = Modifier.weight(1f),
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
-                ) {
-                    AnimatedActionButton(
-                        label = "Single Exercise",
-                        icon = Icons.Outlined.FitnessCenter,
-                        onClick = { navController.navigate(NavigationRoutes.SingleExercise.route) },
-                        isPrimary = false,
-                        iconAnimation = IconAnimation.TILT,
-                    )
-                    AnimatedActionButton(
-                        label = "Just Lift",
-                        icon = null,
-                        onClick = {
-                            navController.navigate(NavigationRoutes.JustLift.route)
-                        },
-                        isPrimary = true,
-                        isFireButton = true, // Fire animation effect
-                        iconAnimation = IconAnimation.NONE,
-                    )
-                }
+            if (!useCompactAccessibility) {
+                // Bottom FAB Grid: 2 columns, equal width - positioned directly above the navbar
+                HomeActionGrid(
+                    navController = navController,
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .fillMaxWidth()
+                        .padding(horizontal = 12.dp),
+                )
             }
 
             // Connection Error Handling
@@ -294,6 +257,57 @@ fun HomeScreen(navController: NavController, viewModel: MainViewModel, themeMode
                     onDismiss = { viewModel.clearConnectionError() },
                 )
             }
+        }
+    }
+}
+
+@Composable
+private fun HomeActionGrid(navController: NavController, modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            AnimatedActionButton(
+                label = "Cycles",
+                icon = Icons.Default.Loop,
+                onClick = { navController.navigate(NavigationRoutes.TrainingCycles.route) },
+                isPrimary = false,
+                iconAnimation = IconAnimation.ROTATE,
+            )
+            AnimatedActionButton(
+                label = "Routines",
+                icon = Icons.AutoMirrored.Filled.FormatListBulleted,
+                onClick = { navController.navigate(NavigationRoutes.DailyRoutines.route) },
+                isPrimary = false,
+                iconAnimation = IconAnimation.NONE,
+            )
+        }
+
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            AnimatedActionButton(
+                label = "Single Exercise",
+                icon = Icons.Outlined.FitnessCenter,
+                onClick = { navController.navigate(NavigationRoutes.SingleExercise.route) },
+                isPrimary = false,
+                iconAnimation = IconAnimation.TILT,
+            )
+            AnimatedActionButton(
+                label = "Just Lift",
+                icon = null,
+                onClick = {
+                    navController.navigate(NavigationRoutes.JustLift.route)
+                },
+                isPrimary = true,
+                isFireButton = true,
+                iconAnimation = IconAnimation.NONE,
+            )
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/JustLiftScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/JustLiftScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -28,8 +29,10 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Timer
@@ -42,6 +45,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
@@ -99,6 +103,7 @@ import com.devil.phoenixproject.presentation.components.ProfileSidePanel
 import com.devil.phoenixproject.presentation.components.ProgressionSlider
 import com.devil.phoenixproject.presentation.components.RestTimePickerDialog
 import com.devil.phoenixproject.presentation.navigation.NavigationRoutes
+import com.devil.phoenixproject.presentation.util.isCompactAccessibilityLayout
 import com.devil.phoenixproject.presentation.viewmodel.MainViewModel
 import com.devil.phoenixproject.ui.theme.AccessibilityTheme
 import com.devil.phoenixproject.ui.theme.Spacing
@@ -279,6 +284,9 @@ fun JustLiftScreen(navController: NavController, viewModel: MainViewModel, theme
         viewModel.updateTopBarTitle("Just Lift")
     }
 
+    val useCompactAccessibility = isCompactAccessibilityLayout()
+    val contentScrollState = rememberScrollState()
+
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -288,8 +296,9 @@ fun JustLiftScreen(navController: NavController, viewModel: MainViewModel, theme
             modifier = Modifier
                 .fillMaxSize()
                 .navigationBarsPadding()
-                .padding(horizontal = Spacing.medium, vertical = Spacing.small),
-            verticalArrangement = Arrangement.spacedBy(Spacing.small),
+                .padding(horizontal = Spacing.medium, vertical = Spacing.small)
+                .then(if (useCompactAccessibility) Modifier.verticalScroll(contentScrollState) else Modifier),
+            verticalArrangement = Arrangement.spacedBy(if (useCompactAccessibility) Spacing.medium else Spacing.small),
         ) {
             // Auto-Start/Stop Banner (compact, always visible when idle)
             if (workoutState is WorkoutState.Idle) {
@@ -311,7 +320,7 @@ fun JustLiftScreen(navController: NavController, viewModel: MainViewModel, theme
             Card(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .weight(1f),
+                    .then(if (useCompactAccessibility) Modifier else Modifier.weight(1f)),
                 colors = CardDefaults.cardColors(
                     containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
                 ),
@@ -319,9 +328,13 @@ fun JustLiftScreen(navController: NavController, viewModel: MainViewModel, theme
             ) {
                 Column(
                     modifier = Modifier
-                        .fillMaxSize()
+                        .then(if (useCompactAccessibility) Modifier.fillMaxWidth() else Modifier.fillMaxSize())
                         .padding(Spacing.medium),
-                    verticalArrangement = Arrangement.SpaceEvenly,
+                    verticalArrangement = if (useCompactAccessibility) {
+                        Arrangement.spacedBy(Spacing.small)
+                    } else {
+                        Arrangement.SpaceEvenly
+                    },
                 ) {
                     Text(
                         "Workout Mode",
@@ -330,14 +343,29 @@ fun JustLiftScreen(navController: NavController, viewModel: MainViewModel, theme
                         color = MaterialTheme.colorScheme.onSurface,
                     )
 
-                    SingleChoiceSegmentedButtonRow(
-                        modifier = Modifier.fillMaxWidth(),
-                    ) {
-                        val modes = listOf(
-                            "Old School" to WorkoutMode.OldSchool,
-                            "Pump" to WorkoutMode.Pump,
-                            "Echo" to WorkoutMode.Echo(echoLevel),
-                        )
+                    val modes = listOf(
+                        "Old School" to WorkoutMode.OldSchool,
+                        "Pump" to WorkoutMode.Pump,
+                        "Echo" to WorkoutMode.Echo(echoLevel),
+                    )
+                    if (useCompactAccessibility) {
+                        FlowRow(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalArrangement = Arrangement.spacedBy(4.dp),
+                        ) {
+                            modes.forEach { (label, mode) ->
+                                FilterChip(
+                                    selected = selectedMode::class == mode::class,
+                                    onClick = { selectedMode = mode },
+                                    label = { Text(label) },
+                                )
+                            }
+                        }
+                    } else {
+                        SingleChoiceSegmentedButtonRow(
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
                         modes.forEachIndexed { index, (label, mode) ->
                             SegmentedButton(
                                 shape = SegmentedButtonDefaults.itemShape(index = index, count = modes.size),
@@ -347,6 +375,7 @@ fun JustLiftScreen(navController: NavController, viewModel: MainViewModel, theme
                             ) {
                                 Text(label, maxLines = 1)
                             }
+                        }
                         }
                     }
 
@@ -370,7 +399,7 @@ fun JustLiftScreen(navController: NavController, viewModel: MainViewModel, theme
                 Card(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .weight(1f),
+                        .then(if (useCompactAccessibility) Modifier else Modifier.weight(1f)),
                     colors = CardDefaults.cardColors(
                         containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
                     ),
@@ -378,7 +407,7 @@ fun JustLiftScreen(navController: NavController, viewModel: MainViewModel, theme
                 ) {
                     Column(
                         modifier = Modifier
-                            .fillMaxSize()
+                            .then(if (useCompactAccessibility) Modifier.fillMaxWidth() else Modifier.fillMaxSize())
                             .padding(Spacing.medium),
                         verticalArrangement = Arrangement.Center,
                     ) {
@@ -426,7 +455,7 @@ fun JustLiftScreen(navController: NavController, viewModel: MainViewModel, theme
                 Card(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .weight(1f),
+                        .then(if (useCompactAccessibility) Modifier else Modifier.weight(1f)),
                     colors = CardDefaults.cardColors(
                         containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
                     ),
@@ -434,9 +463,13 @@ fun JustLiftScreen(navController: NavController, viewModel: MainViewModel, theme
                 ) {
                     Column(
                         modifier = Modifier
-                            .fillMaxSize()
+                            .then(if (useCompactAccessibility) Modifier.fillMaxWidth() else Modifier.fillMaxSize())
                             .padding(Spacing.medium),
-                        verticalArrangement = Arrangement.SpaceEvenly,
+                        verticalArrangement = if (useCompactAccessibility) {
+                            Arrangement.spacedBy(Spacing.small)
+                        } else {
+                            Arrangement.SpaceEvenly
+                        },
                     ) {
                         Text(
                             "Weight Change Per Rep",
@@ -468,7 +501,7 @@ fun JustLiftScreen(navController: NavController, viewModel: MainViewModel, theme
                 Card(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .weight(1f),
+                        .then(if (useCompactAccessibility) Modifier else Modifier.weight(1f)),
                     colors = CardDefaults.cardColors(
                         containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
                     ),
@@ -476,9 +509,13 @@ fun JustLiftScreen(navController: NavController, viewModel: MainViewModel, theme
                 ) {
                     Column(
                         modifier = Modifier
-                            .fillMaxSize()
+                            .then(if (useCompactAccessibility) Modifier.fillMaxWidth() else Modifier.fillMaxSize())
                             .padding(Spacing.medium),
-                        verticalArrangement = Arrangement.SpaceEvenly,
+                        verticalArrangement = if (useCompactAccessibility) {
+                            Arrangement.spacedBy(Spacing.small)
+                        } else {
+                            Arrangement.SpaceEvenly
+                        },
                     ) {
                         Text(
                             "Eccentric Load",
@@ -533,7 +570,7 @@ fun JustLiftScreen(navController: NavController, viewModel: MainViewModel, theme
                 Card(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .weight(1f),
+                        .then(if (useCompactAccessibility) Modifier else Modifier.weight(1f)),
                     colors = CardDefaults.cardColors(
                         containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
                     ),
@@ -541,9 +578,13 @@ fun JustLiftScreen(navController: NavController, viewModel: MainViewModel, theme
                 ) {
                     Column(
                         modifier = Modifier
-                            .fillMaxSize()
+                            .then(if (useCompactAccessibility) Modifier.fillMaxWidth() else Modifier.fillMaxSize())
                             .padding(Spacing.medium),
-                        verticalArrangement = Arrangement.SpaceEvenly,
+                        verticalArrangement = if (useCompactAccessibility) {
+                            Arrangement.spacedBy(Spacing.small)
+                        } else {
+                            Arrangement.SpaceEvenly
+                        },
                     ) {
                         Text(
                             "Echo Level",
@@ -552,19 +593,38 @@ fun JustLiftScreen(navController: NavController, viewModel: MainViewModel, theme
                             color = MaterialTheme.colorScheme.onSurface,
                         )
 
-                        SingleChoiceSegmentedButtonRow(
-                            modifier = Modifier.fillMaxWidth(),
-                        ) {
-                            EchoLevel.entries.forEachIndexed { index, level ->
-                                SegmentedButton(
-                                    shape = SegmentedButtonDefaults.itemShape(index = index, count = EchoLevel.entries.size),
-                                    onClick = {
-                                        echoLevel = level
-                                        selectedMode = WorkoutMode.Echo(level)
-                                    },
-                                    selected = echoLevel == level,
-                                ) {
-                                    Text(level.displayName, maxLines = 1)
+                        if (useCompactAccessibility) {
+                            FlowRow(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                verticalArrangement = Arrangement.spacedBy(4.dp),
+                            ) {
+                                EchoLevel.entries.forEach { level ->
+                                    FilterChip(
+                                        selected = echoLevel == level,
+                                        onClick = {
+                                            echoLevel = level
+                                            selectedMode = WorkoutMode.Echo(level)
+                                        },
+                                        label = { Text(level.displayName) },
+                                    )
+                                }
+                            }
+                        } else {
+                            SingleChoiceSegmentedButtonRow(
+                                modifier = Modifier.fillMaxWidth(),
+                            ) {
+                                EchoLevel.entries.forEachIndexed { index, level ->
+                                    SegmentedButton(
+                                        shape = SegmentedButtonDefaults.itemShape(index = index, count = EchoLevel.entries.size),
+                                        onClick = {
+                                            echoLevel = level
+                                            selectedMode = WorkoutMode.Echo(level)
+                                        },
+                                        selected = echoLevel == level,
+                                    ) {
+                                        Text(level.displayName, maxLines = 1)
+                                    }
                                 }
                             }
                         }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/WorkoutHud.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/WorkoutHud.kt
@@ -5,8 +5,10 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
@@ -36,6 +38,7 @@ import com.devil.phoenixproject.presentation.util.LocalWindowSizeClass
 import com.devil.phoenixproject.presentation.util.WeightDisplayFormatter
 import com.devil.phoenixproject.presentation.util.ResponsiveDimensions
 import com.devil.phoenixproject.presentation.util.WindowWidthSizeClass
+import com.devil.phoenixproject.presentation.util.isCompactAccessibilityLayout
 import com.devil.phoenixproject.ui.theme.velocityZoneColor
 import com.devil.phoenixproject.ui.theme.velocityZoneLabel
 import kotlin.math.abs
@@ -877,10 +880,13 @@ private fun StatsPage(
         return
     }
 
+    val useCompactAccessibility = isCompactAccessibilityLayout()
+
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(16.dp),
+            .padding(16.dp)
+            .verticalScroll(rememberScrollState()),
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         // Title
@@ -979,25 +985,51 @@ private fun StatsPage(
                     color = MaterialTheme.colorScheme.primary,
                     letterSpacing = 1.sp,
                 )
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceEvenly,
-                ) {
-                    StatColumn(
-                        label = "Left",
-                        value = formatWeight(metric.loadA, weightUnit),
-                        color = MaterialTheme.colorScheme.primary,
-                    )
-                    StatColumn(
-                        label = "Right",
-                        value = formatWeight(metric.loadB, weightUnit),
-                        color = MaterialTheme.colorScheme.primary,
-                    )
+                if (useCompactAccessibility) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        StatColumn(
+                            label = "Left",
+                            value = formatWeight(metric.loadA, weightUnit),
+                            color = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.weight(1f),
+                        )
+                        StatColumn(
+                            label = "Right",
+                            value = formatWeight(metric.loadB, weightUnit),
+                            color = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.weight(1f),
+                        )
+                    }
                     StatColumn(
                         label = "Total",
                         value = formatWeight(metric.totalLoad, weightUnit),
                         color = MaterialTheme.colorScheme.tertiary,
+                        modifier = Modifier.fillMaxWidth(),
                     )
+                } else {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceEvenly,
+                    ) {
+                        StatColumn(
+                            label = "Left",
+                            value = formatWeight(metric.loadA, weightUnit),
+                            color = MaterialTheme.colorScheme.primary,
+                        )
+                        StatColumn(
+                            label = "Right",
+                            value = formatWeight(metric.loadB, weightUnit),
+                            color = MaterialTheme.colorScheme.primary,
+                        )
+                        StatColumn(
+                            label = "Total",
+                            value = formatWeight(metric.totalLoad, weightUnit),
+                            color = MaterialTheme.colorScheme.tertiary,
+                        )
+                    }
                 }
             }
         }
@@ -1187,8 +1219,9 @@ private fun formatMcv(mmPerSec: Float): String {
 }
 
 @Composable
-private fun StatColumn(label: String, value: String, color: Color) {
+private fun StatColumn(label: String, value: String, color: Color, modifier: Modifier = Modifier) {
     Column(
+        modifier = modifier,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Text(
@@ -1201,6 +1234,8 @@ private fun StatColumn(label: String, value: String, color: Color) {
             style = MaterialTheme.typography.titleLarge,
             fontWeight = FontWeight.Bold,
             color = color,
+            textAlign = TextAlign.Center,
+            maxLines = 2,
         )
     }
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/util/PlatformAccessibilitySettings.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/util/PlatformAccessibilitySettings.kt
@@ -1,0 +1,10 @@
+package com.devil.phoenixproject.presentation.util
+
+import androidx.compose.runtime.Composable
+
+data class PlatformAccessibilitySettings(
+    val boldTextEnabled: Boolean = false,
+)
+
+@Composable
+expect fun rememberPlatformAccessibilitySettings(): PlatformAccessibilitySettings

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/util/PlatformAccessibilitySettings.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/util/PlatformAccessibilitySettings.kt
@@ -1,10 +1,13 @@
 package com.devil.phoenixproject.presentation.util
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.compositionLocalOf
 
 data class PlatformAccessibilitySettings(
     val boldTextEnabled: Boolean = false,
 )
+
+val LocalPlatformAccessibilitySettings = compositionLocalOf { PlatformAccessibilitySettings() }
 
 @Composable
 expect fun rememberPlatformAccessibilitySettings(): PlatformAccessibilitySettings

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/util/WindowSizeClass.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/util/WindowSizeClass.kt
@@ -86,7 +86,7 @@ fun calculateWindowSizeClass(widthDp: Dp, heightDp: Dp): WindowSizeClass {
 fun isCompactAccessibilityLayout(fontScaleThreshold: Float = 1.15f): Boolean {
     val windowSizeClass = LocalWindowSizeClass.current
     val fontScale = LocalDensity.current.fontScale
-    val accessibilitySettings = rememberPlatformAccessibilitySettings()
+    val accessibilitySettings = LocalPlatformAccessibilitySettings.current
     return shouldUseCompactAccessibilityLayout(
         windowSizeClass = windowSizeClass,
         fontScale = fontScale,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/util/WindowSizeClass.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/util/WindowSizeClass.kt
@@ -86,8 +86,26 @@ fun calculateWindowSizeClass(widthDp: Dp, heightDp: Dp): WindowSizeClass {
 fun isCompactAccessibilityLayout(fontScaleThreshold: Float = 1.15f): Boolean {
     val windowSizeClass = LocalWindowSizeClass.current
     val fontScale = LocalDensity.current.fontScale
-    return windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact &&
-        (windowSizeClass.heightSizeClass == WindowHeightSizeClass.Compact || fontScale >= fontScaleThreshold)
+    val accessibilitySettings = rememberPlatformAccessibilitySettings()
+    return shouldUseCompactAccessibilityLayout(
+        windowSizeClass = windowSizeClass,
+        fontScale = fontScale,
+        boldTextEnabled = accessibilitySettings.boldTextEnabled,
+        fontScaleThreshold = fontScaleThreshold,
+    )
+}
+
+fun shouldUseCompactAccessibilityLayout(
+    windowSizeClass: WindowSizeClass,
+    fontScale: Float,
+    boldTextEnabled: Boolean,
+    fontScaleThreshold: Float = 1.15f,
+): Boolean {
+    return windowSizeClass.heightSizeClass == WindowHeightSizeClass.Compact ||
+        (
+            windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact &&
+                (fontScale >= fontScaleThreshold || boldTextEnabled)
+            )
 }
 
 /**

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/util/WindowSizeClassTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/util/WindowSizeClassTest.kt
@@ -1,0 +1,116 @@
+package com.devil.phoenixproject.presentation.util
+
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class WindowSizeClassTest {
+    @Test
+    fun compactWidthWithBoldTextUsesCompactAccessibilityLayout() {
+        val window = WindowSizeClass(
+            widthSizeClass = WindowWidthSizeClass.Compact,
+            heightSizeClass = WindowHeightSizeClass.Medium,
+            widthDp = 390.dp,
+            heightDp = 844.dp,
+        )
+
+        assertTrue(
+            shouldUseCompactAccessibilityLayout(
+                windowSizeClass = window,
+                fontScale = 1f,
+                boldTextEnabled = true,
+            ),
+        )
+    }
+
+    @Test
+    fun compactWidthWithLargeFontScaleUsesCompactAccessibilityLayout() {
+        val window = WindowSizeClass(
+            widthSizeClass = WindowWidthSizeClass.Compact,
+            heightSizeClass = WindowHeightSizeClass.Medium,
+            widthDp = 390.dp,
+            heightDp = 844.dp,
+        )
+
+        assertTrue(
+            shouldUseCompactAccessibilityLayout(
+                windowSizeClass = window,
+                fontScale = 1.2f,
+                boldTextEnabled = false,
+            ),
+        )
+    }
+
+    @Test
+    fun widerLayoutsDoNotUseCompactAccessibilityForBoldTextOnly() {
+        val window = WindowSizeClass(
+            widthSizeClass = WindowWidthSizeClass.Medium,
+            heightSizeClass = WindowHeightSizeClass.Medium,
+            widthDp = 700.dp,
+            heightDp = 844.dp,
+        )
+
+        assertFalse(
+            shouldUseCompactAccessibilityLayout(
+                windowSizeClass = window,
+                fontScale = 1f,
+                boldTextEnabled = true,
+            ),
+        )
+    }
+
+    @Test
+    fun shortHeightCompactWidthUsesCompactAccessibilityLayout() {
+        val window = WindowSizeClass(
+            widthSizeClass = WindowWidthSizeClass.Compact,
+            heightSizeClass = WindowHeightSizeClass.Compact,
+            widthDp = 390.dp,
+            heightDp = 440.dp,
+        )
+
+        assertTrue(
+            shouldUseCompactAccessibilityLayout(
+                windowSizeClass = window,
+                fontScale = 1f,
+                boldTextEnabled = false,
+            ),
+        )
+    }
+
+    @Test
+    fun shortHeightWiderLayoutUsesCompactAccessibilityLayout() {
+        val window = WindowSizeClass(
+            widthSizeClass = WindowWidthSizeClass.Medium,
+            heightSizeClass = WindowHeightSizeClass.Compact,
+            widthDp = 740.dp,
+            heightDp = 390.dp,
+        )
+
+        assertTrue(
+            shouldUseCompactAccessibilityLayout(
+                windowSizeClass = window,
+                fontScale = 1f,
+                boldTextEnabled = false,
+            ),
+        )
+    }
+
+    @Test
+    fun defaultAndroidSizedLayoutPreservesExistingNonCompactBehavior() {
+        val window = WindowSizeClass(
+            widthSizeClass = WindowWidthSizeClass.Compact,
+            heightSizeClass = WindowHeightSizeClass.Medium,
+            widthDp = 400.dp,
+            heightDp = 800.dp,
+        )
+
+        assertFalse(
+            shouldUseCompactAccessibilityLayout(
+                windowSizeClass = window,
+                fontScale = 1f,
+                boldTextEnabled = false,
+            ),
+        )
+    }
+}

--- a/shared/src/iosMain/kotlin/com/devil/phoenixproject/presentation/util/PlatformAccessibilitySettings.ios.kt
+++ b/shared/src/iosMain/kotlin/com/devil/phoenixproject/presentation/util/PlatformAccessibilitySettings.ios.kt
@@ -1,0 +1,36 @@
+package com.devil.phoenixproject.presentation.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import platform.Foundation.NSNotificationCenter
+import platform.Foundation.NSOperationQueue
+import platform.UIKit.UIAccessibilityBoldTextStatusDidChangeNotification
+import platform.UIKit.UIAccessibilityIsBoldTextEnabled
+
+@Composable
+actual fun rememberPlatformAccessibilitySettings(): PlatformAccessibilitySettings {
+    var boldTextEnabled by remember {
+        mutableStateOf(UIAccessibilityIsBoldTextEnabled())
+    }
+
+    DisposableEffect(Unit) {
+        val observer = NSNotificationCenter.defaultCenter.addObserverForName(
+            name = UIAccessibilityBoldTextStatusDidChangeNotification,
+            `object` = null,
+            queue = NSOperationQueue.mainQueue(),
+            usingBlock = {
+                boldTextEnabled = UIAccessibilityIsBoldTextEnabled()
+            },
+        )
+
+        onDispose {
+            NSNotificationCenter.defaultCenter.removeObserver(observer)
+        }
+    }
+
+    return PlatformAccessibilitySettings(boldTextEnabled = boldTextEnabled)
+}


### PR DESCRIPTION
## Summary
- Add a shared accessibility settings bridge so Compose layouts can react to iOS Bold Text without platform-specific UI code.
- Centralize compact-accessibility layout decisions and cover them with unit tests.
- Reflow the affected screens and controls so larger text and Bold Text no longer hide critical actions or content in the issue 389 flows.

## Testing
- Added unit tests for the compact-accessibility helper covering Bold Text, larger font scale, short-height layouts, and default Android behavior.
- Verified shared metadata, Android main, Android host tests, and iOS arm64 compilation all pass locally.
- Confirmed the new layout changes compile cleanly across the shared module.

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/9thLevelSoftware/Project-Phoenix-MP/432)
<!-- GitContextEnd -->