### PR TITLE
feat(workout): refine completion criteria and health integration parity

### DIFF
--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightGamificationRepositoryTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightGamificationRepositoryTest.kt
@@ -3,11 +3,11 @@ package com.devil.phoenixproject.data.repository
 import app.cash.turbine.test
 import com.devil.phoenixproject.database.VitruvianDatabase
 import com.devil.phoenixproject.testutil.createTestDatabase
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class SqlDelightGamificationRepositoryTest {
 
@@ -54,6 +54,58 @@ class SqlDelightGamificationRepositoryTest {
     }
 
     @Test
+    fun `updateStats ignores zero-rep sessions and tracks valid untagged sessions`() = runTest {
+        insertWorkoutSession(id = "session-valid-tagged", totalReps = 10, weightPerCableKg = 20.0, exerciseId = "bench")
+        insertWorkoutSession(id = "session-valid-untagged", totalReps = 8, weightPerCableKg = 15.0, exerciseId = null)
+        insertWorkoutSession(id = "session-invalid", totalReps = 0, weightPerCableKg = 20.0, exerciseId = "squat")
+
+        repository.updateStats(profileId)
+
+        repository.getGamificationStats(profileId).test {
+            val stats = awaitItem()
+            assertEquals(2, stats.totalWorkouts)
+            assertEquals(18, stats.totalReps)
+            assertEquals(1, stats.uniqueExercisesUsed)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `checkAndAwardBadges awards rep exercise and routine completion badges from valid sessions`() = runTest {
+        repeat(5) { index ->
+            insertWorkoutSession(
+                id = "exercise-session-$index",
+                totalReps = 20,
+                weightPerCableKg = 20.0,
+                exerciseId = "exercise-$index",
+            )
+        }
+        repeat(10) { index ->
+            insertWorkoutSession(
+                id = "routine-session-$index",
+                totalReps = 1,
+                weightPerCableKg = 10.0,
+                exerciseId = "exercise-0",
+                routineSessionId = "routine-run-$index",
+            )
+        }
+        insertWorkoutSession(
+            id = "invalid-routine-session",
+            totalReps = 0,
+            weightPerCableKg = 10.0,
+            exerciseId = "invalid-exercise",
+            routineSessionId = "invalid-routine-run",
+        )
+
+        repository.updateStats(profileId)
+        val badges = repository.checkAndAwardBadges(profileId).map { it.id }.toSet()
+
+        assertTrue("reps_100" in badges)
+        assertTrue("exercises_5" in badges)
+        assertTrue("routines_completed_10" in badges)
+    }
+
+    @Test
     fun `checkAndAwardBadges awards first workout badge`() = runTest {
         insertWorkoutSession(id = "session-2", totalReps = 10, weightPerCableKg = 20.0)
         repository.updateStats(profileId)
@@ -63,7 +115,13 @@ class SqlDelightGamificationRepositoryTest {
         assertTrue(badges.any { it.id == "workouts_1" })
     }
 
-    private fun insertWorkoutSession(id: String, totalReps: Long, weightPerCableKg: Double) {
+    private fun insertWorkoutSession(
+        id: String,
+        totalReps: Long,
+        weightPerCableKg: Double,
+        exerciseId: String? = "bench",
+        routineSessionId: String? = null,
+    ) {
         database.vitruvianDatabaseQueries.insertSession(
             id = id,
             timestamp = 1_000_000L,
@@ -79,10 +137,10 @@ class SqlDelightGamificationRepositoryTest {
             stopAtTop = 0L,
             eccentricLoad = 100L,
             echoLevel = 1L,
-            exerciseId = "bench",
-            exerciseName = "Bench Press",
-            routineSessionId = null,
-            routineName = null,
+            exerciseId = exerciseId,
+            exerciseName = exerciseId?.let { "Exercise $it" },
+            routineSessionId = routineSessionId,
+            routineName = routineSessionId?.let { "Routine $it" },
             safetyFlags = 0L,
             deloadWarningCount = 0L,
             romViolationCount = 0L,

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/manager/GamificationManagerTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/manager/GamificationManagerTest.kt
@@ -9,22 +9,21 @@ import com.devil.phoenixproject.testutil.FakeExerciseRepository
 import com.devil.phoenixproject.testutil.FakeGamificationRepository
 import com.devil.phoenixproject.testutil.FakePersonalRecordRepository
 import com.devil.phoenixproject.testutil.TestCoroutineRule
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class GamificationManagerTest {
@@ -156,6 +155,63 @@ class GamificationManagerTest {
             prJob.cancel()
             badgeJob.cancel()
             hapticJob.cancel()
+        } finally {
+            managerScope.cancel()
+        }
+    }
+
+    @Test
+    fun `processPostSaveEvents awards badges for valid completion without exercise id`() = runTest {
+        val managerScope = CoroutineScope(coroutineContext + SupervisorJob())
+        try {
+            val manager = GamificationManager(
+                gamificationRepository = fakeGamificationRepository,
+                personalRecordRepository = fakePersonalRecordRepository,
+                exerciseRepository = fakeExerciseRepository,
+                hapticEvents = hapticEvents,
+                scope = managerScope,
+                gamificationEnabled = MutableStateFlow(true),
+            )
+            val badge = BadgeDefinitions.allBadges.first()
+            fakeGamificationRepository.pendingBadges = mutableListOf(badge)
+
+            val hasCelebrationSound = manager.processPostSaveEvents(
+                exerciseId = null,
+                workingReps = 8,
+                achievedWeightKg = 20f,
+                volumeWeightKg = 20f,
+                programMode = ProgramMode.OldSchool,
+                isJustLift = false,
+                isEchoMode = false,
+            )
+            advanceUntilIdle()
+
+            assertFalse(hasCelebrationSound)
+            assertEquals(0, fakePersonalRecordRepository.updateCalls.size)
+            assertEquals(1, fakeGamificationRepository.updateStatsCallCount)
+            assertEquals(1, fakeGamificationRepository.checkAndAwardBadgesCallCount)
+        } finally {
+            managerScope.cancel()
+        }
+    }
+
+    @Test
+    fun `processSetQualityEvent does not award badges when gamification is disabled`() = runTest {
+        val managerScope = CoroutineScope(coroutineContext + SupervisorJob())
+        try {
+            val manager = GamificationManager(
+                gamificationRepository = fakeGamificationRepository,
+                personalRecordRepository = fakePersonalRecordRepository,
+                exerciseRepository = fakeExerciseRepository,
+                hapticEvents = hapticEvents,
+                scope = managerScope,
+                gamificationEnabled = MutableStateFlow(false),
+            )
+
+            repeat(3) { manager.processSetQualityEvent(90) }
+            advanceUntilIdle()
+
+            assertFalse(fakeGamificationRepository.isBadgeEarned("form_master_bronze", "default"))
         } finally {
             managerScope.cancel()
         }

--- a/shared/src/androidMain/kotlin/com/devil/phoenixproject/data/integration/HealthIntegration.android.kt
+++ b/shared/src/androidMain/kotlin/com/devil/phoenixproject/data/integration/HealthIntegration.android.kt
@@ -24,8 +24,13 @@ private val VITRUVIAN_DEVICE = Device(
 
 internal val requiredHealthPermissions = setOf(
     HealthPermission.getWritePermission(ExerciseSessionRecord::class),
+)
+
+internal val optionalHealthPermissions = setOf(
     HealthPermission.getWritePermission(TotalCaloriesBurnedRecord::class),
 )
+
+internal val requestedHealthPermissions = requiredHealthPermissions + optionalHealthPermissions
 
 /**
  * Android implementation of HealthIntegration using Google Health Connect.
@@ -63,11 +68,15 @@ actual class HealthIntegration(private val context: Context) {
      */
     actual suspend fun requestPermissions(): Boolean = hasPermissions()
 
-    actual suspend fun hasPermissions(): Boolean {
+    actual suspend fun hasPermissions(): Boolean = hasGrantedPermissions(requiredHealthPermissions)
+
+    private suspend fun hasCalorieWritePermission(): Boolean = hasGrantedPermissions(optionalHealthPermissions)
+
+    private suspend fun hasGrantedPermissions(permissions: Set<String>): Boolean {
         val c = client ?: return false
         return try {
             val granted = c.permissionController.getGrantedPermissions()
-            granted.containsAll(requiredHealthPermissions)
+            granted.containsAll(permissions)
         } catch (e: Exception) {
             log.w(e) { "Error checking Health Connect permissions" }
             false
@@ -94,6 +103,18 @@ actual class HealthIntegration(private val context: Context) {
             val durationSeconds = durationMs / 1000L
             val endInstant = startInstant.plusSeconds(durationSeconds)
             val zoneOffset = ZoneId.systemDefault().rules.getOffset(startInstant)
+            val title = buildExerciseTitle(session)
+            val canWriteCalories = hasCalorieWritePermission()
+
+            log.i {
+                "HEALTH_DEBUG_ANDROID_WRITE: sessionId=${session.id}, " +
+                    "exercise=${session.exerciseName ?: "NULL"}, " +
+                    "weightPerCableKg=${session.weightPerCableKg}, cableCount=${session.cableCount ?: -1}, " +
+                    "displayMultiplier=${session.displayMultiplier ?: -1}, " +
+                    "builtTitle=$title, estimatedCalories=${session.estimatedCalories ?: -1f}, " +
+                    "canWriteCalories=$canWriteCalories, " +
+                    "durationMs=${session.duration}, durationSeconds=$durationSeconds"
+            }
 
             val records = buildList {
                 add(
@@ -103,23 +124,27 @@ actual class HealthIntegration(private val context: Context) {
                         endTime = endInstant,
                         endZoneOffset = zoneOffset,
                         exerciseType = ExerciseSessionRecord.EXERCISE_TYPE_WEIGHTLIFTING,
-                        title = buildExerciseTitle(session),
+                        title = title,
                         metadata = Metadata.activelyRecorded(VITRUVIAN_DEVICE),
                     ),
                 )
 
                 val calories = session.estimatedCalories
                 if (calories != null && calories > 0f) {
-                    add(
-                        TotalCaloriesBurnedRecord(
-                            startTime = startInstant,
-                            startZoneOffset = zoneOffset,
-                            endTime = endInstant,
-                            endZoneOffset = zoneOffset,
-                            energy = Energy.kilocalories(calories.toDouble()),
-                            metadata = Metadata.activelyRecorded(VITRUVIAN_DEVICE),
-                        ),
-                    )
+                    if (canWriteCalories) {
+                        add(
+                            TotalCaloriesBurnedRecord(
+                                startTime = startInstant,
+                                startZoneOffset = zoneOffset,
+                                endTime = endInstant,
+                                endZoneOffset = zoneOffset,
+                                energy = Energy.kilocalories(calories.toDouble()),
+                                metadata = Metadata.activelyRecorded(VITRUVIAN_DEVICE),
+                            ),
+                        )
+                    } else {
+                        log.i { "Skipping Health Connect calorie record for session ${session.id}: optional calorie write permission not granted" }
+                    }
                 }
             }
 
@@ -154,6 +179,14 @@ actual class HealthIntegration(private val context: Context) {
             val durationSeconds = durationMs / 1000L
             val endInstant = startInstant.plusSeconds(durationSeconds)
             val zoneOffset = ZoneId.systemDefault().rules.getOffset(startInstant)
+            val canWriteCalories = hasCalorieWritePermission()
+
+            log.i {
+                "HEALTH_DEBUG_ANDROID_ROUTINE: externalId=${data.externalId}, " +
+                    "routineName=${data.routineName}, durationMs=${data.durationMs}, " +
+                    "durationSeconds=$durationSeconds, totalCalories=${data.totalCalories ?: -1f}, " +
+                    "canWriteCalories=$canWriteCalories"
+            }
 
             val records = buildList {
                 add(
@@ -170,16 +203,20 @@ actual class HealthIntegration(private val context: Context) {
 
                 val calories = data.totalCalories
                 if (calories != null && calories > 0f) {
-                    add(
-                        TotalCaloriesBurnedRecord(
-                            startTime = startInstant,
-                            startZoneOffset = zoneOffset,
-                            endTime = endInstant,
-                            endZoneOffset = zoneOffset,
-                            energy = Energy.kilocalories(calories.toDouble()),
-                            metadata = Metadata.activelyRecorded(VITRUVIAN_DEVICE),
-                        ),
-                    )
+                    if (canWriteCalories) {
+                        add(
+                            TotalCaloriesBurnedRecord(
+                                startTime = startInstant,
+                                startZoneOffset = zoneOffset,
+                                endTime = endInstant,
+                                endZoneOffset = zoneOffset,
+                                energy = Energy.kilocalories(calories.toDouble()),
+                                metadata = Metadata.activelyRecorded(VITRUVIAN_DEVICE),
+                            ),
+                        )
+                    } else {
+                        log.i { "Skipping Health Connect calorie record for routine ${data.externalId}: optional calorie write permission not granted" }
+                    }
                 }
             }
 
@@ -196,17 +233,18 @@ actual class HealthIntegration(private val context: Context) {
      * Builds a human-readable title for the exercise session.
      *
      * Weight display logic:
-     * - If cableCount is explicitly set (1 or 2), use it
-     * - If null (legacy data), default to 1 (per-cable weight shown as-is)
+     * - Prefer persisted displayMultiplier when present (established display semantics)
+     * - Fall back to raw physical cableCount only for legacy sessions without displayMultiplier
+     * - If both are null, default to 1 (per-cable weight shown as-is)
      *
-     * This matches the rest of the codebase (effectiveTotalVolumeKg, InsightCards, etc.)
-     * and the official Vitruvian app which displays weight per-cable without doubling.
+     * This keeps Health titles aligned with persisted WorkoutSession display semantics.
      */
     private fun buildExerciseTitle(session: WorkoutSession): String {
         val exerciseName = session.exerciseName?.takeIf { it.isNotBlank() } ?: "Phoenix Workout"
-        // Default to 1 cable for legacy sessions without cableCount metadata
-        // This prevents incorrect weight inflation (Issue #358: 80kg showing as 160kg)
-        val totalWeightKg = session.weightPerCableKg * (session.cableCount ?: 1).toFloat()
+        // Prefer displayMultiplier; raw physical cableCount is only the legacy fallback.
+        // This prevents incorrect bilateral handle inflation (Issue #358: 80kg showing as 160kg).
+        val totalWeightKg = session.weightPerCableKg *
+            (session.displayMultiplier ?: session.cableCount ?: 1).toFloat()
         return if (totalWeightKg > 0f) {
             "$exerciseName — ${totalWeightKg.toInt()}kg"
         } else {

--- a/shared/src/androidMain/kotlin/com/devil/phoenixproject/presentation/components/OptionalPermissionsHandler.android.kt
+++ b/shared/src/androidMain/kotlin/com/devil/phoenixproject/presentation/components/OptionalPermissionsHandler.android.kt
@@ -5,11 +5,29 @@ import android.content.pm.PackageManager
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Favorite
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -20,6 +38,8 @@ import androidx.core.content.ContextCompat
 import androidx.health.connect.client.HealthConnectClient
 import androidx.health.connect.client.PermissionController
 import co.touchlab.kermit.Logger
+import com.devil.phoenixproject.data.integration.optionalHealthPermissions
+import com.devil.phoenixproject.data.integration.requestedHealthPermissions
 import com.devil.phoenixproject.data.integration.requiredHealthPermissions
 import com.devil.phoenixproject.data.preferences.SettingsPreferencesManager
 import org.koin.compose.koinInject
@@ -89,8 +109,10 @@ fun RequireOptionalPermissions(content: @Composable () -> Unit) {
         contract = PermissionController.createRequestPermissionResultContract(),
     ) { grantedPermissions ->
         val granted = grantedPermissions.containsAll(requiredHealthPermissions)
+        val optionalCaloriesGranted = grantedPermissions.containsAll(optionalHealthPermissions)
         log.d {
-            "Health Connect permission result: $granted (got ${grantedPermissions.size} permissions)"
+            "Health Connect permission result: required=$granted, optionalCalories=$optionalCaloriesGranted " +
+                "(got ${grantedPermissions.size} permissions)"
         }
         // Both permissions handled, mark done
         prefsManager.setPermissionsOnboardingShown(true)
@@ -105,7 +127,7 @@ fun RequireOptionalPermissions(content: @Composable () -> Unit) {
         // Mic done, now launch health if available
         if (healthAvailable) {
             phase = "HEALTH_REQUESTED"
-            healthPermissionLauncher.launch(requiredHealthPermissions)
+            healthPermissionLauncher.launch(requestedHealthPermissions)
         } else {
             // No health to request, we're done
             prefsManager.setPermissionsOnboardingShown(true)

--- a/shared/src/androidMain/kotlin/com/devil/phoenixproject/util/HealthPermissionRequester.android.kt
+++ b/shared/src/androidMain/kotlin/com/devil/phoenixproject/util/HealthPermissionRequester.android.kt
@@ -6,6 +6,8 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.health.connect.client.PermissionController
 import co.touchlab.kermit.Logger
+import com.devil.phoenixproject.data.integration.optionalHealthPermissions
+import com.devil.phoenixproject.data.integration.requestedHealthPermissions
 import com.devil.phoenixproject.data.integration.requiredHealthPermissions
 
 private val log = Logger.withTag("HealthPermissionRequester")
@@ -17,17 +19,20 @@ actual class HealthPermissionRequester {
         val launcher = rememberLauncherForActivityResult(
             contract = PermissionController.createRequestPermissionResultContract(),
         ) { grantedPermissions ->
-            val allGranted = grantedPermissions.containsAll(requiredHealthPermissions)
+            val requiredGranted = grantedPermissions.containsAll(requiredHealthPermissions)
+            val optionalGranted = grantedPermissions.containsAll(optionalHealthPermissions)
             log.d {
-                "Health Connect permission contract returned: granted=$allGranted, received=${grantedPermissions.size} permissions: $grantedPermissions"
+                "Health Connect permission contract returned: requiredGranted=$requiredGranted, " +
+                    "optionalCaloriesGranted=$optionalGranted, received=${grantedPermissions.size} permissions: $grantedPermissions"
             }
             log.d { "Required permissions: $requiredHealthPermissions" }
-            onPermissionsResult(allGranted)
+            log.d { "Optional permissions: $optionalHealthPermissions" }
+            onPermissionsResult(requiredGranted)
         }
 
         LaunchedEffect(Unit) {
-            log.d { "Launching Health Connect permission request for: $requiredHealthPermissions" }
-            launcher.launch(requiredHealthPermissions)
+            log.d { "Launching Health Connect permission request for: $requestedHealthPermissions" }
+            launcher.launch(requestedHealthPermissions)
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightGamificationRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightGamificationRepository.kt
@@ -6,11 +6,13 @@ import app.cash.sqldelight.coroutines.mapToOneOrNull
 import co.touchlab.kermit.Logger
 import com.devil.phoenixproject.data.local.BadgeDefinitions
 import com.devil.phoenixproject.database.VitruvianDatabase
-import com.devil.phoenixproject.domain.model.*
+import com.devil.phoenixproject.domain.model.Badge
+import com.devil.phoenixproject.domain.model.BadgeRequirement
+import com.devil.phoenixproject.domain.model.EarnedBadge
+import com.devil.phoenixproject.domain.model.GamificationStats
 import com.devil.phoenixproject.domain.model.RpgInput
 import com.devil.phoenixproject.domain.model.RpgProfile
-import kotlin.time.Clock
-import kotlin.time.Instant
+import com.devil.phoenixproject.domain.model.StreakInfo
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.Flow
@@ -20,6 +22,8 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atStartOfDayIn
 import kotlinx.datetime.toLocalDateTime
+import kotlin.time.Clock
+import kotlin.time.Instant
 
 /**
  * SQLDelight implementation of GamificationRepository.
@@ -288,7 +292,7 @@ class SqlDelightGamificationRepository(db: VitruvianDatabase) : GamificationRepo
 
         // Count sessions with timestamp >= weekStartMs
         val sessions = queries.selectAllSessions(profileId = profileId).executeAsList()
-        return sessions.count { it.timestamp >= weekStartMs }
+        return sessions.count { it.workingReps > 0 && it.timestamp >= weekStartMs }
     }
 
     /**
@@ -298,6 +302,7 @@ class SqlDelightGamificationRepository(db: VitruvianDatabase) : GamificationRepo
      */
     private fun getMaxSingleSessionVolume(profileId: String): Int {
         val sessions = queries.selectAllSessions(profileId = profileId).executeAsList()
+            .filter { it.workingReps > 0 }
         if (sessions.isEmpty()) return 0
 
         return sessions.maxOfOrNull { session ->
@@ -318,6 +323,7 @@ class SqlDelightGamificationRepository(db: VitruvianDatabase) : GamificationRepo
      */
     private fun hasWorkoutAtTime(hourStart: Int, hourEnd: Int, profileId: String): Boolean {
         val sessions = queries.selectAllSessions(profileId = profileId).executeAsList()
+            .filter { it.workingReps > 0 }
 
         return sessions.any { session ->
             val sessionTime = Instant.fromEpochMilliseconds(session.timestamp)
@@ -339,6 +345,7 @@ class SqlDelightGamificationRepository(db: VitruvianDatabase) : GamificationRepo
      */
     private fun countWorkoutsAtTime(hourStart: Int, hourEnd: Int, profileId: String): Int {
         val sessions = queries.selectAllSessions(profileId = profileId).executeAsList()
+            .filter { it.workingReps > 0 }
 
         return sessions.count { session ->
             val sessionTime = Instant.fromEpochMilliseconds(session.timestamp)
@@ -440,6 +447,7 @@ class SqlDelightGamificationRepository(db: VitruvianDatabase) : GamificationRepo
      */
     private fun hasComebackAfterBreak(breakDays: Int, profileId: String): Boolean {
         val sessions = queries.selectAllSessions(profileId = profileId).executeAsList()
+            .filter { it.workingReps > 0 }
         if (sessions.size < 2) return false
 
         val sortedSessions = sessions.sortedBy { it.timestamp }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -578,7 +578,7 @@ class ActiveSessionEngine(
             }
         }
 
-        Logger.i("ActiveSessionEngine") {
+        Logger.d("ActiveSessionEngine") {
             "HEALTH_DEBUG_SUMMARY: cableCountHint=${cableCountHint ?: -1}, " +
                 "heuristicIsSingleCable=$heuristicIsSingleCable, resolvedCableCount=$cableCount, " +
                 "peakCableA=$peakCableA, peakCableB=$peakCableB, " +
@@ -3071,7 +3071,7 @@ class ActiveSessionEngine(
             profileId = userProfileRepository.activeProfile.value?.id ?: "default",
         )
 
-        Logger.i("ActiveSessionEngine") {
+        Logger.d("ActiveSessionEngine") {
             "HEALTH_DEBUG_SESSION: sessionId=${session.id}, " +
                 "exercise=${session.exerciseName ?: "NULL"}, " +
                 "routineSessionId=${session.routineSessionId ?: "NULL"}, " +

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -39,10 +39,10 @@ import com.devil.phoenixproject.domain.model.currentTimeMillis
 import com.devil.phoenixproject.domain.model.elapsedRealtimeMillis
 import com.devil.phoenixproject.domain.model.generateUUID
 import com.devil.phoenixproject.domain.replay.RepBoundaryDetector
-import com.devil.phoenixproject.util.BleConstants
 import com.devil.phoenixproject.domain.usecase.BodyweightVolumeCalculator
 import com.devil.phoenixproject.domain.usecase.RepCounterFromMachine
 import com.devil.phoenixproject.getPlatform
+import com.devil.phoenixproject.util.BleConstants
 import com.devil.phoenixproject.util.BlePacketFactory
 import com.devil.phoenixproject.util.Constants
 import com.devil.phoenixproject.util.DataBackupManager
@@ -57,7 +57,6 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlin.coroutines.cancellation.CancellationException
-import kotlin.coroutines.coroutineContext
 import kotlin.math.roundToInt
 
 /**
@@ -547,6 +546,9 @@ class ActiveSessionEngine(
         // Issue #358: Cap position deltas to POSITION_JUMP_THRESHOLD (20mm) to prevent
         // BLE glitches from inflating calorie estimates. This matches the validation
         // applied in MonitorDataProcessor.validateSample().
+        var calorieMaxRawDeltaMm = 0f
+        var calorieMaxCappedDeltaMm = 0f
+        var calorieTotalWorkJoules = 0.0
         val estimatedCalories = run {
             if (metrics.size < 2) {
                 // Fallback for insufficient samples
@@ -560,15 +562,31 @@ class ActiveSessionEngine(
                     // Average force in N across both cables
                     val avgForceN = ((prev.totalLoad + curr.totalLoad) / 2f) * 9.81f
                     // Distance in meters (position is in mm, capped to filter BLE glitches)
-                    val deltaA = kotlin.math.abs(curr.positionA - prev.positionA)
-                        .coerceAtMost(maxDeltaMm) / 1000f
-                    val deltaB = kotlin.math.abs(curr.positionB - prev.positionB)
-                        .coerceAtMost(maxDeltaMm) / 1000f
+                    val rawDeltaA = kotlin.math.abs(curr.positionA - prev.positionA)
+                    val rawDeltaB = kotlin.math.abs(curr.positionB - prev.positionB)
+                    calorieMaxRawDeltaMm = maxOf(calorieMaxRawDeltaMm, rawDeltaA, rawDeltaB)
+                    val cappedDeltaA = rawDeltaA.coerceAtMost(maxDeltaMm)
+                    val cappedDeltaB = rawDeltaB.coerceAtMost(maxDeltaMm)
+                    calorieMaxCappedDeltaMm = maxOf(calorieMaxCappedDeltaMm, cappedDeltaA, cappedDeltaB)
+                    val deltaA = cappedDeltaA / 1000f
+                    val deltaB = cappedDeltaB / 1000f
                     val avgDelta = if (isSingleCable) maxOf(deltaA, deltaB) else (deltaA + deltaB) / 2f
                     totalWorkJoules += avgForceN * avgDelta
                 }
+                calorieTotalWorkJoules = totalWorkJoules
                 ((totalWorkJoules / 4184.0) * 5.0).toFloat().coerceAtLeast(1f)
             }
+        }
+
+        Logger.i("ActiveSessionEngine") {
+            "HEALTH_DEBUG_SUMMARY: cableCountHint=${cableCountHint ?: -1}, " +
+                "heuristicIsSingleCable=$heuristicIsSingleCable, resolvedCableCount=$cableCount, " +
+                "peakCableA=$peakCableA, peakCableB=$peakCableB, " +
+                "configuredWeightKgPerCable=$configuredWeightKgPerCable, " +
+                "heaviestLiftKgPerCable=$heaviestLiftKgPerCable, totalVolumeKg=$totalVolumeKg, " +
+                "estimatedCalories=$estimatedCalories, metrics=${metrics.size}, " +
+                "maxRawDeltaMm=$calorieMaxRawDeltaMm, maxCappedDeltaMm=$calorieMaxCappedDeltaMm, " +
+                "totalWorkJoules=$calorieTotalWorkJoules"
         }
 
         val peakLoadKgPerCable = heaviestLiftKgPerCable
@@ -1627,6 +1645,9 @@ class ActiveSessionEngine(
         cancelJustLiftEggTimer()
         interruptedSetRecovery = null
         pendingStartOverride = null
+        coordinator.currentSessionId = null
+        coordinator.workoutStartTime = 0
+        coordinator.collectedMetrics.value = emptyList()
         coordinator.restDeadlineElapsedRealtimeMs = null
         coordinator._restSecondsRemaining.value = 0
         coordinator._restOriginalDuration.value = 0
@@ -2377,6 +2398,7 @@ class ActiveSessionEngine(
             coordinator.currentRoutineName = null
             coordinator.currentRoutineId = null
             coordinator.routineAccumulatedCalories = 0f
+            coordinator._completedRoutineSetKeys.value = emptySet()
             return
         }
 
@@ -2563,6 +2585,17 @@ class ActiveSessionEngine(
                 profileId = userProfileRepository.activeProfile.value?.id ?: "default",
             )
             workoutRepository.saveSession(session)
+            val isRoutineSet = session.routineSessionId != null
+            if (isRoutineSet && isValidCompletedSession(session)) {
+                session.estimatedCalories?.let { cal ->
+                    if (cal > 0f) coordinator.routineAccumulatedCalories += cal
+                }
+                coordinator._completedRoutineSetKeys.update {
+                    it + (coordinator._currentExerciseIndex.value to coordinator._currentSetIndex.value)
+                }
+            } else if (!isRoutineSet) {
+                enqueueWorkoutHealthPush(session)
+            }
             val persistedSummary = summary.copy(
                 sessionId = session.id,
                 taggedExerciseId = params.selectedExerciseId,
@@ -2633,6 +2666,7 @@ class ActiveSessionEngine(
                 coordinator.currentRoutineName = null
                 coordinator.currentRoutineId = null
                 coordinator.routineAccumulatedCalories = 0f
+                coordinator._completedRoutineSetKeys.value = emptySet()
             } else {
                 coordinator._workoutState.value = persistedSummary
             }
@@ -2807,6 +2841,58 @@ class ActiveSessionEngine(
         return plannedSets.find { it.setNumber == setIndex }?.id
     }
 
+    private fun isValidCompletedSession(session: WorkoutSession): Boolean =
+        session.workingReps > 0 && session.duration > 0L
+
+    private fun healthProviderForPlatform(): IntegrationProvider = if (getPlatform().name.startsWith("iOS")) {
+        IntegrationProvider.APPLE_HEALTH
+    } else {
+        IntegrationProvider.GOOGLE_HEALTH
+    }
+
+    private fun enqueueWorkoutHealthPush(session: WorkoutSession) {
+        val healthIntegration = healthIntegration ?: return
+        val externalActivityRepository = externalActivityRepository ?: return
+
+        if (!isValidCompletedSession(session)) {
+            Logger.i("ActiveSessionEngine") {
+                "HEALTH_DEBUG_PUSH: skipped invalid workout sessionId=${session.id}, " +
+                    "exerciseId=${session.exerciseId ?: "NULL"}, workingReps=${session.workingReps}, durationMs=${session.duration}"
+            }
+            return
+        }
+
+        val profileId = session.profileId
+        scope.launch {
+            try {
+                val provider = healthProviderForPlatform()
+                val status = externalActivityRepository.getIntegrationStatus(provider, profileId).first()
+                Logger.i("ActiveSessionEngine") {
+                    "HEALTH_DEBUG_PUSH: provider=${provider.key}, status=${status?.status}, " +
+                        "sessionId=${session.id}, exercise=${session.exerciseName ?: "NULL"}, " +
+                        "weightPerCableKg=${session.weightPerCableKg}, cableCount=${session.cableCount ?: -1}, " +
+                        "estimatedCalories=${session.estimatedCalories ?: -1f}"
+                }
+                if (status?.status != ConnectionStatus.CONNECTED) {
+                    Logger.i("ActiveSessionEngine") {
+                        "Health auto-push skipped: ${provider.displayName} is not connected (status=${status?.status})"
+                    }
+                    return@launch
+                }
+
+                healthIntegration.writeWorkout(session)
+                    .onSuccess {
+                        Logger.i("ActiveSessionEngine") { "Auto-pushed workout to ${provider.displayName}: sessionId=${session.id}" }
+                    }
+                    .onFailure { e ->
+                        Logger.w("ActiveSessionEngine") { "Health auto-push failed (non-fatal): ${e.message}" }
+                    }
+            } catch (e: Exception) {
+                Logger.w("ActiveSessionEngine") { "Health auto-push failed (non-fatal): ${e.message}" }
+            }
+        }
+    }
+
     /**
      * Issue #395: Write a single aggregate workout to the health platform
      * for a completed routine. Fire-and-forget; failure is non-fatal.
@@ -2817,34 +2903,61 @@ class ActiveSessionEngine(
         val routineSessionId = coordinator.currentRoutineSessionId ?: return
         val startTime = coordinator.routineStartTime
         if (startTime <= 0L) return
-        if (healthIntegration == null || externalActivityRepository == null) return
+        val healthIntegration = healthIntegration ?: return
+        val externalActivityRepository = externalActivityRepository ?: return
 
         val routineName = coordinator.currentRoutineName ?: "Phoenix Routine"
         val durationMs = currentTimeMillis() - startTime
         val totalCalories = coordinator.routineAccumulatedCalories.takeIf { it > 0f }
         val profileId = userProfileRepository.activeProfile.value?.id ?: "default"
+        val skippedIndices = coordinator._skippedExercises.value
+        val completedSetKeys = coordinator._completedRoutineSetKeys.value.filterNot { it.first in skippedIndices }
+        val completedExerciseCount = (
+            (coordinator._completedExercises.value - skippedIndices) +
+                completedSetKeys.map { it.first }.toSet()
+            ).size
+
+        if (completedExerciseCount <= 0 || completedSetKeys.isEmpty()) {
+            Logger.i("ActiveSessionEngine") {
+                "Routine health push skipped: no valid completed routine sets " +
+                    "(routineSessionId=$routineSessionId, completedExercises=$completedExerciseCount, completedSets=${completedSetKeys.size})"
+            }
+            coordinator.routineAccumulatedCalories = 0f
+            return
+        }
 
         scope.launch {
             try {
-                val provider = if (getPlatform().name.startsWith("iOS")) {
-                    IntegrationProvider.APPLE_HEALTH
-                } else {
-                    IntegrationProvider.GOOGLE_HEALTH
-                }
+                val provider = healthProviderForPlatform()
                 val status = externalActivityRepository.getIntegrationStatus(provider, profileId).first()
-                if (status?.status == ConnectionStatus.CONNECTED) {
-                    val data = RoutineHealthData(
-                        routineName = routineName,
-                        startTimeMs = startTime,
-                        durationMs = durationMs,
-                        totalCalories = totalCalories,
-                        externalId = routineSessionId,
-                    )
-                    healthIntegration.writeRoutineWorkout(data)
-                    Logger.i("ActiveSessionEngine") {
-                        "Auto-pushed routine workout to ${provider.displayName}: $routineName (${durationMs / 1000}s)"
-                    }
+                Logger.i("ActiveSessionEngine") {
+                    "HEALTH_DEBUG_ROUTINE_PUSH: provider=${provider.key}, status=${status?.status}, " +
+                        "routineSessionId=$routineSessionId, completedExercises=$completedExerciseCount, " +
+                        "completedSets=${completedSetKeys.size}, skippedExercises=${skippedIndices.size}, calories=${totalCalories ?: -1f}"
                 }
+                if (status?.status != ConnectionStatus.CONNECTED) {
+                    Logger.i("ActiveSessionEngine") {
+                        "Routine health push skipped: ${provider.displayName} is not connected (status=${status?.status})"
+                    }
+                    return@launch
+                }
+
+                val data = RoutineHealthData(
+                    routineName = routineName,
+                    startTimeMs = startTime,
+                    durationMs = durationMs,
+                    totalCalories = totalCalories,
+                    externalId = routineSessionId,
+                )
+                healthIntegration.writeRoutineWorkout(data)
+                    .onSuccess {
+                        Logger.i("ActiveSessionEngine") {
+                            "Auto-pushed routine workout to ${provider.displayName}: $routineName (${durationMs / 1000}s)"
+                        }
+                    }
+                    .onFailure { e ->
+                        Logger.w("ActiveSessionEngine") { "Routine health push failed (non-fatal): ${e.message}" }
+                    }
             } catch (e: Exception) {
                 Logger.w("ActiveSessionEngine") { "Routine health push failed (non-fatal): ${e.message}" }
             } finally {
@@ -2958,38 +3071,37 @@ class ActiveSessionEngine(
             profileId = userProfileRepository.activeProfile.value?.id ?: "default",
         )
 
+        Logger.i("ActiveSessionEngine") {
+            "HEALTH_DEBUG_SESSION: sessionId=${session.id}, " +
+                "exercise=${session.exerciseName ?: "NULL"}, " +
+                "routineSessionId=${session.routineSessionId ?: "NULL"}, " +
+                "weightPerCableKg=${session.weightPerCableKg}, cableCount=${session.cableCount ?: -1}, " +
+                "displayMultiplier=${session.displayMultiplier ?: -1}, " +
+                "heaviestLiftKg=${session.heaviestLiftKg ?: -1f}, " +
+                "totalVolumeKg=${session.totalVolumeKg ?: -1f}, " +
+                "estimatedCalories=${session.estimatedCalories ?: -1f}, durationMs=${session.duration}, " +
+                "totalReps=${session.totalReps}, metrics=${metricsSnapshot.size}"
+        }
+
         workoutRepository.saveSession(session)
 
         // Issue #395: Accumulate calories for routine-level aggregate health write.
         // Only write per-set to health platform for non-routine (Just Lift) workouts.
         val isRoutineSet = session.routineSessionId != null
-        if (isRoutineSet) {
+        if (isRoutineSet && isValidCompletedSession(session)) {
             session.estimatedCalories?.let { cal ->
                 if (cal > 0f) coordinator.routineAccumulatedCalories += cal
+            }
+            coordinator._completedRoutineSetKeys.update {
+                it + (coordinator._currentExerciseIndex.value to coordinator._currentSetIndex.value)
             }
         }
 
         // Fire-and-forget health push: auto-push to Health Connect (Android) or HealthKit (iOS)
         // after the session is persisted. Failure is non-fatal and never blocks workout completion.
         // Issue #395: Skip per-set writes for routine sets — aggregate written at routine completion.
-        if (!isRoutineSet && healthIntegration != null && externalActivityRepository != null) {
-            val profileId = session.profileId
-            scope.launch {
-                try {
-                    val provider = if (getPlatform().name.startsWith("iOS")) {
-                        IntegrationProvider.APPLE_HEALTH
-                    } else {
-                        IntegrationProvider.GOOGLE_HEALTH
-                    }
-                    val status = externalActivityRepository.getIntegrationStatus(provider, profileId).first()
-                    if (status?.status == ConnectionStatus.CONNECTED) {
-                        healthIntegration.writeWorkout(session)
-                        Logger.i("ActiveSessionEngine") { "Auto-pushed workout to ${provider.displayName}" }
-                    }
-                } catch (e: Exception) {
-                    Logger.w("ActiveSessionEngine") { "Health auto-push failed (non-fatal): ${e.message}" }
-                }
-            }
+        if (!isRoutineSet) {
+            enqueueWorkoutHealthPush(session)
         }
 
         if (metricsSnapshot.isNotEmpty()) {
@@ -3849,6 +3961,7 @@ class ActiveSessionEngine(
             coordinator.currentRoutineSessionId = null
             coordinator.currentRoutineName = null
             coordinator.currentRoutineId = null
+            coordinator._completedRoutineSetKeys.value = emptySet()
             repCounter.reset()
             resetAutoStopState()
         }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/DefaultWorkoutSessionManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/DefaultWorkoutSessionManager.kt
@@ -693,7 +693,7 @@ class DefaultWorkoutSessionManager(
 
                 // Mark exercise as completed if this was the last set of THIS exercise and it has valid working reps.
                 val summary = coordinator._workoutState.value as? WorkoutState.SetSummary
-                val completedWorkingReps = maxOf(summary?.workingReps ?: 0, summary?.repCount ?: 0)
+                val completedWorkingReps = summary?.workingReps ?: 0
                 if (isLastSetOfExercise && completedWorkingReps > 0) {
                     val currentExerciseIndex = coordinator._currentExerciseIndex.value
                     coordinator._completedExercises.value = coordinator._completedExercises.value + currentExerciseIndex

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/DefaultWorkoutSessionManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/DefaultWorkoutSessionManager.kt
@@ -691,9 +691,13 @@ class DefaultWorkoutSessionManager(
                 val currentExercise = routine.exercises.getOrNull(coordinator._currentExerciseIndex.value)
                 val isLastSetOfExercise = coordinator._currentSetIndex.value >= (currentExercise?.setReps?.size ?: 1) - 1
 
-                // Mark exercise as completed if this was the last set of THIS exercise
-                if (isLastSetOfExercise) {
-                    coordinator._completedExercises.value = coordinator._completedExercises.value + coordinator._currentExerciseIndex.value
+                // Mark exercise as completed if this was the last set of THIS exercise and it has valid working reps.
+                val summary = coordinator._workoutState.value as? WorkoutState.SetSummary
+                val completedWorkingReps = maxOf(summary?.workingReps ?: 0, summary?.repCount ?: 0)
+                if (isLastSetOfExercise && completedWorkingReps > 0) {
+                    val currentExerciseIndex = coordinator._currentExerciseIndex.value
+                    coordinator._completedExercises.value = coordinator._completedExercises.value + currentExerciseIndex
+                    coordinator._skippedExercises.value = coordinator._skippedExercises.value - currentExerciseIndex
                 }
 
                 // Check if there are ANY more steps using superset-aware navigation
@@ -723,6 +727,7 @@ class DefaultWorkoutSessionManager(
                     coordinator.currentRoutineSessionId = null
                     coordinator.currentRoutineName = null
                     coordinator.currentRoutineId = null
+                    coordinator._completedRoutineSetKeys.value = emptySet()
                     return@launch
                 }
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/GamificationManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/GamificationManager.kt
@@ -85,20 +85,30 @@ class GamificationManager(
         }
         val effectiveProfileId = profileId.ifBlank { "default" }
 
+        if (workingReps <= 0) {
+            Logger.w {
+                "GAMIFICATION: Skipped — invalid completion (workingReps=$workingReps)"
+            }
+            return false
+        }
+
         // Always track PRs (skip for Just Lift and Echo modes)
         // Uses mode-specific PR lookup to track PRs separately per workout mode (#111)
-        if (exerciseId == null) {
-            Logger.w { "PR_TRACK: Skipped — exerciseId is null (exercise not in library?)" }
-        }
-        exerciseId?.let { exId ->
-            if (workingReps <= 0) {
-                Logger.w { "PR_TRACK: Skipped — workingReps=$workingReps (no completed reps)" }
-            } else if (isJustLift) {
+        when {
+            exerciseId.isNullOrBlank() -> {
+                Logger.d { "PR_TRACK: Skipped — no exerciseId for completed workout" }
+            }
+
+            isJustLift -> {
                 Logger.d { "PR_TRACK: Skipped — Just Lift mode (PRs not tracked)" }
-            } else if (isEchoMode) {
+            }
+
+            isEchoMode -> {
                 Logger.d { "PR_TRACK: Skipped — Echo mode (PRs not tracked)" }
             }
-            if (workingReps > 0 && !isJustLift && !isEchoMode) {
+
+            else -> {
+                val exId = exerciseId
                 try {
                     val workoutMode = programMode.displayName
                     val timestamp = currentTimeMillis()
@@ -224,6 +234,8 @@ class GamificationManager(
      * @param profileId Active profile ID for profile-scoped badge awarding
      */
     suspend fun processSetQualityEvent(averageSetQuality: Int, profileId: String = "default") {
+        if (!gamificationEnabled.value) return
+
         if (averageSetQuality >= 85) {
             consecutiveQualitySets++
             Logger.d(

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/RoutineFlowManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/RoutineFlowManager.kt
@@ -83,6 +83,23 @@ class RoutineFlowManager(
      */
     internal lateinit var lifecycleDelegate: WorkoutLifecycleDelegate
 
+    private fun markExerciseSkipped(index: Int) {
+        coordinator._skippedExercises.update { it + index }
+        coordinator._completedExercises.update { it - index }
+        coordinator._completedRoutineSetKeys.update { completed ->
+            completed.filterNot { it.first == index }.toSet()
+        }
+    }
+
+    private fun markExerciseCompleted(index: Int) {
+        coordinator._completedExercises.update { it + index }
+        coordinator._skippedExercises.update { it - index }
+    }
+
+    private fun markExerciseActive(index: Int) {
+        coordinator._skippedExercises.update { it - index }
+    }
+
     // ===== Init Block: Routine-Related Collectors =====
     // These were collectors #1 and #2 in DWSM's init block.
     // RoutineFlowManager is constructed before other sub-managers in DWSM,
@@ -703,6 +720,7 @@ class RoutineFlowManager(
         coordinator._currentSetIndex.value = 0
         coordinator._skippedExercises.value = emptySet()
         coordinator._completedExercises.value = emptySet()
+        coordinator._completedRoutineSetKeys.value = emptySet()
 
         // Issue #222 diagnostic: Reset bodyweight counter for new routine
         coordinator.bodyweightSetsCompletedInRoutine = 0
@@ -808,6 +826,7 @@ class RoutineFlowManager(
             coordinator._currentSetIndex.value = 0
             coordinator._skippedExercises.value = emptySet()
             coordinator._completedExercises.value = emptySet()
+            coordinator._completedRoutineSetKeys.value = emptySet()
             coordinator._workoutState.value = WorkoutState.Idle
             coordinator._routineFlowState.value = RoutineFlowState.Overview(
                 routine = normalized,
@@ -1066,6 +1085,7 @@ class RoutineFlowManager(
         coordinator.currentRoutineName = null
         coordinator.currentRoutineId = null
         coordinator.routineAccumulatedCalories = 0f
+        coordinator._completedRoutineSetKeys.value = emptySet()
     }
 
     /**
@@ -1079,6 +1099,17 @@ class RoutineFlowManager(
             return
         }
         val routine = coordinator._loadedRoutine.value ?: return
+        val skippedIndices = coordinator._skippedExercises.value
+        val completedSetKeys = coordinator._completedRoutineSetKeys.value
+            .filterNot { it.first in skippedIndices }
+            .toSet()
+        val completedExerciseIndices = (
+            (coordinator._completedExercises.value - skippedIndices) +
+                completedSetKeys.map { it.first }.toSet()
+            ).filter { it in routine.exercises.indices }
+            .toSet()
+        val completedSetCount = completedSetKeys.size.takeIf { it > 0 }
+            ?: completedExerciseIndices.sumOf { index -> routine.exercises.getOrNull(index)?.setReps?.size ?: 0 }
         // Issue #195: Use coordinator.routineStartTime (set on first set) for total duration
         val duration = if (coordinator.routineStartTime > 0) {
             currentTimeMillis() - coordinator.routineStartTime
@@ -1087,8 +1118,8 @@ class RoutineFlowManager(
         }
         coordinator._routineFlowState.value = RoutineFlowState.Complete(
             routineName = routine.name,
-            totalSets = routine.exercises.sumOf { it.setReps.size },
-            totalExercises = routine.exercises.size,
+            totalSets = completedSetCount,
+            totalExercises = completedExerciseIndices.size,
             totalDurationMs = duration,
         )
     }
@@ -1102,6 +1133,7 @@ class RoutineFlowManager(
         coordinator.currentRoutineName = null
         coordinator.currentRoutineId = null
         coordinator.routineAccumulatedCalories = 0f
+        coordinator._completedRoutineSetKeys.value = emptySet()
     }
 
     // ===== Exercise Navigation =====
@@ -1120,6 +1152,7 @@ class RoutineFlowManager(
      * Internal helper to perform the actual exercise navigation.
      */
     private fun navigateToExerciseInternal(routine: Routine, index: Int) {
+        markExerciseActive(index)
         coordinator._currentExerciseIndex.value = index
         coordinator._currentSetIndex.value = 0
 
@@ -1199,12 +1232,12 @@ class RoutineFlowManager(
         // Save current exercise progress
         val currentRepCount = coordinator._repCount.value
         if (currentRepCount.workingReps > 0 && coordinator._workoutState.value !is WorkoutState.Completed) {
-            coordinator._completedExercises.update { it + coordinator._currentExerciseIndex.value }
+            markExerciseCompleted(coordinator._currentExerciseIndex.value)
             Logger.d("RoutineFlowManager") {
                 "Saving progress for exercise ${coordinator._currentExerciseIndex.value}: ${currentRepCount.workingReps} reps"
             }
         } else if (coordinator._workoutState.value !is WorkoutState.Completed) {
-            coordinator._skippedExercises.update { it + coordinator._currentExerciseIndex.value }
+            markExerciseSkipped(coordinator._currentExerciseIndex.value)
             Logger.d("RoutineFlowManager") { "Skipping exercise ${coordinator._currentExerciseIndex.value}" }
         }
 
@@ -1245,7 +1278,7 @@ class RoutineFlowManager(
         val currentExIndex = coordinator._currentExerciseIndex.value
         // Mark as skipped first so getNextStep skips past the current exercise
         // when looking for the next navigable exercise.
-        coordinator._skippedExercises.update { it + currentExIndex }
+        markExerciseSkipped(currentExIndex)
         val next = getNextStep(routine, currentExIndex, currentSetIndex = 0)
         if (next != null) {
             jumpToExercise(next.first)
@@ -1261,7 +1294,7 @@ class RoutineFlowManager(
         val currentExIndex = coordinator._currentExerciseIndex.value
         val currentSetIndex = coordinator._currentSetIndex.value
 
-        coordinator._skippedExercises.update { it + currentExIndex }
+        markExerciseSkipped(currentExIndex)
 
         val nextStep = getNextStep(routine, currentExIndex, currentSetIndex) ?: return false
         val (nextExIdx, nextSetIdx) = nextStep

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutCoordinator.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutCoordinator.kt
@@ -238,6 +238,9 @@ class WorkoutCoordinator(
     internal val _completedExercises = MutableStateFlow<Set<Int>>(emptySet())
     val completedExercises: StateFlow<Set<Int>> = _completedExercises.asStateFlow()
 
+    /** Completed routine working-set positions, keyed by exercise index to set index. */
+    internal val _completedRoutineSetKeys = MutableStateFlow<Set<Pair<Int, Int>>>(emptySet())
+
     // RPE tracking for current set (Phase 2: Training Cycles)
     internal val _currentSetRpe = MutableStateFlow<Int?>(null)
     val currentSetRpe: StateFlow<Int?> = _currentSetRpe.asStateFlow()

--- a/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
+++ b/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
@@ -1247,7 +1247,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, :profileId);
 
 -- Analytics helpers for gamification (profile-scoped)
 countTotalWorkouts:
-SELECT COUNT(*) FROM WorkoutSession WHERE profile_id = :profileId;
+SELECT COUNT(*) FROM WorkoutSession WHERE profile_id = :profileId AND workingReps > 0;
 
 -- Count queries for streaming backup progress (global, all profiles)
 countAllWorkoutSessions:
@@ -1260,19 +1260,19 @@ countAllRoutineExercises:
 SELECT COUNT(*) FROM RoutineExercise;
 
 countTotalReps:
-SELECT SUM(totalReps) FROM WorkoutSession WHERE profile_id = :profileId;
+SELECT SUM(totalReps) FROM WorkoutSession WHERE profile_id = :profileId AND workingReps > 0;
 
 countTotalVolume:
-SELECT SUM(COALESCE(totalVolumeKg, totalReps * weightPerCableKg * COALESCE(cableCount, 1))) FROM WorkoutSession WHERE profile_id = :profileId;
+SELECT SUM(COALESCE(totalVolumeKg, totalReps * weightPerCableKg * COALESCE(cableCount, 1))) FROM WorkoutSession WHERE profile_id = :profileId AND workingReps > 0;
 
 countUniqueExercises:
-SELECT COUNT(DISTINCT exerciseId) FROM WorkoutSession WHERE exerciseId IS NOT NULL AND profile_id = :profileId;
+SELECT COUNT(DISTINCT exerciseId) FROM WorkoutSession WHERE exerciseId IS NOT NULL AND exerciseId != '' AND profile_id = :profileId AND workingReps > 0;
 
 countPersonalRecords:
 SELECT COUNT(*) FROM PersonalRecord WHERE profile_id = :profileId;
 
 selectWorkoutDates:
-SELECT DISTINCT DATE(timestamp / 1000, 'unixepoch') AS workoutDate FROM WorkoutSession WHERE profile_id = :profileId ORDER BY timestamp DESC;
+SELECT DISTINCT DATE(timestamp / 1000, 'unixepoch') AS workoutDate FROM WorkoutSession WHERE profile_id = :profileId AND workingReps > 0 ORDER BY timestamp DESC;
 
 -- ==================== RPG ATTRIBUTES QUERIES ====================
 
@@ -1287,26 +1287,26 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, :profileId);
 
 -- RPG computation helpers (profile-scoped)
 selectMaxWeightLifted:
-SELECT MAX(heaviestLiftKg) FROM WorkoutSession WHERE heaviestLiftKg IS NOT NULL AND profile_id = :profileId;
+SELECT MAX(heaviestLiftKg) FROM WorkoutSession WHERE heaviestLiftKg IS NOT NULL AND profile_id = :profileId AND workingReps > 0;
 
 selectAvgWorkingWeight:
-SELECT AVG(workingAvgWeightKg) FROM WorkoutSession WHERE workingAvgWeightKg IS NOT NULL AND profile_id = :profileId;
+SELECT AVG(workingAvgWeightKg) FROM WorkoutSession WHERE workingAvgWeightKg IS NOT NULL AND profile_id = :profileId AND workingReps > 0;
 
 selectPeakRepPower:
 SELECT MAX(peakPowerWatts) FROM RepMetric;
 
 countTrainingDays:
-SELECT COUNT(DISTINCT DATE(timestamp / 1000, 'unixepoch')) FROM WorkoutSession WHERE profile_id = :profileId;
+SELECT COUNT(DISTINCT DATE(timestamp / 1000, 'unixepoch')) FROM WorkoutSession WHERE profile_id = :profileId AND workingReps > 0;
 
 -- ==================== ADDITIONAL GAMIFICATION QUERIES ====================
 
 -- Count workouts by workout mode (profile-scoped)
 countWorkoutsByMode:
-SELECT mode, COUNT(*) AS count FROM WorkoutSession WHERE profile_id = :profileId GROUP BY mode;
+SELECT mode, COUNT(*) AS count FROM WorkoutSession WHERE profile_id = :profileId AND workingReps > 0 GROUP BY mode;
 
 -- Get all unique workout modes used (profile-scoped)
 selectUniqueWorkoutModes:
-SELECT DISTINCT mode FROM WorkoutSession WHERE profile_id = :profileId;
+SELECT DISTINCT mode FROM WorkoutSession WHERE profile_id = :profileId AND workingReps > 0;
 
 -- Get peak power from all workout metrics
 selectPeakPower:
@@ -1317,17 +1317,17 @@ selectUniqueMuscleGroupsFromWorkouts:
 SELECT DISTINCT e.muscleGroup
 FROM WorkoutSession ws
 INNER JOIN Exercise e ON ws.exerciseId = e.id
-WHERE ws.exerciseId IS NOT NULL AND ws.profile_id = :profileId;
+WHERE ws.exerciseId IS NOT NULL AND ws.exerciseId != '' AND ws.profile_id = :profileId AND ws.workingReps > 0;
 
 -- Count workouts completed on weekends (profile-scoped)
 countWeekendWorkouts:
 SELECT COUNT(*) FROM WorkoutSession
 WHERE CAST(strftime('%w', timestamp / 1000, 'unixepoch') AS INTEGER) IN (0, 6)
-AND profile_id = :profileId;
+AND profile_id = :profileId AND workingReps > 0;
 
 -- Count completed routine sessions (profile-scoped)
 countCompletedRoutineSessions:
-SELECT COUNT(DISTINCT routineSessionId) FROM WorkoutSession WHERE routineSessionId IS NOT NULL AND profile_id = :profileId;
+SELECT COUNT(DISTINCT routineSessionId) FROM WorkoutSession WHERE routineSessionId IS NOT NULL AND routineSessionId != '' AND profile_id = :profileId AND workingReps > 0;
 
 -- Count custom routines created (profile-scoped)
 countCreatedRoutines:
@@ -1336,7 +1336,7 @@ SELECT COUNT(*) FROM Routine WHERE profile_id = :profileId AND deletedAt IS NULL
 -- Get days since last workout (for comeback badge, profile-scoped)
 selectDaysSinceLastWorkout:
 SELECT CAST((julianday('now') - julianday(MAX(timestamp) / 1000, 'unixepoch')) AS INTEGER) AS daysSince
-FROM WorkoutSession WHERE profile_id = :profileId;
+FROM WorkoutSession WHERE profile_id = :profileId AND workingReps > 0;
 
 -- Check if a streak was previously broken and rebuilt (profile-scoped)
 -- Returns the count of streak breaks (transitions from >0 streak to 0)

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/integration/HealthDataMappingTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/integration/HealthDataMappingTest.kt
@@ -14,14 +14,14 @@ class HealthDataMappingTest {
 
     @Test
     fun titleWithExerciseNameAndWeight() {
-        // Single cable exercise (default when cableCount is unspecified/null)
+        // Default display semantics when displayMultiplier/cableCount are unspecified/null
         val title = buildTitle(exerciseName = "Calf Raise", weightPerCableKg = 80f)
         assertEquals("Calf Raise \u2014 80.0kg", title)
     }
 
     @Test
     fun titleWithDualCableExercise() {
-        // Dual cable exercise - weight is doubled (50kg per cable x 2)
+        // Legacy fallback: dual physical cable count doubles when displayMultiplier is absent
         val title = buildTitle(exerciseName = "Bench Press", weightPerCableKg = 50f, cableCount = 2)
         assertEquals("Bench Press \u2014 100.0kg", title)
     }
@@ -45,10 +45,27 @@ class HealthDataMappingTest {
     }
 
     @Test
-    fun titleWeightIsDoubledForDualCable() {
-        // Weight convention: stored per-cable, displayed as total (x2) for dual-cable
-        val title = buildTitle(exerciseName = "Squat", weightPerCableKg = 110f, cableCount = 2)
+    fun titleWeightIsDoubledForUnifiedDualDisplay() {
+        // Persisted display semantics: unified dual display doubles title weight
+        val title = buildTitle(
+            exerciseName = "Squat",
+            weightPerCableKg = 110f,
+            cableCount = 2,
+            displayMultiplier = 2,
+        )
         assertEquals("Squat \u2014 220.0kg", title)
+    }
+
+    @Test
+    fun titleWeightIsNotDoubledForBilateralHandleDisplay() {
+        // Persisted display semantics take precedence over raw physical cableCount.
+        val title = buildTitle(
+            exerciseName = "Bench Press",
+            weightPerCableKg = 50f,
+            cableCount = 2,
+            displayMultiplier = 1,
+        )
+        assertEquals("Bench Press \u2014 50.0kg", title)
     }
 
     @Test
@@ -148,10 +165,15 @@ class HealthDataMappingTest {
 
     // ---- Extracted pure functions matching both platform implementations ----
 
-    private fun buildTitle(exerciseName: String?, weightPerCableKg: Float, cableCount: Int? = null): String {
+    private fun buildTitle(
+        exerciseName: String?,
+        weightPerCableKg: Float,
+        cableCount: Int? = null,
+        displayMultiplier: Int? = null,
+    ): String {
         val name = exerciseName?.takeIf { it.isNotBlank() } ?: "Phoenix Workout"
-        // Default to 1 cable for legacy sessions without cableCount metadata
-        val totalWeightKg = weightPerCableKg * (cableCount ?: 1).toFloat()
+        // Prefer persisted displayMultiplier; cableCount is only the legacy fallback.
+        val totalWeightKg = weightPerCableKg * (displayMultiplier ?: cableCount ?: 1).toFloat()
         return if (totalWeightKg > 0f) {
             val rounded = (totalWeightKg * 10).toInt() / 10.0
             "$name \u2014 ${rounded}kg"

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMRoutineFlowTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMRoutineFlowTest.kt
@@ -375,6 +375,38 @@ class DWSMRoutineFlowTest {
     }
 
     @Test
+    fun proceedFromSummary_warmupOnlySetDoesNotMarkExerciseCompleted() = runTest {
+        val harness = DWSMTestHarness(this)
+        val routine = WorkoutStateFixtures.createTestRoutine(exerciseCount = 1, setsPerExercise = 1)
+        routine.exercises.forEach { harness.fakeExerciseRepo.addExercise(it.exercise) }
+        advanceUntilIdle()
+
+        harness.dwsm.loadRoutine(routine)
+        advanceUntilIdle()
+
+        harness.dwsm.coordinator._workoutState.value = WorkoutState.SetSummary(
+            metrics = emptyList(),
+            peakLoadKgPerCable = 20f,
+            avgLoadKgPerCable = 18f,
+            repCount = 3,
+            workingReps = 0,
+            warmupReps = 3,
+        )
+
+        harness.dwsm.proceedFromSummary()
+        advanceUntilIdle()
+
+        assertEquals(
+            emptySet(),
+            harness.dwsm.coordinator.completedExercises.value,
+            "Warmup-only summary should not mark the exercise complete",
+        )
+        val complete = assertIs<RoutineFlowState.Complete>(harness.dwsm.coordinator.routineFlowState.value)
+        assertEquals(0, complete.totalExercises, "Warmup-only completion should not count as a completed exercise")
+        harness.cleanup()
+    }
+
+    @Test
     fun goToPreviousExercise_navigatesBackward() = runTest {
         val harness = DWSMTestHarness(this)
         val routine = WorkoutStateFixtures.createTestRoutine(exerciseCount = 3)

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMRoutineFlowTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMRoutineFlowTest.kt
@@ -1,17 +1,18 @@
 package com.devil.phoenixproject.presentation.manager
 
-import com.devil.phoenixproject.domain.model.*
+import com.devil.phoenixproject.domain.model.RoutineFlowState
+import com.devil.phoenixproject.domain.model.WorkoutState
 import com.devil.phoenixproject.testutil.DWSMTestHarness
 import com.devil.phoenixproject.testutil.TestFixtures
 import com.devil.phoenixproject.testutil.WorkoutStateFixtures
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
-import kotlinx.coroutines.test.advanceTimeBy
-import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.runTest
 
 /**
  * Characterization tests for DefaultWorkoutSessionManager routine flow.
@@ -344,6 +345,32 @@ class DWSMRoutineFlowTest {
             params.selectedExerciseId,
             "After skip, selected exercise should be the second exercise",
         )
+        harness.cleanup()
+    }
+
+    @Test
+    fun showRoutineComplete_countsOnlyCompletedNonSkippedExercisesAndSets() = runTest {
+        val harness = DWSMTestHarness(this)
+        val routine = WorkoutStateFixtures.createTestRoutine(exerciseCount = 3, setsPerExercise = 2)
+        routine.exercises.forEach { harness.fakeExerciseRepo.addExercise(it.exercise) }
+        advanceUntilIdle()
+
+        harness.dwsm.loadRoutine(routine)
+        advanceUntilIdle()
+
+        harness.dwsm.coordinator._completedRoutineSetKeys.value = setOf(
+            0 to 0,
+            0 to 1,
+            2 to 0,
+        )
+        harness.dwsm.coordinator._completedExercises.value = setOf(0, 1, 2)
+        harness.dwsm.coordinator._skippedExercises.value = setOf(1)
+
+        harness.dwsm.showRoutineComplete()
+
+        val complete = assertIs<RoutineFlowState.Complete>(harness.dwsm.coordinator.routineFlowState.value)
+        assertEquals(3, complete.totalSets, "Skipped exercises should not contribute completed set count")
+        assertEquals(2, complete.totalExercises, "Skipped exercises should not contribute completed exercise count")
         harness.cleanup()
     }
 

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMWorkoutLifecycleTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMWorkoutLifecycleTest.kt
@@ -2,6 +2,10 @@ package com.devil.phoenixproject.presentation.manager
 
 import app.cash.turbine.test
 import com.devil.phoenixproject.data.repository.RepNotification
+import com.devil.phoenixproject.domain.model.Badge
+import com.devil.phoenixproject.domain.model.BadgeCategory
+import com.devil.phoenixproject.domain.model.BadgeRequirement
+import com.devil.phoenixproject.domain.model.BadgeTier
 import com.devil.phoenixproject.domain.model.Exercise
 import com.devil.phoenixproject.domain.model.ExerciseCableIntent
 import com.devil.phoenixproject.domain.model.PRType
@@ -14,7 +18,6 @@ import com.devil.phoenixproject.domain.model.WorkoutMetric
 import com.devil.phoenixproject.domain.model.WorkoutParameters
 import com.devil.phoenixproject.domain.model.WorkoutSession
 import com.devil.phoenixproject.domain.model.WorkoutState
-import com.devil.phoenixproject.presentation.manager.WorkoutServicePhase
 import com.devil.phoenixproject.domain.model.currentTimeMillis
 import com.devil.phoenixproject.testutil.DWSMTestHarness
 import com.devil.phoenixproject.testutil.TestFixtures
@@ -290,6 +293,43 @@ class DWSMWorkoutLifecycleTest {
             null,
             harness.dwsm.coordinator.repRanges.value,
             "resetForNewWorkout should clear repRanges to null",
+        )
+        harness.cleanup()
+    }
+
+    @Test
+    fun `resetForNewWorkout clears retained session scope and metrics`() = runTest {
+        val harness = activeDWSM()
+
+        harness.dwsm.coordinator.currentSessionId = "stale-session-id"
+        harness.dwsm.coordinator.workoutStartTime = 1700000000000L
+        harness.dwsm.coordinator.collectedMetrics.value = listOf(
+            WorkoutMetric(
+                timestamp = 100L,
+                loadA = 25f,
+                loadB = 25f,
+                positionA = 120f,
+                positionB = 120f,
+                velocityA = 40.0,
+                velocityB = 40.0,
+            ),
+        )
+
+        harness.dwsm.resetForNewWorkout()
+
+        assertEquals(
+            null,
+            harness.dwsm.coordinator.currentSessionId,
+            "resetForNewWorkout should clear stale session id",
+        )
+        assertEquals(
+            0L,
+            harness.dwsm.coordinator.workoutStartTime,
+            "resetForNewWorkout should zero stale workout start time",
+        )
+        assertTrue(
+            harness.dwsm.coordinator.collectedMetrics.value.isEmpty(),
+            "resetForNewWorkout should clear collected metrics",
         )
         harness.cleanup()
     }
@@ -1540,6 +1580,66 @@ class DWSMWorkoutLifecycleTest {
             session.routineName,
             "Single-exercise temp routines should not set routineName",
         )
+        harness.cleanup()
+    }
+
+    @Test
+    fun `gamification skips invalid completions with no working reps`() = runTest {
+        val harness = DWSMTestHarness(this)
+        harness.fakeGamificationRepo.pendingBadges += Badge(
+            id = "test_invalid_completion",
+            name = "Invalid Completion",
+            description = "Should not be awarded for skipped sets",
+            category = BadgeCategory.DEDICATION,
+            iconResource = "test",
+            tier = BadgeTier.BRONZE,
+            requirement = BadgeRequirement.TotalWorkouts(1),
+        )
+
+        val result = harness.gamificationManager.processPostSaveEvents(
+            exerciseId = TestFixtures.benchPress.id,
+            workingReps = 0,
+            achievedWeightKg = 50f,
+            volumeWeightKg = 50f,
+            programMode = ProgramMode.OldSchool,
+            isJustLift = false,
+            isEchoMode = false,
+        )
+
+        assertFalse(result)
+        assertEquals(0, harness.fakePRRepo.updateCalls.size, "Invalid completions should not update PRs")
+        assertEquals(0, harness.fakeGamificationRepo.updateStatsCallCount, "Invalid completions should not update gamification stats")
+        assertEquals(0, harness.fakeGamificationRepo.checkAndAwardBadgesCallCount, "Invalid completions should not award badges")
+        harness.cleanup()
+    }
+
+    @Test
+    fun `gamification updates stats for valid completions without exercise id`() = runTest {
+        val harness = DWSMTestHarness(this)
+        harness.fakeGamificationRepo.pendingBadges += Badge(
+            id = "test_untagged_completion",
+            name = "Untagged Completion",
+            description = "Should be awarded for a valid untagged workout",
+            category = BadgeCategory.DEDICATION,
+            iconResource = "test",
+            tier = BadgeTier.BRONZE,
+            requirement = BadgeRequirement.TotalWorkouts(1),
+        )
+
+        val result = harness.gamificationManager.processPostSaveEvents(
+            exerciseId = null,
+            workingReps = 8,
+            achievedWeightKg = 50f,
+            volumeWeightKg = 50f,
+            programMode = ProgramMode.OldSchool,
+            isJustLift = false,
+            isEchoMode = false,
+        )
+
+        assertFalse(result)
+        assertEquals(0, harness.fakePRRepo.updateCalls.size, "Untagged completions should not update PRs")
+        assertEquals(1, harness.fakeGamificationRepo.updateStatsCallCount, "Valid untagged completions should update gamification stats")
+        assertEquals(1, harness.fakeGamificationRepo.checkAndAwardBadgesCallCount, "Valid untagged completions should award stat badges")
         harness.cleanup()
     }
 

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeGamificationRepository.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeGamificationRepository.kt
@@ -32,6 +32,9 @@ class FakeGamificationRepository : GamificationRepository {
     // Badges that will be awarded on next checkAndAwardBadges call
     var pendingBadges = mutableListOf<Badge>()
 
+    var updateStatsCallCount = 0
+    var checkAndAwardBadgesCallCount = 0
+
     // Captured RPG profile from saveRpgProfile calls
     var savedRpgProfile: RpgProfile? = null
 
@@ -61,6 +64,8 @@ class FakeGamificationRepository : GamificationRepository {
         uncelebratedBadgeIds.clear()
         badgeProgress.clear()
         pendingBadges.clear()
+        updateStatsCallCount = 0
+        checkAndAwardBadgesCallCount = 0
         savedRpgProfile = null
         _earnedBadgesFlow.value = emptyList()
         _streakInfoFlow.value = StreakInfo.EMPTY
@@ -132,10 +137,12 @@ class FakeGamificationRepository : GamificationRepository {
     }
 
     override suspend fun updateStats(profileId: String) {
+        updateStatsCallCount++
         // No-op in fake - stats are set directly via setGamificationStats
     }
 
     override suspend fun checkAndAwardBadges(profileId: String): List<Badge> {
+        checkAndAwardBadgesCallCount++
         val awarded = pendingBadges.toList()
         pendingBadges.forEach { badge ->
             earnedBadges[badge.id] = EarnedBadge(

--- a/shared/src/iosMain/kotlin/com/devil/phoenixproject/data/integration/HealthIntegration.ios.kt
+++ b/shared/src/iosMain/kotlin/com/devil/phoenixproject/data/integration/HealthIntegration.ios.kt
@@ -43,16 +43,16 @@ actual class HealthIntegration {
         HKQuantityType.quantityTypeForIdentifier(HKQuantityTypeIdentifierActiveEnergyBurned)
     }
 
-    /**
-     * The set of HealthKit types this integration writes.
-     * Used for both authorization requests and status checks.
-     */
-    private val writeTypes: Set<HKObjectType> by lazy {
-        buildSet {
-            add(workoutType)
-            activeEnergyType?.let { add(it) }
-        }
+    /** Required HealthKit write types. Calories are optional so disabling them does not block workout sync. */
+    private val requiredWriteTypes: Set<HKObjectType> by lazy { setOf(workoutType) }
+
+    /** Optional HealthKit write types requested for richer workout metadata. */
+    private val optionalWriteTypes: Set<HKObjectType> by lazy {
+        buildSet { activeEnergyType?.let { add(it) } }
     }
+
+    /** The full set requested from HealthKit when presenting authorization UI. */
+    private val writeTypes: Set<HKObjectType> by lazy { requiredWriteTypes + optionalWriteTypes }
 
     /**
      * Checks whether HealthKit is available on this device.
@@ -76,12 +76,23 @@ actual class HealthIntegration {
         if (!isAvailable()) return false
 
         return try {
-            writeTypes.all { type ->
-                healthStore.authorizationStatusForType(type) ==
-                    HKAuthorizationStatusSharingAuthorized
-            }
+            hasAuthorizationForTypes(requiredWriteTypes)
         } catch (e: Exception) {
             log.w(e) { "Error checking HealthKit authorization status" }
+            false
+        }
+    }
+
+    private fun hasAuthorizationForTypes(types: Set<HKObjectType>): Boolean = types.all { type ->
+        healthStore.authorizationStatusForType(type) == HKAuthorizationStatusSharingAuthorized
+    }
+
+    private fun canWriteActiveEnergy(): Boolean {
+        val type = activeEnergyType ?: return false
+        return try {
+            hasAuthorizationForTypes(setOf(type))
+        } catch (e: Exception) {
+            log.w(e) { "Error checking HealthKit active energy authorization" }
             false
         }
     }
@@ -140,8 +151,8 @@ actual class HealthIntegration {
      * - Optional calorie data from session.estimatedCalories
      * - Metadata with external UUID (session.id) for deduplication
      *
-     * Weight display uses actual cableCount: weightPerCableKg * cableCount.
-     * Defaults to 1 for legacy sessions without cableCount metadata (Issue #358).
+     * Weight display follows persisted display semantics: prefer displayMultiplier,
+     * fall back to raw physical cableCount only for legacy sessions, then default to 1.
      */
     actual suspend fun writeWorkout(session: WorkoutSession): Result<Unit> {
         if (!isAvailable()) {
@@ -175,9 +186,10 @@ actual class HealthIntegration {
                     (epochSeconds + durationSeconds) - UNIX_TO_APPLE_EPOCH_OFFSET,
             )
 
-            // Build optional calorie quantity
+            // Build optional calorie quantity. Active energy permission is optional; do not block workout sync.
+            val canWriteCalories = canWriteActiveEnergy()
             val calorieQuantity: HKQuantity? = session.estimatedCalories?.let { cal ->
-                if (cal > 0f) {
+                if (cal > 0f && canWriteCalories) {
                     HKQuantity.quantityWithUnit(
                         unit = HKUnit.unitFromString("kcal"),
                         doubleValue = cal.toDouble(),
@@ -186,8 +198,11 @@ actual class HealthIntegration {
                     null
                 }
             }
+            if ((session.estimatedCalories ?: 0f) > 0f && !canWriteCalories) {
+                log.i { "Skipping HealthKit calorie value for session ${session.id}: optional active energy permission not granted" }
+            }
 
-            // Build exercise title with dual-cable weight convention
+            // Build exercise title with Android-parity persisted display semantics
             val title = buildExerciseTitle(session)
 
             // Build metadata for deduplication and display
@@ -270,8 +285,9 @@ actual class HealthIntegration {
                     (epochSeconds + durationSeconds) - UNIX_TO_APPLE_EPOCH_OFFSET,
             )
 
+            val canWriteCalories = canWriteActiveEnergy()
             val calorieQuantity: HKQuantity? = data.totalCalories?.let { cal ->
-                if (cal > 0f) {
+                if (cal > 0f && canWriteCalories) {
                     HKQuantity.quantityWithUnit(
                         unit = HKUnit.unitFromString("kcal"),
                         doubleValue = cal.toDouble(),
@@ -279,6 +295,9 @@ actual class HealthIntegration {
                 } else {
                     null
                 }
+            }
+            if ((data.totalCalories ?: 0f) > 0f && !canWriteCalories) {
+                log.i { "Skipping HealthKit calorie value for routine ${data.externalId}: optional active energy permission not granted" }
             }
 
             val metadata = mutableMapOf<Any?, Any?>(
@@ -329,14 +348,15 @@ actual class HealthIntegration {
 
     /**
      * Builds a human-readable title for the exercise session.
-     * Total weight shown is per-cable x cableCount (respects single vs dual cable).
+     * Total weight shown is per-cable x persisted displayMultiplier when available.
      *
-     * Default to 1 cable for legacy sessions without cableCount metadata (Issue #358).
-     * This matches Android behavior, effectiveTotalVolumeKg(), and official Vitruvian app.
+     * Falls back to raw physical cableCount only for legacy sessions without displayMultiplier,
+     * then defaults to 1. This preserves Android/iOS Health title parity (Issue #358).
      */
     private fun buildExerciseTitle(session: WorkoutSession): String {
         val exerciseName = session.exerciseName?.takeIf { it.isNotBlank() } ?: "Phoenix Workout"
-        val totalWeightKg = session.weightPerCableKg * (session.cableCount ?: 1).toFloat()
+        val totalWeightKg = session.weightPerCableKg *
+            (session.displayMultiplier ?: session.cableCount ?: 1).toFloat()
         return if (totalWeightKg > 0f) {
             "$exerciseName — ${totalWeightKg.toInt()}kg"
         } else {


### PR DESCRIPTION
Improve accuracy of workout statistics and health platform syncing by enforcing stricter completion requirements and standardizing weight display logic across platforms.

- **Completion Logic**: Update `DefaultWorkoutSessionManager` and `RoutineFlowManager` to mark exercises and sets as completed only when they contain valid working reps (> 0).
- **Health Sync**: Standardize workout titles using `displayMultiplier` (falling back to `cableCount`) to ensure weight display parity between Android and iOS.
- **Permissions**: Refactor Health Connect (Android) and HealthKit (iOS) integrations to treat calorie-writing as an optional permission, ensuring workout sync continues even if calorie access is denied.
- **State Management**: Introduce `_completedRoutineSetKeys` in `WorkoutCoordinator` to precisely track routine progress. Ensure `ActiveSessionEngine` clears stale metrics, session IDs, and start times during workout resets.
- **Gamification**: Update `GamificationManager` and SQL queries to filter out zero-rep sessions from total volume, rep counts, and exercise statistics.
- **Diagnostics**: Add detailed debug logging in `ActiveSessionEngine` for calorie calculations and health push events.
- **Tests**: Add regression tests for untagged completions, gamification skipping, and standardized health title mapping.