### PR TITLE
Fix bodyweight rep prompt for untimed sets

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -3301,9 +3301,10 @@ class ActiveSessionEngine(
 
             val currentExercise = coordinator._loadedRoutine.value?.exercises?.getOrNull(coordinator._currentExerciseIndex.value)
             val wasBodyweight = isBodyweightExercise(currentExercise)
+            val wasTimedBodyweight = wasBodyweight && currentExercise?.duration?.let { it > 0 } == true
             val selectedBodyweightVariant = coordinator.bodyweightCompletionVariantOverride
 
-            if (wasBodyweight && selectedBodyweightVariant == null && currentExercise != null) {
+            if (wasTimedBodyweight && selectedBodyweightVariant == null && currentExercise != null) {
                 Logger.d("ActiveSessionEngine") {
                     "Timed bodyweight set finished; prompting for reps before saving " +
                         "(exercise=${currentExercise.exercise.name}, set=${coordinator._currentSetIndex.value + 1})"

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMWorkoutLifecycleTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMWorkoutLifecycleTest.kt
@@ -1710,6 +1710,34 @@ class DWSMWorkoutLifecycleTest {
     }
 
     @Test
+    fun `Issue 427 - untimed bodyweight set does not prompt for manual reps`() = runTest {
+        val harness = DWSMTestHarness(this)
+        harness.fakeBleRepo.simulateConnect("Vee_Test")
+        harness.fakePrefsManager.setBodyWeightKg(80f)
+        val routine = createBodyweightRoutine(sets = 1, repsPerSet = 10, durationSeconds = 0)
+        routine.exercises.forEach { harness.fakeExerciseRepo.addExercise(it.exercise) }
+
+        harness.dwsm.loadRoutine(routine)
+        advanceUntilIdle()
+        harness.dwsm.enterSetReady(0, 0)
+        advanceUntilIdle()
+        harness.dwsm.startWorkout(skipCountdown = true)
+        runCurrent()
+
+        advanceTimeBy(30_100)
+        runCurrent()
+
+        val state = harness.dwsm.coordinator.workoutState.value
+        assertFalse(
+            state is WorkoutState.BodyweightRepEntry,
+            "Untimed bodyweight completion should not force the timed rep-entry prompt",
+        )
+        assertIs<WorkoutState.SetSummary>(state)
+
+        harness.cleanup()
+    }
+
+    @Test
     fun `Issue 427 - confirming bodyweight reps saves selected variant volume`() = runTest {
         val harness = DWSMTestHarness(this)
         harness.fakeBleRepo.simulateConnect("Vee_Test")


### PR DESCRIPTION
## Summary
- Follow-up to #444 for the late Codex P1 review comment.
- Restrict the bodyweight rep-entry prompt to bodyweight routine sets with an explicit timed duration.
- Preserve the normal completion flow for untimed bodyweight sets.

## Testing
- .\gradlew.bat --% :shared:testAndroidHostTest --tests "*DWSMWorkoutLifecycleTest*" -Pskip.supabase.check=true
- .\gradlew.bat --% :androidApp:assembleDebug -Pskip.supabase.check=true