### PR TITLE
fix(workout): restore firmware warmup rep tracking for standard sets

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -2330,8 +2330,15 @@ class ActiveSessionEngine(
                 // Using effectiveParams caused the rep counter to misclassify the first 3
                 // reps of each warm-up set as firmware warmup reps, making sets appear to
                 // end 3 reps early and corrupting weight tracking.
+                val repCounterWarmupTarget = if (isInWarmupPhase && warmupOverrideParams !== effectiveParams) {
+                    // Variable warm-up set active: firmware warmup is intentionally disabled (0)
+                    warmupOverrideParams.warmupReps
+                } else {
+                    // Normal cable sets: mirror machine firmware warmup target (typically 3)
+                    effectiveParams.warmupReps
+                }
                 repCounter.configure(
-                    warmupTarget = warmupOverrideParams.warmupReps,
+                    warmupTarget = repCounterWarmupTarget,
                     workingTarget = if (isTimedCableExercise) 0 else warmupOverrideParams.reps,
                     isJustLift = isJustLiftMode,
                     stopAtTop = warmupOverrideParams.stopAtTop,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -2227,6 +2227,7 @@ class ActiveSessionEngine(
                 val warmupSetIndex = coordinator._currentWarmupSetIndex.value
                 val isInWarmupPhase = warmupSetIndex >= 0
                 val skipVariableWarmupOverride = startOverride?.skipVariableWarmupOverride == true
+                val hasVariableWarmupOverrideApplied: Boolean
                 val warmupOverrideParams = if (!skipVariableWarmupOverride && isInWarmupPhase && currentExercise != null) {
                     val warmupSet = currentExercise.warmupSets.getOrNull(warmupSetIndex)
                     if (warmupSet != null) {
@@ -2236,6 +2237,7 @@ class ActiveSessionEngine(
                             "WarmupSet ${warmupSetIndex + 1}/${currentExercise.warmupSets.size}: " +
                                 "${warmupSet.reps} reps @ ${warmupSet.percentOfWorking}% = ${warmupWeight}kg (working=${effectiveParams.weightPerCableKg}kg)"
                         }
+                        hasVariableWarmupOverrideApplied = true
                         effectiveParams.copy(
                             weightPerCableKg = warmupWeight,
                             reps = warmupSet.reps,
@@ -2245,13 +2247,15 @@ class ActiveSessionEngine(
                     } else {
                         Logger.w { "WarmupSet index $warmupSetIndex out of bounds for ${currentExercise.warmupSets.size} warmup sets - falling through to working set" }
                         coordinator._currentWarmupSetIndex.value = -1
+                        hasVariableWarmupOverrideApplied = false
                         effectiveParams
                     }
                 } else {
+                    hasVariableWarmupOverrideApplied = false
                     effectiveParams
                 }
                 // Update coordinator params if warm-up override applied
-                if (isInWarmupPhase && warmupOverrideParams !== effectiveParams) {
+                if (hasVariableWarmupOverrideApplied) {
                     coordinator._workoutParameters.value = warmupOverrideParams
                 }
 
@@ -2330,7 +2334,7 @@ class ActiveSessionEngine(
                 // Using effectiveParams caused the rep counter to misclassify the first 3
                 // reps of each warm-up set as firmware warmup reps, making sets appear to
                 // end 3 reps early and corrupting weight tracking.
-                val repCounterWarmupTarget = if (isInWarmupPhase && warmupOverrideParams !== effectiveParams) {
+                val repCounterWarmupTarget = if (hasVariableWarmupOverrideApplied) {
                     // Variable warm-up set active: firmware warmup is intentionally disabled (0)
                     warmupOverrideParams.warmupReps
                 } else {


### PR DESCRIPTION
### Motivation
- Users reported the 3 ROM warmup reps counted by the machine were not reflected in the app UI, causing warmup display to remain at `0/3` while the machine progressed to weight engagement.
- Investigation showed the rep counter was being configured with the variable-warmup parameters unconditionally, which desynchronized the app from firmware warmup tracking for standard sets.

### Description
- Update `ActiveSessionEngine` to compute a `repCounterWarmupTarget` that uses `effectiveParams.warmupReps` for normal sets and `warmupOverrideParams.warmupReps` only when an actual variable warm-up override is active.
- Pass `repCounterWarmupTarget` into `repCounter.configure(...)` so the rep counter mirrors firmware warmup behavior for non-variable warmups while preserving variable warm-up handling.
- The change is localized to `shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt` and does not alter rep event listeners or BLE parsing logic.

### Testing
- Compiled shared metadata with `./gradlew :shared:compileKotlinMetadata -Pskip.supabase.check=true -q` which completed successfully.
- Attempting `./gradlew :shared:compileKotlinMetadata -q` in this environment failed due to missing local Supabase credentials gating the build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0da78b798483228f881e9cf8583799)