### PR TITLE
fix(workout): detect single-cable usage from telemetry (#340)

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepository.kt
@@ -860,7 +860,7 @@ class SqlDelightWorkoutRepository(private val db: VitruvianDatabase, private val
             val newVolume = weightKg * reps
             val exercise = exerciseRepository.getExerciseById(exerciseId)
             val exerciseName = exercise?.name ?: ""
-            val cableCount = exercise?.displayMultiplier
+            val cableCount = exercise?.preferredCableCount
 
             val combinedPhase = "COMBINED"
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/CableUsageDetector.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/CableUsageDetector.kt
@@ -1,0 +1,81 @@
+package com.devil.phoenixproject.domain.usecase
+
+import com.devil.phoenixproject.domain.model.WorkoutMetric
+
+/**
+ * Detects when a set was performed on a single cable despite dual-cable metadata or
+ * both cables being physically connected (Issue #340).
+ */
+object CableUsageDetector {
+    private const val LOAD_IMBALANCE_RATIO = 3f
+    private const val ROM_IMBALANCE_RATIO = 3f
+    private const val MIN_MEANINGFUL_ROM_MM = 20f
+    private const val CONCENTRIC_VELOCITY_THRESHOLD = 10.0
+    private const val VELOCITY_DOMINANCE_RATIO = 1.5
+    private const val VELOCITY_DOMINANCE_FRACTION = 0.7f
+
+    /**
+     * Returns true when telemetry indicates a single active cable for the set.
+     */
+    fun isSingleCableUsage(metrics: List<WorkoutMetric>): Boolean {
+        if (metrics.isEmpty()) return false
+
+        if (isLoadImbalanced(metrics)) return true
+        if (isRomImbalanced(metrics)) return true
+        if (hasDominantConcentricCable(metrics)) return true
+
+        return false
+    }
+
+    private fun isLoadImbalanced(metrics: List<WorkoutMetric>): Boolean {
+        val peakCableA = metrics.maxOf { it.loadA }
+        val peakCableB = metrics.maxOf { it.loadB }
+
+        return (
+            peakCableA > 0f && peakCableB > 0f &&
+                (peakCableA / peakCableB > LOAD_IMBALANCE_RATIO || peakCableB / peakCableA > LOAD_IMBALANCE_RATIO)
+            ) ||
+            (peakCableA > 0f && peakCableB == 0f) ||
+            (peakCableB > 0f && peakCableA == 0f)
+    }
+
+    private fun isRomImbalanced(metrics: List<WorkoutMetric>): Boolean {
+        if (metrics.size < 2) return false
+
+        var romA = 0f
+        var romB = 0f
+        for (index in 1 until metrics.size) {
+            romA += kotlin.math.abs(metrics[index].positionA - metrics[index - 1].positionA)
+            romB += kotlin.math.abs(metrics[index].positionB - metrics[index - 1].positionB)
+        }
+
+        val maxRom = maxOf(romA, romB)
+        val minRom = minOf(romA, romB).coerceAtLeast(0.1f)
+        return maxRom >= MIN_MEANINGFUL_ROM_MM && maxRom / minRom >= ROM_IMBALANCE_RATIO
+    }
+
+    private fun hasDominantConcentricCable(metrics: List<WorkoutMetric>): Boolean {
+        val concentric = metrics.filter {
+            it.velocityA > CONCENTRIC_VELOCITY_THRESHOLD || it.velocityB > CONCENTRIC_VELOCITY_THRESHOLD
+        }
+        if (concentric.isEmpty()) return false
+
+        val dominantA = concentric.count { sample ->
+            sample.velocityA > CONCENTRIC_VELOCITY_THRESHOLD &&
+                (
+                    sample.velocityB <= CONCENTRIC_VELOCITY_THRESHOLD ||
+                        sample.velocityA >= sample.velocityB * VELOCITY_DOMINANCE_RATIO
+                    )
+        }
+        val dominantB = concentric.count { sample ->
+            sample.velocityB > CONCENTRIC_VELOCITY_THRESHOLD &&
+                (
+                    sample.velocityA <= CONCENTRIC_VELOCITY_THRESHOLD ||
+                        sample.velocityB >= sample.velocityA * VELOCITY_DOMINANCE_RATIO
+                    )
+        }
+
+        val threshold = (concentric.size * VELOCITY_DOMINANCE_FRACTION).toInt().coerceAtLeast(1)
+        return dominantA >= threshold || dominantB >= threshold
+    }
+}

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -41,6 +41,7 @@ import com.devil.phoenixproject.domain.model.elapsedRealtimeMillis
 import com.devil.phoenixproject.domain.model.generateUUID
 import com.devil.phoenixproject.domain.replay.RepBoundaryDetector
 import com.devil.phoenixproject.domain.usecase.BodyweightVolumeCalculator
+import com.devil.phoenixproject.domain.usecase.CableUsageDetector
 import com.devil.phoenixproject.domain.usecase.RepCounterFromMachine
 import com.devil.phoenixproject.getPlatform
 import com.devil.phoenixproject.util.BleConstants
@@ -469,20 +470,18 @@ class ActiveSessionEngine(
         val peakCableA = metrics.maxOf { it.loadA }
         val peakCableB = metrics.maxOf { it.loadB }
 
-        // Issue #6 Fix: Detect single-cable (unilateral) exercises and don't halve the weight.
-        // Heuristic: if one cable's peak load is > 5x the other's, treat as single-cable.
-        // For single-cable, use the max of the active cable. For double-cable, use totalLoad/2.
-        val heuristicIsSingleCable = (
-            peakCableA > 0f && peakCableB > 0f &&
-                (peakCableA / peakCableB > 5f || peakCableB / peakCableA > 5f)
-            ) ||
-            (peakCableA > 0f && peakCableB == 0f) ||
-            (peakCableB > 0f && peakCableA == 0f)
+        // Issue #340: Telemetry can override dual-cable metadata when only one cable is active
+        // (e.g. pulldown with both retractors attached but ROM/velocity on one side only).
+        val heuristicIsSingleCable = CableUsageDetector.isSingleCableUsage(metrics)
 
-        val cableCount = when (cableCountHint) {
-            1 -> 1
-            2 -> 2
-            else -> if (heuristicIsSingleCable) 1 else 2
+        val cableCount = if (heuristicIsSingleCable) {
+            1
+        } else {
+            when (cableCountHint) {
+                1 -> 1
+                2 -> 2
+                else -> 2
+            }
         }
         val isSingleCable = cableCount == 1
 
@@ -662,7 +661,8 @@ class ActiveSessionEngine(
             durationMs = durationMs,
             totalVolumeKg = totalVolumeKg,
             cableCount = cableCount,
-            displayMultiplier = displayMultiplierHint ?: cableCount,
+            // Persist per-cable display when telemetry proves single-cable usage (Issue #340).
+            displayMultiplier = if (cableCount == 1) 1 else (displayMultiplierHint ?: cableCount),
             heaviestLiftKgPerCable = heaviestLiftKgPerCable,
             configuredWeightKgPerCable = configuredWeightKgPerCable,
             peakForceConcentricA = peakConcentricA,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/DefaultWorkoutSessionManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/DefaultWorkoutSessionManager.kt
@@ -391,7 +391,7 @@ class DefaultWorkoutSessionManager(
                 workoutMode = taggedSession.mode,
                 timestamp = currentTimeMillis(),
                 profileId = taggedSession.profileId,
-                cableCount = taggedSession.displayMultiplier,
+                cableCount = taggedSession.cableCount,
             ).onFailure { error ->
                 Logger.e(error) { "Failed to update PRs while tagging Just Lift session $sessionId" }
             }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/GamificationManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/GamificationManager.kt
@@ -114,7 +114,7 @@ class GamificationManager(
                     val timestamp = currentTimeMillis()
                     // Resolve exercise once for both PR storage and celebration display
                     val exercise = exerciseRepository.getExerciseById(exId)
-                    val cableCount = exercise?.displayMultiplier
+                    val cableCount = exercise?.preferredCableCount
 
                     // Check COMBINED (traditional) PRs
                     val result = personalRecordRepository.updatePRsIfBetter(

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/HistoryTab.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/HistoryTab.kt
@@ -60,6 +60,7 @@ import com.devil.phoenixproject.domain.model.RepMetricData
 import com.devil.phoenixproject.domain.model.WeightUnit
 import com.devil.phoenixproject.domain.model.WorkoutSession
 import com.devil.phoenixproject.domain.model.currentTimeMillis
+import com.devil.phoenixproject.domain.model.displayLoadMultiplier
 import com.devil.phoenixproject.domain.model.effectiveHeaviestKgPerCable
 import com.devil.phoenixproject.domain.model.toSetSummary
 import com.devil.phoenixproject.presentation.util.WeightDisplayFormatter
@@ -351,7 +352,7 @@ fun WorkoutHistoryCard(
                     } else {
                         WeightDisplayFormatter.formatDisplayWeight(
                             session.effectiveHeaviestKgPerCable(),
-                            session.displayMultiplier ?: session.cableCount,
+                            session.displayLoadMultiplier(),
                             weightUnit,
                         ) + " ${if (weightUnit == WeightUnit.LB) "lbs" else "kg"}"
                     },
@@ -440,7 +441,7 @@ fun WorkoutHistoryCard(
                     // CompletedSet breakdown (set-level tracking)
                     CompletedSetsSection(
                         sessionId = session.id,
-                        cableCount = session.displayMultiplier ?: session.cableCount,
+                        cableCount = session.displayLoadMultiplier(),
                         weightUnit = weightUnit,
                         formatWeight = formatWeight,
                     )
@@ -875,7 +876,7 @@ fun GroupedRoutineCard(
                 // Use max cableCount from sessions in this group for display
                 val groupCableCount = groupedItem.sessions
                     .filter { it.exerciseId == exerciseGroup.exerciseId }
-                    .mapNotNull { it.displayMultiplier ?: it.cableCount }
+                    .map { it.displayLoadMultiplier() }
                     .maxOrNull()
 
                 Row(
@@ -997,7 +998,7 @@ fun GroupedRoutineCard(
                         // CompletedSet breakdown per session
                         CompletedSetsSection(
                             sessionId = session.id,
-                            cableCount = session.displayMultiplier ?: session.cableCount,
+                            cableCount = session.displayLoadMultiplier(),
                             weightUnit = weightUnit,
                             formatWeight = formatWeight,
                         )
@@ -1155,7 +1156,7 @@ fun WorkoutSessionCard(
                     color = MaterialTheme.colorScheme.onSurface,
                 )
                 Text(
-                    "${WeightDisplayFormatter.formatDisplayWeight(session.weightPerCableKg, session.displayMultiplier ?: session.cableCount, weightUnit)} ${if (weightUnit == WeightUnit.LB) "lbs" else "kg"} • ${session.totalReps} reps • ${session.mode}",
+                    "${WeightDisplayFormatter.formatDisplayWeight(session.weightPerCableKg, session.displayLoadMultiplier(), weightUnit)} ${if (weightUnit == WeightUnit.LB) "lbs" else "kg"} • ${session.totalReps} reps • ${session.mode}",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/CableUsageDetectorTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/CableUsageDetectorTest.kt
@@ -1,0 +1,62 @@
+package com.devil.phoenixproject.domain.usecase
+
+import com.devil.phoenixproject.domain.model.WorkoutMetric
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class CableUsageDetectorTest {
+
+    @Test
+    fun `detects load imbalance between cables`() {
+        val metrics = listOf(
+            sample(loadA = 30f, loadB = 8f, positionA = 100f, positionB = 100f, velocityA = 50.0, velocityB = 5.0),
+            sample(loadA = 28f, loadB = 9f, positionA = 180f, positionB = 102f, velocityA = -40.0, velocityB = -5.0),
+        )
+
+        assertTrue(CableUsageDetector.isSingleCableUsage(metrics))
+    }
+
+    @Test
+    fun `detects ROM imbalance when idle cable load is noisy`() {
+        val metrics = listOf(
+            sample(loadA = 28f, loadB = 18f, positionA = 100f, positionB = 100f, velocityA = 80.0, velocityB = 12.0),
+            sample(loadA = 30f, loadB = 20f, positionA = 220f, positionB = 105f, velocityA = -70.0, velocityB = -10.0),
+            sample(loadA = 27f, loadB = 19f, positionA = 110f, positionB = 103f, velocityA = 75.0, velocityB = 15.0),
+        )
+
+        assertTrue(CableUsageDetector.isSingleCableUsage(metrics))
+    }
+
+    @Test
+    fun `does not flag balanced dual-cable work`() {
+        val metrics = listOf(
+            sample(loadA = 40f, loadB = 38f, positionA = 100f, positionB = 100f, velocityA = 80.0, velocityB = 78.0),
+            sample(loadA = 42f, loadB = 41f, positionA = 200f, positionB = 198f, velocityA = -75.0, velocityB = -74.0),
+        )
+
+        assertFalse(CableUsageDetector.isSingleCableUsage(metrics))
+    }
+
+    @Test
+    fun `returns false for empty metrics`() {
+        assertFalse(CableUsageDetector.isSingleCableUsage(emptyList()))
+    }
+
+    private fun sample(
+        loadA: Float,
+        loadB: Float,
+        positionA: Float,
+        positionB: Float,
+        velocityA: Double,
+        velocityB: Double,
+    ): WorkoutMetric = WorkoutMetric(
+        timestamp = 0L,
+        loadA = loadA,
+        loadB = loadB,
+        positionA = positionA,
+        positionB = positionB,
+        velocityA = velocityA,
+        velocityB = velocityB,
+    )
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMWorkoutLifecycleTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMWorkoutLifecycleTest.kt
@@ -1185,6 +1185,45 @@ class DWSMWorkoutLifecycleTest {
     }
 
     @Test
+    fun `Issue 340 - dual cable hint downgrades to single cable when telemetry shows one active side`() = runTest {
+        val harness = DWSMTestHarness(this)
+
+        val summary = harness.activeSessionEngine.calculateSetSummaryMetrics(
+            metrics = listOf(
+                WorkoutMetric(
+                    timestamp = 100L,
+                    loadA = 28f,
+                    loadB = 18f,
+                    positionA = 100f,
+                    positionB = 100f,
+                    velocityA = 80.0,
+                    velocityB = 12.0,
+                ),
+                WorkoutMetric(
+                    timestamp = 200L,
+                    loadA = 30f,
+                    loadB = 20f,
+                    positionA = 220f,
+                    positionB = 105f,
+                    velocityA = -70.0,
+                    velocityB = -10.0,
+                ),
+            ),
+            repCount = 10,
+            fallbackWeightKg = 30f,
+            configuredWeightKgPerCable = 30f,
+            isEchoMode = false,
+            cableCountHint = 2,
+            displayMultiplierHint = 2,
+        )
+
+        assertEquals(1, summary.cableCount)
+        assertEquals(1, summary.displayMultiplier)
+        assertEquals(300f, summary.totalVolumeKg)
+        harness.cleanup()
+    }
+
+    @Test
     fun `set summary honors unilateral cable hint when inactive side has noisy load`() = runTest {
         val harness = DWSMTestHarness(this)
 


### PR DESCRIPTION
## Summary

Fixes remaining cases of doubled volume/weight for single-cable workouts when exercise metadata still indicates dual-cable (e.g. Wide Grip Pulldown with both retractors connected but only one cable active).

Addresses the open edge case in #340 after the earlier `mvp` hardcoded `×2` cleanup.

## Problem

- `calculateSetSummaryMetrics()` treated `preferredCableCount = 2` as authoritative, so telemetry never downgraded to single-cable.
- Idle cable load/ROM noise (e.g. ~2.5× load ratio, not 5×) failed the old heuristic.
- `displayMultiplier` from unified-bar metadata (2) was persisted even when only one cable was active, doubling history weight display.
- Some PR/tagging paths stored `displayMultiplier` as physical `cableCount`.

## Solution

- **`CableUsageDetector`**: single-cable detection from load imbalance (3× peak ratio), ROM imbalance (position delta), and concentric velocity dominance on one cable.
- **`ActiveSessionEngine`**: telemetry overrides dual-cable hints; `displayMultiplier = 1` when resolved `cableCount = 1`.
- **PR metadata**: use `preferredCableCount` / session `cableCount` instead of `displayMultiplier` in `GamificationManager`, `DefaultWorkoutSessionManager`, and `SqlDelightWorkoutRepository`.
- **`HistoryTab`**: use `displayLoadMultiplier()` for consistent weight display.

## Test plan

- [x] `CableUsageDetectorTest` — load, ROM, balanced dual-cable cases
- [x] `DWSMWorkoutLifecycleTest` — dual hint + single-cable telemetry → `cableCount=1`, volume not doubled
- [ ] `./gradlew :shared:testAndroidHostTest -Pskip.supabase.check=true`
- [ ] Manual: single-cable pulldown/row with both retractors attached; confirm volume = `weight × reps` (not ×2)

## Out of scope

- No backfill/migration for sessions already saved with doubled `totalVolumeKg`.

---
Contributed from [@Jdub7575](https://github.com/Jdub7575) — happy to adjust based on review feedback.

Made with [Cursor](https://cursor.com)