### PR TITLE
refactor(presentation): replace obsolete Timber TODO with Kermit logging

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/ConnectingOverlay.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/ConnectingOverlay.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import co.touchlab.kermit.Logger
 import org.jetbrains.compose.resources.stringResource
 import vitruvianprojectphoenix.shared.generated.resources.*
 import vitruvianprojectphoenix.shared.generated.resources.Res
@@ -60,7 +61,7 @@ fun ConnectingOverlay(onCancel: () -> Unit = {}) {
                     )
                     TextButton(
                         onClick = {
-                            // TODO: Add logging when timber is available in KMP
+                            Logger.i("ConnectingOverlay") { "User cancelled device connection attempt" }
                             onCancel()
                         },
                         modifier = Modifier.padding(top = 8.dp),


### PR DESCRIPTION
Addresses an outdated TODO comment in ConnectingOverlay.kt. Since Timber is an Android-only library and not available in KMP, this PR replaces the comment with Kermit Logger, which is the standard KMP logging library used across the domain, data, and presentation layers in this project. This also provides useful diagnostic telemetry when a user cancels a connection scan attempt.