### PR TITLE
[Follow-up] Guard legacy display multiplier behavior for historical sessions

### DIFF
--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/WorkoutMetricTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/WorkoutMetricTest.kt
@@ -163,6 +163,19 @@ class WorkoutSessionTest {
     }
 
     @Test
+    fun `displayLoadMultiplier uses legacy multiplier when cable metadata is missing`() {
+        val session = WorkoutSession(
+            weightPerCableKg = 30f,
+            totalReps = 12,
+            cableCount = null,
+            displayMultiplier = 2,
+        )
+
+        assertEquals(2, session.displayLoadMultiplier())
+        assertEquals(720f, session.effectiveTotalVolumeKg())
+    }
+
+    @Test
     fun `toSetSummary uses legacy display multiplier for saved-session display count`() {
         val session = WorkoutSession(
             weightPerCableKg = 50f,


### PR DESCRIPTION
### Motivation
- Prevent a regression that would cause historical sessions with a persisted `display_multiplier` (where physical `cableCount` and display count differed) to be rendered with incorrect doubled loads in history/insights paths.

### Description
- Add a regression test in `shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/WorkoutMetricTest.kt` that asserts `displayLoadMultiplier()` continues to honor `displayMultiplier` when `cableCount` is `null` and verifies `effectiveTotalVolumeKg()` uses `weightPerCableKg * displayMultiplier * totalReps` for legacy rows.

### Testing
- Attempted to run targeted unit tests with `./gradlew :shared:testDebugUnitTest --tests "com.devil.phoenixproject.domain.model.WorkoutSessionTest"` and `./gradlew -Pskip.supabase.check=true :shared:testAndroidHostTest --tests "com.devil.phoenixproject.domain.model.WorkoutSessionTest"`, but runs were blocked by environment constraints (missing Supabase credentials and missing Android SDK / `sdk.dir`), so the new test is added and committed but could not be executed end-to-end in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10c14a01a88322936f2a74143da9cc)