### PR TITLE
Preserve routine cable overrides when merging pulled routines

### DIFF
--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepositoryTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepositoryTest.kt
@@ -272,4 +272,84 @@ class SqlDelightSyncRepositoryTest {
 
         assertEquals(2L, row.cableCountOverride)
     }
+
+    @Test
+    fun `mergePortalRoutines preserves cable count override by exercise name when ids change`() = runTest {
+        val routineId = "portal-routine-preserve-cable-override-by-name"
+
+        database.vitruvianDatabaseQueries.insertRoutine(
+            id = routineId,
+            name = "Local Cable Routine",
+            description = "",
+            createdAt = 1_700_000_000_000L,
+            lastUsed = null,
+            useCount = 0L,
+            profile_id = "active-profile",
+            groupId = null,
+        )
+        database.vitruvianDatabaseQueries.insertRoutineExercise(
+            id = "local-exercise-id",
+            routineId = routineId,
+            exerciseName = "Cable Row",
+            exerciseMuscleGroup = "Back",
+            exerciseEquipment = "HANDLES",
+            exerciseDefaultCableConfig = "DOUBLE",
+            exerciseId = null,
+            cableConfig = "DOUBLE",
+            orderIndex = 0L,
+            setReps = "10,10,10",
+            weightPerCableKg = 30.0,
+            setWeights = "",
+            mode = "OLD_SCHOOL",
+            eccentricLoad = 100L,
+            echoLevel = 1L,
+            progressionKg = 0.0,
+            restSeconds = 90L,
+            duration = null,
+            setRestSeconds = "[]",
+            perSetRestTime = 0L,
+            isAMRAP = 0L,
+            supersetId = null,
+            orderInSuperset = 0L,
+            usePercentOfPR = 0L,
+            weightPercentOfPR = 80L,
+            prTypeForScaling = "MAX_WEIGHT",
+            setWeightsPercentOfPR = null,
+            cableCountOverride = 1L,
+            stallDetectionEnabled = 1L,
+            stopAtTop = 0L,
+            repCountTiming = "TOP",
+            setEchoLevels = "",
+            warmupSets = "",
+        )
+
+        repository.mergePortalRoutines(
+            routines = listOf(
+                PullRoutineDto(
+                    id = routineId,
+                    name = "Portal Cable Routine",
+                    exercises = listOf(
+                        PullRoutineExerciseDto(
+                            id = "portal-exercise-id",
+                            name = "Cable Row",
+                            muscleGroup = "Back",
+                            exerciseEquipment = "HANDLES",
+                            sets = 3,
+                            reps = 10,
+                            weight = 35f,
+                        ),
+                    ),
+                ),
+            ),
+            lastSync = 0L,
+            profileId = "active-profile",
+        )
+
+        val row = database.vitruvianDatabaseQueries
+            .selectExercisesByRoutine(routineId)
+            .executeAsOne()
+
+        assertEquals(1L, row.cableCountOverride)
+    }
+
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt
@@ -541,9 +541,12 @@ class SqlDelightSyncRepository(
                     // partial response, or deserialization issue). Deleting local exercises
                     // when we have nothing to replace them with causes permanent data loss.
                     if (portalRoutine.exercises.isNotEmpty()) {
-                        val existingCableOverridesByExerciseId = queries.selectExercisesByRoutine(portalRoutine.id)
+                        val existingRoutineExercises = queries.selectExercisesByRoutine(portalRoutine.id)
                             .executeAsList()
+                        val existingCableOverridesByExerciseId = existingRoutineExercises
                             .associate { it.id to it.cableCountOverride }
+                        val existingCableOverridesByExerciseName = existingRoutineExercises
+                            .associate { it.exerciseName to it.cableCountOverride }
 
                         // Replace routine exercises and supersets: delete existing then insert portal versions
                         queries.deleteRoutineExercises(portalRoutine.id)
@@ -666,6 +669,7 @@ class SqlDelightSyncRepository(
                                 setWeightsPercentOfPR = null,
                                 cableCountOverride = exercise.resolvedCableCountOverride(
                                     existingCableOverridesByExerciseId[exercise.id],
+                                    existingCableOverridesByExerciseName[exercise.name],
                                 ),
                                 stallDetectionEnabled = if (behaviorFields.stallDetectionEnabled) 1L else 0L,
                                 stopAtTop = if (behaviorFields.stopAtTop) 1L else 0L,
@@ -1521,9 +1525,12 @@ class SqlDelightSyncRepository(
 
                     // Replace exercises if portal provided them (non-empty list)
                     if (portalRoutine.exercises.isNotEmpty()) {
-                        val existingCableOverridesByExerciseId = queries.selectExercisesByRoutine(portalRoutine.id)
+                        val existingRoutineExercises = queries.selectExercisesByRoutine(portalRoutine.id)
                             .executeAsList()
+                        val existingCableOverridesByExerciseId = existingRoutineExercises
                             .associate { it.id to it.cableCountOverride }
+                        val existingCableOverridesByExerciseName = existingRoutineExercises
+                            .associate { it.exerciseName to it.cableCountOverride }
 
                         queries.deleteRoutineExercises(portalRoutine.id)
                         queries.deleteSupersetsByRoutine(portalRoutine.id)
@@ -1632,6 +1639,7 @@ class SqlDelightSyncRepository(
                                 setWeightsPercentOfPR = null,
                                 cableCountOverride = exercise.resolvedCableCountOverride(
                                     existingCableOverridesByExerciseId[exercise.id],
+                                    existingCableOverridesByExerciseName[exercise.name],
                                 ),
                                 stallDetectionEnabled = if (behaviorFields.stallDetectionEnabled) 1L else 0L,
                                 stopAtTop = if (behaviorFields.stopAtTop) 1L else 0L,
@@ -1963,11 +1971,15 @@ class SqlDelightSyncRepository(
         } ?: "HANDLES"
     }
 
-    private fun PullRoutineExerciseDto.resolvedCableCountOverride(existingOverride: Long?): Long? =
+    private fun PullRoutineExerciseDto.resolvedCableCountOverride(
+        existingOverrideById: Long?,
+        existingOverrideByName: Long?,
+    ): Long? =
         cableCountOverride
             ?.takeIf { it in 1..2 }
             ?.toLong()
-            ?: existingOverride?.takeIf { it in 1L..2L }
+            ?: existingOverrideById?.takeIf { it in 1L..2L }
+            ?: existingOverrideByName?.takeIf { it in 1L..2L }
 
     private fun PullRoutineExerciseDto.sanitizedBehaviorFields(resolvedEquipment: String): RoutineExerciseBehaviorFields {
         val isBodyweightExercise = Exercise(


### PR DESCRIPTION
### Motivation
- Fix a high-priority bug where local `cableCountOverride` values are erased during portal pull sync because routine exercises are fully replaced (delete + reinsert) and the write path previously nullified overrides when the incoming payload omitted them.
- Ensure user-selected cable overrides survive sync even when portal exercise IDs change or the portal omits the override field.

### Description
- Collect existing routine exercises before deletion and build maps of existing overrides by both exercise ID and exercise name (`existingRoutineExercises`, `existingCableOverridesByExerciseId`, `existingCableOverridesByExerciseName`).
- Update insert site to call `resolvedCableCountOverride` with both `existingOverrideById` and `existingOverrideByName` so the resolver can fall back from incoming override → local-by-ID → local-by-name.
- Change `PullRoutineExerciseDto.resolvedCableCountOverride` signature to accept both `existingOverrideById` and `existingOverrideByName` and prefer valid values in that order.
- Add an Android host test `mergePortalRoutines preserves cable count override by exercise name when ids change` that verifies a local override is preserved when portal omits the override and the portal exercise ID differs but the name matches.

### Testing
- Added a host test (`SqlDelightSyncRepositoryTest.mergePortalRoutines preserves cable count override by exercise name when ids change`) to cover the regression; the test is included in the patch and should pass in CI or a local environment with Android SDK configured.
- Attempted to run the targeted host test in this environment but automated runs failed due to environment constraints: initial build failed on missing Supabase credentials, and subsequent test attempts failed because the Android SDK location (`ANDROID_HOME`/`sdk.dir`) is not configured here, so tests could not be executed in this CI sandbox.
- Please run the new host test in a local developer environment or CI (with Android SDK and any required credentials) to validate the change; it is expected to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10c16f8e008322877ac9f383aab231)