### PR TITLE
[PR #453 follow-up] Add regression coverage for legacy display multiplier behavior

### DIFF
--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/WorkoutMetricTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/WorkoutMetricTest.kt
@@ -176,6 +176,19 @@ class WorkoutSessionTest {
     }
 
     @Test
+    fun `displayLoadMultiplier uses legacy multiplier when cable metadata is missing`() {
+        val session = WorkoutSession(
+            weightPerCableKg = 30f,
+            totalReps = 12,
+            cableCount = null,
+            displayMultiplier = 2,
+        )
+
+        assertEquals(2, session.displayLoadMultiplier())
+        assertEquals(720f, session.effectiveTotalVolumeKg())
+    }
+
+    @Test
     fun `toSetSummary uses legacy display multiplier for saved-session display count`() {
         val session = WorkoutSession(
             weightPerCableKg = 50f,

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/WorkoutMetricTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/WorkoutMetricTest.kt
@@ -163,6 +163,19 @@ class WorkoutSessionTest {
     }
 
     @Test
+    fun `displayLoadMultiplier falls back to cable count when legacy multiplier is invalid`() {
+        val session = WorkoutSession(
+            weightPerCableKg = 50f,
+            totalReps = 8,
+            cableCount = 2,
+            displayMultiplier = 0,
+        )
+
+        assertEquals(2, session.displayLoadMultiplier())
+        assertEquals(800f, session.effectiveTotalVolumeKg())
+    }
+
+    @Test
     fun `toSetSummary uses legacy display multiplier for saved-session display count`() {
         val session = WorkoutSession(
             weightPerCableKg = 50f,


### PR DESCRIPTION
### Motivation
- Ensure legacy `display_multiplier` semantics are preserved and that code safely falls back to `cableCount` when persisted `display_multiplier` is invalid, preventing historical sessions from being double-counted.

### Description
- Add a unit test at `shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/WorkoutMetricTest.kt` which asserts that `displayLoadMultiplier()` falls back to `cableCount` and that `effectiveTotalVolumeKg()` computes accordingly when `displayMultiplier = 0`.

### Testing
- Attempted to run targeted tests with `./gradlew :shared:testDebugUnitTest --tests "com.devil.phoenixproject.domain.model.WorkoutMetricTest"` which failed because the task is not present in this module layout, and `./gradlew -Pskip.supabase.check=true :shared:testAndroidHostTest --tests "com.devil.phoenixproject.domain.model.WorkoutMetricTest"` which was blocked by a missing Android SDK path in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10c248b774832287ee3106a464f37e)