### PR TITLE
Follow-up: validate cable count override behavior during routine pull sync

### DIFF
--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepositoryTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepositoryTest.kt
@@ -272,4 +272,85 @@ class SqlDelightSyncRepositoryTest {
 
         assertEquals(2L, row.cableCountOverride)
     }
+
+    @Test
+    fun `mergePortalRoutines applies portal cable count override when provided`() = runTest {
+        val routineId = "portal-routine-apply-cable-override"
+        val routineExerciseId = "portal-exercise-apply-cable-override"
+
+        database.vitruvianDatabaseQueries.insertRoutine(
+            id = routineId,
+            name = "Local Cable Routine",
+            description = "",
+            createdAt = 1_700_000_000_000L,
+            lastUsed = null,
+            useCount = 0L,
+            profile_id = "active-profile",
+            groupId = null,
+        )
+        database.vitruvianDatabaseQueries.insertRoutineExercise(
+            id = routineExerciseId,
+            routineId = routineId,
+            exerciseName = "Cable Row",
+            exerciseMuscleGroup = "Back",
+            exerciseEquipment = "HANDLES",
+            exerciseDefaultCableConfig = "DOUBLE",
+            exerciseId = null,
+            cableConfig = "DOUBLE",
+            orderIndex = 0L,
+            setReps = "10,10,10",
+            weightPerCableKg = 30.0,
+            setWeights = "",
+            mode = "OLD_SCHOOL",
+            eccentricLoad = 100L,
+            echoLevel = 1L,
+            progressionKg = 0.0,
+            restSeconds = 90L,
+            duration = null,
+            setRestSeconds = "[]",
+            perSetRestTime = 0L,
+            isAMRAP = 0L,
+            supersetId = null,
+            orderInSuperset = 0L,
+            usePercentOfPR = 0L,
+            weightPercentOfPR = 80L,
+            prTypeForScaling = "MAX_WEIGHT",
+            setWeightsPercentOfPR = null,
+            cableCountOverride = 2L,
+            stallDetectionEnabled = 1L,
+            stopAtTop = 0L,
+            repCountTiming = "TOP",
+            setEchoLevels = "",
+            warmupSets = "",
+        )
+
+        repository.mergePortalRoutines(
+            routines = listOf(
+                PullRoutineDto(
+                    id = routineId,
+                    name = "Portal Cable Routine",
+                    exercises = listOf(
+                        PullRoutineExerciseDto(
+                            id = routineExerciseId,
+                            name = "Cable Row",
+                            muscleGroup = "Back",
+                            exerciseEquipment = "HANDLES",
+                            sets = 3,
+                            reps = 10,
+                            weight = 35f,
+                            cableCountOverride = 1,
+                        ),
+                    ),
+                ),
+            ),
+            lastSync = 0L,
+            profileId = "active-profile",
+        )
+
+        val row = database.vitruvianDatabaseQueries
+            .selectExercisesByRoutine(routineId)
+            .executeAsOne()
+
+        assertEquals(1L, row.cableCountOverride)
+    }
 }


### PR DESCRIPTION
### Motivation
- A Codex review flagged a high-priority issue where `cableCountOverride` could be erased during pull sync when the portal payload omitted an explicit override, so the merge behavior needs to be firmly specified and regression-protected. 
- The goal is to ensure the repository behavior both preserves a local override when the portal omits it and accepts an explicit portal-provided override when present.

### Description
- Added a host-side regression test `mergePortalRoutines applies portal cable count override when provided` in `shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepositoryTest.kt` that verifies an incoming `cableCountOverride = 1` from the portal replaces the existing local override. 
- Kept and relied on the existing test `mergePortalRoutines preserves local cable count override when portal omits override` to guard the preservation behavior, so both sides of the merge contract are covered.

### Testing
- Attempted to run the targeted host test via `./gradlew -Pskip.supabase.check=true :shared:testAndroidHostTest --tests "com.devil.phoenixproject.data.repository.SqlDelightSyncRepositoryTest.mergePortalRoutines applies portal cable count override when provided"`, but the execution failed because the Android SDK is not configured in this environment (`ANDROID_HOME` / `sdk.dir` missing). 
- An initial run without the skip flag failed due to missing Supabase credentials; listing tasks with `./gradlew -Pskip.supabase.check=true :shared:tasks --all` confirmed relevant host-test tasks are present. 
- The new test file was added and committed successfully (`Add regression test for portal cable override sync`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10c257e9148322a78b19745e44354c)