### PR TITLE
Fix cable-count sync and backup restore display-multiplier regressions

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapter.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapter.kt
@@ -505,6 +505,7 @@ object PortalSyncAdapter {
                     },
                 warmupSets = normalizedEx.warmupSets.takeIf { it.isNotEmpty() }
                     ?.let { Json.encodeToString(it) },
+                cableCountOverride = normalizedEx.cableCountOverride,
             )
         }
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/BackupModels.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/BackupModels.kt
@@ -58,6 +58,7 @@ data class WorkoutSessionBackup(
     val heaviestLiftKg: Float? = null,
     val totalVolumeKg: Float? = null,
     val cableCount: Int? = null,
+    val displayMultiplier: Int? = null,
     val estimatedCalories: Float? = null,
     val warmupAvgWeightKg: Float? = null,
     val workingAvgWeightKg: Float? = null,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/DataBackupManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/DataBackupManager.kt
@@ -425,7 +425,7 @@ abstract class BaseDataBackupManager(
                                 heaviestLiftKg = session.heaviestLiftKg?.toDouble(),
                                 totalVolumeKg = session.totalVolumeKg?.toDouble(),
                                 cableCount = session.cableCount?.toLong(),
-                                display_multiplier = null,
+                                display_multiplier = session.displayMultiplier?.toLong(),
                                 estimatedCalories = session.estimatedCalories?.toDouble(),
                                 warmupAvgWeightKg = session.warmupAvgWeightKg?.toDouble(),
                                 workingAvgWeightKg = session.workingAvgWeightKg?.toDouble(),
@@ -1053,6 +1053,7 @@ abstract class BaseDataBackupManager(
                                                         heaviestLiftKg = session.heaviestLiftKg?.toDouble(),
                                                         totalVolumeKg = session.totalVolumeKg?.toDouble(),
                                                         cableCount = session.cableCount?.toLong(),
+                                                        display_multiplier = session.displayMultiplier?.toLong(),
                                                         estimatedCalories = session.estimatedCalories?.toDouble(),
                                                         warmupAvgWeightKg = session.warmupAvgWeightKg?.toDouble(),
                                                         workingAvgWeightKg = session.workingAvgWeightKg?.toDouble(),
@@ -1066,7 +1067,6 @@ abstract class BaseDataBackupManager(
                                                         strengthProfile = session.strengthProfile,
                                                         formScore = session.formScore,
                                                         profile_id = session.profileId ?: "default",
-                                                        display_multiplier = null,
                                                     )
                                                 }
                                                 if (inserted != null) {
@@ -2201,6 +2201,7 @@ abstract class BaseDataBackupManager(
             heaviestLiftKg = session.heaviestLiftKg?.toFloat(),
             totalVolumeKg = session.totalVolumeKg?.toFloat(),
             cableCount = session.cableCount?.toInt(),
+            displayMultiplier = session.display_multiplier?.toInt(),
             estimatedCalories = session.estimatedCalories?.toFloat(),
             warmupAvgWeightKg = session.warmupAvgWeightKg?.toFloat(),
             workingAvgWeightKg = session.workingAvgWeightKg?.toFloat(),


### PR DESCRIPTION
### Motivation
- Fix a regression where routine-level `cableCountOverride` was not propagated on outbound routine pushes, causing user overrides to be lost across devices.
- Preserve legacy display semantics during backup restore by round-tripping the `display_multiplier` value instead of writing `null`, preventing historical sessions from being reinterpreted incorrectly.

### Description
- Populate `cableCountOverride` when building `PortalRoutineExerciseSyncDto` in `PortalSyncAdapter.toPortalRoutine()`. (`shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapter.kt`)
- Add `displayMultiplier` to the `WorkoutSessionBackup` model so legacy display semantics are included in backup payloads. (`shared/src/commonMain/kotlin/com/devil/phoenixproject/util/BackupModels.kt`)
- Populate `display_multiplier` on restore from `WorkoutSessionBackup.displayMultiplier` in both streaming and non-streaming import paths instead of forcing `null`. (`shared/src/commonMain/kotlin/com/devil/phoenixproject/util/DataBackupManager.kt`)
- Populate `displayMultiplier` when exporting sessions to backups so the value round-trips. (`shared/src/commonMain/kotlin/com/devil/phoenixproject/util/DataBackupManager.kt`)

### Testing
- Ran `./gradlew :shared:compileKotlinMetadata -Pskip.supabase.check=true` which completed successfully.
- Running `./gradlew :shared:compileKotlinMetadata` without `-Pskip.supabase.check=true` failed in this environment due to missing Supabase credentials (expected in CI/local dev).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10c25e9c488322a0a04a98ec4e3c39)