### PR TITLE
[Follow-up to #453] Fix HealthKit export title multiplier fallback for legacy sessions

### DIFF
--- a/shared/src/iosMain/kotlin/com/devil/phoenixproject/data/integration/HealthIntegration.ios.kt
+++ b/shared/src/iosMain/kotlin/com/devil/phoenixproject/data/integration/HealthIntegration.ios.kt
@@ -2,6 +2,7 @@ package com.devil.phoenixproject.data.integration
 
 import co.touchlab.kermit.Logger
 import com.devil.phoenixproject.domain.model.WorkoutSession
+import com.devil.phoenixproject.domain.model.displayLoadMultiplier
 import kotlinx.coroutines.suspendCancellableCoroutine
 import platform.Foundation.NSDate
 import platform.Foundation.NSError
@@ -348,14 +349,14 @@ actual class HealthIntegration {
 
     /**
      * Builds a human-readable title for the exercise session.
-     * Total weight shown is per-cable x persisted cableCount when available.
+     * Total weight shown is per-cable x persisted display load multiplier.
      *
-     * Defaults to 1 if cableCount is null. This preserves Android/iOS Health title parity (Issue #358).
+     * Uses legacy-safe multiplier fallback: displayMultiplier -> cableCount -> 1.
      */
     private fun buildExerciseTitle(session: WorkoutSession): String {
         val exerciseName = session.exerciseName?.takeIf { it.isNotBlank() } ?: "Phoenix Workout"
         val totalWeightKg = session.weightPerCableKg *
-            (session.cableCount ?: 1).toFloat()
+            session.displayLoadMultiplier().toFloat()
         return if (totalWeightKg > 0f) {
             "$exerciseName — ${totalWeightKg.toInt()}kg"
         } else {


### PR DESCRIPTION
### Motivation
- Ensure iOS HealthKit workout titles preserve historical total-weight semantics by honoring the legacy `displayMultiplier` when present instead of always using `cableCount`, preventing under/over-reporting for migrated or older sessions.

### Description
- Import and use the domain helper `displayLoadMultiplier()` and compute `session.displayLoadMultiplier().toFloat()` when building HealthKit exercise titles instead of `(session.cableCount ?: 1).toFloat()`.
- Update the `buildExerciseTitle` documentation to state the multiplier fallback chain (`displayMultiplier -> cableCount -> 1`).

### Testing
- Attempted to run the targeted unit test with `./gradlew :shared:testDebugUnitTest --tests "com.devil.phoenixproject.presentation.util.WeightDisplayRegressionTest"` but the build was blocked by the Supabase credential check and failed.
- Retried with `-Pskip.supabase.check=true` but the requested task `:shared:testDebugUnitTest` does not exist for this KMP module, so the test run did not execute.
- Inspected available tasks with `./gradlew :shared:tasks --all -Pskip.supabase.check=true` to validate test task names, which completed successfully.
- Verified the shared module compiles metadata with `./gradlew :shared:compileKotlinMetadata -Pskip.supabase.check=true`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10f0e0d878832292561e8da5fb32f2)