### PR TITLE
[PR #453 follow-up] Preserve per-cable HUD display for dual-handle exercises

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/Exercise.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/Exercise.kt
@@ -60,11 +60,25 @@ data class Exercise(
         }
 
     /**
+     * Whether this exercise uses a unified attachment (bar/belt) that combines
+     * both cables into one effective load for user-facing display.
+     */
+    private val usesUnifiedAttachment: Boolean
+        get() {
+            val equipmentParts = equipment.split(",").map { it.trim().uppercase() }
+            return equipmentParts.any { it == "BAR" || it == "BELT" }
+        }
+
+    /**
      * Cable count for UI surfaces that need a deterministic label or selected
      * control state even when calculation semantics remain heuristic-driven.
      */
     val displayCableCount: Int
-        get() = preferredCableCount ?: 1
+        get() = userCableCount ?: when (cableIntent) {
+            ExerciseCableIntent.SINGLE -> 1
+            ExerciseCableIntent.DUAL -> if (usesUnifiedAttachment) 2 else 1
+            ExerciseCableIntent.EITHER, null -> 1
+        }
 
     companion object {
         /** Equipment that physically attaches to the machine's cables */

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/ExerciseTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/ExerciseTest.kt
@@ -95,4 +95,31 @@ class ExerciseTest {
         assertEquals(2, userOverride.preferredCableCount)
     }
 
+    @Test
+    fun `displayCableCount preserves per-cable display for dual handles unless unified or overridden`() {
+        val dualHandles = Exercise(
+            name = "Dual Handle Curl",
+            muscleGroup = "Biceps",
+            cableIntent = ExerciseCableIntent.DUAL,
+            equipment = "HANDLES",
+        )
+        val dualBar = Exercise(
+            name = "Dual Bar Row",
+            muscleGroup = "Back",
+            cableIntent = ExerciseCableIntent.DUAL,
+            equipment = "BAR",
+        )
+        val dualHandleOverride = Exercise(
+            name = "Dual Handle Override",
+            muscleGroup = "Back",
+            cableIntent = ExerciseCableIntent.DUAL,
+            equipment = "HANDLES",
+            userCableCount = 2,
+        )
+
+        assertEquals(1, dualHandles.displayCableCount)
+        assertEquals(2, dualBar.displayCableCount)
+        assertEquals(2, dualHandleOverride.displayCableCount)
+    }
+
 }


### PR DESCRIPTION
### Motivation
- Fix a high-priority regression where mapping every `ExerciseCableIntent.DUAL` to a two-cable display removed the unified-accessory guard and caused HUD/labels to show doubled loads for dual-handle (per-cable) exercises.
- Restore predictable UI semantics so dual-handle (independent) accessories remain per-cable unless an explicit override or a unified attachment is present.

### Description
- Added a private helper `usesUnifiedAttachment` to `Exercise` that returns true for unified accessories (`BAR` / `BELT`).
- Changed `displayCableCount` to honor `userCableCount` first and to return `2` for dual intent only when `usesUnifiedAttachment` is true, otherwise return per-cable `1` for dual-handle accessories.
- Kept `preferredCableCount` behavior unchanged so summary/telemetry calculations still treat explicit dual metadata as `2`.
- Added a unit test `displayCableCount preserves per-cable display for dual handles unless unified or overridden` covering dual+HANDLES => `1`, dual+BAR => `2`, and dual+HANDLES with `userCableCount=2` => `2`.

### Testing
- Added a new `ExerciseTest` case under `shared/src/commonTest` that verifies the three display scenarios and compiles in the test source tree.
- Attempted to run `:shared:test` and it failed because the task name is ambiguous in this KMP project, so the specific unit test could not be executed that way.
- Attempted `:shared:testAndroid` and test-scoped runs, but execution was blocked in this environment due to missing Android SDK and initial Supabase configuration checks; no test run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10f0e81520832283a4b44ae61849f2)