### PR TITLE
Preserve display multiplier on synced session inserts

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt
@@ -276,7 +276,7 @@ class SqlDelightSyncRepository(
                         serverId = dto.serverId,
                         deletedAt = dto.deletedAt,
                         profile_id = userProfileRepository.activeProfile.value?.id ?: "default",
-                        display_multiplier = null,
+                        display_multiplier = session.displayMultiplier?.toLong(),
                     )
                 }
             }
@@ -880,7 +880,7 @@ class SqlDelightSyncRepository(
                         formScore = session.formScore?.toLong(),
                         updatedAt = session.timestamp, // Mark as already-synced to prevent re-push
                         profile_id = session.profileId,
-                        display_multiplier = null,
+                        display_multiplier = session.displayMultiplier?.toLong(),
                     )
                 }
             }
@@ -1495,7 +1495,7 @@ class SqlDelightSyncRepository(
                         formScore = session.formScore?.toLong(),
                         updatedAt = session.timestamp, // Mark as already-synced
                         profile_id = profileId,
-                        display_multiplier = null,
+                        display_multiplier = session.displayMultiplier?.toLong(),
                     )
                 }
 


### PR DESCRIPTION
### Motivation
- Pulled `WorkoutSession` imports were being inserted with `display_multiplier = null`, which silently dropped persisted display/load semantics for legacy rows where `cableCount` is absent.
- Overwriting an incoming `displayMultiplier` on pull can corrupt historical sessions and break downstream history, analytics, and export logic that rely on the persisted multiplier.
- The change ensures imported sessions retain the display semantics provided by the server or backup during sync.

### Description
- Updated `shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt` to set `display_multiplier = session.displayMultiplier?.toLong()` instead of `null` for pulled session inserts. 
- Applied the fix in the single-session merge path (`mergePortalSessions` / portal session loop) and in the transactional bulk pull path (`mergeAllPullData`) so both import flows preserve the incoming multiplier value. 
- The change uses the existing `displayMultiplier` property on `WorkoutSession` and converts it to `Long` for the `display_multiplier` column to maintain type consistency.

### Testing
- Ran `./gradlew :shared:compileKotlinMetadata` which failed in this environment due to missing Supabase credentials. 
- Ran `./gradlew :shared:compileKotlinMetadata -Pskip.supabase.check=true` which completed successfully and reported schema validation (build successful).
- The modified code paths were compiled as part of the metadata build and no compilation errors were observed when skipping the Supabase check.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10f661180c8322a3b2c9bc8cfe917d)