### PR TITLE
fix: resolve routine auto-start (#462) and early load dump on warmups…

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -2005,7 +2005,7 @@ class ActiveSessionEngine(
         return baseParams.copy(
             weightPerCableKg = warmupWeight,
             reps = reps,
-            warmupReps = 0,
+            warmupReps = Constants.DEFAULT_WARMUP_REPS,
             isAMRAP = false,
         )
     }
@@ -2241,7 +2241,7 @@ class ActiveSessionEngine(
                         effectiveParams.copy(
                             weightPerCableKg = warmupWeight,
                             reps = warmupSet.reps,
-                            warmupReps = 0, // No firmware warmup for variable warm-up sets
+                            warmupReps = Constants.DEFAULT_WARMUP_REPS, // Preserving 3-rep firmware warmup buffer for calibration
                             isAMRAP = false, // Warm-up sets are always fixed reps
                         )
                     } else {
@@ -2327,18 +2327,16 @@ class ActiveSessionEngine(
                 } else {
                     repCounter.reset()
                 }
-                // Issue #357: Use warmupOverrideParams (the actual BLE params) for rep counter
-                // configuration. During variable warm-up sets, effectiveParams still has
-                // warmupReps=3 (firmware ramp), but warmupOverrideParams correctly has
-                // warmupReps=0 since variable warm-up sets handle their own weight scaling.
-                // Using effectiveParams caused the rep counter to misclassify the first 3
-                // reps of each warm-up set as firmware warmup reps, making sets appear to
-                // end 3 reps early and corrupting weight tracking.
+                // Issue #411: Keep the 3-rep firmware warmup buffer (warmupReps = 3) for variable
+                // warm-up sets. Because the machine firmware always consumes the first 3 reps
+                // for ROM/cable calibration before incrementing repsSetCount, setting warmupReps = 0
+                // in the BLE command reduced the machine's total capacity, causing the machine to
+                // dump the load 3 reps early. By setting warmupReps = 3, the machine allows the full
+                // count of working reps, and the rep counter correctly counts the first 3 calibration
+                // reps as warmup and the remaining as working.
                 val repCounterWarmupTarget = if (hasVariableWarmupOverrideApplied) {
-                    // Variable warm-up set active: firmware warmup is intentionally disabled (0)
                     warmupOverrideParams.warmupReps
                 } else {
-                    // Normal cable sets: mirror machine firmware warmup target (typically 3)
                     effectiveParams.warmupReps
                 }
                 repCounter.configure(

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RoutineOverviewScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RoutineOverviewScreen.kt
@@ -122,18 +122,36 @@ fun RoutineOverviewScreen(navController: NavController, viewModel: MainViewModel
     if (routine == null) {
         return
     }
-
     // Issue #190: Auto-start routine — skip overview and enter SetReady for exercise 0
     // Uses a one-shot flag to prevent re-triggering on recomposition or back-navigation.
     // Guard conditions: pref enabled, routine non-empty, BLE connected, no resumable progress.
     var autoStartFired by remember { mutableStateOf(false) }
+
+    // 1. Attempt auto-connection once when entering the screen if auto-start is enabled.
+    // We exclude connectionState from the keys to avoid infinite loops on connection failure/cancellation.
     LaunchedEffect(routine.id, userPreferences.autoStartRoutine) {
+        if (
+            userPreferences.autoStartRoutine &&
+            routine.exercises.isNotEmpty() &&
+            !viewModel.hasResumableProgress(routine.id) &&
+            connectionState is ConnectionState.Disconnected
+        ) {
+            Logger.d("AutoStart") { "AutoStart: routine auto-start active but disconnected, initiating connection" }
+            viewModel.ensureConnection(
+                onConnected = { /* Handled by the navigation LaunchedEffect */ },
+                onFailed = {}
+            )
+        }
+    }
+
+    // 2. Handle the actual auto-start navigation when connected.
+    LaunchedEffect(routine.id, userPreferences.autoStartRoutine, connectionState) {
         if (
             !autoStartFired &&
             userPreferences.autoStartRoutine &&
             routine.exercises.isNotEmpty() &&
-            connectionState is ConnectionState.Connected &&
-            !viewModel.hasResumableProgress(routine.id)
+            !viewModel.hasResumableProgress(routine.id) &&
+            connectionState is ConnectionState.Connected
         ) {
             autoStartFired = true
             Logger.d("AutoStart") { "AutoStart: skipping overview, entering SetReady for exercise 0" }


### PR DESCRIPTION
… (#411) (#463)

* fix: resolve routine auto-start (#462) and early load dump on warmups (#411)

- Collects connectionState as LaunchedEffect key in RoutineOverviewScreen to trigger auto-start upon device connection, and auto-starts scan/connection if disconnected.
- Retains 3-rep firmware calibration/warmup buffer for variable warmups in ActiveSessionEngine to prevent early load dumping by the trainer machine.

* fix(presentation): split auto-start LaunchedEffects to prevent connection loops

Splits auto-start connection initiation and auto-start navigation into two separate LaunchedEffects. The connection initiation effect excludes connectionState from its keys, preventing infinite auto-connect loops when a connection fails or is cancelled by the user.