### PR TITLE
Fix stale "Exercise Variety" recency for exercise ID/name variants

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/premium/SmartSuggestionsEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/premium/SmartSuggestionsEngine.kt
@@ -37,6 +37,11 @@ object SmartSuggestionsEngine {
     private const val MIN_SESSIONS_FOR_OPTIMAL = 3
     private const val MIN_DISTINCT_DAYS_FOR_OPTIMAL = 2
 
+    private fun normalizedExerciseKey(session: SessionSummary): String {
+        val normalizedName = session.exerciseName.trim().lowercase()
+        return if (normalizedName.isNotEmpty()) normalizedName else session.exerciseId
+    }
+
     /**
      * SUGG-01: Compute weekly volume per muscle group.
      * Filters sessions from current 7-day window (nowMs - 7 days to nowMs).
@@ -156,7 +161,7 @@ object SmartSuggestionsEngine {
     fun findNeglectedExercises(sessions: List<SessionSummary>, nowMs: Long): List<NeglectedExercise> {
         // For each exercise, find the most recent session
         val latestByExercise = sessions
-            .groupBy { it.exerciseId }
+            .groupBy { normalizedExerciseKey(it) }
             .mapValues { (_, exerciseSessions) -> exerciseSessions.maxBy { it.timestamp } }
 
         return latestByExercise.values

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/premium/SmartSuggestionsEngineTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/premium/SmartSuggestionsEngineTest.kt
@@ -184,6 +184,21 @@ class SmartSuggestionsEngineTest {
         assertTrue(neglected.isEmpty()) // 5 days < 14 day threshold
     }
 
+    @Test
+    fun neglectedUsesLatestSessionAcrossExerciseIdVariantsWithSameName() {
+        val sessions = listOf(
+            session(exerciseId = "legacy-shoulder-press", exerciseName = "Shoulder Press", timestamp = NOW - ONE_DAY_MS * 59),
+            session(exerciseId = "new-shoulder-press", exerciseName = "Shoulder Press ", timestamp = NOW - ONE_DAY_MS * 7),
+        )
+
+        val neglected = SmartSuggestionsEngine.findNeglectedExercises(sessions, NOW)
+
+        assertTrue(
+            neglected.none { it.exerciseName.trim().equals("Shoulder Press", ignoreCase = true) },
+            "Exercise variants with same display name should use the most recent performed date",
+        )
+    }
+
     // ==========================================================
     // SUGG-04: Plateau Detection
     // ==========================================================


### PR DESCRIPTION
## Summary
- fix neglected-exercise grouping in `SmartSuggestionsEngine.findNeglectedExercises` so recency is calculated across exercise-ID variants that share the same display name
- normalize grouping key using trimmed, lowercased `exerciseName` (fallback to `exerciseId` if name is blank)
- add regression test covering a real-world case where an older legacy ID and a newer ID both map to "Shoulder Press"

## Why
Issue #468 reports `Insights > Exercise Variety` showing an exercise as neglected (e.g., "59 days ago") even though it was trained recently in Analytics. This happens when history contains multiple IDs/variants for the same exercise label, and the old logic grouped strictly by `exerciseId`.

## Files changed
- `shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/premium/SmartSuggestionsEngine.kt`
- `shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/premium/SmartSuggestionsEngineTest.kt`

## Validation
- Static review only (no runtime/test execution in this pass).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12687e619483229c3daab5c00a08e5)