### PR TITLE
Implement mobile API feature architecture for expanded integration sync

### DIFF
--- a/.cursor/hooks/state/continual-learning.json
+++ b/.cursor/hooks/state/continual-learning.json
@@ -1,0 +1,8 @@
+{
+  "version": 1,
+  "lastRunAtMs": 0,
+  "turnsSinceLastRun": 3,
+  "lastTranscriptMtimeMs": null,
+  "lastProcessedGenerationId": "3451d0a9-4f8d-4414-93ac-ef23bc24ecbd",
+  "trialStartedAtMs": null
+}

--- a/.cursor/hooks/state/continual-learning.json
+++ b/.cursor/hooks/state/continual-learning.json
@@ -1,8 +1,0 @@
-{
-  "version": 1,
-  "lastRunAtMs": 0,
-  "turnsSinceLastRun": 3,
-  "lastTranscriptMtimeMs": null,
-  "lastProcessedGenerationId": "3451d0a9-4f8d-4414-93ac-ef23bc24ecbd",
-  "trialStartedAtMs": null
-}

--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ LAST_SESSION.md
 CHANGELOG.md
 .aider*
 /.devilmcp/
+/.cursor/hooks/state/
 
 # Reference/decompiled code (not for distribution)
 /reference/

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -208,8 +208,8 @@ sqldelight {
     databases {
         create("VitruvianDatabase") {
             packageName.set("com.devil.phoenixproject.database")
-            // Version 31 = initial schema (1) + 30 migrations (1.sqm through 30.sqm).
-            version = 31
+            // Version 32 = initial schema (1) + 31 migrations (1.sqm through 31.sqm).
+            version = 32
         }
     }
 }

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExternalProgramsViewModelTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExternalProgramsViewModelTest.kt
@@ -1,0 +1,91 @@
+package com.devil.phoenixproject.presentation.viewmodel
+
+import com.devil.phoenixproject.data.integration.IntegrationManager
+import com.devil.phoenixproject.data.sync.IntegrationPlaygroundPreviewDto
+import com.devil.phoenixproject.data.sync.IntegrationPlaygroundSimulationResponse
+import com.devil.phoenixproject.domain.model.ExternalProgram
+import com.devil.phoenixproject.domain.model.IntegrationProvider
+import com.devil.phoenixproject.testutil.FakeExternalActivityRepository
+import com.devil.phoenixproject.testutil.FakeExternalExerciseTemplateRepository
+import com.devil.phoenixproject.testutil.FakeExternalMeasurementRepository
+import com.devil.phoenixproject.testutil.FakeExternalProgramRepository
+import com.devil.phoenixproject.testutil.FakeExternalRoutineRepository
+import com.devil.phoenixproject.testutil.FakeIntegrationSyncCursorRepository
+import com.devil.phoenixproject.testutil.FakePortalApiClient
+import com.devil.phoenixproject.testutil.FakeUserProfileRepository
+import com.devil.phoenixproject.testutil.TestCoroutineRule
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+
+class ExternalProgramsViewModelTest {
+
+    @get:Rule
+    val testCoroutineRule = TestCoroutineRule()
+
+    @Test
+    fun commitPreviewDoesNotUpdateDifferentProgram() = runTest {
+        val programRepository = FakeExternalProgramRepository()
+        val apiClient = FakePortalApiClient()
+        val userProfileRepository = FakeUserProfileRepository().apply {
+            setActiveProfileForTest(id = "profile-1")
+        }
+        val programA = ExternalProgram(
+            id = "program-local-a",
+            externalId = "program-a",
+            provider = IntegrationProvider.LIFTOSAUR,
+            name = "Program A",
+            scriptText = "old A",
+            profileId = "profile-1",
+        )
+        val programB = ExternalProgram(
+            id = "program-local-b",
+            externalId = "program-b",
+            provider = IntegrationProvider.LIFTOSAUR,
+            name = "Program B",
+            scriptText = "old B",
+            profileId = "profile-1",
+        )
+        programRepository.upsertPrograms(listOf(programA, programB))
+        apiClient.playgroundSimulationResult = Result.success(
+            IntegrationPlaygroundSimulationResponse(
+                status = "ok",
+                preview = IntegrationPlaygroundPreviewDto(
+                    programExternalId = programA.externalId,
+                    updatedProgramText = "new A",
+                ),
+            ),
+        )
+        val viewModel = ExternalProgramsViewModel(
+            repository = programRepository,
+            integrationManager = createIntegrationManager(apiClient, programRepository),
+            userProfileRepository = userProfileRepository,
+        )
+        advanceUntilIdle()
+
+        viewModel.simulateProgram(programA)
+        advanceUntilIdle()
+        viewModel.commitPreview(programB)
+        advanceUntilIdle()
+
+        assertEquals("old B", programRepository.programs.single { it.id == programB.id }.scriptText)
+        assertEquals(false, programRepository.programs.single { it.id == programB.id }.needsSync)
+        assertNull(viewModel.uiState.value.playgroundPreview)
+    }
+
+    private fun createIntegrationManager(
+        apiClient: FakePortalApiClient,
+        programRepository: FakeExternalProgramRepository,
+    ) = IntegrationManager(
+        apiClient = apiClient,
+        activityRepository = FakeExternalActivityRepository(),
+        routineRepository = FakeExternalRoutineRepository(),
+        programRepository = programRepository,
+        measurementRepository = FakeExternalMeasurementRepository(),
+        templateRepository = FakeExternalExerciseTemplateRepository(),
+        cursorRepository = FakeIntegrationSyncCursorRepository(),
+    )
+}

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/integration/ExternalActivityRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/integration/ExternalActivityRepository.kt
@@ -46,6 +46,18 @@ interface ExternalActivityRepository {
     suspend fun markSyncedBySyncKeys(syncKeys: List<ExternalActivitySyncKey>, profileId: String)
 
     /**
+     * Mark provider-deleted activities as tombstoned while preserving the local row for
+     * sync/conflict history.
+     */
+    suspend fun markDeletedByExternalIds(
+        provider: IntegrationProvider,
+        profileId: String,
+        externalIds: List<String>,
+        deletedAt: Long,
+        needsSync: Boolean,
+    )
+
+    /**
      * Delete all activities from a specific provider for a given profile.
      * Used when disconnecting an integration.
      */

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/integration/ExternalIntegrationRepositories.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/integration/ExternalIntegrationRepositories.kt
@@ -1,0 +1,61 @@
+package com.devil.phoenixproject.data.integration
+
+import com.devil.phoenixproject.domain.model.ExternalBodyMeasurement
+import com.devil.phoenixproject.domain.model.ExternalExerciseTemplate
+import com.devil.phoenixproject.domain.model.ExternalExerciseTemplateMapping
+import com.devil.phoenixproject.domain.model.ExternalProgram
+import com.devil.phoenixproject.domain.model.ExternalProgramStats
+import com.devil.phoenixproject.domain.model.ExternalRoutine
+import com.devil.phoenixproject.domain.model.ExternalRoutineFolder
+import com.devil.phoenixproject.domain.model.IntegrationProvider
+import kotlinx.coroutines.flow.Flow
+
+data class IntegrationSyncCursor(
+    val provider: IntegrationProvider,
+    val profileId: String,
+    val cursorType: String,
+    val cursorValue: String?,
+    val updatedAt: Long,
+)
+
+interface ExternalRoutineRepository {
+    fun observeRoutines(profileId: String, provider: IntegrationProvider? = null): Flow<List<ExternalRoutine>>
+    fun observeFolders(profileId: String, provider: IntegrationProvider? = null): Flow<List<ExternalRoutineFolder>>
+    suspend fun upsertRoutines(routines: List<ExternalRoutine>)
+    suspend fun upsertFolders(folders: List<ExternalRoutineFolder>)
+    suspend fun deleteProviderRoutines(provider: IntegrationProvider, profileId: String)
+}
+
+interface ExternalProgramRepository {
+    fun observePrograms(profileId: String, provider: IntegrationProvider? = null): Flow<List<ExternalProgram>>
+    fun observeCurrentProgram(profileId: String, provider: IntegrationProvider): Flow<ExternalProgram?>
+    fun observeProgramStats(profileId: String, provider: IntegrationProvider? = null): Flow<Map<String, ExternalProgramStats>>
+    suspend fun findProgram(provider: IntegrationProvider, externalId: String, profileId: String): ExternalProgram?
+    suspend fun upsertPrograms(programs: List<ExternalProgram>)
+    suspend fun upsertStats(stats: List<ExternalProgramStats>)
+    suspend fun updateProgramText(programId: String, scriptText: String, markNeedsSync: Boolean)
+    suspend fun deleteProviderPrograms(provider: IntegrationProvider, profileId: String)
+}
+
+interface ExternalMeasurementRepository {
+    fun observeMeasurements(profileId: String, provider: IntegrationProvider? = null): Flow<List<ExternalBodyMeasurement>>
+    fun observeMeasurementsByType(profileId: String, measurementType: String): Flow<List<ExternalBodyMeasurement>>
+    suspend fun upsertMeasurements(measurements: List<ExternalBodyMeasurement>)
+    suspend fun deleteProviderMeasurements(provider: IntegrationProvider, profileId: String)
+}
+
+interface ExternalExerciseTemplateRepository {
+    fun observeTemplates(profileId: String, provider: IntegrationProvider? = null): Flow<List<ExternalExerciseTemplate>>
+    fun observeTemplateCounts(profileId: String): Flow<Map<IntegrationProvider, Int>>
+    suspend fun upsertTemplates(templates: List<ExternalExerciseTemplate>)
+    suspend fun findTemplate(provider: IntegrationProvider, externalId: String, profileId: String): ExternalExerciseTemplate?
+    suspend fun upsertMapping(mapping: ExternalExerciseTemplateMapping)
+    suspend fun findMapping(provider: IntegrationProvider, externalTemplateId: String, profileId: String): ExternalExerciseTemplateMapping?
+    suspend fun deleteProviderTemplates(provider: IntegrationProvider, profileId: String)
+}
+
+interface IntegrationSyncCursorRepository {
+    suspend fun getCursor(provider: IntegrationProvider, profileId: String, cursorType: String): IntegrationSyncCursor?
+    suspend fun upsertCursor(cursor: IntegrationSyncCursor)
+    suspend fun deleteProviderCursors(provider: IntegrationProvider, profileId: String)
+}

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/integration/ExternalIntegrationRepositories.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/integration/ExternalIntegrationRepositories.kt
@@ -31,6 +31,8 @@ interface ExternalProgramRepository {
     fun observeCurrentProgram(profileId: String, provider: IntegrationProvider): Flow<ExternalProgram?>
     fun observeProgramStats(profileId: String, provider: IntegrationProvider? = null): Flow<Map<String, ExternalProgramStats>>
     suspend fun findProgram(provider: IntegrationProvider, externalId: String, profileId: String): ExternalProgram?
+    suspend fun findPrograms(provider: IntegrationProvider, externalIds: List<String>, profileId: String): List<ExternalProgram> =
+        externalIds.mapNotNull { externalId -> findProgram(provider, externalId, profileId) }
     suspend fun upsertPrograms(programs: List<ExternalProgram>)
     suspend fun upsertStats(stats: List<ExternalProgramStats>)
     suspend fun updateProgramText(programId: String, scriptText: String, markNeedsSync: Boolean)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/integration/IntegrationManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/integration/IntegrationManager.kt
@@ -2,188 +2,111 @@ package com.devil.phoenixproject.data.integration
 
 import co.touchlab.kermit.Logger
 import com.devil.phoenixproject.data.sync.IntegrationActivityDto
+import com.devil.phoenixproject.data.sync.IntegrationBodyMeasurementDto
+import com.devil.phoenixproject.data.sync.IntegrationEntityErrorDto
+import com.devil.phoenixproject.data.sync.IntegrationExerciseTemplateDto
+import com.devil.phoenixproject.data.sync.IntegrationPlaygroundPreviewDto
+import com.devil.phoenixproject.data.sync.IntegrationPlaygroundSimulationRequest
+import com.devil.phoenixproject.data.sync.IntegrationProgramDto
+import com.devil.phoenixproject.data.sync.IntegrationProgramStatsDto
+import com.devil.phoenixproject.data.sync.IntegrationRoutineDto
+import com.devil.phoenixproject.data.sync.IntegrationRoutineExerciseDto
+import com.devil.phoenixproject.data.sync.IntegrationRoutineFolderDto
+import com.devil.phoenixproject.data.sync.IntegrationRoutineSetDto
 import com.devil.phoenixproject.data.sync.IntegrationSyncRequest
+import com.devil.phoenixproject.data.sync.IntegrationSyncResponse
 import com.devil.phoenixproject.data.sync.PortalApiClient
 import com.devil.phoenixproject.domain.model.ConnectionStatus
 import com.devil.phoenixproject.domain.model.ExternalActivity
+import com.devil.phoenixproject.domain.model.ExternalBodyMeasurement
+import com.devil.phoenixproject.domain.model.ExternalExerciseTemplate
+import com.devil.phoenixproject.domain.model.ExternalPlaygroundPreview
+import com.devil.phoenixproject.domain.model.ExternalProgram
+import com.devil.phoenixproject.domain.model.ExternalProgramStats
+import com.devil.phoenixproject.domain.model.ExternalRoutine
+import com.devil.phoenixproject.domain.model.ExternalRoutineExercise
+import com.devil.phoenixproject.domain.model.ExternalRoutineFolder
+import com.devil.phoenixproject.domain.model.ExternalRoutineSet
+import com.devil.phoenixproject.domain.model.IntegrationEntitlementState
 import com.devil.phoenixproject.domain.model.IntegrationProvider
+import com.devil.phoenixproject.domain.model.IntegrationSyncProgress
+import com.devil.phoenixproject.domain.model.IntegrationSyncResult
+import com.devil.phoenixproject.domain.model.IntegrationSyncWarning
 import com.devil.phoenixproject.domain.model.currentTimeMillis
 import com.devil.phoenixproject.domain.model.generateUUID
 import kotlinx.datetime.Instant
 
-/**
- * Manages third-party integration lifecycle: connect, sync, and disconnect.
- *
- * Delegates network calls to [PortalApiClient] and persists results via
- * [ExternalActivityRepository]. Status updates are written transactionally
- * so local state always reflects the last known portal outcome.
- */
-class IntegrationManager(private val apiClient: PortalApiClient, private val repository: ExternalActivityRepository) {
+private const val MAX_SYNC_PAGES_PER_ENTITY = 50
 
-    /**
-     * Connect a provider by submitting an API key to the portal Edge Function.
-     * On success, the returned activities are upserted locally and the
-     * integration status is set to CONNECTED.
-     *
-     * @param provider  The integration provider to connect.
-     * @param apiKey    The user-supplied API key for the provider.
-     * @param profileId The local profile ID scoping the data.
-     * @param isPaidUser Whether the user has an active paid subscription.
-     *                   Activities get [ExternalActivity.needsSync] = true only for paid users.
-     */
+/**
+ * Multi-entity coordinator for third-party integrations.
+ *
+ * Mobile still talks only to the portal integration endpoint. The manager maps
+ * the expanded payload into focused local repositories and keeps the previous
+ * activity-only response shape backward compatible.
+ */
+class IntegrationManager(
+    private val apiClient: PortalApiClient,
+    private val activityRepository: ExternalActivityRepository,
+    private val routineRepository: ExternalRoutineRepository,
+    private val programRepository: ExternalProgramRepository,
+    private val measurementRepository: ExternalMeasurementRepository,
+    private val templateRepository: ExternalExerciseTemplateRepository,
+    private val cursorRepository: IntegrationSyncCursorRepository,
+) {
     suspend fun connectProvider(
         provider: IntegrationProvider,
         apiKey: String,
         profileId: String,
         isPaidUser: Boolean,
-    ): Result<List<ExternalActivity>> {
+    ): Result<IntegrationSyncResult> {
         Logger.d("IntegrationManager") { "Connecting provider ${provider.key}" }
-
-        val request = IntegrationSyncRequest(
-            provider = provider.key,
+        return syncProviderInternal(
+            provider = provider,
             action = "connect",
             apiKey = apiKey,
-        )
-
-        return apiClient.callIntegrationSync(request).fold(
-            onSuccess = { response ->
-                if (response.status == "error") {
-                    Logger.w("IntegrationManager") {
-                        "Connect responded with error for ${provider.key}: ${response.error}"
-                    }
-                    repository.updateIntegrationStatus(
-                        provider = provider,
-                        status = ConnectionStatus.ERROR,
-                        profileId = profileId,
-                        errorMessage = response.error,
-                    )
-                    Result.failure(Exception(response.error ?: "Unknown error from portal"))
-                } else {
-                    val activities = response.activities.map { dto ->
-                        dto.toDomain(provider, profileId, isPaidUser)
-                    }
-                    if (activities.isNotEmpty()) {
-                        repository.upsertActivities(activities)
-                    }
-                    repository.updateIntegrationStatus(
-                        provider = provider,
-                        status = ConnectionStatus.CONNECTED,
-                        profileId = profileId,
-                        lastSyncAt = currentTimeMillis(),
-                    )
-                    Logger.i("IntegrationManager") {
-                        "Connected ${provider.key}: ${activities.size} activities"
-                    }
-                    Result.success(activities)
-                }
-            },
-            onFailure = { error ->
-                Logger.e("IntegrationManager") {
-                    "Connect failed for ${provider.key}: ${error.message}"
-                }
-                repository.updateIntegrationStatus(
-                    provider = provider,
-                    status = ConnectionStatus.ERROR,
-                    profileId = profileId,
-                    errorMessage = error.message,
-                )
-                Result.failure(error)
-            },
+            profileId = profileId,
+            isPaidUser = isPaidUser,
+            startCursor = null,
         )
     }
 
-    /**
-     * Sync a previously connected provider. No API key is needed — the portal
-     * uses the stored token for the provider.
-     *
-     * @param provider  The integration provider to sync.
-     * @param profileId The local profile ID scoping the data.
-     * @param isPaidUser Whether the user has an active paid subscription.
-     */
-    suspend fun syncProvider(provider: IntegrationProvider, profileId: String, isPaidUser: Boolean): Result<List<ExternalActivity>> {
+    suspend fun syncProvider(
+        provider: IntegrationProvider,
+        profileId: String,
+        isPaidUser: Boolean,
+    ): Result<IntegrationSyncResult> {
         Logger.d("IntegrationManager") { "Syncing provider ${provider.key}" }
-
-        val request = IntegrationSyncRequest(
-            provider = provider.key,
+        val startCursor = cursorRepository.getCursor(provider, profileId, "integration_sync")?.cursorValue
+        return syncProviderInternal(
+            provider = provider,
             action = "sync",
-        )
-
-        return apiClient.callIntegrationSync(request).fold(
-            onSuccess = { response ->
-                if (response.status == "error") {
-                    Logger.w("IntegrationManager") {
-                        "Sync responded with error for ${provider.key}: ${response.error}"
-                    }
-                    repository.updateIntegrationStatus(
-                        provider = provider,
-                        status = ConnectionStatus.ERROR,
-                        profileId = profileId,
-                        errorMessage = response.error,
-                    )
-                    Result.failure(Exception(response.error ?: "Unknown error from portal"))
-                } else {
-                    val activities = response.activities.map { dto ->
-                        dto.toDomain(provider, profileId, isPaidUser)
-                    }
-                    if (activities.isNotEmpty()) {
-                        repository.upsertActivities(activities)
-                    }
-                    repository.updateIntegrationStatus(
-                        provider = provider,
-                        status = ConnectionStatus.CONNECTED,
-                        profileId = profileId,
-                        lastSyncAt = currentTimeMillis(),
-                    )
-                    Logger.i("IntegrationManager") {
-                        "Synced ${provider.key}: ${activities.size} activities"
-                    }
-                    Result.success(activities)
-                }
-            },
-            onFailure = { error ->
-                Logger.e("IntegrationManager") {
-                    "Sync failed for ${provider.key}: ${error.message}"
-                }
-                repository.updateIntegrationStatus(
-                    provider = provider,
-                    status = ConnectionStatus.ERROR,
-                    profileId = profileId,
-                    errorMessage = error.message,
-                )
-                Result.failure(error)
-            },
+            apiKey = null,
+            profileId = profileId,
+            isPaidUser = isPaidUser,
+            startCursor = startCursor,
         )
     }
 
-    /**
-     * Disconnect a provider: notifies the portal, deletes local activities,
-     * and updates status to DISCONNECTED.
-     *
-     * Portal-side disconnection failure is treated as non-critical — local
-     * data is still cleared regardless (mirrors the sign-out pattern).
-     *
-     * @param provider  The integration provider to disconnect.
-     * @param profileId The local profile ID scoping the data.
-     */
     suspend fun disconnectProvider(provider: IntegrationProvider, profileId: String): Result<Unit> {
         Logger.d("IntegrationManager") { "Disconnecting provider ${provider.key}" }
 
-        val request = IntegrationSyncRequest(
-            provider = provider.key,
-            action = "disconnect",
+        val portalResult = apiClient.callIntegrationSync(
+            IntegrationSyncRequest(provider = provider.key, action = "disconnect"),
         )
-
-        // Notify portal (best-effort; we proceed regardless of outcome)
-        val portalResult = apiClient.callIntegrationSync(request)
         portalResult.onFailure { error ->
             Logger.w("IntegrationManager") {
                 "Portal disconnect call failed for ${provider.key} (non-fatal): ${error.message}"
             }
         }
 
-        // Always clean up local state
-        repository.deleteActivities(provider, profileId)
-        repository.updateIntegrationStatus(
+        activityRepository.deleteActivities(provider, profileId)
+        routineRepository.deleteProviderRoutines(provider, profileId)
+        programRepository.deleteProviderPrograms(provider, profileId)
+        measurementRepository.deleteProviderMeasurements(provider, profileId)
+        templateRepository.deleteProviderTemplates(provider, profileId)
+        cursorRepository.deleteProviderCursors(provider, profileId)
+        activityRepository.updateIntegrationStatus(
             provider = provider,
             status = ConnectionStatus.DISCONNECTED,
             profileId = profileId,
@@ -193,25 +116,203 @@ class IntegrationManager(private val apiClient: PortalApiClient, private val rep
         return Result.success(Unit)
     }
 
-    // ─── Mapping ─────────────────────────────────────────────────────────────
+    suspend fun simulatePlayground(
+        provider: IntegrationProvider,
+        externalProgramId: String,
+        scriptText: String,
+        commands: List<String>,
+        profileId: String,
+    ): Result<ExternalPlaygroundPreview> = apiClient.callIntegrationPlaygroundSimulation(
+        IntegrationPlaygroundSimulationRequest(
+            provider = provider.key,
+            externalProgramId = externalProgramId,
+            scriptText = scriptText,
+            commands = commands,
+            profileId = profileId,
+        ),
+    ).mapCatching { response ->
+        if (response.status == "error") {
+            throw IllegalStateException(response.error ?: "Playground simulation failed")
+        }
+        val preview = response.preview ?: IntegrationPlaygroundPreviewDto(
+            programExternalId = externalProgramId,
+            updatedProgramText = response.updatedProgramText,
+        )
+        preview.toDomain()
+    }
 
-    private fun IntegrationActivityDto.toDomain(provider: IntegrationProvider, profileId: String, isPaidUser: Boolean): ExternalActivity {
-        val startEpochMillis = try {
-            Instant.parse(startedAt).toEpochMilliseconds()
-        } catch (_: Exception) {
-            Logger.w("IntegrationManager") {
-                "Could not parse startedAt '$startedAt' for $externalId — using current time"
+    suspend fun commitProgramText(programId: String, updatedProgramText: String, markNeedsSync: Boolean = true) {
+        programRepository.updateProgramText(programId, updatedProgramText, markNeedsSync)
+    }
+
+    private suspend fun syncProviderInternal(
+        provider: IntegrationProvider,
+        action: String,
+        apiKey: String?,
+        profileId: String,
+        isPaidUser: Boolean,
+        startCursor: String?,
+    ): Result<IntegrationSyncResult> {
+        var page = 0
+        var cursor = startCursor
+        var aggregate = IntegrationSyncResult(provider = provider)
+
+        while (page < MAX_SYNC_PAGES_PER_ENTITY) {
+            val request = IntegrationSyncRequest(
+                provider = provider.key,
+                action = action,
+                apiKey = if (page == 0) apiKey else null,
+                entityTypes = ALL_ENTITY_TYPES,
+                cursor = cursor,
+                includeRawData = true,
+            )
+
+            val response = apiClient.callIntegrationSync(request).getOrElse { error ->
+                Logger.e("IntegrationManager") { "$action failed for ${provider.key}: ${error.message}" }
+                activityRepository.updateIntegrationStatus(
+                    provider = provider,
+                    status = ConnectionStatus.ERROR,
+                    profileId = profileId,
+                    errorMessage = error.message,
+                )
+                return Result.failure(error)
             }
-            currentTimeMillis()
+
+            if (response.status == "error" && !response.requiresUpgrade) {
+                val message = response.error ?: "Unknown error from portal"
+                Logger.w("IntegrationManager") { "$action responded with error for ${provider.key}: $message" }
+                activityRepository.updateIntegrationStatus(
+                    provider = provider,
+                    status = ConnectionStatus.ERROR,
+                    profileId = profileId,
+                    errorMessage = message,
+                )
+                return Result.failure(Exception(message))
+            }
+
+            val pageResult = persistResponse(provider, profileId, isPaidUser, response)
+            aggregate = aggregate.merge(pageResult)
+
+            val cursorValue = response.providerSyncCursor ?: response.nextCursor
+            if (cursorValue != null) {
+                cursorRepository.upsertCursor(
+                    IntegrationSyncCursor(
+                        provider = provider,
+                        profileId = profileId,
+                        cursorType = "integration_sync",
+                        cursorValue = cursorValue,
+                        updatedAt = currentTimeMillis(),
+                    ),
+                )
+            }
+
+            if (!response.hasMore || response.nextCursor == null) break
+            cursor = response.nextCursor
+            page++
         }
 
+        if (page >= MAX_SYNC_PAGES_PER_ENTITY) {
+            aggregate = aggregate.copy(
+                partial = true,
+                warnings = aggregate.warnings + IntegrationSyncWarning(
+                    entityType = "sync",
+                    code = "page_cap_reached",
+                    message = "Stopped after $MAX_SYNC_PAGES_PER_ENTITY pages to avoid an infinite sync loop.",
+                ),
+            )
+        }
+
+        activityRepository.updateIntegrationStatus(
+            provider = provider,
+            status = ConnectionStatus.CONNECTED,
+            profileId = profileId,
+            lastSyncAt = currentTimeMillis(),
+            errorMessage = aggregate.warnings.firstOrNull()?.message,
+        )
+
+        Logger.i("IntegrationManager") {
+            "${action.replaceFirstChar { it.uppercase() }} ${provider.key}: ${aggregate.progress}"
+        }
+        return Result.success(aggregate)
+    }
+
+    private suspend fun persistResponse(
+        provider: IntegrationProvider,
+        profileId: String,
+        isPaidUser: Boolean,
+        response: IntegrationSyncResponse,
+    ): IntegrationSyncResult {
+        val activities = response.activities.map { it.toDomain(provider, profileId, isPaidUser) }
+        val folders = response.routineFolders.map { it.toDomain(provider, profileId) }
+        val routines = response.routines.map { it.toDomain(provider, profileId) }
+        val templates = response.exerciseTemplates.map { it.toDomain(provider, profileId) }
+        val measurements = response.bodyMeasurements.map { it.toDomain(provider, profileId) }
+        val programs = response.programs.map { it.toDomain(provider, profileId) }
+
+        if (activities.isNotEmpty()) activityRepository.upsertActivities(activities)
+        if (response.deletedExternalIds.isNotEmpty()) {
+            activityRepository.markDeletedByExternalIds(
+                provider = provider,
+                profileId = profileId,
+                externalIds = response.deletedExternalIds,
+                deletedAt = currentTimeMillis(),
+                needsSync = isPaidUser,
+            )
+        }
+        if (folders.isNotEmpty()) routineRepository.upsertFolders(folders)
+        if (routines.isNotEmpty()) routineRepository.upsertRoutines(routines)
+        if (templates.isNotEmpty()) templateRepository.upsertTemplates(templates)
+        if (measurements.isNotEmpty()) measurementRepository.upsertMeasurements(measurements)
+        if (programs.isNotEmpty()) programRepository.upsertPrograms(programs)
+
+        val stats = response.programStats.mapNotNull { dto ->
+            val localProgram = programRepository.findProgram(provider, dto.externalProgramId, profileId)
+            if (localProgram == null) {
+                Logger.w("IntegrationManager") {
+                    "Skipping stats for missing ${provider.key} program ${dto.externalProgramId}"
+                }
+                null
+            } else {
+                dto.toDomain(localProgram.id)
+            }
+        }
+        if (stats.isNotEmpty()) programRepository.upsertStats(stats)
+
+        val warnings = response.errors.map { it.toWarning() }
+        val entitlementState = response.toEntitlementState(provider)
+
+        return IntegrationSyncResult(
+            provider = provider,
+            progress = IntegrationSyncProgress(
+                activitiesImported = activities.size,
+                routinesImported = routines.size,
+                routineFoldersImported = folders.size,
+                exerciseTemplatesImported = templates.size,
+                measurementsImported = measurements.size,
+                programsImported = programs.size,
+                programStatsImported = stats.size,
+            ),
+            entitlementState = entitlementState,
+            partial = response.partial || response.errors.isNotEmpty(),
+            warnings = warnings,
+            nextCursor = response.nextCursor,
+            hasMore = response.hasMore,
+        )
+    }
+
+    private fun IntegrationActivityDto.toDomain(
+        fallbackProvider: IntegrationProvider,
+        profileId: String,
+        isPaidUser: Boolean,
+    ): ExternalActivity {
+        val parsedProvider = IntegrationProvider.fromKey(provider) ?: fallbackProvider
         return ExternalActivity(
             id = generateUUID(),
             externalId = externalId,
-            provider = provider,
+            provider = parsedProvider,
             name = name,
             activityType = activityType,
-            startedAt = startEpochMillis,
+            startedAt = startedAt.parseEpochMillisOrNow("startedAt", externalId),
             durationSeconds = durationSeconds,
             distanceMeters = distanceMeters,
             calories = calories,
@@ -222,6 +323,199 @@ class IntegrationManager(private val apiClient: PortalApiClient, private val rep
             syncedAt = currentTimeMillis(),
             profileId = profileId,
             needsSync = isPaidUser,
+        )
+    }
+
+    private fun IntegrationRoutineDto.toDomain(fallbackProvider: IntegrationProvider, profileId: String): ExternalRoutine {
+        val routineId = generateUUID()
+        return ExternalRoutine(
+            id = routineId,
+            externalId = externalId,
+            provider = IntegrationProvider.fromKey(provider) ?: fallbackProvider,
+            title = title,
+            folderExternalId = folderExternalId,
+            folderName = folderName,
+            updatedAt = updatedAt?.parseEpochMillisOrNull("routine.updatedAt", externalId),
+            exercises = exercises.map { it.toDomain(routineId) },
+            rawData = rawData,
+            profileId = profileId,
+            syncedAt = currentTimeMillis(),
+        )
+    }
+
+    private fun IntegrationRoutineExerciseDto.toDomain(routineId: String): ExternalRoutineExercise {
+        val exerciseId = generateUUID()
+        return ExternalRoutineExercise(
+            id = exerciseId,
+            externalRoutineId = routineId,
+            externalExerciseTemplateId = externalExerciseTemplateId,
+            title = title,
+            exerciseType = exerciseType,
+            primaryMuscleGroups = primaryMuscleGroups,
+            secondaryMuscleGroups = secondaryMuscleGroups,
+            orderIndex = orderIndex,
+            sets = sets.map { it.toDomain(exerciseId) },
+            rawData = rawData,
+        )
+    }
+
+    private fun IntegrationRoutineSetDto.toDomain(exerciseId: String): ExternalRoutineSet = ExternalRoutineSet(
+        id = generateUUID(),
+        externalRoutineExerciseId = exerciseId,
+        index = index,
+        setType = setType,
+        weightKg = weightKg,
+        reps = reps,
+        minReps = minReps,
+        maxReps = maxReps,
+        restSeconds = restSeconds,
+        rpe = rpe,
+        durationSeconds = durationSeconds,
+        distanceMeters = distanceMeters,
+        rawData = rawData,
+    )
+
+    private fun IntegrationRoutineFolderDto.toDomain(
+        fallbackProvider: IntegrationProvider,
+        profileId: String,
+    ): ExternalRoutineFolder = ExternalRoutineFolder(
+        id = generateUUID(),
+        externalId = externalId,
+        provider = IntegrationProvider.fromKey(provider) ?: fallbackProvider,
+        title = title,
+        index = index,
+        createdAt = createdAt?.parseEpochMillisOrNull("folder.createdAt", externalId),
+        updatedAt = updatedAt?.parseEpochMillisOrNull("folder.updatedAt", externalId),
+        profileId = profileId,
+        rawData = rawData,
+    )
+
+    private fun IntegrationExerciseTemplateDto.toDomain(
+        fallbackProvider: IntegrationProvider,
+        profileId: String,
+    ): ExternalExerciseTemplate = ExternalExerciseTemplate(
+        id = generateUUID(),
+        externalId = externalId,
+        provider = IntegrationProvider.fromKey(provider) ?: fallbackProvider,
+        title = title,
+        exerciseType = exerciseType,
+        primaryMuscleGroups = primaryMuscleGroups,
+        secondaryMuscleGroups = secondaryMuscleGroups,
+        isCustom = isCustom,
+        rawData = rawData,
+        updatedAt = updatedAt?.parseEpochMillisOrNull("template.updatedAt", externalId),
+        profileId = profileId,
+    )
+
+    private fun IntegrationBodyMeasurementDto.toDomain(
+        fallbackProvider: IntegrationProvider,
+        profileId: String,
+    ): ExternalBodyMeasurement = ExternalBodyMeasurement(
+        id = generateUUID(),
+        externalId = externalId,
+        provider = IntegrationProvider.fromKey(provider) ?: fallbackProvider,
+        measurementType = measurementType,
+        value = value,
+        unit = unit,
+        measuredAt = measuredAt.parseEpochMillisOrNow("measurement.measuredAt", externalId),
+        rawData = rawData,
+        profileId = profileId,
+        syncedAt = currentTimeMillis(),
+    )
+
+    private fun IntegrationProgramDto.toDomain(
+        fallbackProvider: IntegrationProvider,
+        profileId: String,
+    ): ExternalProgram = ExternalProgram(
+        id = generateUUID(),
+        externalId = externalId,
+        provider = IntegrationProvider.fromKey(provider) ?: fallbackProvider,
+        name = name,
+        isCurrent = isCurrent,
+        scriptText = scriptText,
+        rawData = rawData,
+        updatedAt = updatedAt?.parseEpochMillisOrNull("program.updatedAt", externalId),
+        syncedAt = currentTimeMillis(),
+        profileId = profileId,
+    )
+
+    private fun IntegrationProgramStatsDto.toDomain(localProgramId: String): ExternalProgramStats = ExternalProgramStats(
+        id = generateUUID(),
+        externalProgramId = localProgramId,
+        days = days,
+        approximateMinutes = approximateMinutes,
+        setCount = setCount,
+        muscleGroupBreakdownJson = muscleGroupBreakdownJson,
+        rawData = rawData,
+        computedAt = computedAt?.parseEpochMillisOrNull("programStats.computedAt", externalProgramId),
+    )
+
+    private fun IntegrationPlaygroundPreviewDto.toDomain(): ExternalPlaygroundPreview = ExternalPlaygroundPreview(
+        programExternalId = programExternalId,
+        currentWorkoutText = currentWorkoutText,
+        nextWorkoutText = nextWorkoutText,
+        updatedProgramText = updatedProgramText,
+        commandsApplied = commandsApplied,
+        rawData = rawData,
+        generatedAt = generatedAt?.parseEpochMillisOrNull("playground.generatedAt", programExternalId) ?: currentTimeMillis(),
+    )
+
+    private fun IntegrationEntityErrorDto.toWarning(): IntegrationSyncWarning = IntegrationSyncWarning(
+        entityType = entityType,
+        code = code,
+        message = message,
+        retryAfterSeconds = retryAfterSeconds,
+    )
+
+    private fun IntegrationSyncResponse.toEntitlementState(provider: IntegrationProvider): IntegrationEntitlementState? {
+        if (!requiresUpgrade && entitlementStatus == null && upgradeReason == null && providerPlanName == null) return null
+        return IntegrationEntitlementState(
+            provider = provider,
+            status = entitlementStatus,
+            requiresUpgrade = requiresUpgrade,
+            upgradeReason = upgradeReason,
+            providerPlanName = providerPlanName,
+        )
+    }
+
+    private fun IntegrationSyncResult.merge(other: IntegrationSyncResult): IntegrationSyncResult = copy(
+        progress = IntegrationSyncProgress(
+            activitiesImported = progress.activitiesImported + other.progress.activitiesImported,
+            routinesImported = progress.routinesImported + other.progress.routinesImported,
+            routineFoldersImported = progress.routineFoldersImported + other.progress.routineFoldersImported,
+            exerciseTemplatesImported = progress.exerciseTemplatesImported + other.progress.exerciseTemplatesImported,
+            measurementsImported = progress.measurementsImported + other.progress.measurementsImported,
+            programsImported = progress.programsImported + other.progress.programsImported,
+            programStatsImported = progress.programStatsImported + other.progress.programStatsImported,
+        ),
+        entitlementState = other.entitlementState ?: entitlementState,
+        partial = partial || other.partial,
+        warnings = warnings + other.warnings,
+        nextCursor = other.nextCursor ?: nextCursor,
+        hasMore = other.hasMore,
+    )
+
+    private fun String.parseEpochMillisOrNow(field: String, externalId: String): Long =
+        parseEpochMillisOrNull(field, externalId) ?: currentTimeMillis()
+
+    private fun String.parseEpochMillisOrNull(field: String, externalId: String): Long? = try {
+        Instant.parse(this).toEpochMilliseconds()
+    } catch (_: Exception) {
+        Logger.w("IntegrationManager") {
+            "Could not parse $field '$this' for $externalId"
+        }
+        null
+    }
+
+    private companion object {
+        val ALL_ENTITY_TYPES = listOf(
+            "activities",
+            "routines",
+            "routineFolders",
+            "templates",
+            "measurements",
+            "programs",
+            "programStats",
         )
     }
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/integration/IntegrationManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/integration/IntegrationManager.kt
@@ -156,6 +156,7 @@ class IntegrationManager(
         var page = 0
         var cursor = startCursor
         var aggregate = IntegrationSyncResult(provider = provider)
+        var latestProviderSyncCursor: String? = null
 
         while (page < MAX_SYNC_PAGES_PER_ENTITY) {
             val request = IntegrationSyncRequest(
@@ -192,19 +193,7 @@ class IntegrationManager(
 
             val pageResult = persistResponse(provider, profileId, isPaidUser, response)
             aggregate = aggregate.merge(pageResult)
-
-            val cursorValue = response.providerSyncCursor ?: response.nextCursor
-            if (cursorValue != null) {
-                cursorRepository.upsertCursor(
-                    IntegrationSyncCursor(
-                        provider = provider,
-                        profileId = profileId,
-                        cursorType = "integration_sync",
-                        cursorValue = cursorValue,
-                        updatedAt = currentTimeMillis(),
-                    ),
-                )
-            }
+            response.providerSyncCursor?.let { latestProviderSyncCursor = it }
 
             if (!response.hasMore || response.nextCursor == null) break
             cursor = response.nextCursor
@@ -218,6 +207,18 @@ class IntegrationManager(
                     entityType = "sync",
                     code = "page_cap_reached",
                     message = "Stopped after $MAX_SYNC_PAGES_PER_ENTITY pages to avoid an infinite sync loop.",
+                ),
+            )
+        }
+
+        if (latestProviderSyncCursor != null) {
+            cursorRepository.upsertCursor(
+                IntegrationSyncCursor(
+                    provider = provider,
+                    profileId = profileId,
+                    cursorType = "integration_sync",
+                    cursorValue = latestProviderSyncCursor,
+                    updatedAt = currentTimeMillis(),
                 ),
             )
         }
@@ -265,8 +266,13 @@ class IntegrationManager(
         if (measurements.isNotEmpty()) measurementRepository.upsertMeasurements(measurements)
         if (programs.isNotEmpty()) programRepository.upsertPrograms(programs)
 
+        val programsByExternalId = programRepository.findPrograms(
+            provider = provider,
+            externalIds = response.programStats.map { it.externalProgramId }.distinct(),
+            profileId = profileId,
+        ).associateBy { it.externalId }
         val stats = response.programStats.mapNotNull { dto ->
-            val localProgram = programRepository.findProgram(provider, dto.externalProgramId, profileId)
+            val localProgram = programsByExternalId[dto.externalProgramId]
             if (localProgram == null) {
                 Logger.w("IntegrationManager") {
                     "Skipping stats for missing ${provider.key} program ${dto.externalProgramId}"

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/integration/SqlDelightExternalActivityRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/integration/SqlDelightExternalActivityRepository.kt
@@ -28,7 +28,7 @@ class SqlDelightExternalActivityRepository(db: VitruvianDatabase) : ExternalActi
     private fun com.devil.phoenixproject.database.ExternalActivity.toDomain(): ExternalActivity = ExternalActivity(
         id = id,
         externalId = externalId,
-        provider = IntegrationProvider.fromKey(provider) ?: IntegrationProvider.HEVY,
+        provider = IntegrationProvider.fromKey(provider) ?: IntegrationProvider.UNKNOWN,
         name = name,
         activityType = activityType,
         startedAt = startedAt,
@@ -46,7 +46,7 @@ class SqlDelightExternalActivityRepository(db: VitruvianDatabase) : ExternalActi
     )
 
     private fun com.devil.phoenixproject.database.IntegrationStatus.toDomain(): IntegrationStatus = IntegrationStatus(
-        provider = IntegrationProvider.fromKey(provider) ?: IntegrationProvider.HEVY,
+        provider = IntegrationProvider.fromKey(provider) ?: IntegrationProvider.UNKNOWN,
         status = runCatching { ConnectionStatus.valueOf(status.uppercase()) }
             .getOrDefault(ConnectionStatus.DISCONNECTED),
         lastSyncAt = lastSyncAt,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/integration/SqlDelightExternalActivityRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/integration/SqlDelightExternalActivityRepository.kt
@@ -42,6 +42,7 @@ class SqlDelightExternalActivityRepository(db: VitruvianDatabase) : ExternalActi
         syncedAt = syncedAt,
         profileId = profileId,
         needsSync = needsSync != 0L,
+        deletedAt = deletedAt,
     )
 
     private fun com.devil.phoenixproject.database.IntegrationStatus.toDomain(): IntegrationStatus = IntegrationStatus(
@@ -98,6 +99,7 @@ class SqlDelightExternalActivityRepository(db: VitruvianDatabase) : ExternalActi
                         syncedAt = activity.syncedAt,
                         profileId = activity.profileId,
                         needsSync = if (activity.needsSync) 1L else 0L,
+                        deletedAt = activity.deletedAt,
                     )
                     // UPDATE: updates data fields for any existing row.
                     // Preserves id and needsSync (not touched by this statement).
@@ -114,9 +116,10 @@ class SqlDelightExternalActivityRepository(db: VitruvianDatabase) : ExternalActi
                         elevationGainMeters = activity.elevationGainMeters,
                         rawData = activity.rawData,
                         syncedAt = activity.syncedAt,
-                        profileId = activity.profileId,
+                        deletedAt = activity.deletedAt,
                         externalId = activity.externalId,
                         provider = activity.provider.key,
+                        profileId = activity.profileId,
                     )
                 }
             }
@@ -142,6 +145,29 @@ class SqlDelightExternalActivityRepository(db: VitruvianDatabase) : ExternalActi
                     queries.markExternalActivitySyncedBySyncKey(
                         externalId = syncKey.externalId,
                         provider = syncKey.provider.key,
+                        profileId = profileId,
+                    )
+                }
+            }
+        }
+    }
+
+    override suspend fun markDeletedByExternalIds(
+        provider: IntegrationProvider,
+        profileId: String,
+        externalIds: List<String>,
+        deletedAt: Long,
+        needsSync: Boolean,
+    ) {
+        if (externalIds.isEmpty()) return
+        withContext(Dispatchers.IO) {
+            queries.transaction {
+                for (externalId in externalIds) {
+                    queries.markExternalActivityDeletedBySyncKey(
+                        deletedAt = deletedAt,
+                        needsSync = if (needsSync) 1L else 0L,
+                        externalId = externalId,
+                        provider = provider.key,
                         profileId = profileId,
                     )
                 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/integration/SqlDelightExternalIntegrationRepositories.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/integration/SqlDelightExternalIntegrationRepositories.kt
@@ -1,0 +1,550 @@
+package com.devil.phoenixproject.data.integration
+
+import app.cash.sqldelight.coroutines.asFlow
+import app.cash.sqldelight.coroutines.mapToList
+import app.cash.sqldelight.coroutines.mapToOneOrNull
+import com.devil.phoenixproject.database.VitruvianDatabase
+import com.devil.phoenixproject.domain.model.ExternalBodyMeasurement
+import com.devil.phoenixproject.domain.model.ExternalExerciseTemplate
+import com.devil.phoenixproject.domain.model.ExternalExerciseTemplateMapping
+import com.devil.phoenixproject.domain.model.ExternalProgram
+import com.devil.phoenixproject.domain.model.ExternalProgramStats
+import com.devil.phoenixproject.domain.model.ExternalRoutine
+import com.devil.phoenixproject.domain.model.ExternalRoutineExercise
+import com.devil.phoenixproject.domain.model.ExternalRoutineFolder
+import com.devil.phoenixproject.domain.model.ExternalRoutineSet
+import com.devil.phoenixproject.domain.model.IntegrationProvider
+import com.devil.phoenixproject.domain.model.currentTimeMillis
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
+
+private const val LIST_SEPARATOR = "|"
+
+private fun List<String>.encodeList(): String = joinToString(LIST_SEPARATOR)
+private fun String.decodeList(): List<String> = split(LIST_SEPARATOR).filter { it.isNotBlank() }
+private fun providerFromKey(key: String): IntegrationProvider = IntegrationProvider.fromKey(key) ?: IntegrationProvider.HEVY
+
+class SqlDelightExternalRoutineRepository(db: VitruvianDatabase) : ExternalRoutineRepository {
+    private val queries = db.vitruvianDatabaseQueries
+
+    private fun com.devil.phoenixproject.database.ExternalRoutine.toDomain(): ExternalRoutine {
+        val exercises = queries.getExternalRoutineExercises(id).executeAsList().map { it.toDomain() }
+        return ExternalRoutine(
+            id = id,
+            externalId = externalId,
+            provider = providerFromKey(provider),
+            title = title,
+            folderExternalId = folderExternalId,
+            folderName = folderName,
+            updatedAt = updatedAt,
+            exercises = exercises,
+            rawData = rawData,
+            profileId = profileId,
+            syncedAt = syncedAt,
+            needsSync = needsSync != 0L,
+            deletedAt = deletedAt,
+        )
+    }
+
+    private fun com.devil.phoenixproject.database.ExternalRoutineExercise.toDomain(): ExternalRoutineExercise {
+        val sets = queries.getExternalRoutineSets(id).executeAsList().map { it.toDomain() }
+        return ExternalRoutineExercise(
+            id = id,
+            externalRoutineId = externalRoutineId,
+            externalExerciseTemplateId = externalExerciseTemplateId,
+            title = title,
+            exerciseType = exerciseType,
+            primaryMuscleGroups = primaryMuscleGroups.decodeList(),
+            secondaryMuscleGroups = secondaryMuscleGroups.decodeList(),
+            orderIndex = orderIndex.toInt(),
+            sets = sets,
+            rawData = rawData,
+        )
+    }
+
+    private fun com.devil.phoenixproject.database.ExternalRoutineSet.toDomain(): ExternalRoutineSet = ExternalRoutineSet(
+        id = id,
+        externalRoutineExerciseId = externalRoutineExerciseId,
+        index = setIndex.toInt(),
+        setType = setType,
+        weightKg = weightKg,
+        reps = reps?.toInt(),
+        minReps = minReps?.toInt(),
+        maxReps = maxReps?.toInt(),
+        restSeconds = restSeconds?.toInt(),
+        rpe = rpe,
+        durationSeconds = durationSeconds?.toInt(),
+        distanceMeters = distanceMeters,
+        rawData = rawData,
+    )
+
+    private fun com.devil.phoenixproject.database.ExternalRoutineFolder.toDomain(): ExternalRoutineFolder = ExternalRoutineFolder(
+        id = id,
+        externalId = externalId,
+        provider = providerFromKey(provider),
+        title = title,
+        index = folderIndex?.toInt(),
+        createdAt = createdAt,
+        updatedAt = updatedAt,
+        profileId = profileId,
+        rawData = rawData,
+    )
+
+    override fun observeRoutines(profileId: String, provider: IntegrationProvider?): Flow<List<ExternalRoutine>> {
+        val query = if (provider == null) {
+            queries.getExternalRoutines(profileId)
+        } else {
+            queries.getExternalRoutinesByProvider(profileId, provider.key)
+        }
+        return query.asFlow().mapToList(Dispatchers.IO).map { rows -> rows.map { it.toDomain() } }
+    }
+
+    override fun observeFolders(profileId: String, provider: IntegrationProvider?): Flow<List<ExternalRoutineFolder>> {
+        val query = if (provider == null) {
+            queries.getExternalRoutineFolders(profileId)
+        } else {
+            queries.getExternalRoutineFoldersByProvider(profileId, provider.key)
+        }
+        return query.asFlow().mapToList(Dispatchers.IO).map { rows -> rows.map { it.toDomain() } }
+    }
+
+    override suspend fun upsertRoutines(routines: List<ExternalRoutine>) {
+        if (routines.isEmpty()) return
+        withContext(Dispatchers.IO) {
+            queries.transaction {
+                for (routine in routines) {
+                    queries.insertExternalRoutineIfNew(
+                        id = routine.id,
+                        externalId = routine.externalId,
+                        provider = routine.provider.key,
+                        title = routine.title,
+                        folderExternalId = routine.folderExternalId,
+                        folderName = routine.folderName,
+                        updatedAt = routine.updatedAt,
+                        syncedAt = routine.syncedAt,
+                        rawData = routine.rawData,
+                        profileId = routine.profileId,
+                        needsSync = if (routine.needsSync) 1L else 0L,
+                        deletedAt = routine.deletedAt,
+                    )
+                    queries.updateExternalRoutineOnConflict(
+                        title = routine.title,
+                        folderExternalId = routine.folderExternalId,
+                        folderName = routine.folderName,
+                        updatedAt = routine.updatedAt,
+                        syncedAt = routine.syncedAt,
+                        rawData = routine.rawData,
+                        deletedAt = routine.deletedAt,
+                        provider = routine.provider.key,
+                        externalId = routine.externalId,
+                        profileId = routine.profileId,
+                    )
+                    val localRoutine = queries.getExternalRoutineBySyncKey(
+                        provider = routine.provider.key,
+                        externalId = routine.externalId,
+                        profileId = routine.profileId,
+                    ).executeAsOne()
+
+                    queries.deleteExternalRoutineSetsByRoutine(localRoutine.id)
+                    queries.deleteExternalRoutineExercisesByRoutine(localRoutine.id)
+                    for (exercise in routine.exercises.sortedBy { it.orderIndex }) {
+                        queries.insertExternalRoutineExercise(
+                            id = exercise.id,
+                            externalRoutineId = localRoutine.id,
+                            externalExerciseTemplateId = exercise.externalExerciseTemplateId,
+                            title = exercise.title,
+                            exerciseType = exercise.exerciseType,
+                            primaryMuscleGroups = exercise.primaryMuscleGroups.encodeList(),
+                            secondaryMuscleGroups = exercise.secondaryMuscleGroups.encodeList(),
+                            orderIndex = exercise.orderIndex.toLong(),
+                            rawData = exercise.rawData,
+                        )
+                        for (set in exercise.sets.sortedBy { it.index }) {
+                            queries.insertExternalRoutineSet(
+                                id = set.id,
+                                externalRoutineExerciseId = exercise.id,
+                                setIndex = set.index.toLong(),
+                                setType = set.setType,
+                                weightKg = set.weightKg,
+                                reps = set.reps?.toLong(),
+                                minReps = set.minReps?.toLong(),
+                                maxReps = set.maxReps?.toLong(),
+                                restSeconds = set.restSeconds?.toLong(),
+                                rpe = set.rpe,
+                                durationSeconds = set.durationSeconds?.toLong(),
+                                distanceMeters = set.distanceMeters,
+                                rawData = set.rawData,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    override suspend fun upsertFolders(folders: List<ExternalRoutineFolder>) {
+        if (folders.isEmpty()) return
+        withContext(Dispatchers.IO) {
+            queries.transaction {
+                for (folder in folders) {
+                    queries.upsertExternalRoutineFolder(
+                        id = folder.id,
+                        externalId = folder.externalId,
+                        provider = folder.provider.key,
+                        title = folder.title,
+                        folderIndex = folder.index?.toLong(),
+                        createdAt = folder.createdAt,
+                        updatedAt = folder.updatedAt,
+                        profileId = folder.profileId,
+                        rawData = folder.rawData,
+                    )
+                }
+            }
+        }
+    }
+
+    override suspend fun deleteProviderRoutines(provider: IntegrationProvider, profileId: String) = withContext(Dispatchers.IO) {
+        queries.transaction {
+            queries.deleteExternalRoutineSetsByProvider(provider.key, profileId)
+            queries.deleteExternalRoutineExercisesByProvider(provider.key, profileId)
+            queries.deleteExternalRoutinesByProvider(provider.key, profileId)
+            queries.deleteExternalRoutineFoldersByProvider(provider.key, profileId)
+        }
+    }
+}
+
+class SqlDelightExternalProgramRepository(db: VitruvianDatabase) : ExternalProgramRepository {
+    private val queries = db.vitruvianDatabaseQueries
+
+    private fun com.devil.phoenixproject.database.ExternalProgram.toDomain(): ExternalProgram = ExternalProgram(
+        id = id,
+        externalId = externalId,
+        provider = providerFromKey(provider),
+        name = name,
+        isCurrent = isCurrent != 0L,
+        scriptText = scriptText,
+        rawData = rawData,
+        updatedAt = updatedAt,
+        syncedAt = syncedAt,
+        profileId = profileId,
+        needsSync = needsSync != 0L,
+        deletedAt = deletedAt,
+    )
+
+    private fun com.devil.phoenixproject.database.ExternalProgramStats.toDomain(): ExternalProgramStats = ExternalProgramStats(
+        id = id,
+        externalProgramId = externalProgramId,
+        days = days?.toInt(),
+        approximateMinutes = approximateMinutes?.toInt(),
+        setCount = setCount?.toInt(),
+        muscleGroupBreakdownJson = muscleGroupBreakdownJson,
+        rawData = rawData,
+        computedAt = computedAt,
+    )
+
+    override fun observePrograms(profileId: String, provider: IntegrationProvider?): Flow<List<ExternalProgram>> {
+        val query = if (provider == null) {
+            queries.getExternalPrograms(profileId)
+        } else {
+            queries.getExternalProgramsByProvider(profileId, provider.key)
+        }
+        return query.asFlow().mapToList(Dispatchers.IO).map { rows -> rows.map { it.toDomain() } }
+    }
+
+    override fun observeCurrentProgram(profileId: String, provider: IntegrationProvider): Flow<ExternalProgram?> =
+        queries.getCurrentExternalProgram(profileId, provider.key)
+            .asFlow()
+            .mapToOneOrNull(Dispatchers.IO)
+            .map { it?.toDomain() }
+
+    override fun observeProgramStats(profileId: String, provider: IntegrationProvider?): Flow<Map<String, ExternalProgramStats>> {
+        val query = if (provider == null) {
+            queries.getExternalProgramStatsByProfile(profileId)
+        } else {
+            queries.getExternalProgramStatsByProvider(profileId, provider.key)
+        }
+        return query.asFlow().mapToList(Dispatchers.IO).map { rows ->
+            rows.associate { it.externalProgramId to it.toDomain() }
+        }
+    }
+
+    override suspend fun findProgram(provider: IntegrationProvider, externalId: String, profileId: String): ExternalProgram? = withContext(Dispatchers.IO) {
+        queries.getExternalProgramBySyncKey(provider.key, externalId, profileId).executeAsOneOrNull()?.toDomain()
+    }
+
+    override suspend fun upsertPrograms(programs: List<ExternalProgram>) {
+        if (programs.isEmpty()) return
+        withContext(Dispatchers.IO) {
+            queries.transaction {
+                for (program in programs) {
+                    queries.insertExternalProgramIfNew(
+                        id = program.id,
+                        externalId = program.externalId,
+                        provider = program.provider.key,
+                        name = program.name,
+                        isCurrent = if (program.isCurrent) 1L else 0L,
+                        scriptText = program.scriptText,
+                        rawData = program.rawData,
+                        updatedAt = program.updatedAt,
+                        syncedAt = program.syncedAt,
+                        profileId = program.profileId,
+                        needsSync = if (program.needsSync) 1L else 0L,
+                        deletedAt = program.deletedAt,
+                    )
+                    queries.updateExternalProgramOnConflict(
+                        name = program.name,
+                        isCurrent = if (program.isCurrent) 1L else 0L,
+                        scriptText = program.scriptText,
+                        rawData = program.rawData,
+                        updatedAt = program.updatedAt,
+                        syncedAt = program.syncedAt,
+                        deletedAt = program.deletedAt,
+                        provider = program.provider.key,
+                        externalId = program.externalId,
+                        profileId = program.profileId,
+                    )
+                }
+            }
+        }
+    }
+
+    override suspend fun upsertStats(stats: List<ExternalProgramStats>) {
+        if (stats.isEmpty()) return
+        withContext(Dispatchers.IO) {
+            queries.transaction {
+                for (stat in stats) {
+                    queries.insertExternalProgramStats(
+                        id = stat.id,
+                        externalProgramId = stat.externalProgramId,
+                        days = stat.days?.toLong(),
+                        approximateMinutes = stat.approximateMinutes?.toLong(),
+                        setCount = stat.setCount?.toLong(),
+                        muscleGroupBreakdownJson = stat.muscleGroupBreakdownJson,
+                        rawData = stat.rawData,
+                        computedAt = stat.computedAt,
+                    )
+                }
+            }
+        }
+    }
+
+    override suspend fun updateProgramText(programId: String, scriptText: String, markNeedsSync: Boolean) = withContext(Dispatchers.IO) {
+        queries.updateExternalProgramText(
+            scriptText = scriptText,
+            updatedAt = currentTimeMillis(),
+            syncedAt = currentTimeMillis(),
+            needsSync = if (markNeedsSync) 1L else 0L,
+            id = programId,
+        )
+        Unit
+    }
+
+    override suspend fun deleteProviderPrograms(provider: IntegrationProvider, profileId: String) = withContext(Dispatchers.IO) {
+        queries.transaction {
+            queries.deleteExternalProgramStatsByProvider(provider.key, profileId)
+            queries.deleteExternalProgramsByProvider(provider.key, profileId)
+        }
+    }
+}
+
+class SqlDelightExternalMeasurementRepository(db: VitruvianDatabase) : ExternalMeasurementRepository {
+    private val queries = db.vitruvianDatabaseQueries
+
+    private fun com.devil.phoenixproject.database.ExternalBodyMeasurement.toDomain(): ExternalBodyMeasurement = ExternalBodyMeasurement(
+        id = id,
+        externalId = externalId,
+        provider = providerFromKey(provider),
+        measurementType = measurementType,
+        value = value_,
+        unit = unit,
+        measuredAt = measuredAt,
+        rawData = rawData,
+        profileId = profileId,
+        syncedAt = syncedAt,
+    )
+
+    override fun observeMeasurements(profileId: String, provider: IntegrationProvider?): Flow<List<ExternalBodyMeasurement>> {
+        val query = if (provider == null) {
+            queries.getExternalBodyMeasurements(profileId)
+        } else {
+            queries.getExternalBodyMeasurementsByProvider(profileId, provider.key)
+        }
+        return query.asFlow().mapToList(Dispatchers.IO).map { rows -> rows.map { it.toDomain() } }
+    }
+
+    override fun observeMeasurementsByType(profileId: String, measurementType: String): Flow<List<ExternalBodyMeasurement>> =
+        queries.getExternalBodyMeasurementsByType(profileId, measurementType)
+            .asFlow()
+            .mapToList(Dispatchers.IO)
+            .map { rows -> rows.map { it.toDomain() } }
+
+    override suspend fun upsertMeasurements(measurements: List<ExternalBodyMeasurement>) {
+        if (measurements.isEmpty()) return
+        withContext(Dispatchers.IO) {
+            queries.transaction {
+                for (measurement in measurements) {
+                    queries.upsertExternalBodyMeasurement(
+                        id = measurement.id,
+                        externalId = measurement.externalId,
+                        provider = measurement.provider.key,
+                        measurementType = measurement.measurementType,
+                        value_ = measurement.value,
+                        unit = measurement.unit,
+                        measuredAt = measurement.measuredAt,
+                        syncedAt = measurement.syncedAt,
+                        rawData = measurement.rawData,
+                        profileId = measurement.profileId,
+                    )
+                }
+            }
+        }
+    }
+
+    override suspend fun deleteProviderMeasurements(provider: IntegrationProvider, profileId: String) = withContext(Dispatchers.IO) {
+        queries.deleteExternalBodyMeasurementsByProvider(provider.key, profileId)
+        Unit
+    }
+}
+
+class SqlDelightExternalExerciseTemplateRepository(db: VitruvianDatabase) : ExternalExerciseTemplateRepository {
+    private val queries = db.vitruvianDatabaseQueries
+
+    private fun com.devil.phoenixproject.database.ExternalExerciseTemplate.toDomain(): ExternalExerciseTemplate = ExternalExerciseTemplate(
+        id = id,
+        externalId = externalId,
+        provider = providerFromKey(provider),
+        title = title,
+        exerciseType = exerciseType,
+        primaryMuscleGroups = primaryMuscleGroups.decodeList(),
+        secondaryMuscleGroups = secondaryMuscleGroups.decodeList(),
+        isCustom = isCustom != 0L,
+        rawData = rawData,
+        updatedAt = updatedAt,
+        profileId = profileId,
+    )
+
+    private fun com.devil.phoenixproject.database.ExternalExerciseTemplateMapping.toDomain(): ExternalExerciseTemplateMapping = ExternalExerciseTemplateMapping(
+        id = id,
+        provider = providerFromKey(provider),
+        externalTemplateId = externalTemplateId,
+        localExerciseId = localExerciseId,
+        profileId = profileId,
+        createdAt = createdAt,
+        updatedAt = updatedAt,
+        rawData = rawData,
+    )
+
+    override fun observeTemplates(profileId: String, provider: IntegrationProvider?): Flow<List<ExternalExerciseTemplate>> {
+        val query = if (provider == null) {
+            queries.getExternalExerciseTemplates(profileId)
+        } else {
+            queries.getExternalExerciseTemplatesByProvider(profileId, provider.key)
+        }
+        return query.asFlow().mapToList(Dispatchers.IO).map { rows -> rows.map { it.toDomain() } }
+    }
+
+    override fun observeTemplateCounts(profileId: String): Flow<Map<IntegrationProvider, Int>> =
+        queries.countExternalExerciseTemplatesByProvider(profileId)
+            .asFlow()
+            .mapToList(Dispatchers.IO)
+            .map { rows ->
+                rows.mapNotNull { row ->
+                    IntegrationProvider.fromKey(row.provider)?.let { provider ->
+                        provider to row.templateCount.toInt()
+                    }
+                }.toMap()
+            }
+
+    override suspend fun upsertTemplates(templates: List<ExternalExerciseTemplate>) {
+        if (templates.isEmpty()) return
+        withContext(Dispatchers.IO) {
+            queries.transaction {
+                for (template in templates) {
+                    queries.upsertExternalExerciseTemplate(
+                        id = template.id,
+                        externalId = template.externalId,
+                        provider = template.provider.key,
+                        title = template.title,
+                        exerciseType = template.exerciseType,
+                        primaryMuscleGroups = template.primaryMuscleGroups.encodeList(),
+                        secondaryMuscleGroups = template.secondaryMuscleGroups.encodeList(),
+                        isCustom = if (template.isCustom) 1L else 0L,
+                        rawData = template.rawData,
+                        updatedAt = template.updatedAt,
+                        profileId = template.profileId,
+                    )
+                }
+            }
+        }
+    }
+
+    override suspend fun findTemplate(provider: IntegrationProvider, externalId: String, profileId: String): ExternalExerciseTemplate? = withContext(Dispatchers.IO) {
+        queries.getExternalExerciseTemplateBySyncKey(provider.key, externalId, profileId).executeAsOneOrNull()?.toDomain()
+    }
+
+    override suspend fun upsertMapping(mapping: ExternalExerciseTemplateMapping) = withContext(Dispatchers.IO) {
+        queries.upsertExternalExerciseTemplateMapping(
+            id = mapping.id,
+            provider = mapping.provider.key,
+            externalTemplateId = mapping.externalTemplateId,
+            localExerciseId = mapping.localExerciseId,
+            profileId = mapping.profileId,
+            createdAt = mapping.createdAt,
+            updatedAt = mapping.updatedAt,
+            rawData = mapping.rawData,
+        )
+        Unit
+    }
+
+    override suspend fun findMapping(
+        provider: IntegrationProvider,
+        externalTemplateId: String,
+        profileId: String,
+    ): ExternalExerciseTemplateMapping? = withContext(Dispatchers.IO) {
+        queries.getExternalExerciseTemplateMapping(provider.key, externalTemplateId, profileId)
+            .executeAsOneOrNull()
+            ?.toDomain()
+    }
+
+    override suspend fun deleteProviderTemplates(provider: IntegrationProvider, profileId: String) = withContext(Dispatchers.IO) {
+        queries.transaction {
+            queries.deleteExternalExerciseTemplateMappingsByProvider(provider.key, profileId)
+            queries.deleteExternalExerciseTemplatesByProvider(provider.key, profileId)
+        }
+    }
+}
+
+class SqlDelightIntegrationSyncCursorRepository(db: VitruvianDatabase) : IntegrationSyncCursorRepository {
+    private val queries = db.vitruvianDatabaseQueries
+
+    private fun com.devil.phoenixproject.database.IntegrationSyncCursor.toDomain(): IntegrationSyncCursor = IntegrationSyncCursor(
+        provider = providerFromKey(provider),
+        profileId = profileId,
+        cursorType = cursorType,
+        cursorValue = cursorValue,
+        updatedAt = updatedAt,
+    )
+
+    override suspend fun getCursor(provider: IntegrationProvider, profileId: String, cursorType: String): IntegrationSyncCursor? = withContext(Dispatchers.IO) {
+        queries.getIntegrationSyncCursor(provider.key, profileId, cursorType).executeAsOneOrNull()?.toDomain()
+    }
+
+    override suspend fun upsertCursor(cursor: IntegrationSyncCursor) = withContext(Dispatchers.IO) {
+        queries.upsertIntegrationSyncCursor(
+            provider = cursor.provider.key,
+            profileId = cursor.profileId,
+            cursorType = cursor.cursorType,
+            cursorValue = cursor.cursorValue,
+            updatedAt = cursor.updatedAt,
+        )
+        Unit
+    }
+
+    override suspend fun deleteProviderCursors(provider: IntegrationProvider, profileId: String) = withContext(Dispatchers.IO) {
+        queries.deleteIntegrationSyncCursorsByProvider(provider.key, profileId)
+        Unit
+    }
+}

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/integration/SqlDelightExternalIntegrationRepositories.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/integration/SqlDelightExternalIntegrationRepositories.kt
@@ -25,45 +25,43 @@ private const val LIST_SEPARATOR = "|"
 
 private fun List<String>.encodeList(): String = joinToString(LIST_SEPARATOR)
 private fun String.decodeList(): List<String> = split(LIST_SEPARATOR).filter { it.isNotBlank() }
-private fun providerFromKey(key: String): IntegrationProvider = IntegrationProvider.fromKey(key) ?: IntegrationProvider.HEVY
+private fun providerFromKey(key: String): IntegrationProvider = IntegrationProvider.fromKey(key) ?: IntegrationProvider.UNKNOWN
 
 class SqlDelightExternalRoutineRepository(db: VitruvianDatabase) : ExternalRoutineRepository {
     private val queries = db.vitruvianDatabaseQueries
 
-    private fun com.devil.phoenixproject.database.ExternalRoutine.toDomain(): ExternalRoutine {
-        val exercises = queries.getExternalRoutineExercises(id).executeAsList().map { it.toDomain() }
-        return ExternalRoutine(
-            id = id,
-            externalId = externalId,
-            provider = providerFromKey(provider),
-            title = title,
-            folderExternalId = folderExternalId,
-            folderName = folderName,
-            updatedAt = updatedAt,
-            exercises = exercises,
-            rawData = rawData,
-            profileId = profileId,
-            syncedAt = syncedAt,
-            needsSync = needsSync != 0L,
-            deletedAt = deletedAt,
-        )
-    }
+    private fun com.devil.phoenixproject.database.ExternalRoutine.toDomain(
+        exercises: List<ExternalRoutineExercise>,
+    ): ExternalRoutine = ExternalRoutine(
+        id = id,
+        externalId = externalId,
+        provider = providerFromKey(provider),
+        title = title,
+        folderExternalId = folderExternalId,
+        folderName = folderName,
+        updatedAt = updatedAt,
+        exercises = exercises,
+        rawData = rawData,
+        profileId = profileId,
+        syncedAt = syncedAt,
+        needsSync = needsSync != 0L,
+        deletedAt = deletedAt,
+    )
 
-    private fun com.devil.phoenixproject.database.ExternalRoutineExercise.toDomain(): ExternalRoutineExercise {
-        val sets = queries.getExternalRoutineSets(id).executeAsList().map { it.toDomain() }
-        return ExternalRoutineExercise(
-            id = id,
-            externalRoutineId = externalRoutineId,
-            externalExerciseTemplateId = externalExerciseTemplateId,
-            title = title,
-            exerciseType = exerciseType,
-            primaryMuscleGroups = primaryMuscleGroups.decodeList(),
-            secondaryMuscleGroups = secondaryMuscleGroups.decodeList(),
-            orderIndex = orderIndex.toInt(),
-            sets = sets,
-            rawData = rawData,
-        )
-    }
+    private fun com.devil.phoenixproject.database.ExternalRoutineExercise.toDomain(
+        sets: List<ExternalRoutineSet>,
+    ): ExternalRoutineExercise = ExternalRoutineExercise(
+        id = id,
+        externalRoutineId = externalRoutineId,
+        externalExerciseTemplateId = externalExerciseTemplateId,
+        title = title,
+        exerciseType = exerciseType,
+        primaryMuscleGroups = primaryMuscleGroups.decodeList(),
+        secondaryMuscleGroups = secondaryMuscleGroups.decodeList(),
+        orderIndex = orderIndex.toInt(),
+        sets = sets,
+        rawData = rawData,
+    )
 
     private fun com.devil.phoenixproject.database.ExternalRoutineSet.toDomain(): ExternalRoutineSet = ExternalRoutineSet(
         id = id,
@@ -99,7 +97,25 @@ class SqlDelightExternalRoutineRepository(db: VitruvianDatabase) : ExternalRouti
         } else {
             queries.getExternalRoutinesByProvider(profileId, provider.key)
         }
-        return query.asFlow().mapToList(Dispatchers.IO).map { rows -> rows.map { it.toDomain() } }
+        return query.asFlow().mapToList(Dispatchers.IO).map { rows ->
+            if (rows.isEmpty()) {
+                emptyList()
+            } else {
+                val exerciseRows = queries.getExternalRoutineExercisesForRoutines(rows.map { it.id }).executeAsList()
+                val setRows = if (exerciseRows.isEmpty()) {
+                    emptyList()
+                } else {
+                    queries.getExternalRoutineSetsForExercises(exerciseRows.map { it.id }).executeAsList()
+                }
+                val setsByExerciseId = setRows
+                    .groupBy { it.externalRoutineExerciseId }
+                    .mapValues { (_, sets) -> sets.map { it.toDomain() } }
+                val exercisesByRoutineId = exerciseRows
+                    .map { exercise -> exercise.toDomain(setsByExerciseId[exercise.id].orEmpty()) }
+                    .groupBy { it.externalRoutineId }
+                rows.map { routine -> routine.toDomain(exercisesByRoutineId[routine.id].orEmpty()) }
+            }
+        }
     }
 
     override fun observeFolders(profileId: String, provider: IntegrationProvider?): Flow<List<ExternalRoutineFolder>> {
@@ -146,38 +162,40 @@ class SqlDelightExternalRoutineRepository(db: VitruvianDatabase) : ExternalRouti
                         provider = routine.provider.key,
                         externalId = routine.externalId,
                         profileId = routine.profileId,
-                    ).executeAsOne()
+                    ).executeAsOneOrNull()
 
-                    queries.deleteExternalRoutineSetsByRoutine(localRoutine.id)
-                    queries.deleteExternalRoutineExercisesByRoutine(localRoutine.id)
-                    for (exercise in routine.exercises.sortedBy { it.orderIndex }) {
-                        queries.insertExternalRoutineExercise(
-                            id = exercise.id,
-                            externalRoutineId = localRoutine.id,
-                            externalExerciseTemplateId = exercise.externalExerciseTemplateId,
-                            title = exercise.title,
-                            exerciseType = exercise.exerciseType,
-                            primaryMuscleGroups = exercise.primaryMuscleGroups.encodeList(),
-                            secondaryMuscleGroups = exercise.secondaryMuscleGroups.encodeList(),
-                            orderIndex = exercise.orderIndex.toLong(),
-                            rawData = exercise.rawData,
-                        )
-                        for (set in exercise.sets.sortedBy { it.index }) {
-                            queries.insertExternalRoutineSet(
-                                id = set.id,
-                                externalRoutineExerciseId = exercise.id,
-                                setIndex = set.index.toLong(),
-                                setType = set.setType,
-                                weightKg = set.weightKg,
-                                reps = set.reps?.toLong(),
-                                minReps = set.minReps?.toLong(),
-                                maxReps = set.maxReps?.toLong(),
-                                restSeconds = set.restSeconds?.toLong(),
-                                rpe = set.rpe,
-                                durationSeconds = set.durationSeconds?.toLong(),
-                                distanceMeters = set.distanceMeters,
-                                rawData = set.rawData,
+                    if (localRoutine != null) {
+                        queries.deleteExternalRoutineSetsByRoutine(localRoutine.id)
+                        queries.deleteExternalRoutineExercisesByRoutine(localRoutine.id)
+                        for (exercise in routine.exercises.sortedBy { it.orderIndex }) {
+                            queries.insertExternalRoutineExercise(
+                                id = exercise.id,
+                                externalRoutineId = localRoutine.id,
+                                externalExerciseTemplateId = exercise.externalExerciseTemplateId,
+                                title = exercise.title,
+                                exerciseType = exercise.exerciseType,
+                                primaryMuscleGroups = exercise.primaryMuscleGroups.encodeList(),
+                                secondaryMuscleGroups = exercise.secondaryMuscleGroups.encodeList(),
+                                orderIndex = exercise.orderIndex.toLong(),
+                                rawData = exercise.rawData,
                             )
+                            for (set in exercise.sets.sortedBy { it.index }) {
+                                queries.insertExternalRoutineSet(
+                                    id = set.id,
+                                    externalRoutineExerciseId = exercise.id,
+                                    setIndex = set.index.toLong(),
+                                    setType = set.setType,
+                                    weightKg = set.weightKg,
+                                    reps = set.reps?.toLong(),
+                                    minReps = set.minReps?.toLong(),
+                                    maxReps = set.maxReps?.toLong(),
+                                    restSeconds = set.restSeconds?.toLong(),
+                                    rpe = set.rpe,
+                                    durationSeconds = set.durationSeconds?.toLong(),
+                                    distanceMeters = set.distanceMeters,
+                                    rawData = set.rawData,
+                                )
+                            }
                         }
                     }
                 }
@@ -273,6 +291,14 @@ class SqlDelightExternalProgramRepository(db: VitruvianDatabase) : ExternalProgr
 
     override suspend fun findProgram(provider: IntegrationProvider, externalId: String, profileId: String): ExternalProgram? = withContext(Dispatchers.IO) {
         queries.getExternalProgramBySyncKey(provider.key, externalId, profileId).executeAsOneOrNull()?.toDomain()
+    }
+
+    override suspend fun findPrograms(provider: IntegrationProvider, externalIds: List<String>, profileId: String): List<ExternalProgram> = withContext(Dispatchers.IO) {
+        if (externalIds.isEmpty()) {
+            emptyList()
+        } else {
+            queries.getExternalProgramsBySyncKeys(provider.key, profileId, externalIds).executeAsList().map { it.toDomain() }
+        }
     }
 
     override suspend fun upsertPrograms(programs: List<ExternalProgram>) {

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/MigrationStatements.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/MigrationStatements.kt
@@ -49,7 +49,7 @@ internal fun applyMigrationResilient(
  * Get the SQL statements for a specific migration version.
  *
  * These mirror the .sqm files exactly, split into individual statements so
- * the resilient executor can apply them one-by-one. Every version from 1-30
+ * the resilient executor can apply them one-by-one. Every version from 1-31
  * is covered. Version 18 is intentionally empty (NOOP).
  */
 internal fun getMigrationStatements(version: Int): List<String> = when (version) {
@@ -687,6 +687,156 @@ WHERE gs.rowid = (
     // Migration 30: Exercise display name
     30 -> listOf(
         "ALTER TABLE Exercise ADD COLUMN displayName TEXT",
+    )
+
+    // Migration 31: Expanded mobile integration entities
+    31 -> listOf(
+        "ALTER TABLE ExternalActivity ADD COLUMN deletedAt INTEGER",
+        "DROP INDEX IF EXISTS idx_external_activity_dedup",
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_external_activity_dedup ON ExternalActivity(provider, externalId, profileId)",
+        """CREATE TABLE IF NOT EXISTS ExternalRoutine (
+            id TEXT NOT NULL PRIMARY KEY,
+            externalId TEXT NOT NULL,
+            provider TEXT NOT NULL,
+            title TEXT NOT NULL,
+            folderExternalId TEXT,
+            folderName TEXT,
+            updatedAt INTEGER,
+            syncedAt INTEGER NOT NULL,
+            rawData TEXT,
+            profileId TEXT NOT NULL DEFAULT 'default',
+            needsSync INTEGER NOT NULL DEFAULT 0,
+            deletedAt INTEGER
+        )""",
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_external_routine_dedup ON ExternalRoutine(provider, externalId, profileId)",
+        "CREATE INDEX IF NOT EXISTS idx_external_routine_profile_provider ON ExternalRoutine(profileId, provider)",
+        "CREATE INDEX IF NOT EXISTS idx_external_routine_folder ON ExternalRoutine(profileId, provider, folderExternalId)",
+        "CREATE INDEX IF NOT EXISTS idx_external_routine_updated ON ExternalRoutine(updatedAt DESC)",
+        """CREATE TABLE IF NOT EXISTS ExternalRoutineExercise (
+            id TEXT NOT NULL PRIMARY KEY,
+            externalRoutineId TEXT NOT NULL,
+            externalExerciseTemplateId TEXT,
+            title TEXT NOT NULL,
+            exerciseType TEXT,
+            primaryMuscleGroups TEXT NOT NULL DEFAULT '',
+            secondaryMuscleGroups TEXT NOT NULL DEFAULT '',
+            orderIndex INTEGER NOT NULL DEFAULT 0,
+            rawData TEXT
+        )""",
+        "CREATE INDEX IF NOT EXISTS idx_external_routine_exercise_routine ON ExternalRoutineExercise(externalRoutineId)",
+        "CREATE INDEX IF NOT EXISTS idx_external_routine_exercise_template ON ExternalRoutineExercise(externalExerciseTemplateId)",
+        """CREATE TABLE IF NOT EXISTS ExternalRoutineSet (
+            id TEXT NOT NULL PRIMARY KEY,
+            externalRoutineExerciseId TEXT NOT NULL,
+            setIndex INTEGER NOT NULL DEFAULT 0,
+            setType TEXT,
+            weightKg REAL,
+            reps INTEGER,
+            minReps INTEGER,
+            maxReps INTEGER,
+            restSeconds INTEGER,
+            rpe REAL,
+            durationSeconds INTEGER,
+            distanceMeters REAL,
+            rawData TEXT
+        )""",
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_external_routine_set_dedup ON ExternalRoutineSet(externalRoutineExerciseId, setIndex)",
+        "CREATE INDEX IF NOT EXISTS idx_external_routine_set_exercise ON ExternalRoutineSet(externalRoutineExerciseId)",
+        """CREATE TABLE IF NOT EXISTS ExternalRoutineFolder (
+            id TEXT NOT NULL PRIMARY KEY,
+            externalId TEXT NOT NULL,
+            provider TEXT NOT NULL,
+            title TEXT NOT NULL,
+            folderIndex INTEGER,
+            createdAt INTEGER,
+            updatedAt INTEGER,
+            profileId TEXT NOT NULL DEFAULT 'default',
+            rawData TEXT
+        )""",
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_external_routine_folder_dedup ON ExternalRoutineFolder(provider, externalId, profileId)",
+        "CREATE INDEX IF NOT EXISTS idx_external_routine_folder_profile_provider ON ExternalRoutineFolder(profileId, provider)",
+        """CREATE TABLE IF NOT EXISTS ExternalProgram (
+            id TEXT NOT NULL PRIMARY KEY,
+            externalId TEXT NOT NULL,
+            provider TEXT NOT NULL,
+            name TEXT NOT NULL,
+            isCurrent INTEGER NOT NULL DEFAULT 0,
+            scriptText TEXT,
+            rawData TEXT,
+            updatedAt INTEGER,
+            syncedAt INTEGER NOT NULL,
+            profileId TEXT NOT NULL DEFAULT 'default',
+            needsSync INTEGER NOT NULL DEFAULT 0,
+            deletedAt INTEGER
+        )""",
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_external_program_dedup ON ExternalProgram(provider, externalId, profileId)",
+        "CREATE INDEX IF NOT EXISTS idx_external_program_profile_provider ON ExternalProgram(profileId, provider)",
+        "CREATE INDEX IF NOT EXISTS idx_external_program_current ON ExternalProgram(profileId, provider, isCurrent)",
+        "CREATE INDEX IF NOT EXISTS idx_external_program_updated ON ExternalProgram(updatedAt DESC)",
+        """CREATE TABLE IF NOT EXISTS ExternalProgramStats (
+            id TEXT NOT NULL PRIMARY KEY,
+            externalProgramId TEXT NOT NULL,
+            days INTEGER,
+            approximateMinutes INTEGER,
+            setCount INTEGER,
+            muscleGroupBreakdownJson TEXT,
+            rawData TEXT,
+            computedAt INTEGER
+        )""",
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_external_program_stats_program ON ExternalProgramStats(externalProgramId)",
+        "CREATE INDEX IF NOT EXISTS idx_external_program_stats_computed ON ExternalProgramStats(computedAt DESC)",
+        """CREATE TABLE IF NOT EXISTS ExternalExerciseTemplate (
+            id TEXT NOT NULL PRIMARY KEY,
+            externalId TEXT NOT NULL,
+            provider TEXT NOT NULL,
+            title TEXT NOT NULL,
+            exerciseType TEXT,
+            primaryMuscleGroups TEXT NOT NULL DEFAULT '',
+            secondaryMuscleGroups TEXT NOT NULL DEFAULT '',
+            isCustom INTEGER NOT NULL DEFAULT 0,
+            rawData TEXT,
+            updatedAt INTEGER,
+            profileId TEXT NOT NULL DEFAULT 'default'
+        )""",
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_external_exercise_template_dedup ON ExternalExerciseTemplate(provider, externalId, profileId)",
+        "CREATE INDEX IF NOT EXISTS idx_external_exercise_template_profile_provider ON ExternalExerciseTemplate(profileId, provider)",
+        "CREATE INDEX IF NOT EXISTS idx_external_exercise_template_title ON ExternalExerciseTemplate(title)",
+        """CREATE TABLE IF NOT EXISTS ExternalExerciseTemplateMapping (
+            id TEXT NOT NULL PRIMARY KEY,
+            provider TEXT NOT NULL,
+            externalTemplateId TEXT NOT NULL,
+            localExerciseId TEXT NOT NULL,
+            profileId TEXT NOT NULL DEFAULT 'default',
+            createdAt INTEGER NOT NULL,
+            updatedAt INTEGER NOT NULL,
+            rawData TEXT
+        )""",
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_external_template_mapping_dedup ON ExternalExerciseTemplateMapping(provider, externalTemplateId, profileId)",
+        "CREATE INDEX IF NOT EXISTS idx_external_template_mapping_local ON ExternalExerciseTemplateMapping(localExerciseId)",
+        """CREATE TABLE IF NOT EXISTS ExternalBodyMeasurement (
+            id TEXT NOT NULL PRIMARY KEY,
+            externalId TEXT NOT NULL,
+            provider TEXT NOT NULL,
+            measurementType TEXT NOT NULL,
+            value REAL NOT NULL,
+            unit TEXT NOT NULL,
+            measuredAt INTEGER NOT NULL,
+            syncedAt INTEGER NOT NULL,
+            rawData TEXT,
+            profileId TEXT NOT NULL DEFAULT 'default'
+        )""",
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_external_body_measurement_dedup ON ExternalBodyMeasurement(provider, externalId, profileId)",
+        "CREATE INDEX IF NOT EXISTS idx_external_body_measurement_profile_provider ON ExternalBodyMeasurement(profileId, provider)",
+        "CREATE INDEX IF NOT EXISTS idx_external_body_measurement_type_date ON ExternalBodyMeasurement(profileId, measurementType, measuredAt DESC)",
+        """CREATE TABLE IF NOT EXISTS IntegrationSyncCursor (
+            provider TEXT NOT NULL,
+            profileId TEXT NOT NULL DEFAULT 'default',
+            cursorType TEXT NOT NULL,
+            cursorValue TEXT,
+            updatedAt INTEGER NOT NULL,
+            PRIMARY KEY(provider, profileId, cursorType)
+        )""",
+        "CREATE INDEX IF NOT EXISTS idx_integration_sync_cursor_profile_provider ON IntegrationSyncCursor(profileId, provider)",
     )
 
     else -> emptyList()

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/MigrationStatements.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/MigrationStatements.kt
@@ -714,7 +714,7 @@ WHERE gs.rowid = (
         "CREATE INDEX IF NOT EXISTS idx_external_routine_updated ON ExternalRoutine(updatedAt DESC)",
         """CREATE TABLE IF NOT EXISTS ExternalRoutineExercise (
             id TEXT NOT NULL PRIMARY KEY,
-            externalRoutineId TEXT NOT NULL,
+            externalRoutineId TEXT NOT NULL REFERENCES ExternalRoutine(id) ON DELETE CASCADE,
             externalExerciseTemplateId TEXT,
             title TEXT NOT NULL,
             exerciseType TEXT,
@@ -727,7 +727,7 @@ WHERE gs.rowid = (
         "CREATE INDEX IF NOT EXISTS idx_external_routine_exercise_template ON ExternalRoutineExercise(externalExerciseTemplateId)",
         """CREATE TABLE IF NOT EXISTS ExternalRoutineSet (
             id TEXT NOT NULL PRIMARY KEY,
-            externalRoutineExerciseId TEXT NOT NULL,
+            externalRoutineExerciseId TEXT NOT NULL REFERENCES ExternalRoutineExercise(id) ON DELETE CASCADE,
             setIndex INTEGER NOT NULL DEFAULT 0,
             setType TEXT,
             weightKg REAL,
@@ -775,7 +775,7 @@ WHERE gs.rowid = (
         "CREATE INDEX IF NOT EXISTS idx_external_program_updated ON ExternalProgram(updatedAt DESC)",
         """CREATE TABLE IF NOT EXISTS ExternalProgramStats (
             id TEXT NOT NULL PRIMARY KEY,
-            externalProgramId TEXT NOT NULL,
+            externalProgramId TEXT NOT NULL REFERENCES ExternalProgram(id) ON DELETE CASCADE,
             days INTEGER,
             approximateMinutes INTEGER,
             setCount INTEGER,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/SchemaManifest.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/SchemaManifest.kt
@@ -518,7 +518,7 @@ internal val manifestTables: List<SchemaTableOperation> = listOf(
         createSql = """
             CREATE TABLE IF NOT EXISTS ExternalRoutineExercise (
                 id TEXT NOT NULL PRIMARY KEY,
-                externalRoutineId TEXT NOT NULL,
+                externalRoutineId TEXT NOT NULL REFERENCES ExternalRoutine(id) ON DELETE CASCADE,
                 externalExerciseTemplateId TEXT,
                 title TEXT NOT NULL,
                 exerciseType TEXT,
@@ -535,7 +535,7 @@ internal val manifestTables: List<SchemaTableOperation> = listOf(
         createSql = """
             CREATE TABLE IF NOT EXISTS ExternalRoutineSet (
                 id TEXT NOT NULL PRIMARY KEY,
-                externalRoutineExerciseId TEXT NOT NULL,
+                externalRoutineExerciseId TEXT NOT NULL REFERENCES ExternalRoutineExercise(id) ON DELETE CASCADE,
                 setIndex INTEGER NOT NULL DEFAULT 0,
                 setType TEXT,
                 weightKg REAL,
@@ -593,7 +593,7 @@ internal val manifestTables: List<SchemaTableOperation> = listOf(
         createSql = """
             CREATE TABLE IF NOT EXISTS ExternalProgramStats (
                 id TEXT NOT NULL PRIMARY KEY,
-                externalProgramId TEXT NOT NULL,
+                externalProgramId TEXT NOT NULL REFERENCES ExternalProgram(id) ON DELETE CASCADE,
                 days INTEGER,
                 approximateMinutes INTEGER,
                 setCount INTEGER,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/SchemaManifest.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/SchemaManifest.kt
@@ -470,7 +470,8 @@ internal val manifestTables: List<SchemaTableOperation> = listOf(
                 rawData TEXT,
                 syncedAt INTEGER NOT NULL,
                 profileId TEXT NOT NULL DEFAULT 'default',
-                needsSync INTEGER NOT NULL DEFAULT 1
+                needsSync INTEGER NOT NULL DEFAULT 1,
+                deletedAt INTEGER
             )
         """.trimIndent(),
     ),
@@ -487,6 +488,185 @@ internal val manifestTables: List<SchemaTableOperation> = listOf(
                 errorMessage TEXT,
                 profileId TEXT NOT NULL DEFAULT 'default',
                 PRIMARY KEY(provider, profileId)
+            )
+        """.trimIndent(),
+    ),
+
+    // ExternalRoutine -- migration 31 (expanded third-party integration routines)
+    SchemaTableOperation(
+        table = "ExternalRoutine",
+        createSql = """
+            CREATE TABLE IF NOT EXISTS ExternalRoutine (
+                id TEXT NOT NULL PRIMARY KEY,
+                externalId TEXT NOT NULL,
+                provider TEXT NOT NULL,
+                title TEXT NOT NULL,
+                folderExternalId TEXT,
+                folderName TEXT,
+                updatedAt INTEGER,
+                syncedAt INTEGER NOT NULL,
+                rawData TEXT,
+                profileId TEXT NOT NULL DEFAULT 'default',
+                needsSync INTEGER NOT NULL DEFAULT 0,
+                deletedAt INTEGER
+            )
+        """.trimIndent(),
+    ),
+
+    SchemaTableOperation(
+        table = "ExternalRoutineExercise",
+        createSql = """
+            CREATE TABLE IF NOT EXISTS ExternalRoutineExercise (
+                id TEXT NOT NULL PRIMARY KEY,
+                externalRoutineId TEXT NOT NULL,
+                externalExerciseTemplateId TEXT,
+                title TEXT NOT NULL,
+                exerciseType TEXT,
+                primaryMuscleGroups TEXT NOT NULL DEFAULT '',
+                secondaryMuscleGroups TEXT NOT NULL DEFAULT '',
+                orderIndex INTEGER NOT NULL DEFAULT 0,
+                rawData TEXT
+            )
+        """.trimIndent(),
+    ),
+
+    SchemaTableOperation(
+        table = "ExternalRoutineSet",
+        createSql = """
+            CREATE TABLE IF NOT EXISTS ExternalRoutineSet (
+                id TEXT NOT NULL PRIMARY KEY,
+                externalRoutineExerciseId TEXT NOT NULL,
+                setIndex INTEGER NOT NULL DEFAULT 0,
+                setType TEXT,
+                weightKg REAL,
+                reps INTEGER,
+                minReps INTEGER,
+                maxReps INTEGER,
+                restSeconds INTEGER,
+                rpe REAL,
+                durationSeconds INTEGER,
+                distanceMeters REAL,
+                rawData TEXT
+            )
+        """.trimIndent(),
+    ),
+
+    SchemaTableOperation(
+        table = "ExternalRoutineFolder",
+        createSql = """
+            CREATE TABLE IF NOT EXISTS ExternalRoutineFolder (
+                id TEXT NOT NULL PRIMARY KEY,
+                externalId TEXT NOT NULL,
+                provider TEXT NOT NULL,
+                title TEXT NOT NULL,
+                folderIndex INTEGER,
+                createdAt INTEGER,
+                updatedAt INTEGER,
+                profileId TEXT NOT NULL DEFAULT 'default',
+                rawData TEXT
+            )
+        """.trimIndent(),
+    ),
+
+    SchemaTableOperation(
+        table = "ExternalProgram",
+        createSql = """
+            CREATE TABLE IF NOT EXISTS ExternalProgram (
+                id TEXT NOT NULL PRIMARY KEY,
+                externalId TEXT NOT NULL,
+                provider TEXT NOT NULL,
+                name TEXT NOT NULL,
+                isCurrent INTEGER NOT NULL DEFAULT 0,
+                scriptText TEXT,
+                rawData TEXT,
+                updatedAt INTEGER,
+                syncedAt INTEGER NOT NULL,
+                profileId TEXT NOT NULL DEFAULT 'default',
+                needsSync INTEGER NOT NULL DEFAULT 0,
+                deletedAt INTEGER
+            )
+        """.trimIndent(),
+    ),
+
+    SchemaTableOperation(
+        table = "ExternalProgramStats",
+        createSql = """
+            CREATE TABLE IF NOT EXISTS ExternalProgramStats (
+                id TEXT NOT NULL PRIMARY KEY,
+                externalProgramId TEXT NOT NULL,
+                days INTEGER,
+                approximateMinutes INTEGER,
+                setCount INTEGER,
+                muscleGroupBreakdownJson TEXT,
+                rawData TEXT,
+                computedAt INTEGER
+            )
+        """.trimIndent(),
+    ),
+
+    SchemaTableOperation(
+        table = "ExternalExerciseTemplate",
+        createSql = """
+            CREATE TABLE IF NOT EXISTS ExternalExerciseTemplate (
+                id TEXT NOT NULL PRIMARY KEY,
+                externalId TEXT NOT NULL,
+                provider TEXT NOT NULL,
+                title TEXT NOT NULL,
+                exerciseType TEXT,
+                primaryMuscleGroups TEXT NOT NULL DEFAULT '',
+                secondaryMuscleGroups TEXT NOT NULL DEFAULT '',
+                isCustom INTEGER NOT NULL DEFAULT 0,
+                rawData TEXT,
+                updatedAt INTEGER,
+                profileId TEXT NOT NULL DEFAULT 'default'
+            )
+        """.trimIndent(),
+    ),
+
+    SchemaTableOperation(
+        table = "ExternalExerciseTemplateMapping",
+        createSql = """
+            CREATE TABLE IF NOT EXISTS ExternalExerciseTemplateMapping (
+                id TEXT NOT NULL PRIMARY KEY,
+                provider TEXT NOT NULL,
+                externalTemplateId TEXT NOT NULL,
+                localExerciseId TEXT NOT NULL,
+                profileId TEXT NOT NULL DEFAULT 'default',
+                createdAt INTEGER NOT NULL,
+                updatedAt INTEGER NOT NULL,
+                rawData TEXT
+            )
+        """.trimIndent(),
+    ),
+
+    SchemaTableOperation(
+        table = "ExternalBodyMeasurement",
+        createSql = """
+            CREATE TABLE IF NOT EXISTS ExternalBodyMeasurement (
+                id TEXT NOT NULL PRIMARY KEY,
+                externalId TEXT NOT NULL,
+                provider TEXT NOT NULL,
+                measurementType TEXT NOT NULL,
+                value REAL NOT NULL,
+                unit TEXT NOT NULL,
+                measuredAt INTEGER NOT NULL,
+                syncedAt INTEGER NOT NULL,
+                rawData TEXT,
+                profileId TEXT NOT NULL DEFAULT 'default'
+            )
+        """.trimIndent(),
+    ),
+
+    SchemaTableOperation(
+        table = "IntegrationSyncCursor",
+        createSql = """
+            CREATE TABLE IF NOT EXISTS IntegrationSyncCursor (
+                provider TEXT NOT NULL,
+                profileId TEXT NOT NULL DEFAULT 'default',
+                cursorType TEXT NOT NULL,
+                cursorValue TEXT,
+                updatedAt INTEGER NOT NULL,
+                PRIMARY KEY(provider, profileId, cursorType)
             )
         """.trimIndent(),
     ),
@@ -1081,6 +1261,10 @@ internal val manifestColumns: List<SchemaHealOperation> = listOf(
     // ── Routine (1 column, migration 27) ───────────────────────────────
     // Migration 27: routine grouping
     SchemaHealOperation("Routine", "groupId", "ALTER TABLE Routine ADD COLUMN groupId TEXT REFERENCES RoutineGroup(id) ON DELETE SET NULL"),
+
+    // ── ExternalActivity (1 column, migration 31) ──────────────────────
+    // Migration 31: provider tombstone handling
+    SchemaHealOperation("ExternalActivity", "deletedAt", "ALTER TABLE ExternalActivity ADD COLUMN deletedAt INTEGER"),
 )
 
 // ============================================================
@@ -1184,10 +1368,41 @@ internal val manifestIndexes: List<SchemaIndexOperation> = listOf(
     SchemaIndexOperation("idx_progression_profile", "CREATE INDEX IF NOT EXISTS idx_progression_profile ON ProgressionEvent(profile_id)"),
 
     // ── ExternalActivity ────────────────────────────────────────────────
-    SchemaIndexOperation("idx_external_activity_dedup", "CREATE UNIQUE INDEX IF NOT EXISTS idx_external_activity_dedup ON ExternalActivity(externalId, provider)"),
+    SchemaIndexOperation(
+        name = "idx_external_activity_dedup",
+        createSql = "CREATE UNIQUE INDEX IF NOT EXISTS idx_external_activity_dedup ON ExternalActivity(provider, externalId, profileId)",
+        preDropSql = "DROP INDEX IF EXISTS idx_external_activity_dedup",
+    ),
     SchemaIndexOperation("idx_external_activity_profile", "CREATE INDEX IF NOT EXISTS idx_external_activity_profile ON ExternalActivity(profileId)"),
     SchemaIndexOperation("idx_external_activity_provider", "CREATE INDEX IF NOT EXISTS idx_external_activity_provider ON ExternalActivity(provider)"),
     SchemaIndexOperation("idx_external_activity_started", "CREATE INDEX IF NOT EXISTS idx_external_activity_started ON ExternalActivity(startedAt DESC)"),
+
+    // ── Expanded External Integration Entities ─────────────────────────
+    SchemaIndexOperation("idx_external_routine_dedup", "CREATE UNIQUE INDEX IF NOT EXISTS idx_external_routine_dedup ON ExternalRoutine(provider, externalId, profileId)"),
+    SchemaIndexOperation("idx_external_routine_profile_provider", "CREATE INDEX IF NOT EXISTS idx_external_routine_profile_provider ON ExternalRoutine(profileId, provider)"),
+    SchemaIndexOperation("idx_external_routine_folder", "CREATE INDEX IF NOT EXISTS idx_external_routine_folder ON ExternalRoutine(profileId, provider, folderExternalId)"),
+    SchemaIndexOperation("idx_external_routine_updated", "CREATE INDEX IF NOT EXISTS idx_external_routine_updated ON ExternalRoutine(updatedAt DESC)"),
+    SchemaIndexOperation("idx_external_routine_exercise_routine", "CREATE INDEX IF NOT EXISTS idx_external_routine_exercise_routine ON ExternalRoutineExercise(externalRoutineId)"),
+    SchemaIndexOperation("idx_external_routine_exercise_template", "CREATE INDEX IF NOT EXISTS idx_external_routine_exercise_template ON ExternalRoutineExercise(externalExerciseTemplateId)"),
+    SchemaIndexOperation("idx_external_routine_set_dedup", "CREATE UNIQUE INDEX IF NOT EXISTS idx_external_routine_set_dedup ON ExternalRoutineSet(externalRoutineExerciseId, setIndex)"),
+    SchemaIndexOperation("idx_external_routine_set_exercise", "CREATE INDEX IF NOT EXISTS idx_external_routine_set_exercise ON ExternalRoutineSet(externalRoutineExerciseId)"),
+    SchemaIndexOperation("idx_external_routine_folder_dedup", "CREATE UNIQUE INDEX IF NOT EXISTS idx_external_routine_folder_dedup ON ExternalRoutineFolder(provider, externalId, profileId)"),
+    SchemaIndexOperation("idx_external_routine_folder_profile_provider", "CREATE INDEX IF NOT EXISTS idx_external_routine_folder_profile_provider ON ExternalRoutineFolder(profileId, provider)"),
+    SchemaIndexOperation("idx_external_program_dedup", "CREATE UNIQUE INDEX IF NOT EXISTS idx_external_program_dedup ON ExternalProgram(provider, externalId, profileId)"),
+    SchemaIndexOperation("idx_external_program_profile_provider", "CREATE INDEX IF NOT EXISTS idx_external_program_profile_provider ON ExternalProgram(profileId, provider)"),
+    SchemaIndexOperation("idx_external_program_current", "CREATE INDEX IF NOT EXISTS idx_external_program_current ON ExternalProgram(profileId, provider, isCurrent)"),
+    SchemaIndexOperation("idx_external_program_updated", "CREATE INDEX IF NOT EXISTS idx_external_program_updated ON ExternalProgram(updatedAt DESC)"),
+    SchemaIndexOperation("idx_external_program_stats_program", "CREATE UNIQUE INDEX IF NOT EXISTS idx_external_program_stats_program ON ExternalProgramStats(externalProgramId)"),
+    SchemaIndexOperation("idx_external_program_stats_computed", "CREATE INDEX IF NOT EXISTS idx_external_program_stats_computed ON ExternalProgramStats(computedAt DESC)"),
+    SchemaIndexOperation("idx_external_exercise_template_dedup", "CREATE UNIQUE INDEX IF NOT EXISTS idx_external_exercise_template_dedup ON ExternalExerciseTemplate(provider, externalId, profileId)"),
+    SchemaIndexOperation("idx_external_exercise_template_profile_provider", "CREATE INDEX IF NOT EXISTS idx_external_exercise_template_profile_provider ON ExternalExerciseTemplate(profileId, provider)"),
+    SchemaIndexOperation("idx_external_exercise_template_title", "CREATE INDEX IF NOT EXISTS idx_external_exercise_template_title ON ExternalExerciseTemplate(title)"),
+    SchemaIndexOperation("idx_external_template_mapping_dedup", "CREATE UNIQUE INDEX IF NOT EXISTS idx_external_template_mapping_dedup ON ExternalExerciseTemplateMapping(provider, externalTemplateId, profileId)"),
+    SchemaIndexOperation("idx_external_template_mapping_local", "CREATE INDEX IF NOT EXISTS idx_external_template_mapping_local ON ExternalExerciseTemplateMapping(localExerciseId)"),
+    SchemaIndexOperation("idx_external_body_measurement_dedup", "CREATE UNIQUE INDEX IF NOT EXISTS idx_external_body_measurement_dedup ON ExternalBodyMeasurement(provider, externalId, profileId)"),
+    SchemaIndexOperation("idx_external_body_measurement_profile_provider", "CREATE INDEX IF NOT EXISTS idx_external_body_measurement_profile_provider ON ExternalBodyMeasurement(profileId, provider)"),
+    SchemaIndexOperation("idx_external_body_measurement_type_date", "CREATE INDEX IF NOT EXISTS idx_external_body_measurement_type_date ON ExternalBodyMeasurement(profileId, measurementType, measuredAt DESC)"),
+    SchemaIndexOperation("idx_integration_sync_cursor_profile_provider", "CREATE INDEX IF NOT EXISTS idx_integration_sync_cursor_profile_provider ON IntegrationSyncCursor(profileId, provider)"),
 
     // ── SessionNotes (Phase 3.5, migration 26.sqm) ──────────────────────
     SchemaIndexOperation("idx_session_notes_updated_at", "CREATE INDEX IF NOT EXISTS idx_session_notes_updated_at ON SessionNotes(updatedAt)"),

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/IntegrationDtos.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/IntegrationDtos.kt
@@ -10,12 +10,38 @@ import kotlinx.serialization.Serializable
  */
 
 @Serializable
-data class IntegrationSyncRequest(val provider: String, val action: String, val apiKey: String? = null)
+data class IntegrationSyncRequest(
+    val provider: String,
+    val action: String,
+    val apiKey: String? = null,
+    val entityTypes: List<String>? = null,
+    val cursor: String? = null,
+    val forceFullRefresh: Boolean? = null,
+    val includeRawData: Boolean? = null,
+)
 
 @Serializable
 data class IntegrationSyncResponse(
     val status: String,
     val activities: List<IntegrationActivityDto> = emptyList(),
+    val routines: List<IntegrationRoutineDto> = emptyList(),
+    val routineFolders: List<IntegrationRoutineFolderDto> = emptyList(),
+    val exerciseTemplates: List<IntegrationExerciseTemplateDto> = emptyList(),
+    val bodyMeasurements: List<IntegrationBodyMeasurementDto> = emptyList(),
+    val programs: List<IntegrationProgramDto> = emptyList(),
+    val programStats: List<IntegrationProgramStatsDto> = emptyList(),
+    val playground: IntegrationPlaygroundPreviewDto? = null,
+    val requiresUpgrade: Boolean = false,
+    val upgradeReason: String? = null,
+    val providerPlanName: String? = null,
+    val entitlementStatus: String? = null,
+    val nextCursor: String? = null,
+    val hasMore: Boolean = false,
+    val partial: Boolean = false,
+    val deletedExternalIds: List<String> = emptyList(),
+    val updatedExternalIds: List<String> = emptyList(),
+    val providerSyncCursor: String? = null,
+    val errors: List<IntegrationEntityErrorDto> = emptyList(),
     val error: String? = null,
 )
 
@@ -33,4 +59,137 @@ data class IntegrationActivityDto(
     val maxHeartRate: Int? = null,
     val elevationGainMeters: Double? = null,
     val rawData: String? = null,
+)
+
+@Serializable
+data class IntegrationRoutineDto(
+    val externalId: String,
+    val provider: String,
+    val title: String,
+    val folderExternalId: String? = null,
+    val folderName: String? = null,
+    val updatedAt: String? = null,
+    val exercises: List<IntegrationRoutineExerciseDto> = emptyList(),
+    val rawData: String? = null,
+)
+
+@Serializable
+data class IntegrationRoutineExerciseDto(
+    val externalExerciseTemplateId: String? = null,
+    val title: String,
+    val exerciseType: String? = null,
+    val primaryMuscleGroups: List<String> = emptyList(),
+    val secondaryMuscleGroups: List<String> = emptyList(),
+    val orderIndex: Int = 0,
+    val sets: List<IntegrationRoutineSetDto> = emptyList(),
+    val rawData: String? = null,
+)
+
+@Serializable
+data class IntegrationRoutineSetDto(
+    val index: Int = 0,
+    val setType: String? = null,
+    val weightKg: Double? = null,
+    val reps: Int? = null,
+    val minReps: Int? = null,
+    val maxReps: Int? = null,
+    val restSeconds: Int? = null,
+    val rpe: Double? = null,
+    val durationSeconds: Int? = null,
+    val distanceMeters: Double? = null,
+    val rawData: String? = null,
+)
+
+@Serializable
+data class IntegrationRoutineFolderDto(
+    val externalId: String,
+    val provider: String,
+    val title: String,
+    val index: Int? = null,
+    val createdAt: String? = null,
+    val updatedAt: String? = null,
+    val rawData: String? = null,
+)
+
+@Serializable
+data class IntegrationExerciseTemplateDto(
+    val externalId: String,
+    val provider: String,
+    val title: String,
+    val exerciseType: String? = null,
+    val primaryMuscleGroups: List<String> = emptyList(),
+    val secondaryMuscleGroups: List<String> = emptyList(),
+    val isCustom: Boolean = false,
+    val rawData: String? = null,
+    val updatedAt: String? = null,
+)
+
+@Serializable
+data class IntegrationBodyMeasurementDto(
+    val externalId: String,
+    val provider: String,
+    val measurementType: String,
+    val value: Double,
+    val unit: String,
+    val measuredAt: String,
+    val rawData: String? = null,
+)
+
+@Serializable
+data class IntegrationProgramDto(
+    val externalId: String,
+    val provider: String,
+    val name: String,
+    val isCurrent: Boolean = false,
+    val scriptText: String? = null,
+    val rawData: String? = null,
+    val updatedAt: String? = null,
+)
+
+@Serializable
+data class IntegrationProgramStatsDto(
+    val externalProgramId: String,
+    val days: Int? = null,
+    val approximateMinutes: Int? = null,
+    val setCount: Int? = null,
+    val muscleGroupBreakdownJson: String? = null,
+    val rawData: String? = null,
+    val computedAt: String? = null,
+)
+
+@Serializable
+data class IntegrationPlaygroundPreviewDto(
+    val programExternalId: String,
+    val currentWorkoutText: String? = null,
+    val nextWorkoutText: String? = null,
+    val updatedProgramText: String? = null,
+    val commandsApplied: List<String> = emptyList(),
+    val rawData: String? = null,
+    val generatedAt: String? = null,
+)
+
+@Serializable
+data class IntegrationEntityErrorDto(
+    val entityType: String,
+    val code: String? = null,
+    val message: String,
+    val retryAfterSeconds: Int? = null,
+)
+
+@Serializable
+data class IntegrationPlaygroundSimulationRequest(
+    val provider: String,
+    val externalProgramId: String,
+    val scriptText: String,
+    val commands: List<String> = emptyList(),
+    val profileId: String,
+)
+
+@Serializable
+data class IntegrationPlaygroundSimulationResponse(
+    val status: String,
+    val preview: IntegrationPlaygroundPreviewDto? = null,
+    val updatedProgramText: String? = null,
+    val error: String? = null,
+    val requiresUpgrade: Boolean = false,
 )

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalApiClient.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalApiClient.kt
@@ -528,6 +528,16 @@ open class PortalApiClient(private val supabaseConfig: SupabaseConfig, private v
         }
     }
 
+    open suspend fun callIntegrationPlaygroundSimulation(
+        request: IntegrationPlaygroundSimulationRequest,
+    ): Result<IntegrationPlaygroundSimulationResponse> = authenticatedRequest { token ->
+        httpClient.post("${supabaseConfig.url}/functions/v1/mobile-integration-playground") {
+            bearerAuth(token)
+            header("apikey", supabaseConfig.anonKey)
+            setBody(request)
+        }
+    }
+
     // === Private Helpers ===
 
     /**

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/SyncManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/SyncManager.kt
@@ -1379,7 +1379,7 @@ class SyncManager(
                     externalId = dto.externalId,
                     provider = IntegrationProvider.fromKey(
                         dto.provider,
-                    ) ?: IntegrationProvider.HEVY,
+                    ) ?: IntegrationProvider.UNKNOWN,
                     name = dto.name,
                     activityType = dto.activityType,
                     startedAt = try {

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/di/DataModule.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/di/DataModule.kt
@@ -1,7 +1,17 @@
 package com.devil.phoenixproject.di
 
 import com.devil.phoenixproject.data.integration.ExternalActivityRepository
+import com.devil.phoenixproject.data.integration.ExternalExerciseTemplateRepository
+import com.devil.phoenixproject.data.integration.ExternalMeasurementRepository
+import com.devil.phoenixproject.data.integration.ExternalProgramRepository
+import com.devil.phoenixproject.data.integration.ExternalRoutineRepository
+import com.devil.phoenixproject.data.integration.IntegrationSyncCursorRepository
 import com.devil.phoenixproject.data.integration.SqlDelightExternalActivityRepository
+import com.devil.phoenixproject.data.integration.SqlDelightExternalExerciseTemplateRepository
+import com.devil.phoenixproject.data.integration.SqlDelightExternalMeasurementRepository
+import com.devil.phoenixproject.data.integration.SqlDelightExternalProgramRepository
+import com.devil.phoenixproject.data.integration.SqlDelightExternalRoutineRepository
+import com.devil.phoenixproject.data.integration.SqlDelightIntegrationSyncCursorRepository
 import com.devil.phoenixproject.data.local.DatabaseFactory
 import com.devil.phoenixproject.data.local.ExerciseImporter
 import com.devil.phoenixproject.data.repository.*
@@ -43,4 +53,9 @@ val dataModule = module {
 
     // External Activity Repository (Task 3 - third-party integrations)
     single<ExternalActivityRepository> { SqlDelightExternalActivityRepository(get()) }
+    single<ExternalRoutineRepository> { SqlDelightExternalRoutineRepository(get()) }
+    single<ExternalProgramRepository> { SqlDelightExternalProgramRepository(get()) }
+    single<ExternalMeasurementRepository> { SqlDelightExternalMeasurementRepository(get()) }
+    single<ExternalExerciseTemplateRepository> { SqlDelightExternalExerciseTemplateRepository(get()) }
+    single<IntegrationSyncCursorRepository> { SqlDelightIntegrationSyncCursorRepository(get()) }
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/di/PresentationModule.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/di/PresentationModule.kt
@@ -4,6 +4,10 @@ import com.devil.phoenixproject.presentation.viewmodel.AssessmentViewModel
 import com.devil.phoenixproject.presentation.viewmodel.ConnectionLogsViewModel
 import com.devil.phoenixproject.presentation.viewmodel.CycleEditorViewModel
 import com.devil.phoenixproject.presentation.viewmodel.EulaViewModel
+import com.devil.phoenixproject.presentation.viewmodel.ExternalActivitiesViewModel
+import com.devil.phoenixproject.presentation.viewmodel.ExternalMeasurementsViewModel
+import com.devil.phoenixproject.presentation.viewmodel.ExternalProgramsViewModel
+import com.devil.phoenixproject.presentation.viewmodel.ExternalRoutinesViewModel
 import com.devil.phoenixproject.presentation.viewmodel.GamificationViewModel
 import com.devil.phoenixproject.presentation.viewmodel.IntegrationsViewModel
 import com.devil.phoenixproject.presentation.viewmodel.ThemeViewModel
@@ -15,7 +19,11 @@ val presentationModule = module {
     factory { ConnectionLogsViewModel() }
     factory { CycleEditorViewModel(get(), get()) }
     factory { GamificationViewModel(get(), get()) }
-    factory { IntegrationsViewModel(get(), get(), get(), get(), get(), get()) }
+    factory { IntegrationsViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
+    factory { ExternalActivitiesViewModel(get(), get()) }
+    factory { ExternalRoutinesViewModel(get(), get()) }
+    factory { ExternalProgramsViewModel(get(), get(), get()) }
+    factory { ExternalMeasurementsViewModel(get(), get()) }
     factory { AssessmentViewModel(get(), get(), get()) }
     // ThemeViewModel as singleton - app-wide theme state that must persist
     single { ThemeViewModel(get()) }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/di/SyncModule.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/di/SyncModule.kt
@@ -31,7 +31,7 @@ val syncModule = module {
         )
     }
     single { SyncTriggerManager(get(), get()) }
-    single { IntegrationManager(get(), get()) }
+    single { IntegrationManager(get(), get(), get(), get(), get(), get(), get()) }
 
     // Auth (using Supabase GoTrue)
     single<AuthRepository> { PortalAuthRepository(get(), get(), get(), get(), get()) }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/ExternalActivity.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/ExternalActivity.kt
@@ -60,4 +60,5 @@ data class ExternalActivity(
     val syncedAt: Long = currentTimeMillis(),
     val profileId: String = "default",
     val needsSync: Boolean = false,
+    val deletedAt: Long? = null,
 )

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/ExternalActivity.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/ExternalActivity.kt
@@ -10,6 +10,7 @@ enum class IntegrationProvider(val key: String, val displayName: String) {
     STRONG("strong", "Strong"),
     APPLE_HEALTH("apple_health", "Apple Health"),
     GOOGLE_HEALTH("google_health", "Google Health Connect"),
+    UNKNOWN("unknown", "Unknown"),
     ;
 
     companion object {

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/ExternalIntegrationModels.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/ExternalIntegrationModels.kt
@@ -1,0 +1,168 @@
+package com.devil.phoenixproject.domain.model
+
+data class ExternalRoutine(
+    val id: String = generateUUID(),
+    val externalId: String,
+    val provider: IntegrationProvider,
+    val title: String,
+    val folderExternalId: String? = null,
+    val folderName: String? = null,
+    val updatedAt: Long? = null,
+    val exercises: List<ExternalRoutineExercise> = emptyList(),
+    val rawData: String? = null,
+    val profileId: String = "default",
+    val syncedAt: Long = currentTimeMillis(),
+    val needsSync: Boolean = false,
+    val deletedAt: Long? = null,
+)
+
+data class ExternalRoutineExercise(
+    val id: String = generateUUID(),
+    val externalRoutineId: String,
+    val externalExerciseTemplateId: String? = null,
+    val title: String,
+    val exerciseType: String? = null,
+    val primaryMuscleGroups: List<String> = emptyList(),
+    val secondaryMuscleGroups: List<String> = emptyList(),
+    val orderIndex: Int = 0,
+    val sets: List<ExternalRoutineSet> = emptyList(),
+    val rawData: String? = null,
+)
+
+data class ExternalRoutineSet(
+    val id: String = generateUUID(),
+    val externalRoutineExerciseId: String,
+    val index: Int = 0,
+    val setType: String? = null,
+    val weightKg: Double? = null,
+    val reps: Int? = null,
+    val minReps: Int? = null,
+    val maxReps: Int? = null,
+    val restSeconds: Int? = null,
+    val rpe: Double? = null,
+    val durationSeconds: Int? = null,
+    val distanceMeters: Double? = null,
+    val rawData: String? = null,
+)
+
+data class ExternalRoutineFolder(
+    val id: String = generateUUID(),
+    val externalId: String,
+    val provider: IntegrationProvider,
+    val title: String,
+    val index: Int? = null,
+    val createdAt: Long? = null,
+    val updatedAt: Long? = null,
+    val profileId: String = "default",
+    val rawData: String? = null,
+)
+
+data class ExternalProgram(
+    val id: String = generateUUID(),
+    val externalId: String,
+    val provider: IntegrationProvider,
+    val name: String,
+    val isCurrent: Boolean = false,
+    val scriptText: String? = null,
+    val rawData: String? = null,
+    val updatedAt: Long? = null,
+    val syncedAt: Long = currentTimeMillis(),
+    val profileId: String = "default",
+    val needsSync: Boolean = false,
+    val deletedAt: Long? = null,
+)
+
+data class ExternalProgramStats(
+    val id: String = generateUUID(),
+    val externalProgramId: String,
+    val days: Int? = null,
+    val approximateMinutes: Int? = null,
+    val setCount: Int? = null,
+    val muscleGroupBreakdownJson: String? = null,
+    val rawData: String? = null,
+    val computedAt: Long? = null,
+)
+
+data class ExternalExerciseTemplate(
+    val id: String = generateUUID(),
+    val externalId: String,
+    val provider: IntegrationProvider,
+    val title: String,
+    val exerciseType: String? = null,
+    val primaryMuscleGroups: List<String> = emptyList(),
+    val secondaryMuscleGroups: List<String> = emptyList(),
+    val isCustom: Boolean = false,
+    val rawData: String? = null,
+    val updatedAt: Long? = null,
+    val profileId: String = "default",
+)
+
+data class ExternalExerciseTemplateMapping(
+    val id: String = generateUUID(),
+    val provider: IntegrationProvider,
+    val externalTemplateId: String,
+    val localExerciseId: String,
+    val profileId: String = "default",
+    val createdAt: Long = currentTimeMillis(),
+    val updatedAt: Long = currentTimeMillis(),
+    val rawData: String? = null,
+)
+
+data class ExternalBodyMeasurement(
+    val id: String = generateUUID(),
+    val externalId: String,
+    val provider: IntegrationProvider,
+    val measurementType: String,
+    val value: Double,
+    val unit: String,
+    val measuredAt: Long,
+    val rawData: String? = null,
+    val profileId: String = "default",
+    val syncedAt: Long = currentTimeMillis(),
+)
+
+data class ExternalPlaygroundPreview(
+    val programExternalId: String,
+    val currentWorkoutText: String? = null,
+    val nextWorkoutText: String? = null,
+    val updatedProgramText: String? = null,
+    val commandsApplied: List<String> = emptyList(),
+    val rawData: String? = null,
+    val generatedAt: Long = currentTimeMillis(),
+)
+
+data class IntegrationEntitlementState(
+    val provider: IntegrationProvider,
+    val status: String? = null,
+    val requiresUpgrade: Boolean = false,
+    val upgradeReason: String? = null,
+    val providerPlanName: String? = null,
+    val retryAfterSeconds: Int? = null,
+)
+
+data class IntegrationSyncWarning(
+    val entityType: String,
+    val message: String,
+    val code: String? = null,
+    val retryAfterSeconds: Int? = null,
+)
+
+data class IntegrationSyncProgress(
+    val activitiesImported: Int = 0,
+    val routinesImported: Int = 0,
+    val routineFoldersImported: Int = 0,
+    val exerciseTemplatesImported: Int = 0,
+    val measurementsImported: Int = 0,
+    val programsImported: Int = 0,
+    val programStatsImported: Int = 0,
+)
+
+data class IntegrationSyncResult(
+    val provider: IntegrationProvider,
+    val progress: IntegrationSyncProgress = IntegrationSyncProgress(),
+    val entitlementState: IntegrationEntitlementState? = null,
+    val partial: Boolean = false,
+    val warnings: List<IntegrationSyncWarning> = emptyList(),
+    val nextCursor: String? = null,
+    val hasMore: Boolean = false,
+)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/navigation/NavGraph.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/navigation/NavGraph.kt
@@ -631,9 +631,36 @@ fun NavGraph(
                 val weightUnit by viewModel.weightUnit.collectAsState()
                 IntegrationsScreen(
                     weightUnit = weightUnit,
-                    onNavigateToExternalActivities = {
-                        navController.navigate(NavigationRoutes.ExternalActivities.route)
+                    onNavigateToExternalData = {
+                        navController.navigate(NavigationRoutes.ExternalIntegrationHub.route)
                     },
+                    onSetTitle = { viewModel.updateTopBarTitle(it) },
+                )
+            }
+
+            // External integration data hub
+            composable(
+                route = NavigationRoutes.ExternalIntegrationHub.route,
+                enterTransition = {
+                    slideIntoContainer(
+                        towards = AnimatedContentTransitionScope.SlideDirection.Left,
+                        animationSpec = tween(300),
+                    )
+                },
+                exitTransition = { fadeOut(animationSpec = tween(200)) },
+                popEnterTransition = { fadeIn(animationSpec = tween(200)) },
+                popExitTransition = {
+                    slideOutOfContainer(
+                        towards = AnimatedContentTransitionScope.SlideDirection.Right,
+                        animationSpec = tween(300),
+                    )
+                },
+            ) {
+                ExternalIntegrationHubScreen(
+                    onNavigateToActivities = { navController.navigate(NavigationRoutes.ExternalActivities.route) },
+                    onNavigateToRoutines = { navController.navigate(NavigationRoutes.ExternalRoutines.route) },
+                    onNavigateToPrograms = { navController.navigate(NavigationRoutes.ExternalPrograms.route) },
+                    onNavigateToMeasurements = { navController.navigate(NavigationRoutes.ExternalMeasurementTrends.route) },
                     onSetTitle = { viewModel.updateTopBarTitle(it) },
                 )
             }
@@ -657,6 +684,165 @@ fun NavGraph(
                 },
             ) {
                 ExternalActivitiesScreen(
+                    onSetTitle = { viewModel.updateTopBarTitle(it) },
+                )
+            }
+
+            composable(
+                route = NavigationRoutes.ExternalRoutines.route,
+                enterTransition = {
+                    slideIntoContainer(
+                        towards = AnimatedContentTransitionScope.SlideDirection.Left,
+                        animationSpec = tween(300),
+                    )
+                },
+                exitTransition = { fadeOut(animationSpec = tween(200)) },
+                popEnterTransition = { fadeIn(animationSpec = tween(200)) },
+                popExitTransition = {
+                    slideOutOfContainer(
+                        towards = AnimatedContentTransitionScope.SlideDirection.Right,
+                        animationSpec = tween(300),
+                    )
+                },
+            ) {
+                ExternalRoutinesScreen(
+                    onRoutineClick = { provider, externalId ->
+                        navController.navigate(NavigationRoutes.ExternalRoutineDetail.createRoute(provider.key, externalId))
+                    },
+                    onSetTitle = { viewModel.updateTopBarTitle(it) },
+                )
+            }
+
+            composable(
+                route = NavigationRoutes.ExternalRoutineDetail.route,
+                arguments = listOf(
+                    navArgument("provider") { type = NavType.StringType },
+                    navArgument("externalRoutineId") { type = NavType.StringType },
+                ),
+                enterTransition = {
+                    slideIntoContainer(
+                        towards = AnimatedContentTransitionScope.SlideDirection.Left,
+                        animationSpec = tween(300),
+                    )
+                },
+                exitTransition = { fadeOut(animationSpec = tween(200)) },
+                popEnterTransition = { fadeIn(animationSpec = tween(200)) },
+                popExitTransition = {
+                    slideOutOfContainer(
+                        towards = AnimatedContentTransitionScope.SlideDirection.Right,
+                        animationSpec = tween(300),
+                    )
+                },
+            ) { backStackEntry ->
+                ExternalRoutineDetailScreen(
+                    providerKey = backStackEntry.arguments?.read { getStringOrNull("provider") } ?: "",
+                    externalRoutineId = backStackEntry.arguments?.read { getStringOrNull("externalRoutineId") } ?: "",
+                    onSetTitle = { viewModel.updateTopBarTitle(it) },
+                )
+            }
+
+            composable(
+                route = NavigationRoutes.ExternalPrograms.route,
+                enterTransition = {
+                    slideIntoContainer(
+                        towards = AnimatedContentTransitionScope.SlideDirection.Left,
+                        animationSpec = tween(300),
+                    )
+                },
+                exitTransition = { fadeOut(animationSpec = tween(200)) },
+                popEnterTransition = { fadeIn(animationSpec = tween(200)) },
+                popExitTransition = {
+                    slideOutOfContainer(
+                        towards = AnimatedContentTransitionScope.SlideDirection.Right,
+                        animationSpec = tween(300),
+                    )
+                },
+            ) {
+                ExternalProgramsScreen(
+                    onProgramClick = { provider, externalId ->
+                        navController.navigate(NavigationRoutes.ExternalProgramDetail.createRoute(provider.key, externalId))
+                    },
+                    onSetTitle = { viewModel.updateTopBarTitle(it) },
+                )
+            }
+
+            composable(
+                route = NavigationRoutes.ExternalProgramDetail.route,
+                arguments = listOf(
+                    navArgument("provider") { type = NavType.StringType },
+                    navArgument("externalProgramId") { type = NavType.StringType },
+                ),
+                enterTransition = {
+                    slideIntoContainer(
+                        towards = AnimatedContentTransitionScope.SlideDirection.Left,
+                        animationSpec = tween(300),
+                    )
+                },
+                exitTransition = { fadeOut(animationSpec = tween(200)) },
+                popEnterTransition = { fadeIn(animationSpec = tween(200)) },
+                popExitTransition = {
+                    slideOutOfContainer(
+                        towards = AnimatedContentTransitionScope.SlideDirection.Right,
+                        animationSpec = tween(300),
+                    )
+                },
+            ) { backStackEntry ->
+                ExternalProgramDetailScreen(
+                    providerKey = backStackEntry.arguments?.read { getStringOrNull("provider") } ?: "",
+                    externalProgramId = backStackEntry.arguments?.read { getStringOrNull("externalProgramId") } ?: "",
+                    onNavigateToPlayground = { provider, externalId ->
+                        navController.navigate(NavigationRoutes.ExternalProgramPlayground.createRoute(provider.key, externalId))
+                    },
+                    onSetTitle = { viewModel.updateTopBarTitle(it) },
+                )
+            }
+
+            composable(
+                route = NavigationRoutes.ExternalProgramPlayground.route,
+                arguments = listOf(
+                    navArgument("provider") { type = NavType.StringType },
+                    navArgument("externalProgramId") { type = NavType.StringType },
+                ),
+                enterTransition = {
+                    slideIntoContainer(
+                        towards = AnimatedContentTransitionScope.SlideDirection.Left,
+                        animationSpec = tween(300),
+                    )
+                },
+                exitTransition = { fadeOut(animationSpec = tween(200)) },
+                popEnterTransition = { fadeIn(animationSpec = tween(200)) },
+                popExitTransition = {
+                    slideOutOfContainer(
+                        towards = AnimatedContentTransitionScope.SlideDirection.Right,
+                        animationSpec = tween(300),
+                    )
+                },
+            ) { backStackEntry ->
+                ExternalProgramPlaygroundScreen(
+                    providerKey = backStackEntry.arguments?.read { getStringOrNull("provider") } ?: "",
+                    externalProgramId = backStackEntry.arguments?.read { getStringOrNull("externalProgramId") } ?: "",
+                    onSetTitle = { viewModel.updateTopBarTitle(it) },
+                )
+            }
+
+            composable(
+                route = NavigationRoutes.ExternalMeasurementTrends.route,
+                enterTransition = {
+                    slideIntoContainer(
+                        towards = AnimatedContentTransitionScope.SlideDirection.Left,
+                        animationSpec = tween(300),
+                    )
+                },
+                exitTransition = { fadeOut(animationSpec = tween(200)) },
+                popEnterTransition = { fadeIn(animationSpec = tween(200)) },
+                popExitTransition = {
+                    slideOutOfContainer(
+                        towards = AnimatedContentTransitionScope.SlideDirection.Right,
+                        animationSpec = tween(300),
+                    )
+                },
+            ) {
+                ExternalMeasurementTrendsScreen(
                     onSetTitle = { viewModel.updateTopBarTitle(it) },
                 )
             }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/navigation/NavigationRoutes.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/navigation/NavigationRoutes.kt
@@ -47,7 +47,38 @@ sealed class NavigationRoutes(val route: String) {
 
     // Integration routes
     object Integrations : NavigationRoutes("integrations")
+    object ExternalIntegrationHub : NavigationRoutes("external_integration_hub")
     object ExternalActivities : NavigationRoutes("external_activities")
+    object ExternalRoutines : NavigationRoutes("external_routines")
+    object ExternalRoutineDetail : NavigationRoutes("external_routine/{provider}/{externalRoutineId}") {
+        fun createRoute(provider: String, externalRoutineId: String) =
+            "external_routine/${provider.encodeRouteSegment()}/${externalRoutineId.encodeRouteSegment()}"
+    }
+    object ExternalPrograms : NavigationRoutes("external_programs")
+    object ExternalProgramDetail : NavigationRoutes("external_program/{provider}/{externalProgramId}") {
+        fun createRoute(provider: String, externalProgramId: String) =
+            "external_program/${provider.encodeRouteSegment()}/${externalProgramId.encodeRouteSegment()}"
+    }
+    object ExternalProgramPlayground : NavigationRoutes("external_program_playground/{provider}/{externalProgramId}") {
+        fun createRoute(provider: String, externalProgramId: String) =
+            "external_program_playground/${provider.encodeRouteSegment()}/${externalProgramId.encodeRouteSegment()}"
+    }
+    object ExternalMeasurementTrends : NavigationRoutes("external_measurements")
+}
+
+private fun String.encodeRouteSegment(): String = buildString {
+    for (c in this@encodeRouteSegment) {
+        when {
+            c.isLetterOrDigit() || c == '-' || c == '_' || c == '.' || c == '~' -> append(c)
+            else -> {
+                for (b in c.toString().encodeToByteArray()) {
+                    append('%')
+                    append(((b.toInt() shr 4) and 0xF).toString(16).uppercase())
+                    append((b.toInt() and 0xF).toString(16).uppercase())
+                }
+            }
+        }
+    }
 }
 
 /**

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExternalActivitiesScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExternalActivitiesScreen.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.devil.phoenixproject.domain.model.ExternalActivity
 import com.devil.phoenixproject.domain.model.IntegrationProvider
-import com.devil.phoenixproject.presentation.viewmodel.IntegrationsViewModel
+import com.devil.phoenixproject.presentation.viewmodel.ExternalActivitiesViewModel
 import com.devil.phoenixproject.ui.theme.Spacing
 import com.devil.phoenixproject.util.KmpUtils
 import org.koin.compose.viewmodel.koinViewModel
@@ -26,7 +26,7 @@ import org.koin.compose.viewmodel.koinViewModel
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ExternalActivitiesScreen(onSetTitle: (String) -> Unit = {}, modifier: Modifier = Modifier) {
-    val viewModel: IntegrationsViewModel = koinViewModel()
+    val viewModel: ExternalActivitiesViewModel = koinViewModel()
     val uiState by viewModel.uiState.collectAsState()
 
     LaunchedEffect(Unit) {
@@ -36,7 +36,7 @@ fun ExternalActivitiesScreen(onSetTitle: (String) -> Unit = {}, modifier: Modifi
     // ── Provider filter state ─────────────────────────────────────────────────
     var selectedProvider by remember { mutableStateOf<IntegrationProvider?>(null) }
 
-    val allActivities = uiState.externalActivities
+    val allActivities = uiState.activities
     val filteredActivities = remember(allActivities, selectedProvider) {
         if (selectedProvider == null) {
             allActivities
@@ -124,8 +124,10 @@ fun ExternalActivitiesScreen(onSetTitle: (String) -> Unit = {}, modifier: Modifi
 
 @Composable
 private fun ExternalActivityItem(activity: ExternalActivity) {
+    var expanded by remember { mutableStateOf(false) }
     Card(
         modifier = Modifier.fillMaxWidth(),
+        onClick = { expanded = !expanded },
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
         ),
@@ -196,6 +198,38 @@ private fun ExternalActivityItem(activity: ExternalActivity) {
                     Text(
                         activity.activityType.replaceFirstChar { it.uppercase() },
                         style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+        if (expanded) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = Spacing.medium, end = Spacing.medium, bottom = Spacing.medium),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                Text(
+                    "Provider ID: ${activity.externalId}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                if (activity.calories != null || activity.distanceMeters != null || activity.avgHeartRate != null) {
+                    Text(
+                        listOfNotNull(
+                            activity.calories?.let { "$it kcal" },
+                            activity.distanceMeters?.let { "${it.toInt()} m" },
+                            activity.avgHeartRate?.let { "$it avg bpm" },
+                            activity.maxHeartRate?.let { "$it max bpm" },
+                        ).joinToString(" / "),
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+                activity.rawData?.let {
+                    Text(
+                        it.take(320),
+                        style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExternalIntegrationScreens.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExternalIntegrationScreens.kt
@@ -1,0 +1,541 @@
+package com.devil.phoenixproject.presentation.screen
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.List
+import androidx.compose.material.icons.filled.Analytics
+import androidx.compose.material.icons.filled.Code
+import androidx.compose.material.icons.filled.FitnessCenter
+import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material.icons.filled.Insights
+import androidx.compose.material.icons.filled.Scale
+import androidx.compose.material.icons.filled.Science
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.devil.phoenixproject.domain.model.ExternalBodyMeasurement
+import com.devil.phoenixproject.domain.model.ExternalProgram
+import com.devil.phoenixproject.domain.model.ExternalRoutine
+import com.devil.phoenixproject.domain.model.IntegrationProvider
+import com.devil.phoenixproject.presentation.viewmodel.ExternalMeasurementsViewModel
+import com.devil.phoenixproject.presentation.viewmodel.ExternalProgramsViewModel
+import com.devil.phoenixproject.presentation.viewmodel.ExternalRoutinesViewModel
+import com.devil.phoenixproject.presentation.viewmodel.IntegrationsViewModel
+import com.devil.phoenixproject.ui.theme.Spacing
+import com.devil.phoenixproject.util.KmpUtils
+import org.koin.compose.viewmodel.koinViewModel
+
+@Composable
+fun ExternalIntegrationHubScreen(
+    onNavigateToActivities: () -> Unit,
+    onNavigateToRoutines: () -> Unit,
+    onNavigateToPrograms: () -> Unit,
+    onNavigateToMeasurements: () -> Unit,
+    onSetTitle: (String) -> Unit = {},
+    modifier: Modifier = Modifier,
+) {
+    val viewModel: IntegrationsViewModel = koinViewModel()
+    val uiState by viewModel.uiState.collectAsState()
+
+    LaunchedEffect(Unit) {
+        onSetTitle("Integration Data")
+    }
+
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(Spacing.medium),
+        verticalArrangement = Arrangement.spacedBy(Spacing.small),
+    ) {
+        item {
+            HubCard(
+                title = "Workouts",
+                subtitle = "${uiState.externalActivities.size} imported activities",
+                icon = { Icon(Icons.AutoMirrored.Filled.List, contentDescription = null) },
+                onClick = onNavigateToActivities,
+            )
+        }
+        item {
+            HubCard(
+                title = "Hevy Routines",
+                subtitle = "${uiState.externalRoutines.size} routines, ${uiState.externalRoutineFolders.size} folders",
+                icon = { Icon(Icons.Default.FitnessCenter, contentDescription = null) },
+                onClick = onNavigateToRoutines,
+            )
+        }
+        item {
+            HubCard(
+                title = "Liftosaur Programs",
+                subtitle = "${uiState.externalPrograms.size} programs, ${uiState.externalProgramStatsByProgramId.size} stats records",
+                icon = { Icon(Icons.Default.Code, contentDescription = null) },
+                onClick = onNavigateToPrograms,
+            )
+        }
+        item {
+            HubCard(
+                title = "Measurements",
+                subtitle = "${uiState.externalMeasurements.size} Hevy measurement records",
+                icon = { Icon(Icons.Default.Scale, contentDescription = null) },
+                onClick = onNavigateToMeasurements,
+            )
+        }
+    }
+}
+
+@Composable
+fun ExternalRoutinesScreen(
+    onRoutineClick: (IntegrationProvider, String) -> Unit,
+    onSetTitle: (String) -> Unit = {},
+    modifier: Modifier = Modifier,
+) {
+    val viewModel: ExternalRoutinesViewModel = koinViewModel()
+    val state by viewModel.uiState.collectAsState()
+
+    LaunchedEffect(Unit) {
+        onSetTitle("External Routines")
+    }
+
+    if (state.routines.isEmpty()) {
+        EmptyIntegrationState("No routines imported yet")
+        return
+    }
+
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(Spacing.medium),
+        verticalArrangement = Arrangement.spacedBy(Spacing.small),
+    ) {
+        val grouped = state.routines.groupBy { it.folderName ?: "Unfiled" }
+        grouped.forEach { (folder, routines) ->
+            item {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    modifier = Modifier.padding(top = 4.dp),
+                ) {
+                    Icon(Icons.Default.Folder, contentDescription = null, modifier = Modifier.size(18.dp))
+                    Text(folder, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                }
+            }
+            items(routines, key = { it.id }) { routine ->
+                RoutineCard(routine = routine, onClick = { onRoutineClick(routine.provider, routine.externalId) })
+            }
+        }
+    }
+}
+
+@Composable
+fun ExternalRoutineDetailScreen(
+    providerKey: String,
+    externalRoutineId: String,
+    onSetTitle: (String) -> Unit = {},
+    modifier: Modifier = Modifier,
+) {
+    val viewModel: ExternalRoutinesViewModel = koinViewModel()
+    val state by viewModel.uiState.collectAsState()
+    val routine = state.routines.firstOrNull { it.provider.key == providerKey && it.externalId == externalRoutineId }
+
+    LaunchedEffect(routine?.title) {
+        onSetTitle(routine?.title ?: "Routine")
+    }
+
+    if (routine == null) {
+        EmptyIntegrationState("Routine not found")
+        return
+    }
+
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(Spacing.medium),
+        verticalArrangement = Arrangement.spacedBy(Spacing.small),
+    ) {
+        item {
+            Text(routine.title, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
+            Text(
+                routine.folderName ?: routine.provider.displayName,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(8.dp))
+            Surface(
+                color = MaterialTheme.colorScheme.secondaryContainer,
+                shape = RoundedCornerShape(8.dp),
+            ) {
+                Text(
+                    "Review exercise mappings before converting. External weights are preserved as informational until per-cable mapping is confirmed.",
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.padding(Spacing.small),
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                )
+            }
+        }
+        items(routine.exercises, key = { it.id }) { exercise ->
+            EntityCard {
+                Text(exercise.title, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                Text(
+                    listOfNotNull(exercise.exerciseType, exercise.primaryMuscleGroups.joinToString(", ").ifBlank { null }).joinToString(" / "),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                exercise.sets.forEach { set ->
+                    Text(
+                        "Set ${set.index + 1}: ${set.setType ?: "normal"} ${set.reps ?: "-"} reps ${set.weightKg?.let { "@ ${it}kg" } ?: ""}",
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun ExternalProgramsScreen(
+    onProgramClick: (IntegrationProvider, String) -> Unit,
+    onSetTitle: (String) -> Unit = {},
+    modifier: Modifier = Modifier,
+) {
+    val viewModel: ExternalProgramsViewModel = koinViewModel()
+    val state by viewModel.uiState.collectAsState()
+
+    LaunchedEffect(Unit) {
+        onSetTitle("External Programs")
+    }
+
+    if (state.programs.isEmpty()) {
+        EmptyIntegrationState("No programs imported yet")
+        return
+    }
+
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(Spacing.medium),
+        verticalArrangement = Arrangement.spacedBy(Spacing.small),
+    ) {
+        items(state.programs, key = { it.id }) { program ->
+            ProgramCard(program = program, onClick = { onProgramClick(program.provider, program.externalId) })
+        }
+    }
+}
+
+@Composable
+fun ExternalProgramDetailScreen(
+    providerKey: String,
+    externalProgramId: String,
+    onNavigateToPlayground: (IntegrationProvider, String) -> Unit,
+    onSetTitle: (String) -> Unit = {},
+    modifier: Modifier = Modifier,
+) {
+    val viewModel: ExternalProgramsViewModel = koinViewModel()
+    val state by viewModel.uiState.collectAsState()
+    val program = state.programs.firstOrNull { it.provider.key == providerKey && it.externalId == externalProgramId }
+
+    LaunchedEffect(program?.name) {
+        onSetTitle(program?.name ?: "Program")
+    }
+
+    if (program == null) {
+        EmptyIntegrationState("Program not found")
+        return
+    }
+
+    val stats = state.statsByProgramId[program.id]
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(Spacing.medium),
+        verticalArrangement = Arrangement.spacedBy(Spacing.small),
+    ) {
+        item {
+            Text(program.name, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
+            if (program.isCurrent) StatusChip("Current program")
+            Spacer(Modifier.height(8.dp))
+            EntityCard {
+                Text("Stats", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                Text("${stats?.days ?: 0} days")
+                Text("${stats?.approximateMinutes ?: 0} approximate minutes")
+                Text("${stats?.setCount ?: 0} sets")
+                stats?.muscleGroupBreakdownJson?.let { Text(it, style = MaterialTheme.typography.bodySmall) }
+            }
+            OutlinedButton(
+                onClick = { onNavigateToPlayground(program.provider, program.externalId) },
+                enabled = !program.scriptText.isNullOrBlank(),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Icon(Icons.Default.Science, contentDescription = null)
+                Text("Preview Playground")
+            }
+            Surface(
+                color = MaterialTheme.colorScheme.secondaryContainer,
+                shape = RoundedCornerShape(8.dp),
+            ) {
+                Text(
+                    "Liftosaur conversion is read-only here. Manual Phoenix cycle conversion should happen only after validating Liftoscript mappings.",
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.padding(Spacing.small),
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                )
+            }
+        }
+        item {
+            Text(program.scriptText ?: "No script text available", style = MaterialTheme.typography.bodySmall)
+        }
+    }
+}
+
+@Composable
+fun ExternalProgramPlaygroundScreen(
+    providerKey: String,
+    externalProgramId: String,
+    onSetTitle: (String) -> Unit = {},
+    modifier: Modifier = Modifier,
+) {
+    val viewModel: ExternalProgramsViewModel = koinViewModel()
+    val state by viewModel.uiState.collectAsState()
+    val program = state.programs.firstOrNull { it.provider.key == providerKey && it.externalId == externalProgramId }
+    val preview = state.playgroundPreview
+
+    LaunchedEffect(Unit) {
+        onSetTitle("Program Playground")
+    }
+
+    if (program == null) {
+        EmptyIntegrationState("Program not found")
+        return
+    }
+
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(Spacing.medium),
+        verticalArrangement = Arrangement.spacedBy(Spacing.small),
+    ) {
+        item {
+            Text(program.name, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
+            Button(
+                onClick = { viewModel.simulateProgram(program) },
+                enabled = !state.isSimulating,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(if (state.isSimulating) "Simulating..." else "Run Preview")
+            }
+        }
+        item {
+            EntityCard {
+                Text("Current workout", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                Text(preview?.currentWorkoutText ?: "Run a preview to see the current workout.")
+            }
+        }
+        item {
+            EntityCard {
+                Text("Next workout", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                Text(preview?.nextWorkoutText ?: "Run a preview to see the next workout.")
+            }
+        }
+        item {
+            EntityCard {
+                Text("Updated program", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                Text(preview?.updatedProgramText ?: "No updated program text yet.")
+            }
+        }
+        if (preview?.updatedProgramText != null) {
+            item {
+                Row(horizontalArrangement = Arrangement.spacedBy(Spacing.small), modifier = Modifier.fillMaxWidth()) {
+                    Button(onClick = { viewModel.commitPreview(program) }, modifier = Modifier.weight(1f)) {
+                        Text("Commit")
+                    }
+                    TextButton(onClick = { viewModel.clearPreview() }, modifier = Modifier.weight(1f)) {
+                        Text("Discard")
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun ExternalMeasurementTrendsScreen(
+    onSetTitle: (String) -> Unit = {},
+    modifier: Modifier = Modifier,
+) {
+    val viewModel: ExternalMeasurementsViewModel = koinViewModel()
+    val state by viewModel.uiState.collectAsState()
+
+    LaunchedEffect(Unit) {
+        onSetTitle("Measurements")
+    }
+
+    Column(modifier = modifier.fillMaxSize()) {
+        if (state.measurementTypes.isNotEmpty()) {
+            LazyRow(
+                contentPadding = PaddingValues(horizontal = Spacing.medium, vertical = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                item {
+                    FilterChip(
+                        selected = state.selectedType == null,
+                        onClick = { viewModel.selectType(null) },
+                        label = { Text("All") },
+                    )
+                }
+                items(state.measurementTypes) { type ->
+                    FilterChip(
+                        selected = state.selectedType == type,
+                        onClick = { viewModel.selectType(type) },
+                        label = { Text(type) },
+                    )
+                }
+            }
+        }
+        if (state.measurements.isEmpty()) {
+            EmptyIntegrationState(
+                if (state.measurementTypes.isEmpty()) "No measurements imported yet" else "No measurements for this type",
+            )
+        } else {
+            LazyColumn(
+                contentPadding = PaddingValues(Spacing.medium),
+                verticalArrangement = Arrangement.spacedBy(Spacing.small),
+            ) {
+                items(state.measurements, key = { it.id }) { measurement ->
+                    MeasurementCard(measurement)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun HubCard(title: String, subtitle: String, icon: @Composable () -> Unit, onClick: () -> Unit) {
+    Card(
+        onClick = onClick,
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHighest),
+        shape = RoundedCornerShape(8.dp),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(Spacing.medium),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(Spacing.small),
+        ) {
+            icon()
+            Column {
+                Text(title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                Text(subtitle, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+        }
+    }
+}
+
+@Composable
+private fun RoutineCard(routine: ExternalRoutine, onClick: () -> Unit) {
+    EntityCard(onClick = onClick) {
+        Text(routine.title, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+        Text("${routine.exercises.size} exercises", style = MaterialTheme.typography.bodySmall)
+        Text(routine.provider.displayName, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    }
+}
+
+@Composable
+private fun ProgramCard(program: ExternalProgram, onClick: () -> Unit) {
+    EntityCard(onClick = onClick) {
+        Row(horizontalArrangement = Arrangement.spacedBy(6.dp), verticalAlignment = Alignment.CenterVertically) {
+            Text(program.name, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+            if (program.isCurrent) StatusChip("Current")
+        }
+        Text(program.provider.displayName, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    }
+}
+
+@Composable
+private fun MeasurementCard(measurement: ExternalBodyMeasurement) {
+    EntityCard {
+        Row(horizontalArrangement = Arrangement.SpaceBetween, modifier = Modifier.fillMaxWidth()) {
+            Text(measurement.measurementType, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+            Text("${measurement.value} ${measurement.unit}", style = MaterialTheme.typography.titleSmall)
+        }
+        Text(KmpUtils.formatTimestamp(measurement.measuredAt), style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    }
+}
+
+@Composable
+private fun StatusChip(text: String) {
+    Surface(
+        shape = RoundedCornerShape(6.dp),
+        color = MaterialTheme.colorScheme.primaryContainer,
+    ) {
+        Text(
+            text,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onPrimaryContainer,
+            modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
+        )
+    }
+}
+
+@Composable
+private fun EntityCard(onClick: (() -> Unit)? = null, content: @Composable ColumnScope.() -> Unit) {
+    val cardContent: @Composable ColumnScope.() -> Unit = {
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(Spacing.medium),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+            content = content,
+        )
+    }
+    if (onClick == null) {
+        Card(
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHighest),
+            shape = RoundedCornerShape(8.dp),
+            border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+            content = cardContent,
+        )
+    } else {
+        Card(
+            onClick = onClick,
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHighest),
+            shape = RoundedCornerShape(8.dp),
+            border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+            content = cardContent,
+        )
+    }
+}
+
+@Composable
+private fun EmptyIntegrationState(message: String) {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(Spacing.small)) {
+            Icon(Icons.Default.Warning, contentDescription = null, modifier = Modifier.size(40.dp))
+            Text(message, style = MaterialTheme.typography.titleMedium)
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExternalIntegrationScreens.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExternalIntegrationScreens.kt
@@ -34,6 +34,9 @@ import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -55,6 +58,7 @@ import com.devil.phoenixproject.domain.model.IntegrationProvider
 import com.devil.phoenixproject.presentation.viewmodel.ExternalMeasurementsViewModel
 import com.devil.phoenixproject.presentation.viewmodel.ExternalProgramsViewModel
 import com.devil.phoenixproject.presentation.viewmodel.ExternalRoutinesViewModel
+import com.devil.phoenixproject.presentation.viewmodel.IntegrationUiEvent
 import com.devil.phoenixproject.presentation.viewmodel.IntegrationsViewModel
 import com.devil.phoenixproject.ui.theme.Spacing
 import com.devil.phoenixproject.util.KmpUtils
@@ -134,12 +138,13 @@ fun ExternalRoutinesScreen(
         return
     }
 
+    val grouped = remember(state.routines) { state.routines.groupBy { it.folderName ?: "Unfiled" } }
+
     LazyColumn(
         modifier = modifier.fillMaxSize(),
         contentPadding = PaddingValues(Spacing.medium),
         verticalArrangement = Arrangement.spacedBy(Spacing.small),
     ) {
-        val grouped = state.routines.groupBy { it.folderName ?: "Unfiled" }
         grouped.forEach { (folder, routines) ->
             item {
                 Row(
@@ -167,7 +172,9 @@ fun ExternalRoutineDetailScreen(
 ) {
     val viewModel: ExternalRoutinesViewModel = koinViewModel()
     val state by viewModel.uiState.collectAsState()
-    val routine = state.routines.firstOrNull { it.provider.key == providerKey && it.externalId == externalRoutineId }
+    val routine = remember(state.routines, providerKey, externalRoutineId) {
+        state.routines.firstOrNull { it.provider.key == providerKey && it.externalId == externalRoutineId }
+    }
 
     LaunchedEffect(routine?.title) {
         onSetTitle(routine?.title ?: "Routine")
@@ -261,7 +268,9 @@ fun ExternalProgramDetailScreen(
 ) {
     val viewModel: ExternalProgramsViewModel = koinViewModel()
     val state by viewModel.uiState.collectAsState()
-    val program = state.programs.firstOrNull { it.provider.key == providerKey && it.externalId == externalProgramId }
+    val program = remember(state.programs, providerKey, externalProgramId) {
+        state.programs.firstOrNull { it.provider.key == providerKey && it.externalId == externalProgramId }
+    }
 
     LaunchedEffect(program?.name) {
         onSetTitle(program?.name ?: "Program")
@@ -324,11 +333,26 @@ fun ExternalProgramPlaygroundScreen(
 ) {
     val viewModel: ExternalProgramsViewModel = koinViewModel()
     val state by viewModel.uiState.collectAsState()
-    val program = state.programs.firstOrNull { it.provider.key == providerKey && it.externalId == externalProgramId }
-    val preview = state.playgroundPreview
+    val snackbarHostState = remember { SnackbarHostState() }
+    val program = remember(state.programs, providerKey, externalProgramId) {
+        state.programs.firstOrNull { it.provider.key == providerKey && it.externalId == externalProgramId }
+    }
+    val preview = state.playgroundPreview?.takeIf { it.programExternalId == externalProgramId }
 
     LaunchedEffect(Unit) {
         onSetTitle("Program Playground")
+    }
+
+    LaunchedEffect(providerKey, externalProgramId) {
+        viewModel.clearPreview()
+    }
+
+    LaunchedEffect(viewModel) {
+        viewModel.events.collect { event ->
+            when (event) {
+                is IntegrationUiEvent.Snackbar -> snackbarHostState.showSnackbar(event.message)
+            }
+        }
     }
 
     if (program == null) {
@@ -336,47 +360,55 @@ fun ExternalProgramPlaygroundScreen(
         return
     }
 
-    LazyColumn(
-        modifier = modifier.fillMaxSize(),
-        contentPadding = PaddingValues(Spacing.medium),
-        verticalArrangement = Arrangement.spacedBy(Spacing.small),
-    ) {
-        item {
-            Text(program.name, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
-            Button(
-                onClick = { viewModel.simulateProgram(program) },
-                enabled = !state.isSimulating,
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                Text(if (state.isSimulating) "Simulating..." else "Run Preview")
-            }
-        }
-        item {
-            EntityCard {
-                Text("Current workout", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
-                Text(preview?.currentWorkoutText ?: "Run a preview to see the current workout.")
-            }
-        }
-        item {
-            EntityCard {
-                Text("Next workout", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
-                Text(preview?.nextWorkoutText ?: "Run a preview to see the next workout.")
-            }
-        }
-        item {
-            EntityCard {
-                Text("Updated program", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
-                Text(preview?.updatedProgramText ?: "No updated program text yet.")
-            }
-        }
-        if (preview?.updatedProgramText != null) {
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        containerColor = MaterialTheme.colorScheme.background,
+        modifier = modifier,
+    ) { innerPadding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            contentPadding = PaddingValues(Spacing.medium),
+            verticalArrangement = Arrangement.spacedBy(Spacing.small),
+        ) {
             item {
-                Row(horizontalArrangement = Arrangement.spacedBy(Spacing.small), modifier = Modifier.fillMaxWidth()) {
-                    Button(onClick = { viewModel.commitPreview(program) }, modifier = Modifier.weight(1f)) {
-                        Text("Commit")
-                    }
-                    TextButton(onClick = { viewModel.clearPreview() }, modifier = Modifier.weight(1f)) {
-                        Text("Discard")
+                Text(program.name, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
+                Button(
+                    onClick = { viewModel.simulateProgram(program) },
+                    enabled = !state.isSimulating,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(if (state.isSimulating) "Simulating..." else "Run Preview")
+                }
+            }
+            item {
+                EntityCard {
+                    Text("Current workout", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                    Text(preview?.currentWorkoutText ?: "Run a preview to see the current workout.")
+                }
+            }
+            item {
+                EntityCard {
+                    Text("Next workout", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                    Text(preview?.nextWorkoutText ?: "Run a preview to see the next workout.")
+                }
+            }
+            item {
+                EntityCard {
+                    Text("Updated program", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                    Text(preview?.updatedProgramText ?: "No updated program text yet.")
+                }
+            }
+            if (preview?.updatedProgramText != null) {
+                item {
+                    Row(horizontalArrangement = Arrangement.spacedBy(Spacing.small), modifier = Modifier.fillMaxWidth()) {
+                        Button(onClick = { viewModel.commitPreview(program) }, modifier = Modifier.weight(1f)) {
+                            Text("Commit")
+                        }
+                        TextButton(onClick = { viewModel.clearPreview() }, modifier = Modifier.weight(1f)) {
+                            Text("Discard")
+                        }
                     }
                 }
             }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/IntegrationsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/IntegrationsScreen.kt
@@ -2,6 +2,7 @@ package com.devil.phoenixproject.presentation.screen
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -22,6 +23,7 @@ import com.devil.phoenixproject.domain.model.ConnectionStatus
 import com.devil.phoenixproject.domain.model.IntegrationProvider
 import com.devil.phoenixproject.domain.model.WeightUnit
 import com.devil.phoenixproject.isIosPlatform
+import com.devil.phoenixproject.presentation.viewmodel.IntegrationUiEvent
 import com.devil.phoenixproject.presentation.viewmodel.IntegrationsViewModel
 import com.devil.phoenixproject.ui.theme.Spacing
 import com.devil.phoenixproject.util.KmpUtils
@@ -36,7 +38,7 @@ import org.koin.compose.viewmodel.koinViewModel
 @Composable
 fun IntegrationsScreen(
     weightUnit: WeightUnit = WeightUnit.KG,
-    onNavigateToExternalActivities: () -> Unit = {},
+    onNavigateToExternalData: () -> Unit = {},
     onSetTitle: (String) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
@@ -63,6 +65,13 @@ fun IntegrationsScreen(
         uiState.successMessage?.let {
             snackbarHostState.showSnackbar(it)
             viewModel.clearMessages()
+        }
+    }
+    LaunchedEffect(viewModel) {
+        viewModel.uiEvents.collect { event ->
+            when (event) {
+                is IntegrationUiEvent.Snackbar -> snackbarHostState.showSnackbar(event.message)
+            }
         }
     }
     LaunchedEffect(viewModel) {
@@ -271,10 +280,21 @@ fun IntegrationsScreen(
             // Hevy card
             val hevyStatus = uiState.integrationStatuses[IntegrationProvider.HEVY]
             val hevyConnected = hevyStatus?.status == ConnectionStatus.CONNECTED
+            val hevyEntitlement = uiState.entitlementStateByProvider[IntegrationProvider.HEVY]
+            val hevyBusy = uiState.operationLoading.any { it.startsWith("${IntegrationProvider.HEVY.key}:") }
             IntegrationCard(
                 title = "Hevy",
-                subtitle = "Requires Hevy PRO for API sync",
+                subtitle = hevyEntitlement?.upgradeReason
+                    ?: hevyEntitlement?.providerPlanName?.let { "Plan: $it" }
+                    ?: "Workout history, routines, templates, and measurements",
                 statusConnected = hevyConnected,
+                badges = listOf(
+                    "${uiState.externalActivities.count { it.provider == IntegrationProvider.HEVY }} workouts",
+                    "${uiState.externalRoutines.count { it.provider == IntegrationProvider.HEVY }} routines",
+                    "${uiState.externalRoutineFolders.count { it.provider == IntegrationProvider.HEVY }} folders",
+                    "${uiState.externalExerciseTemplateCountByProvider[IntegrationProvider.HEVY] ?: 0} templates",
+                    "${uiState.externalMeasurements.count { it.provider == IntegrationProvider.HEVY }} measurements",
+                ),
                 trailingContent = {
                     Column(
                         horizontalAlignment = Alignment.End,
@@ -286,11 +306,11 @@ fun IntegrationsScreen(
                                     onClick = {
                                         viewModel.syncProvider(IntegrationProvider.HEVY)
                                     },
-                                    enabled = !uiState.isSyncing,
+                                    enabled = !hevyBusy,
                                     shape = RoundedCornerShape(12.dp),
                                     modifier = Modifier.height(36.dp),
                                 ) {
-                                    if (uiState.isSyncing) {
+                                    if (hevyBusy) {
                                         CircularProgressIndicator(Modifier.size(14.dp), strokeWidth = 2.dp)
                                     } else {
                                         Text("Sync", style = MaterialTheme.typography.labelMedium)
@@ -328,10 +348,20 @@ fun IntegrationsScreen(
             // Liftosaur card
             val liftosaurStatus = uiState.integrationStatuses[IntegrationProvider.LIFTOSAUR]
             val liftosaurConnected = liftosaurStatus?.status == ConnectionStatus.CONNECTED
+            val liftosaurEntitlement = uiState.entitlementStateByProvider[IntegrationProvider.LIFTOSAUR]
+            val liftosaurBusy = uiState.operationLoading.any { it.startsWith("${IntegrationProvider.LIFTOSAUR.key}:") }
             IntegrationCard(
                 title = "Liftosaur",
-                subtitle = "Requires Liftosaur Premium",
+                subtitle = liftosaurEntitlement?.upgradeReason
+                    ?: liftosaurEntitlement?.providerPlanName?.let { "Plan: $it" }
+                    ?: "History, programs, stats, and playground previews",
                 statusConnected = liftosaurConnected,
+                badges = listOf(
+                    "${uiState.externalActivities.count { it.provider == IntegrationProvider.LIFTOSAUR }} workouts",
+                    "${uiState.externalPrograms.count { it.provider == IntegrationProvider.LIFTOSAUR }} programs",
+                    if (uiState.activeProgram != null) "1 current" else "0 current",
+                    "${uiState.externalProgramStatsByProgramId.size} stats",
+                ),
                 trailingContent = {
                     Column(
                         horizontalAlignment = Alignment.End,
@@ -343,11 +373,11 @@ fun IntegrationsScreen(
                                     onClick = {
                                         viewModel.syncProvider(IntegrationProvider.LIFTOSAUR)
                                     },
-                                    enabled = !uiState.isSyncing,
+                                    enabled = !liftosaurBusy,
                                     shape = RoundedCornerShape(12.dp),
                                     modifier = Modifier.height(36.dp),
                                 ) {
-                                    if (uiState.isSyncing) {
+                                    if (liftosaurBusy) {
                                         CircularProgressIndicator(Modifier.size(14.dp), strokeWidth = 2.dp)
                                     } else {
                                         Text("Sync", style = MaterialTheme.typography.labelMedium)
@@ -505,7 +535,7 @@ fun IntegrationsScreen(
                 shape = RoundedCornerShape(20.dp),
                 elevation = CardDefaults.cardElevation(defaultElevation = 8.dp),
                 border = BorderStroke(2.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.2f)),
-                onClick = onNavigateToExternalActivities,
+                onClick = onNavigateToExternalData,
             ) {
                 Row(
                     modifier = Modifier
@@ -538,13 +568,13 @@ fun IntegrationsScreen(
                         }
                         Column {
                             Text(
-                                "External Activities",
+                                "Integration Data",
                                 style = MaterialTheme.typography.titleMedium,
                                 fontWeight = FontWeight.Bold,
                             )
                             val count = uiState.externalActivities.size
                             Text(
-                                if (count == 0) "No activities imported" else "$count imported",
+                                if (count == 0) "Browse imported provider data" else "$count workouts plus provider records",
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
@@ -552,7 +582,7 @@ fun IntegrationsScreen(
                     }
                     Icon(
                         Icons.Default.ChevronRight,
-                        contentDescription = "View external activities",
+                        contentDescription = "View integration data",
                         tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
@@ -597,7 +627,13 @@ private fun SectionHeader(icon: androidx.compose.ui.graphics.vector.ImageVector,
 }
 
 @Composable
-private fun IntegrationCard(title: String, subtitle: String, statusConnected: Boolean, trailingContent: @Composable () -> Unit) {
+private fun IntegrationCard(
+    title: String,
+    subtitle: String,
+    statusConnected: Boolean,
+    badges: List<String> = emptyList(),
+    trailingContent: @Composable () -> Unit,
+) {
     Card(
         modifier = Modifier
             .fillMaxWidth()
@@ -652,6 +688,28 @@ private fun IntegrationCard(title: String, subtitle: String, statusConnected: Bo
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
+                if (badges.isNotEmpty()) {
+                    Row(
+                        modifier = Modifier
+                            .padding(top = 6.dp)
+                            .horizontalScroll(rememberScrollState()),
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    ) {
+                        badges.forEach { badge ->
+                            Surface(
+                                shape = RoundedCornerShape(6.dp),
+                                color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.55f),
+                            ) {
+                                Text(
+                                    badge,
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                                    modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
+                                )
+                            }
+                        }
+                    }
+                }
             }
             Spacer(Modifier.width(Spacing.small))
             trailingContent()

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExternalIntegrationViewModels.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExternalIntegrationViewModels.kt
@@ -1,0 +1,178 @@
+package com.devil.phoenixproject.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.devil.phoenixproject.data.integration.ExternalMeasurementRepository
+import com.devil.phoenixproject.data.integration.ExternalProgramRepository
+import com.devil.phoenixproject.data.integration.ExternalRoutineRepository
+import com.devil.phoenixproject.data.integration.ExternalActivityRepository
+import com.devil.phoenixproject.data.integration.IntegrationManager
+import com.devil.phoenixproject.data.repository.UserProfileRepository
+import com.devil.phoenixproject.domain.model.ExternalActivity
+import com.devil.phoenixproject.domain.model.ExternalBodyMeasurement
+import com.devil.phoenixproject.domain.model.ExternalPlaygroundPreview
+import com.devil.phoenixproject.domain.model.ExternalProgram
+import com.devil.phoenixproject.domain.model.ExternalProgramStats
+import com.devil.phoenixproject.domain.model.ExternalRoutine
+import com.devil.phoenixproject.domain.model.ExternalRoutineFolder
+import com.devil.phoenixproject.domain.model.IntegrationProvider
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+data class ExternalActivitiesUiState(
+    val activities: List<ExternalActivity> = emptyList(),
+)
+
+class ExternalActivitiesViewModel(
+    repository: ExternalActivityRepository,
+    userProfileRepository: UserProfileRepository,
+) : ViewModel() {
+    private val activeProfileId = userProfileRepository.activeProfile
+        .map { it?.id ?: "default" }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, "default")
+
+    val uiState: StateFlow<ExternalActivitiesUiState> = activeProfileId.flatMapLatest { profileId ->
+        repository.getAll(profileId)
+            .map { activities -> ExternalActivitiesUiState(activities = activities) }
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, ExternalActivitiesUiState())
+}
+
+data class ExternalRoutinesUiState(
+    val routines: List<ExternalRoutine> = emptyList(),
+    val folders: List<ExternalRoutineFolder> = emptyList(),
+)
+
+class ExternalRoutinesViewModel(
+    private val repository: ExternalRoutineRepository,
+    userProfileRepository: UserProfileRepository,
+) : ViewModel() {
+    private val activeProfileId = userProfileRepository.activeProfile
+        .map { it?.id ?: "default" }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, "default")
+
+    val uiState: StateFlow<ExternalRoutinesUiState> = activeProfileId.flatMapLatest { profileId ->
+        combine(
+            repository.observeRoutines(profileId),
+            repository.observeFolders(profileId),
+        ) { routines, folders ->
+            ExternalRoutinesUiState(routines = routines, folders = folders)
+        }
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, ExternalRoutinesUiState())
+}
+
+data class ExternalProgramsUiState(
+    val programs: List<ExternalProgram> = emptyList(),
+    val statsByProgramId: Map<String, ExternalProgramStats> = emptyMap(),
+    val currentProgram: ExternalProgram? = null,
+    val playgroundPreview: ExternalPlaygroundPreview? = null,
+    val isSimulating: Boolean = false,
+)
+
+class ExternalProgramsViewModel(
+    private val repository: ExternalProgramRepository,
+    private val integrationManager: IntegrationManager,
+    userProfileRepository: UserProfileRepository,
+) : ViewModel() {
+    private val activeProfileId = userProfileRepository.activeProfile
+        .map { it?.id ?: "default" }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, "default")
+
+    private val _uiState = MutableStateFlow(ExternalProgramsUiState())
+    val uiState: StateFlow<ExternalProgramsUiState> = _uiState.asStateFlow()
+
+    private val _events = MutableSharedFlow<IntegrationUiEvent>(extraBufferCapacity = 4)
+    val events: SharedFlow<IntegrationUiEvent> = _events.asSharedFlow()
+
+    init {
+        viewModelScope.launch {
+            activeProfileId.flatMapLatest { profileId ->
+                combine(
+                    repository.observePrograms(profileId),
+                    repository.observeProgramStats(profileId),
+                    repository.observeCurrentProgram(profileId, IntegrationProvider.LIFTOSAUR),
+                ) { programs, stats, current ->
+                    Triple(programs, stats, current)
+                }
+            }.collect { (programs, stats, current) ->
+                _uiState.value = _uiState.value.copy(
+                    programs = programs,
+                    statsByProgramId = stats,
+                    currentProgram = current,
+                )
+            }
+        }
+    }
+
+    fun simulateProgram(program: ExternalProgram, commands: List<String> = emptyList()) {
+        val scriptText = program.scriptText ?: return
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isSimulating = true)
+            integrationManager.simulatePlayground(
+                provider = program.provider,
+                externalProgramId = program.externalId,
+                scriptText = scriptText,
+                commands = commands,
+                profileId = activeProfileId.value,
+            ).onSuccess { preview ->
+                _uiState.value = _uiState.value.copy(playgroundPreview = preview)
+            }.onFailure { error ->
+                _events.emit(IntegrationUiEvent.Snackbar("Simulation failed: ${error.message}"))
+            }
+            _uiState.value = _uiState.value.copy(isSimulating = false)
+        }
+    }
+
+    fun commitPreview(program: ExternalProgram) {
+        val text = _uiState.value.playgroundPreview?.updatedProgramText ?: return
+        viewModelScope.launch {
+            integrationManager.commitProgramText(program.id, text)
+            _uiState.value = _uiState.value.copy(playgroundPreview = null)
+            _events.emit(IntegrationUiEvent.Snackbar("Program text updated"))
+        }
+    }
+
+    fun clearPreview() {
+        _uiState.value = _uiState.value.copy(playgroundPreview = null)
+    }
+}
+
+data class ExternalMeasurementsUiState(
+    val measurements: List<ExternalBodyMeasurement> = emptyList(),
+    val measurementTypes: List<String> = emptyList(),
+    val selectedType: String? = null,
+)
+
+class ExternalMeasurementsViewModel(
+    repository: ExternalMeasurementRepository,
+    userProfileRepository: UserProfileRepository,
+) : ViewModel() {
+    private val selectedType = MutableStateFlow<String?>(null)
+    private val activeProfileId = userProfileRepository.activeProfile
+        .map { it?.id ?: "default" }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, "default")
+
+    val uiState: StateFlow<ExternalMeasurementsUiState> = combine(
+        activeProfileId.flatMapLatest { profileId -> repository.observeMeasurements(profileId) },
+        selectedType,
+    ) { measurements, type ->
+        ExternalMeasurementsUiState(
+            measurements = if (type == null) measurements else measurements.filter { it.measurementType == type },
+            measurementTypes = measurements.map { it.measurementType }.distinct(),
+            selectedType = type,
+        )
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, ExternalMeasurementsUiState())
+
+    fun selectType(type: String?) {
+        selectedType.value = type
+    }
+}

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExternalIntegrationViewModels.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExternalIntegrationViewModels.kt
@@ -133,7 +133,12 @@ class ExternalProgramsViewModel(
     }
 
     fun commitPreview(program: ExternalProgram) {
-        val text = _uiState.value.playgroundPreview?.updatedProgramText ?: return
+        val preview = _uiState.value.playgroundPreview ?: return
+        if (preview.programExternalId != program.externalId) {
+            _uiState.value = _uiState.value.copy(playgroundPreview = null)
+            return
+        }
+        val text = preview.updatedProgramText ?: return
         viewModelScope.launch {
             integrationManager.commitProgramText(program.id, text)
             _uiState.value = _uiState.value.copy(playgroundPreview = null)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/IntegrationsViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/IntegrationsViewModel.kt
@@ -6,6 +6,10 @@ import co.touchlab.kermit.Logger
 import com.devil.phoenixproject.data.integration.CsvImportPreview
 import com.devil.phoenixproject.data.integration.CsvImporter
 import com.devil.phoenixproject.data.integration.ExternalActivityRepository
+import com.devil.phoenixproject.data.integration.ExternalExerciseTemplateRepository
+import com.devil.phoenixproject.data.integration.ExternalMeasurementRepository
+import com.devil.phoenixproject.data.integration.ExternalProgramRepository
+import com.devil.phoenixproject.data.integration.ExternalRoutineRepository
 import com.devil.phoenixproject.data.integration.HealthIntegration
 import com.devil.phoenixproject.data.integration.IntegrationManager
 import com.devil.phoenixproject.data.repository.SubscriptionStatus
@@ -13,7 +17,15 @@ import com.devil.phoenixproject.data.repository.UserProfileRepository
 import com.devil.phoenixproject.data.repository.WorkoutRepository
 import com.devil.phoenixproject.data.sync.PortalTokenStorage
 import com.devil.phoenixproject.domain.model.ExternalActivity
+import com.devil.phoenixproject.domain.model.ExternalBodyMeasurement
+import com.devil.phoenixproject.domain.model.ExternalProgram
+import com.devil.phoenixproject.domain.model.ExternalProgramStats
+import com.devil.phoenixproject.domain.model.ExternalRoutine
+import com.devil.phoenixproject.domain.model.ExternalRoutineFolder
+import com.devil.phoenixproject.domain.model.IntegrationEntitlementState
 import com.devil.phoenixproject.domain.model.IntegrationProvider
+import com.devil.phoenixproject.domain.model.IntegrationSyncProgress
+import com.devil.phoenixproject.domain.model.IntegrationSyncResult
 import com.devil.phoenixproject.domain.model.IntegrationStatus
 import com.devil.phoenixproject.domain.model.WeightUnit
 import com.devil.phoenixproject.isIosPlatform
@@ -33,9 +45,23 @@ import kotlinx.coroutines.launch
 
 private val log = Logger.withTag("IntegrationsViewModel")
 
+sealed class IntegrationUiEvent {
+    data class Snackbar(val message: String) : IntegrationUiEvent()
+}
+
 data class IntegrationsUiState(
     val integrationStatuses: Map<IntegrationProvider, IntegrationStatus> = emptyMap(),
     val externalActivities: List<ExternalActivity> = emptyList(),
+    val externalRoutines: List<ExternalRoutine> = emptyList(),
+    val externalRoutineFolders: List<ExternalRoutineFolder> = emptyList(),
+    val externalPrograms: List<ExternalProgram> = emptyList(),
+    val externalMeasurements: List<ExternalBodyMeasurement> = emptyList(),
+    val externalProgramStatsByProgramId: Map<String, ExternalProgramStats> = emptyMap(),
+    val externalExerciseTemplateCountByProvider: Map<IntegrationProvider, Int> = emptyMap(),
+    val activeProgram: ExternalProgram? = null,
+    val entitlementStateByProvider: Map<IntegrationProvider, IntegrationEntitlementState> = emptyMap(),
+    val syncProgressByProvider: Map<IntegrationProvider, IntegrationSyncProgress> = emptyMap(),
+    val operationLoading: Set<String> = emptySet(),
     val isExporting: Boolean = false,
     val isImporting: Boolean = false,
     val isSyncing: Boolean = false,
@@ -47,6 +73,10 @@ data class IntegrationsUiState(
 
 class IntegrationsViewModel(
     private val externalActivityRepo: ExternalActivityRepository,
+    private val externalRoutineRepo: ExternalRoutineRepository,
+    private val externalProgramRepo: ExternalProgramRepository,
+    private val externalMeasurementRepo: ExternalMeasurementRepository,
+    private val externalTemplateRepo: ExternalExerciseTemplateRepository,
     private val integrationManager: IntegrationManager,
     private val workoutRepository: WorkoutRepository,
     private val healthIntegration: HealthIntegration,
@@ -79,6 +109,9 @@ class IntegrationsViewModel(
     private val _healthPermissionRequests = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     val healthPermissionRequests: SharedFlow<Unit> = _healthPermissionRequests.asSharedFlow()
 
+    private val _uiEvents = MutableSharedFlow<IntegrationUiEvent>(extraBufferCapacity = 8)
+    val uiEvents: SharedFlow<IntegrationUiEvent> = _uiEvents.asSharedFlow()
+
     init {
         viewModelScope.launch {
             // Observe external activities reactively, switching when profile changes
@@ -96,6 +129,62 @@ class IntegrationsViewModel(
             }.collect { statuses ->
                 val statusMap = statuses.associateBy { it.provider }
                 _uiState.value = _uiState.value.copy(integrationStatuses = statusMap)
+            }
+        }
+
+        viewModelScope.launch {
+            activeProfileId.flatMapLatest { profileId ->
+                externalRoutineRepo.observeRoutines(profileId = profileId)
+            }.collect { routines ->
+                _uiState.value = _uiState.value.copy(externalRoutines = routines)
+            }
+        }
+
+        viewModelScope.launch {
+            activeProfileId.flatMapLatest { profileId ->
+                externalRoutineRepo.observeFolders(profileId = profileId)
+            }.collect { folders ->
+                _uiState.value = _uiState.value.copy(externalRoutineFolders = folders)
+            }
+        }
+
+        viewModelScope.launch {
+            activeProfileId.flatMapLatest { profileId ->
+                externalProgramRepo.observePrograms(profileId = profileId)
+            }.collect { programs ->
+                _uiState.value = _uiState.value.copy(externalPrograms = programs)
+            }
+        }
+
+        viewModelScope.launch {
+            activeProfileId.flatMapLatest { profileId ->
+                externalProgramRepo.observeCurrentProgram(profileId = profileId, provider = IntegrationProvider.LIFTOSAUR)
+            }.collect { program ->
+                _uiState.value = _uiState.value.copy(activeProgram = program)
+            }
+        }
+
+        viewModelScope.launch {
+            activeProfileId.flatMapLatest { profileId ->
+                externalProgramRepo.observeProgramStats(profileId = profileId)
+            }.collect { stats ->
+                _uiState.value = _uiState.value.copy(externalProgramStatsByProgramId = stats)
+            }
+        }
+
+        viewModelScope.launch {
+            activeProfileId.flatMapLatest { profileId ->
+                externalMeasurementRepo.observeMeasurements(profileId = profileId)
+            }.collect { measurements ->
+                _uiState.value = _uiState.value.copy(externalMeasurements = measurements)
+            }
+        }
+
+        viewModelScope.launch {
+            activeProfileId.flatMapLatest { profileId ->
+                externalTemplateRepo.observeTemplateCounts(profileId = profileId)
+            }.collect { counts ->
+                _uiState.value = _uiState.value.copy(externalExerciseTemplateCountByProvider = counts)
             }
         }
     }
@@ -198,26 +287,23 @@ class IntegrationsViewModel(
         apiKey: String,
     ) {
         viewModelScope.launch {
-            _uiState.value = _uiState.value.copy(isSyncing = true, errorMessage = null)
+            setOperationLoading(provider, "connect", true)
             try {
                 integrationManager.connectProvider(provider, apiKey, activeProfileId.value, isPaidUser.value)
-                    .onSuccess { activities ->
-                        _uiState.value = _uiState.value.copy(
-                            successMessage = "Connected to ${provider.displayName}: ${activities.size} activities imported",
-                        )
-                        log.i { "Connected ${provider.key}: ${activities.size} activities" }
+                    .onSuccess { result ->
+                        applySyncResult(result)
+                        emitSnackbar("Connected to ${provider.displayName}: ${result.progress.summaryLabel()}")
+                        log.i { "Connected ${provider.key}: ${result.progress}" }
                     }
                     .onFailure { error ->
-                        _uiState.value = _uiState.value.copy(
-                            errorMessage = "Connect failed: ${error.message}",
-                        )
+                        emitSnackbar("Connect failed: ${error.message}")
                         log.w { "Connect to ${provider.key} failed: ${error.message}" }
                     }
             } catch (e: Exception) {
                 log.e(e) { "Unexpected error connecting ${provider.key}" }
-                _uiState.value = _uiState.value.copy(errorMessage = "Connect failed: ${e.message}")
+                emitSnackbar("Connect failed: ${e.message}")
             } finally {
-                _uiState.value = _uiState.value.copy(isSyncing = false)
+                setOperationLoading(provider, "connect", false)
             }
         }
     }
@@ -227,26 +313,24 @@ class IntegrationsViewModel(
      */
     fun syncProvider(provider: IntegrationProvider) {
         viewModelScope.launch {
-            _uiState.value = _uiState.value.copy(isSyncing = true, errorMessage = null)
+            setOperationLoading(provider, "sync", true)
             try {
                 integrationManager.syncProvider(provider, activeProfileId.value, isPaidUser.value)
-                    .onSuccess { activities ->
-                        _uiState.value = _uiState.value.copy(
-                            successMessage = "Synced ${provider.displayName}: ${activities.size} new activities",
-                        )
-                        log.i { "Synced ${provider.key}: ${activities.size} activities" }
+                    .onSuccess { result ->
+                        applySyncResult(result)
+                        val prefix = if (result.partial) "Partially synced" else "Synced"
+                        emitSnackbar("$prefix ${provider.displayName}: ${result.progress.summaryLabel()}")
+                        log.i { "Synced ${provider.key}: ${result.progress}" }
                     }
                     .onFailure { error ->
-                        _uiState.value = _uiState.value.copy(
-                            errorMessage = "Sync failed: ${error.message}",
-                        )
+                        emitSnackbar("Sync failed: ${error.message}")
                         log.w { "Sync ${provider.key} failed: ${error.message}" }
                     }
             } catch (e: Exception) {
                 log.e(e) { "Unexpected error syncing ${provider.key}" }
-                _uiState.value = _uiState.value.copy(errorMessage = "Sync failed: ${e.message}")
+                emitSnackbar("Sync failed: ${e.message}")
             } finally {
-                _uiState.value = _uiState.value.copy(isSyncing = false)
+                setOperationLoading(provider, "sync", false)
             }
         }
     }
@@ -256,26 +340,22 @@ class IntegrationsViewModel(
      */
     fun disconnectProvider(provider: IntegrationProvider) {
         viewModelScope.launch {
-            _uiState.value = _uiState.value.copy(isSyncing = true, errorMessage = null)
+            setOperationLoading(provider, "disconnect", true)
             try {
                 integrationManager.disconnectProvider(provider, activeProfileId.value)
                     .onSuccess {
-                        _uiState.value = _uiState.value.copy(
-                            successMessage = "Disconnected from ${provider.displayName}",
-                        )
+                        emitSnackbar("Disconnected from ${provider.displayName}")
                         log.i { "Disconnected ${provider.key}" }
                     }
                     .onFailure { error ->
-                        _uiState.value = _uiState.value.copy(
-                            errorMessage = "Disconnect failed: ${error.message}",
-                        )
+                        emitSnackbar("Disconnect failed: ${error.message}")
                         log.w { "Disconnect ${provider.key} failed: ${error.message}" }
                     }
             } catch (e: Exception) {
                 log.e(e) { "Unexpected error disconnecting ${provider.key}" }
-                _uiState.value = _uiState.value.copy(errorMessage = "Disconnect failed: ${e.message}")
+                emitSnackbar("Disconnect failed: ${e.message}")
             } finally {
-                _uiState.value = _uiState.value.copy(isSyncing = false)
+                setOperationLoading(provider, "disconnect", false)
             }
         }
     }
@@ -352,6 +432,44 @@ class IntegrationsViewModel(
     /** Clear both error and success messages. */
     fun clearMessages() {
         _uiState.value = _uiState.value.copy(errorMessage = null, successMessage = null)
+    }
+
+    private suspend fun emitSnackbar(message: String) {
+        _uiEvents.emit(IntegrationUiEvent.Snackbar(message))
+        _uiState.value = _uiState.value.copy(errorMessage = null, successMessage = null)
+    }
+
+    private fun setOperationLoading(provider: IntegrationProvider, operation: String, loading: Boolean) {
+        val key = "${provider.key}:$operation"
+        val current = _uiState.value.operationLoading
+        val next = if (loading) current + key else current - key
+        _uiState.value = _uiState.value.copy(
+            operationLoading = next,
+            isSyncing = next.isNotEmpty(),
+            errorMessage = null,
+        )
+    }
+
+    private fun applySyncResult(result: IntegrationSyncResult) {
+        val currentEntitlements = _uiState.value.entitlementStateByProvider.toMutableMap()
+        result.entitlementState?.let { currentEntitlements[result.provider] = it }
+        _uiState.value = _uiState.value.copy(
+            entitlementStateByProvider = currentEntitlements,
+            syncProgressByProvider = _uiState.value.syncProgressByProvider + (result.provider to result.progress),
+        )
+    }
+
+    private fun IntegrationSyncProgress.summaryLabel(): String {
+        val parts = buildList {
+            if (activitiesImported > 0) add("$activitiesImported workouts")
+            if (routinesImported > 0) add("$routinesImported routines")
+            if (routineFoldersImported > 0) add("$routineFoldersImported folders")
+            if (exerciseTemplatesImported > 0) add("$exerciseTemplatesImported templates")
+            if (measurementsImported > 0) add("$measurementsImported measurements")
+            if (programsImported > 0) add("$programsImported programs")
+            if (programStatsImported > 0) add("$programStatsImported stats")
+        }
+        return parts.ifEmpty { listOf("no new data") }.joinToString(", ")
     }
 
     private suspend fun applyHealthPermissionResult(

--- a/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
+++ b/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
@@ -2063,10 +2063,11 @@ CREATE TABLE IF NOT EXISTS ExternalActivity (
     rawData TEXT,
     syncedAt INTEGER NOT NULL,
     profileId TEXT NOT NULL DEFAULT 'default',
-    needsSync INTEGER NOT NULL DEFAULT 1
+    needsSync INTEGER NOT NULL DEFAULT 1,
+    deletedAt INTEGER
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS idx_external_activity_dedup ON ExternalActivity(externalId, provider);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_external_activity_dedup ON ExternalActivity(provider, externalId, profileId);
 CREATE INDEX IF NOT EXISTS idx_external_activity_profile ON ExternalActivity(profileId);
 CREATE INDEX IF NOT EXISTS idx_external_activity_provider ON ExternalActivity(provider);
 CREATE INDEX IF NOT EXISTS idx_external_activity_started ON ExternalActivity(startedAt DESC);
@@ -2080,27 +2081,190 @@ CREATE TABLE IF NOT EXISTS IntegrationStatus (
     PRIMARY KEY(provider, profileId)
 );
 
+CREATE TABLE IF NOT EXISTS ExternalRoutine (
+    id TEXT NOT NULL PRIMARY KEY,
+    externalId TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    title TEXT NOT NULL,
+    folderExternalId TEXT,
+    folderName TEXT,
+    updatedAt INTEGER,
+    syncedAt INTEGER NOT NULL,
+    rawData TEXT,
+    profileId TEXT NOT NULL DEFAULT 'default',
+    needsSync INTEGER NOT NULL DEFAULT 0,
+    deletedAt INTEGER
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_external_routine_dedup ON ExternalRoutine(provider, externalId, profileId);
+CREATE INDEX IF NOT EXISTS idx_external_routine_profile_provider ON ExternalRoutine(profileId, provider);
+CREATE INDEX IF NOT EXISTS idx_external_routine_folder ON ExternalRoutine(profileId, provider, folderExternalId);
+CREATE INDEX IF NOT EXISTS idx_external_routine_updated ON ExternalRoutine(updatedAt DESC);
+
+CREATE TABLE IF NOT EXISTS ExternalRoutineExercise (
+    id TEXT NOT NULL PRIMARY KEY,
+    externalRoutineId TEXT NOT NULL,
+    externalExerciseTemplateId TEXT,
+    title TEXT NOT NULL,
+    exerciseType TEXT,
+    primaryMuscleGroups TEXT NOT NULL DEFAULT '',
+    secondaryMuscleGroups TEXT NOT NULL DEFAULT '',
+    orderIndex INTEGER NOT NULL DEFAULT 0,
+    rawData TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_external_routine_exercise_routine ON ExternalRoutineExercise(externalRoutineId);
+CREATE INDEX IF NOT EXISTS idx_external_routine_exercise_template ON ExternalRoutineExercise(externalExerciseTemplateId);
+
+CREATE TABLE IF NOT EXISTS ExternalRoutineSet (
+    id TEXT NOT NULL PRIMARY KEY,
+    externalRoutineExerciseId TEXT NOT NULL,
+    setIndex INTEGER NOT NULL DEFAULT 0,
+    setType TEXT,
+    weightKg REAL,
+    reps INTEGER,
+    minReps INTEGER,
+    maxReps INTEGER,
+    restSeconds INTEGER,
+    rpe REAL,
+    durationSeconds INTEGER,
+    distanceMeters REAL,
+    rawData TEXT
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_external_routine_set_dedup ON ExternalRoutineSet(externalRoutineExerciseId, setIndex);
+CREATE INDEX IF NOT EXISTS idx_external_routine_set_exercise ON ExternalRoutineSet(externalRoutineExerciseId);
+
+CREATE TABLE IF NOT EXISTS ExternalRoutineFolder (
+    id TEXT NOT NULL PRIMARY KEY,
+    externalId TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    title TEXT NOT NULL,
+    folderIndex INTEGER,
+    createdAt INTEGER,
+    updatedAt INTEGER,
+    profileId TEXT NOT NULL DEFAULT 'default',
+    rawData TEXT
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_external_routine_folder_dedup ON ExternalRoutineFolder(provider, externalId, profileId);
+CREATE INDEX IF NOT EXISTS idx_external_routine_folder_profile_provider ON ExternalRoutineFolder(profileId, provider);
+
+CREATE TABLE IF NOT EXISTS ExternalProgram (
+    id TEXT NOT NULL PRIMARY KEY,
+    externalId TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    name TEXT NOT NULL,
+    isCurrent INTEGER NOT NULL DEFAULT 0,
+    scriptText TEXT,
+    rawData TEXT,
+    updatedAt INTEGER,
+    syncedAt INTEGER NOT NULL,
+    profileId TEXT NOT NULL DEFAULT 'default',
+    needsSync INTEGER NOT NULL DEFAULT 0,
+    deletedAt INTEGER
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_external_program_dedup ON ExternalProgram(provider, externalId, profileId);
+CREATE INDEX IF NOT EXISTS idx_external_program_profile_provider ON ExternalProgram(profileId, provider);
+CREATE INDEX IF NOT EXISTS idx_external_program_current ON ExternalProgram(profileId, provider, isCurrent);
+CREATE INDEX IF NOT EXISTS idx_external_program_updated ON ExternalProgram(updatedAt DESC);
+
+CREATE TABLE IF NOT EXISTS ExternalProgramStats (
+    id TEXT NOT NULL PRIMARY KEY,
+    externalProgramId TEXT NOT NULL,
+    days INTEGER,
+    approximateMinutes INTEGER,
+    setCount INTEGER,
+    muscleGroupBreakdownJson TEXT,
+    rawData TEXT,
+    computedAt INTEGER
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_external_program_stats_program ON ExternalProgramStats(externalProgramId);
+CREATE INDEX IF NOT EXISTS idx_external_program_stats_computed ON ExternalProgramStats(computedAt DESC);
+
+CREATE TABLE IF NOT EXISTS ExternalExerciseTemplate (
+    id TEXT NOT NULL PRIMARY KEY,
+    externalId TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    title TEXT NOT NULL,
+    exerciseType TEXT,
+    primaryMuscleGroups TEXT NOT NULL DEFAULT '',
+    secondaryMuscleGroups TEXT NOT NULL DEFAULT '',
+    isCustom INTEGER NOT NULL DEFAULT 0,
+    rawData TEXT,
+    updatedAt INTEGER,
+    profileId TEXT NOT NULL DEFAULT 'default'
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_external_exercise_template_dedup ON ExternalExerciseTemplate(provider, externalId, profileId);
+CREATE INDEX IF NOT EXISTS idx_external_exercise_template_profile_provider ON ExternalExerciseTemplate(profileId, provider);
+CREATE INDEX IF NOT EXISTS idx_external_exercise_template_title ON ExternalExerciseTemplate(title);
+
+CREATE TABLE IF NOT EXISTS ExternalExerciseTemplateMapping (
+    id TEXT NOT NULL PRIMARY KEY,
+    provider TEXT NOT NULL,
+    externalTemplateId TEXT NOT NULL,
+    localExerciseId TEXT NOT NULL,
+    profileId TEXT NOT NULL DEFAULT 'default',
+    createdAt INTEGER NOT NULL,
+    updatedAt INTEGER NOT NULL,
+    rawData TEXT
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_external_template_mapping_dedup ON ExternalExerciseTemplateMapping(provider, externalTemplateId, profileId);
+CREATE INDEX IF NOT EXISTS idx_external_template_mapping_local ON ExternalExerciseTemplateMapping(localExerciseId);
+
+CREATE TABLE IF NOT EXISTS ExternalBodyMeasurement (
+    id TEXT NOT NULL PRIMARY KEY,
+    externalId TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    measurementType TEXT NOT NULL,
+    value REAL NOT NULL,
+    unit TEXT NOT NULL,
+    measuredAt INTEGER NOT NULL,
+    syncedAt INTEGER NOT NULL,
+    rawData TEXT,
+    profileId TEXT NOT NULL DEFAULT 'default'
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_external_body_measurement_dedup ON ExternalBodyMeasurement(provider, externalId, profileId);
+CREATE INDEX IF NOT EXISTS idx_external_body_measurement_profile_provider ON ExternalBodyMeasurement(profileId, provider);
+CREATE INDEX IF NOT EXISTS idx_external_body_measurement_type_date ON ExternalBodyMeasurement(profileId, measurementType, measuredAt DESC);
+
+CREATE TABLE IF NOT EXISTS IntegrationSyncCursor (
+    provider TEXT NOT NULL,
+    profileId TEXT NOT NULL DEFAULT 'default',
+    cursorType TEXT NOT NULL,
+    cursorValue TEXT,
+    updatedAt INTEGER NOT NULL,
+    PRIMARY KEY(provider, profileId, cursorType)
+);
+
+CREATE INDEX IF NOT EXISTS idx_integration_sync_cursor_profile_provider ON IntegrationSyncCursor(profileId, provider);
+
 -- ExternalActivity queries
 getAllExternalActivities:
 SELECT * FROM ExternalActivity
-WHERE profileId = ?
+WHERE profileId = ? AND deletedAt IS NULL
 ORDER BY startedAt DESC;
 
 getExternalActivitiesByProvider:
 SELECT * FROM ExternalActivity
-WHERE profileId = ? AND provider = ?
+WHERE profileId = ? AND provider = ? AND deletedAt IS NULL
 ORDER BY startedAt DESC;
 
 getUnsyncedExternalActivities:
 SELECT * FROM ExternalActivity
-WHERE profileId = ? AND needsSync = 1;
+WHERE profileId = ? AND needsSync = 1 AND deletedAt IS NULL;
 
 insertExternalActivityIfNew:
 INSERT OR IGNORE INTO ExternalActivity(
     id, externalId, provider, name, activityType, startedAt,
     durationSeconds, distanceMeters, calories, avgHeartRate,
-    maxHeartRate, elevationGainMeters, rawData, syncedAt, profileId, needsSync
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+    maxHeartRate, elevationGainMeters, rawData, syncedAt, profileId, needsSync, deletedAt
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 updateExternalActivityOnConflict:
 UPDATE ExternalActivity SET
@@ -2115,8 +2279,8 @@ UPDATE ExternalActivity SET
     elevationGainMeters = ?,
     rawData = ?,
     syncedAt = ?,
-    profileId = ?
-WHERE externalId = ? AND provider = ?;
+    deletedAt = ?
+WHERE externalId = ? AND provider = ? AND profileId = ?;
 
 markExternalActivitySynced:
 UPDATE ExternalActivity SET needsSync = 0 WHERE id = ?;
@@ -2126,8 +2290,276 @@ UPDATE ExternalActivity
 SET needsSync = 0
 WHERE externalId = ? AND provider = ? AND profileId = ?;
 
+markExternalActivityDeletedBySyncKey:
+UPDATE ExternalActivity
+SET deletedAt = ?, needsSync = ?
+WHERE externalId = ? AND provider = ? AND profileId = ?;
+
 deleteExternalActivitiesByProvider:
 DELETE FROM ExternalActivity WHERE provider = ? AND profileId = ?;
+
+-- ExternalRoutine queries
+getExternalRoutines:
+SELECT * FROM ExternalRoutine
+WHERE profileId = ? AND deletedAt IS NULL
+ORDER BY COALESCE(folderName, ''), title COLLATE NOCASE;
+
+getExternalRoutinesByProvider:
+SELECT * FROM ExternalRoutine
+WHERE profileId = ? AND provider = ? AND deletedAt IS NULL
+ORDER BY COALESCE(folderName, ''), title COLLATE NOCASE;
+
+getExternalRoutineBySyncKey:
+SELECT * FROM ExternalRoutine
+WHERE provider = ? AND externalId = ? AND profileId = ?;
+
+insertExternalRoutineIfNew:
+INSERT OR IGNORE INTO ExternalRoutine(
+    id, externalId, provider, title, folderExternalId, folderName,
+    updatedAt, syncedAt, rawData, profileId, needsSync, deletedAt
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+
+updateExternalRoutineOnConflict:
+UPDATE ExternalRoutine SET
+    title = ?,
+    folderExternalId = ?,
+    folderName = ?,
+    updatedAt = ?,
+    syncedAt = ?,
+    rawData = ?,
+    deletedAt = ?
+WHERE provider = ? AND externalId = ? AND profileId = ?;
+
+insertExternalRoutineExercise:
+INSERT OR REPLACE INTO ExternalRoutineExercise(
+    id, externalRoutineId, externalExerciseTemplateId, title, exerciseType,
+    primaryMuscleGroups, secondaryMuscleGroups, orderIndex, rawData
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
+
+insertExternalRoutineSet:
+INSERT OR REPLACE INTO ExternalRoutineSet(
+    id, externalRoutineExerciseId, setIndex, setType, weightKg, reps,
+    minReps, maxReps, restSeconds, rpe, durationSeconds, distanceMeters, rawData
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+
+getExternalRoutineExercises:
+SELECT * FROM ExternalRoutineExercise
+WHERE externalRoutineId = ?
+ORDER BY orderIndex ASC;
+
+getExternalRoutineSets:
+SELECT * FROM ExternalRoutineSet
+WHERE externalRoutineExerciseId = ?
+ORDER BY setIndex ASC;
+
+deleteExternalRoutineSetsByRoutine:
+DELETE FROM ExternalRoutineSet
+WHERE externalRoutineExerciseId IN (
+    SELECT id FROM ExternalRoutineExercise WHERE externalRoutineId = ?
+);
+
+deleteExternalRoutineExercisesByRoutine:
+DELETE FROM ExternalRoutineExercise WHERE externalRoutineId = ?;
+
+deleteExternalRoutineSetsByProvider:
+DELETE FROM ExternalRoutineSet
+WHERE externalRoutineExerciseId IN (
+    SELECT e.id
+    FROM ExternalRoutineExercise e
+    JOIN ExternalRoutine r ON r.id = e.externalRoutineId
+    WHERE r.provider = ? AND r.profileId = ?
+);
+
+deleteExternalRoutineExercisesByProvider:
+DELETE FROM ExternalRoutineExercise
+WHERE externalRoutineId IN (
+    SELECT id FROM ExternalRoutine WHERE provider = ? AND profileId = ?
+);
+
+deleteExternalRoutinesByProvider:
+DELETE FROM ExternalRoutine WHERE provider = ? AND profileId = ?;
+
+-- ExternalRoutineFolder queries
+getExternalRoutineFolders:
+SELECT * FROM ExternalRoutineFolder
+WHERE profileId = ?
+ORDER BY COALESCE(folderIndex, 2147483647), title COLLATE NOCASE;
+
+getExternalRoutineFoldersByProvider:
+SELECT * FROM ExternalRoutineFolder
+WHERE profileId = ? AND provider = ?
+ORDER BY COALESCE(folderIndex, 2147483647), title COLLATE NOCASE;
+
+upsertExternalRoutineFolder:
+INSERT OR REPLACE INTO ExternalRoutineFolder(
+    id, externalId, provider, title, folderIndex, createdAt, updatedAt, profileId, rawData
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
+
+deleteExternalRoutineFoldersByProvider:
+DELETE FROM ExternalRoutineFolder WHERE provider = ? AND profileId = ?;
+
+-- ExternalProgram queries
+getExternalPrograms:
+SELECT * FROM ExternalProgram
+WHERE profileId = ? AND deletedAt IS NULL
+ORDER BY isCurrent DESC, name COLLATE NOCASE;
+
+getExternalProgramsByProvider:
+SELECT * FROM ExternalProgram
+WHERE profileId = ? AND provider = ? AND deletedAt IS NULL
+ORDER BY isCurrent DESC, name COLLATE NOCASE;
+
+getCurrentExternalProgram:
+SELECT * FROM ExternalProgram
+WHERE profileId = ? AND provider = ? AND isCurrent = 1 AND deletedAt IS NULL
+ORDER BY updatedAt DESC
+LIMIT 1;
+
+getExternalProgramBySyncKey:
+SELECT * FROM ExternalProgram
+WHERE provider = ? AND externalId = ? AND profileId = ?;
+
+insertExternalProgramIfNew:
+INSERT OR IGNORE INTO ExternalProgram(
+    id, externalId, provider, name, isCurrent, scriptText, rawData,
+    updatedAt, syncedAt, profileId, needsSync, deletedAt
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+
+updateExternalProgramOnConflict:
+UPDATE ExternalProgram SET
+    name = ?,
+    isCurrent = ?,
+    scriptText = ?,
+    rawData = ?,
+    updatedAt = ?,
+    syncedAt = ?,
+    deletedAt = ?
+WHERE provider = ? AND externalId = ? AND profileId = ?;
+
+updateExternalProgramText:
+UPDATE ExternalProgram SET
+    scriptText = ?,
+    updatedAt = ?,
+    syncedAt = ?,
+    needsSync = ?
+WHERE id = ?;
+
+deleteExternalProgramsByProvider:
+DELETE FROM ExternalProgram WHERE provider = ? AND profileId = ?;
+
+-- ExternalProgramStats queries
+getExternalProgramStats:
+SELECT * FROM ExternalProgramStats WHERE externalProgramId = ?;
+
+getExternalProgramStatsByProfile:
+SELECT s.*
+FROM ExternalProgramStats s
+JOIN ExternalProgram p ON p.id = s.externalProgramId
+WHERE p.profileId = ? AND p.deletedAt IS NULL;
+
+getExternalProgramStatsByProvider:
+SELECT s.*
+FROM ExternalProgramStats s
+JOIN ExternalProgram p ON p.id = s.externalProgramId
+WHERE p.profileId = ? AND p.provider = ? AND p.deletedAt IS NULL;
+
+insertExternalProgramStats:
+INSERT OR REPLACE INTO ExternalProgramStats(
+    id, externalProgramId, days, approximateMinutes, setCount,
+    muscleGroupBreakdownJson, rawData, computedAt
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?);
+
+deleteExternalProgramStatsByProgram:
+DELETE FROM ExternalProgramStats WHERE externalProgramId = ?;
+
+deleteExternalProgramStatsByProvider:
+DELETE FROM ExternalProgramStats
+WHERE externalProgramId IN (
+    SELECT id FROM ExternalProgram WHERE provider = ? AND profileId = ?
+);
+
+-- ExternalExerciseTemplate queries
+getExternalExerciseTemplates:
+SELECT * FROM ExternalExerciseTemplate
+WHERE profileId = ?
+ORDER BY title COLLATE NOCASE;
+
+getExternalExerciseTemplatesByProvider:
+SELECT * FROM ExternalExerciseTemplate
+WHERE profileId = ? AND provider = ?
+ORDER BY title COLLATE NOCASE;
+
+getExternalExerciseTemplateBySyncKey:
+SELECT * FROM ExternalExerciseTemplate
+WHERE provider = ? AND externalId = ? AND profileId = ?;
+
+upsertExternalExerciseTemplate:
+INSERT OR REPLACE INTO ExternalExerciseTemplate(
+    id, externalId, provider, title, exerciseType, primaryMuscleGroups,
+    secondaryMuscleGroups, isCustom, rawData, updatedAt, profileId
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+
+countExternalExerciseTemplatesByProvider:
+SELECT provider, COUNT(*) AS templateCount
+FROM ExternalExerciseTemplate
+WHERE profileId = ?
+GROUP BY provider;
+
+deleteExternalExerciseTemplatesByProvider:
+DELETE FROM ExternalExerciseTemplate WHERE provider = ? AND profileId = ?;
+
+-- ExternalExerciseTemplateMapping queries
+getExternalExerciseTemplateMapping:
+SELECT * FROM ExternalExerciseTemplateMapping
+WHERE provider = ? AND externalTemplateId = ? AND profileId = ?;
+
+upsertExternalExerciseTemplateMapping:
+INSERT OR REPLACE INTO ExternalExerciseTemplateMapping(
+    id, provider, externalTemplateId, localExerciseId, profileId, createdAt, updatedAt, rawData
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?);
+
+deleteExternalExerciseTemplateMappingsByProvider:
+DELETE FROM ExternalExerciseTemplateMapping WHERE provider = ? AND profileId = ?;
+
+-- ExternalBodyMeasurement queries
+getExternalBodyMeasurements:
+SELECT * FROM ExternalBodyMeasurement
+WHERE profileId = ?
+ORDER BY measuredAt DESC;
+
+getExternalBodyMeasurementsByProvider:
+SELECT * FROM ExternalBodyMeasurement
+WHERE profileId = ? AND provider = ?
+ORDER BY measuredAt DESC;
+
+getExternalBodyMeasurementsByType:
+SELECT * FROM ExternalBodyMeasurement
+WHERE profileId = ? AND measurementType = ?
+ORDER BY measuredAt DESC;
+
+upsertExternalBodyMeasurement:
+INSERT OR REPLACE INTO ExternalBodyMeasurement(
+    id, externalId, provider, measurementType, value, unit, measuredAt, syncedAt, rawData, profileId
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+
+deleteExternalBodyMeasurementsByProvider:
+DELETE FROM ExternalBodyMeasurement WHERE provider = ? AND profileId = ?;
+
+-- IntegrationSyncCursor queries
+getIntegrationSyncCursor:
+SELECT * FROM IntegrationSyncCursor
+WHERE provider = ? AND profileId = ? AND cursorType = ?;
+
+getIntegrationSyncCursorsByProvider:
+SELECT * FROM IntegrationSyncCursor
+WHERE provider = ? AND profileId = ?;
+
+upsertIntegrationSyncCursor:
+INSERT OR REPLACE INTO IntegrationSyncCursor(provider, profileId, cursorType, cursorValue, updatedAt)
+VALUES (?, ?, ?, ?, ?);
+
+deleteIntegrationSyncCursorsByProvider:
+DELETE FROM IntegrationSyncCursor WHERE provider = ? AND profileId = ?;
 
 -- IntegrationStatus queries
 getIntegrationStatus:

--- a/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
+++ b/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
@@ -2103,7 +2103,7 @@ CREATE INDEX IF NOT EXISTS idx_external_routine_updated ON ExternalRoutine(updat
 
 CREATE TABLE IF NOT EXISTS ExternalRoutineExercise (
     id TEXT NOT NULL PRIMARY KEY,
-    externalRoutineId TEXT NOT NULL,
+    externalRoutineId TEXT NOT NULL REFERENCES ExternalRoutine(id) ON DELETE CASCADE,
     externalExerciseTemplateId TEXT,
     title TEXT NOT NULL,
     exerciseType TEXT,
@@ -2118,7 +2118,7 @@ CREATE INDEX IF NOT EXISTS idx_external_routine_exercise_template ON ExternalRou
 
 CREATE TABLE IF NOT EXISTS ExternalRoutineSet (
     id TEXT NOT NULL PRIMARY KEY,
-    externalRoutineExerciseId TEXT NOT NULL,
+    externalRoutineExerciseId TEXT NOT NULL REFERENCES ExternalRoutineExercise(id) ON DELETE CASCADE,
     setIndex INTEGER NOT NULL DEFAULT 0,
     setType TEXT,
     weightKg REAL,
@@ -2172,7 +2172,7 @@ CREATE INDEX IF NOT EXISTS idx_external_program_updated ON ExternalProgram(updat
 
 CREATE TABLE IF NOT EXISTS ExternalProgramStats (
     id TEXT NOT NULL PRIMARY KEY,
-    externalProgramId TEXT NOT NULL,
+    externalProgramId TEXT NOT NULL REFERENCES ExternalProgram(id) ON DELETE CASCADE,
     days INTEGER,
     approximateMinutes INTEGER,
     setCount INTEGER,
@@ -2347,10 +2347,20 @@ SELECT * FROM ExternalRoutineExercise
 WHERE externalRoutineId = ?
 ORDER BY orderIndex ASC;
 
+getExternalRoutineExercisesForRoutines:
+SELECT * FROM ExternalRoutineExercise
+WHERE externalRoutineId IN ?
+ORDER BY externalRoutineId, orderIndex ASC;
+
 getExternalRoutineSets:
 SELECT * FROM ExternalRoutineSet
 WHERE externalRoutineExerciseId = ?
 ORDER BY setIndex ASC;
+
+getExternalRoutineSetsForExercises:
+SELECT * FROM ExternalRoutineSet
+WHERE externalRoutineExerciseId IN ?
+ORDER BY externalRoutineExerciseId, setIndex ASC;
 
 deleteExternalRoutineSetsByRoutine:
 DELETE FROM ExternalRoutineSet
@@ -2418,6 +2428,10 @@ LIMIT 1;
 getExternalProgramBySyncKey:
 SELECT * FROM ExternalProgram
 WHERE provider = ? AND externalId = ? AND profileId = ?;
+
+getExternalProgramsBySyncKeys:
+SELECT * FROM ExternalProgram
+WHERE provider = ? AND profileId = ? AND externalId IN ?;
 
 insertExternalProgramIfNew:
 INSERT OR IGNORE INTO ExternalProgram(

--- a/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/migrations/31.sqm
+++ b/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/migrations/31.sqm
@@ -1,0 +1,169 @@
+-- Migration 31: Expanded mobile integration entities.
+
+ALTER TABLE ExternalActivity ADD COLUMN deletedAt INTEGER;
+
+DROP INDEX IF EXISTS idx_external_activity_dedup;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_external_activity_dedup ON ExternalActivity(provider, externalId, profileId);
+
+CREATE TABLE IF NOT EXISTS ExternalRoutine (
+    id TEXT NOT NULL PRIMARY KEY,
+    externalId TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    title TEXT NOT NULL,
+    folderExternalId TEXT,
+    folderName TEXT,
+    updatedAt INTEGER,
+    syncedAt INTEGER NOT NULL,
+    rawData TEXT,
+    profileId TEXT NOT NULL DEFAULT 'default',
+    needsSync INTEGER NOT NULL DEFAULT 0,
+    deletedAt INTEGER
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_external_routine_dedup ON ExternalRoutine(provider, externalId, profileId);
+CREATE INDEX IF NOT EXISTS idx_external_routine_profile_provider ON ExternalRoutine(profileId, provider);
+CREATE INDEX IF NOT EXISTS idx_external_routine_folder ON ExternalRoutine(profileId, provider, folderExternalId);
+CREATE INDEX IF NOT EXISTS idx_external_routine_updated ON ExternalRoutine(updatedAt DESC);
+
+CREATE TABLE IF NOT EXISTS ExternalRoutineExercise (
+    id TEXT NOT NULL PRIMARY KEY,
+    externalRoutineId TEXT NOT NULL,
+    externalExerciseTemplateId TEXT,
+    title TEXT NOT NULL,
+    exerciseType TEXT,
+    primaryMuscleGroups TEXT NOT NULL DEFAULT '',
+    secondaryMuscleGroups TEXT NOT NULL DEFAULT '',
+    orderIndex INTEGER NOT NULL DEFAULT 0,
+    rawData TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_external_routine_exercise_routine ON ExternalRoutineExercise(externalRoutineId);
+CREATE INDEX IF NOT EXISTS idx_external_routine_exercise_template ON ExternalRoutineExercise(externalExerciseTemplateId);
+
+CREATE TABLE IF NOT EXISTS ExternalRoutineSet (
+    id TEXT NOT NULL PRIMARY KEY,
+    externalRoutineExerciseId TEXT NOT NULL,
+    setIndex INTEGER NOT NULL DEFAULT 0,
+    setType TEXT,
+    weightKg REAL,
+    reps INTEGER,
+    minReps INTEGER,
+    maxReps INTEGER,
+    restSeconds INTEGER,
+    rpe REAL,
+    durationSeconds INTEGER,
+    distanceMeters REAL,
+    rawData TEXT
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_external_routine_set_dedup ON ExternalRoutineSet(externalRoutineExerciseId, setIndex);
+CREATE INDEX IF NOT EXISTS idx_external_routine_set_exercise ON ExternalRoutineSet(externalRoutineExerciseId);
+
+CREATE TABLE IF NOT EXISTS ExternalRoutineFolder (
+    id TEXT NOT NULL PRIMARY KEY,
+    externalId TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    title TEXT NOT NULL,
+    folderIndex INTEGER,
+    createdAt INTEGER,
+    updatedAt INTEGER,
+    profileId TEXT NOT NULL DEFAULT 'default',
+    rawData TEXT
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_external_routine_folder_dedup ON ExternalRoutineFolder(provider, externalId, profileId);
+CREATE INDEX IF NOT EXISTS idx_external_routine_folder_profile_provider ON ExternalRoutineFolder(profileId, provider);
+
+CREATE TABLE IF NOT EXISTS ExternalProgram (
+    id TEXT NOT NULL PRIMARY KEY,
+    externalId TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    name TEXT NOT NULL,
+    isCurrent INTEGER NOT NULL DEFAULT 0,
+    scriptText TEXT,
+    rawData TEXT,
+    updatedAt INTEGER,
+    syncedAt INTEGER NOT NULL,
+    profileId TEXT NOT NULL DEFAULT 'default',
+    needsSync INTEGER NOT NULL DEFAULT 0,
+    deletedAt INTEGER
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_external_program_dedup ON ExternalProgram(provider, externalId, profileId);
+CREATE INDEX IF NOT EXISTS idx_external_program_profile_provider ON ExternalProgram(profileId, provider);
+CREATE INDEX IF NOT EXISTS idx_external_program_current ON ExternalProgram(profileId, provider, isCurrent);
+CREATE INDEX IF NOT EXISTS idx_external_program_updated ON ExternalProgram(updatedAt DESC);
+
+CREATE TABLE IF NOT EXISTS ExternalProgramStats (
+    id TEXT NOT NULL PRIMARY KEY,
+    externalProgramId TEXT NOT NULL,
+    days INTEGER,
+    approximateMinutes INTEGER,
+    setCount INTEGER,
+    muscleGroupBreakdownJson TEXT,
+    rawData TEXT,
+    computedAt INTEGER
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_external_program_stats_program ON ExternalProgramStats(externalProgramId);
+CREATE INDEX IF NOT EXISTS idx_external_program_stats_computed ON ExternalProgramStats(computedAt DESC);
+
+CREATE TABLE IF NOT EXISTS ExternalExerciseTemplate (
+    id TEXT NOT NULL PRIMARY KEY,
+    externalId TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    title TEXT NOT NULL,
+    exerciseType TEXT,
+    primaryMuscleGroups TEXT NOT NULL DEFAULT '',
+    secondaryMuscleGroups TEXT NOT NULL DEFAULT '',
+    isCustom INTEGER NOT NULL DEFAULT 0,
+    rawData TEXT,
+    updatedAt INTEGER,
+    profileId TEXT NOT NULL DEFAULT 'default'
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_external_exercise_template_dedup ON ExternalExerciseTemplate(provider, externalId, profileId);
+CREATE INDEX IF NOT EXISTS idx_external_exercise_template_profile_provider ON ExternalExerciseTemplate(profileId, provider);
+CREATE INDEX IF NOT EXISTS idx_external_exercise_template_title ON ExternalExerciseTemplate(title);
+
+CREATE TABLE IF NOT EXISTS ExternalExerciseTemplateMapping (
+    id TEXT NOT NULL PRIMARY KEY,
+    provider TEXT NOT NULL,
+    externalTemplateId TEXT NOT NULL,
+    localExerciseId TEXT NOT NULL,
+    profileId TEXT NOT NULL DEFAULT 'default',
+    createdAt INTEGER NOT NULL,
+    updatedAt INTEGER NOT NULL,
+    rawData TEXT
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_external_template_mapping_dedup ON ExternalExerciseTemplateMapping(provider, externalTemplateId, profileId);
+CREATE INDEX IF NOT EXISTS idx_external_template_mapping_local ON ExternalExerciseTemplateMapping(localExerciseId);
+
+CREATE TABLE IF NOT EXISTS ExternalBodyMeasurement (
+    id TEXT NOT NULL PRIMARY KEY,
+    externalId TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    measurementType TEXT NOT NULL,
+    value REAL NOT NULL,
+    unit TEXT NOT NULL,
+    measuredAt INTEGER NOT NULL,
+    syncedAt INTEGER NOT NULL,
+    rawData TEXT,
+    profileId TEXT NOT NULL DEFAULT 'default'
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_external_body_measurement_dedup ON ExternalBodyMeasurement(provider, externalId, profileId);
+CREATE INDEX IF NOT EXISTS idx_external_body_measurement_profile_provider ON ExternalBodyMeasurement(profileId, provider);
+CREATE INDEX IF NOT EXISTS idx_external_body_measurement_type_date ON ExternalBodyMeasurement(profileId, measurementType, measuredAt DESC);
+
+CREATE TABLE IF NOT EXISTS IntegrationSyncCursor (
+    provider TEXT NOT NULL,
+    profileId TEXT NOT NULL DEFAULT 'default',
+    cursorType TEXT NOT NULL,
+    cursorValue TEXT,
+    updatedAt INTEGER NOT NULL,
+    PRIMARY KEY(provider, profileId, cursorType)
+);
+
+CREATE INDEX IF NOT EXISTS idx_integration_sync_cursor_profile_provider ON IntegrationSyncCursor(profileId, provider);

--- a/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/migrations/31.sqm
+++ b/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/migrations/31.sqm
@@ -27,7 +27,7 @@ CREATE INDEX IF NOT EXISTS idx_external_routine_updated ON ExternalRoutine(updat
 
 CREATE TABLE IF NOT EXISTS ExternalRoutineExercise (
     id TEXT NOT NULL PRIMARY KEY,
-    externalRoutineId TEXT NOT NULL,
+    externalRoutineId TEXT NOT NULL REFERENCES ExternalRoutine(id) ON DELETE CASCADE,
     externalExerciseTemplateId TEXT,
     title TEXT NOT NULL,
     exerciseType TEXT,
@@ -42,7 +42,7 @@ CREATE INDEX IF NOT EXISTS idx_external_routine_exercise_template ON ExternalRou
 
 CREATE TABLE IF NOT EXISTS ExternalRoutineSet (
     id TEXT NOT NULL PRIMARY KEY,
-    externalRoutineExerciseId TEXT NOT NULL,
+    externalRoutineExerciseId TEXT NOT NULL REFERENCES ExternalRoutineExercise(id) ON DELETE CASCADE,
     setIndex INTEGER NOT NULL DEFAULT 0,
     setType TEXT,
     weightKg REAL,
@@ -96,7 +96,7 @@ CREATE INDEX IF NOT EXISTS idx_external_program_updated ON ExternalProgram(updat
 
 CREATE TABLE IF NOT EXISTS ExternalProgramStats (
     id TEXT NOT NULL PRIMARY KEY,
-    externalProgramId TEXT NOT NULL,
+    externalProgramId TEXT NOT NULL REFERENCES ExternalProgram(id) ON DELETE CASCADE,
     days INTEGER,
     approximateMinutes INTEGER,
     setCount INTEGER,

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/integration/IntegrationManagerTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/integration/IntegrationManagerTest.kt
@@ -643,6 +643,40 @@ class IntegrationManagerTest {
         assertEquals(2, fakeApi.integrationSyncCallCount)
         assertEquals(2, result.progress.activitiesImported)
         assertEquals(2, fakeRepo.activities.size)
-        assertEquals("page-2", fakeCursorRepo.cursors.single().cursorValue)
+        assertEquals(emptyList(), fakeCursorRepo.cursors, "Transient page cursors must not be stored as durable sync cursors")
+    }
+
+    @Test
+    fun syncPersistsProviderSyncCursorWithoutPersistingPageCursor() = runTest {
+        fakeApi.integrationSyncResultsQueue = mutableListOf(
+            Result.success(
+                IntegrationSyncResponse(
+                    status = "ok",
+                    activities = listOf(
+                        IntegrationActivityDto("a1", "hevy", "First", startedAt = "2026-03-20T10:00:00Z"),
+                    ),
+                    hasMore = true,
+                    nextCursor = "page-2",
+                    providerSyncCursor = "provider-checkpoint-1",
+                ),
+            ),
+            Result.success(
+                IntegrationSyncResponse(
+                    status = "ok",
+                    activities = listOf(
+                        IntegrationActivityDto("a2", "hevy", "Second", startedAt = "2026-03-21T10:00:00Z"),
+                    ),
+                    hasMore = false,
+                    providerSyncCursor = "provider-checkpoint-2",
+                ),
+            ),
+        )
+        val manager = createManager()
+
+        manager.syncProvider(IntegrationProvider.HEVY, "profile-1", true).getOrThrow()
+
+        assertEquals(2, fakeApi.integrationSyncCallCount)
+        assertEquals("page-2", fakeApi.lastIntegrationSyncRequest?.cursor, "Pagination should still use nextCursor within the loop")
+        assertEquals("provider-checkpoint-2", fakeCursorRepo.cursors.single().cursorValue)
     }
 }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/integration/IntegrationManagerTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/integration/IntegrationManagerTest.kt
@@ -1,11 +1,24 @@
 package com.devil.phoenixproject.data.integration
 
 import com.devil.phoenixproject.data.sync.IntegrationActivityDto
+import com.devil.phoenixproject.data.sync.IntegrationBodyMeasurementDto
+import com.devil.phoenixproject.data.sync.IntegrationExerciseTemplateDto
+import com.devil.phoenixproject.data.sync.IntegrationProgramDto
+import com.devil.phoenixproject.data.sync.IntegrationProgramStatsDto
+import com.devil.phoenixproject.data.sync.IntegrationRoutineDto
+import com.devil.phoenixproject.data.sync.IntegrationRoutineExerciseDto
+import com.devil.phoenixproject.data.sync.IntegrationRoutineFolderDto
+import com.devil.phoenixproject.data.sync.IntegrationRoutineSetDto
 import com.devil.phoenixproject.data.sync.IntegrationSyncResponse
 import com.devil.phoenixproject.data.sync.PortalApiException
 import com.devil.phoenixproject.domain.model.ConnectionStatus
 import com.devil.phoenixproject.domain.model.IntegrationProvider
 import com.devil.phoenixproject.testutil.FakeExternalActivityRepository
+import com.devil.phoenixproject.testutil.FakeExternalExerciseTemplateRepository
+import com.devil.phoenixproject.testutil.FakeExternalMeasurementRepository
+import com.devil.phoenixproject.testutil.FakeExternalProgramRepository
+import com.devil.phoenixproject.testutil.FakeExternalRoutineRepository
+import com.devil.phoenixproject.testutil.FakeIntegrationSyncCursorRepository
 import com.devil.phoenixproject.testutil.FakePortalApiClient
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -23,10 +36,20 @@ class IntegrationManagerTest {
 
     private val fakeApi = FakePortalApiClient()
     private val fakeRepo = FakeExternalActivityRepository()
+    private val fakeRoutineRepo = FakeExternalRoutineRepository()
+    private val fakeProgramRepo = FakeExternalProgramRepository()
+    private val fakeMeasurementRepo = FakeExternalMeasurementRepository()
+    private val fakeTemplateRepo = FakeExternalExerciseTemplateRepository()
+    private val fakeCursorRepo = FakeIntegrationSyncCursorRepository()
 
     private fun createManager() = IntegrationManager(
         apiClient = fakeApi,
-        repository = fakeRepo,
+        activityRepository = fakeRepo,
+        routineRepository = fakeRoutineRepo,
+        programRepository = fakeProgramRepo,
+        measurementRepository = fakeMeasurementRepo,
+        templateRepository = fakeTemplateRepo,
+        cursorRepository = fakeCursorRepo,
     )
 
     // ===== connectProvider — happy path (paid user) =====
@@ -62,8 +85,10 @@ class IntegrationManagerTest {
         )
 
         assertTrue(result.isSuccess, "Connect should succeed")
-        val activities = result.getOrThrow()
-        assertEquals(2, activities.size, "Should return 2 activities")
+        val syncResult = result.getOrThrow()
+        val activities = fakeRepo.activities
+        assertEquals(2, syncResult.progress.activitiesImported, "Should return 2 imported activities")
+        assertEquals(2, activities.size, "Should store 2 activities")
         assertTrue(
             activities.all {
                 it.needsSync
@@ -125,7 +150,7 @@ class IntegrationManagerTest {
         )
 
         assertTrue(result.isSuccess)
-        val activities = result.getOrThrow()
+        val activities = fakeRepo.activities
         assertEquals(1, activities.size)
         assertFalse(
             activities.single().needsSync,
@@ -223,7 +248,9 @@ class IntegrationManagerTest {
         )
 
         assertTrue(result.isSuccess)
-        val activities = result.getOrThrow()
+        val syncResult = result.getOrThrow()
+        val activities = fakeRepo.activities
+        assertEquals(1, syncResult.progress.activitiesImported)
         assertEquals(1, activities.size)
         assertEquals("hevy-3", activities.single().externalId)
         assertEquals("Shoulder Press", activities.single().name)
@@ -266,7 +293,7 @@ class IntegrationManagerTest {
         )
 
         assertTrue(result.isSuccess)
-        assertTrue(result.getOrThrow().isEmpty(), "Should return empty activity list")
+        assertEquals(0, result.getOrThrow().progress.activitiesImported, "Should return empty activity count")
 
         // No upsert call when activities list is empty
         assertEquals(0, fakeRepo.upsertCallCount, "Should not call upsert for empty activities")
@@ -436,7 +463,7 @@ class IntegrationManagerTest {
         )
 
         assertTrue(result.isSuccess)
-        val activity = result.getOrThrow().single()
+        val activity = fakeRepo.activities.single()
         assertEquals("full-1", activity.externalId)
         assertEquals(IntegrationProvider.HEVY, activity.provider)
         assertEquals("Full Activity", activity.name)
@@ -475,5 +502,147 @@ class IntegrationManagerTest {
         assertEquals(ConnectionStatus.ERROR, statusUpdate.status)
         assertEquals("Token expired", statusUpdate.errorMessage)
         assertEquals(IntegrationProvider.LIFTOSAUR, statusUpdate.provider)
+    }
+
+    @Test
+    fun connectHevyStoresExpandedEntities() = runTest {
+        fakeApi.integrationSyncResult = Result.success(
+            IntegrationSyncResponse(
+                status = "ok",
+                routines = listOf(
+                    IntegrationRoutineDto(
+                        externalId = "routine-1",
+                        provider = "hevy",
+                        title = "Upper",
+                        folderExternalId = "folder-1",
+                        folderName = "Main",
+                        exercises = listOf(
+                            IntegrationRoutineExerciseDto(
+                                externalExerciseTemplateId = "template-1",
+                                title = "Bench",
+                                primaryMuscleGroups = listOf("chest"),
+                                sets = listOf(IntegrationRoutineSetDto(index = 0, reps = 8, weightKg = 80.0)),
+                            ),
+                        ),
+                    ),
+                ),
+                routineFolders = listOf(
+                    IntegrationRoutineFolderDto("folder-1", "hevy", "Main"),
+                ),
+                exerciseTemplates = listOf(
+                    IntegrationExerciseTemplateDto("template-1", "hevy", "Bench"),
+                ),
+                bodyMeasurements = listOf(
+                    IntegrationBodyMeasurementDto(
+                        externalId = "measurement-1",
+                        provider = "hevy",
+                        measurementType = "weight",
+                        value = 82.5,
+                        unit = "kg",
+                        measuredAt = "2026-03-20T10:00:00Z",
+                    ),
+                ),
+            ),
+        )
+        val manager = createManager()
+
+        val result = manager.connectProvider(IntegrationProvider.HEVY, "key", "profile-1", true).getOrThrow()
+
+        assertEquals(1, result.progress.routinesImported)
+        assertEquals(1, result.progress.routineFoldersImported)
+        assertEquals(1, result.progress.exerciseTemplatesImported)
+        assertEquals(1, result.progress.measurementsImported)
+        assertEquals(1, fakeRoutineRepo.routines.size)
+        assertEquals(1, fakeRoutineRepo.folders.size)
+        assertEquals(1, fakeTemplateRepo.templates.size)
+        assertEquals(1, fakeMeasurementRepo.measurements.size)
+        assertEquals("profile-1", fakeRoutineRepo.routines.single().profileId)
+    }
+
+    @Test
+    fun connectLiftosaurStoresProgramsAndStats() = runTest {
+        fakeApi.integrationSyncResult = Result.success(
+            IntegrationSyncResponse(
+                status = "ok",
+                programs = listOf(
+                    IntegrationProgramDto(
+                        externalId = "program-1",
+                        provider = "liftosaur",
+                        name = "Linear Progression",
+                        isCurrent = true,
+                    ),
+                ),
+                programStats = listOf(
+                    IntegrationProgramStatsDto(
+                        externalProgramId = "program-1",
+                        days = 4,
+                        approximateMinutes = 60,
+                        setCount = 24,
+                    ),
+                ),
+            ),
+        )
+        val manager = createManager()
+
+        val result = manager.connectProvider(IntegrationProvider.LIFTOSAUR, "key", "profile-1", true).getOrThrow()
+
+        assertEquals(1, result.progress.programsImported)
+        assertEquals(1, result.progress.programStatsImported)
+        assertEquals(1, fakeProgramRepo.programs.size)
+        assertEquals(1, fakeProgramRepo.stats.size)
+        assertEquals(fakeProgramRepo.programs.single().id, fakeProgramRepo.stats.single().externalProgramId)
+    }
+
+    @Test
+    fun requiresUpgradeResponseKeepsProviderConnected() = runTest {
+        fakeApi.integrationSyncResult = Result.success(
+            IntegrationSyncResponse(
+                status = "error",
+                requiresUpgrade = true,
+                upgradeReason = "Program stats require Premium",
+                entitlementStatus = "requires_upgrade",
+            ),
+        )
+        val manager = createManager()
+
+        val result = manager.syncProvider(IntegrationProvider.LIFTOSAUR, "profile-1", true)
+
+        assertTrue(result.isSuccess)
+        assertTrue(result.getOrThrow().entitlementState?.requiresUpgrade == true)
+        val statusUpdate = fakeRepo.statusUpdates.last()
+        assertEquals(ConnectionStatus.CONNECTED, statusUpdate.status)
+    }
+
+    @Test
+    fun paginationLoopsUntilHasMoreFalse() = runTest {
+        fakeApi.integrationSyncResultsQueue = mutableListOf(
+            Result.success(
+                IntegrationSyncResponse(
+                    status = "ok",
+                    activities = listOf(
+                        IntegrationActivityDto("a1", "hevy", "First", startedAt = "2026-03-20T10:00:00Z"),
+                    ),
+                    hasMore = true,
+                    nextCursor = "page-2",
+                ),
+            ),
+            Result.success(
+                IntegrationSyncResponse(
+                    status = "ok",
+                    activities = listOf(
+                        IntegrationActivityDto("a2", "hevy", "Second", startedAt = "2026-03-21T10:00:00Z"),
+                    ),
+                    hasMore = false,
+                ),
+            ),
+        )
+        val manager = createManager()
+
+        val result = manager.syncProvider(IntegrationProvider.HEVY, "profile-1", true).getOrThrow()
+
+        assertEquals(2, fakeApi.integrationSyncCallCount)
+        assertEquals(2, result.progress.activitiesImported)
+        assertEquals(2, fakeRepo.activities.size)
+        assertEquals("page-2", fakeCursorRepo.cursors.single().cursorValue)
     }
 }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/IntegrationDtosTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/IntegrationDtosTest.kt
@@ -1,0 +1,123 @@
+package com.devil.phoenixproject.data.sync
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+
+class IntegrationDtosTest {
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+        explicitNulls = false
+    }
+
+    @Test
+    fun decodesOldActivityOnlyResponse() {
+        val decoded = json.decodeFromString(
+            IntegrationSyncResponse.serializer(),
+            """
+            {
+              "status": "ok",
+              "activities": [
+                {
+                  "externalId": "a1",
+                  "provider": "hevy",
+                  "name": "Push",
+                  "startedAt": "2026-03-20T10:00:00Z"
+                }
+              ]
+            }
+            """.trimIndent(),
+        )
+
+        assertEquals("ok", decoded.status)
+        assertEquals(1, decoded.activities.size)
+        assertTrue(decoded.routines.isEmpty())
+        assertTrue(decoded.programs.isEmpty())
+        assertFalse(decoded.requiresUpgrade)
+        assertNull(decoded.nextCursor)
+    }
+
+    @Test
+    fun decodesExpandedResponseWithEntitlementAndUnknownFields() {
+        val decoded = json.decodeFromString(
+            IntegrationSyncResponse.serializer(),
+            """
+            {
+              "status": "ok",
+              "unknownField": true,
+              "routines": [
+                {
+                  "externalId": "r1",
+                  "provider": "hevy",
+                  "title": "Upper",
+                  "exercises": [
+                    {
+                      "title": "Bench",
+                      "primaryMuscleGroups": ["chest"],
+                      "sets": [{"index": 0, "reps": 8, "weightKg": 80.0}]
+                    }
+                  ]
+                }
+              ],
+              "routineFolders": [{"externalId": "f1", "provider": "hevy", "title": "Main"}],
+              "exerciseTemplates": [{"externalId": "t1", "provider": "hevy", "title": "Bench"}],
+              "bodyMeasurements": [{"externalId": "m1", "provider": "hevy", "measurementType": "weight", "value": 82.5, "unit": "kg", "measuredAt": "2026-03-21T10:00:00Z"}],
+              "programs": [{"externalId": "p1", "provider": "liftosaur", "name": "LP", "isCurrent": true}],
+              "programStats": [{"externalProgramId": "p1", "days": 4, "setCount": 20}],
+              "requiresUpgrade": true,
+              "upgradeReason": "Program stats require Premium",
+              "providerPlanName": "Free",
+              "entitlementStatus": "requires_upgrade",
+              "partial": true,
+              "hasMore": true,
+              "nextCursor": "cursor-2",
+              "providerSyncCursor": "provider-cursor",
+              "deletedExternalIds": ["a1"],
+              "updatedExternalIds": ["a2"],
+              "errors": [{"entityType": "measurements", "message": "Rate limited", "code": "rate_limited", "retryAfterSeconds": 60}]
+            }
+            """.trimIndent(),
+        )
+
+        assertEquals(1, decoded.routines.size)
+        assertEquals(1, decoded.routines.single().exercises.single().sets.size)
+        assertEquals(1, decoded.routineFolders.size)
+        assertEquals(1, decoded.exerciseTemplates.size)
+        assertEquals(1, decoded.bodyMeasurements.size)
+        assertEquals(1, decoded.programs.size)
+        assertEquals(1, decoded.programStats.size)
+        assertTrue(decoded.requiresUpgrade)
+        assertTrue(decoded.partial)
+        assertEquals("cursor-2", decoded.nextCursor)
+        assertEquals("provider-cursor", decoded.providerSyncCursor)
+        assertEquals("a1", decoded.deletedExternalIds.single())
+        assertEquals("rate_limited", decoded.errors.single().code)
+    }
+
+    @Test
+    fun decodesPlaygroundSimulationResponse() {
+        val decoded = json.decodeFromString(
+            IntegrationPlaygroundSimulationResponse.serializer(),
+            """
+            {
+              "status": "ok",
+              "preview": {
+                "programExternalId": "p1",
+                "currentWorkoutText": "A",
+                "nextWorkoutText": "B",
+                "updatedProgramText": "C",
+                "commandsApplied": ["advance"]
+              }
+            }
+            """.trimIndent(),
+        )
+
+        assertEquals("ok", decoded.status)
+        assertEquals("p1", decoded.preview?.programExternalId)
+        assertEquals("C", decoded.preview?.updatedProgramText)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeExternalActivityRepository.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeExternalActivityRepository.kt
@@ -39,11 +39,13 @@ class FakeExternalActivityRepository : ExternalActivityRepository {
 
     override suspend fun upsertActivities(activities: List<ExternalActivity>) {
         upsertCallCount++
-        // Deduplicate on (externalId, provider) to match real INSERT OR IGNORE + UPDATE behavior.
+        // Deduplicate on (provider, externalId, profileId) to match real INSERT OR IGNORE + UPDATE behavior.
         // Existing rows are updated in-place (preserving id and needsSync); new rows are appended.
         for (activity in activities) {
             val existingIndex = this.activities.indexOfFirst {
-                it.externalId == activity.externalId && it.provider == activity.provider
+                it.externalId == activity.externalId &&
+                    it.provider == activity.provider &&
+                    it.profileId == activity.profileId
             }
             if (existingIndex >= 0) {
                 // Update data fields but preserve id and needsSync from existing row
@@ -64,6 +66,25 @@ class FakeExternalActivityRepository : ExternalActivityRepository {
 
     override suspend fun markSyncedBySyncKeys(syncKeys: List<ExternalActivitySyncKey>, profileId: String) {
         markedSyncedKeys.addAll(syncKeys)
+    }
+
+    override suspend fun markDeletedByExternalIds(
+        provider: IntegrationProvider,
+        profileId: String,
+        externalIds: List<String>,
+        deletedAt: Long,
+        needsSync: Boolean,
+    ) {
+        for (externalId in externalIds) {
+            val index = activities.indexOfFirst {
+                it.provider == provider &&
+                    it.profileId == profileId &&
+                    it.externalId == externalId
+            }
+            if (index >= 0) {
+                activities[index] = activities[index].copy(deletedAt = deletedAt, needsSync = needsSync)
+            }
+        }
     }
 
     override suspend fun deleteActivities(provider: IntegrationProvider, profileId: String) {

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeExternalIntegrationRepositories.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeExternalIntegrationRepositories.kt
@@ -16,18 +16,30 @@ import com.devil.phoenixproject.domain.model.ExternalRoutineFolder
 import com.devil.phoenixproject.domain.model.IntegrationProvider
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
 
 class FakeExternalRoutineRepository : ExternalRoutineRepository {
     val routines = mutableListOf<ExternalRoutine>()
     val folders = mutableListOf<ExternalRoutineFolder>()
+    private val routinesFlow = MutableStateFlow<List<ExternalRoutine>>(emptyList())
+    private val foldersFlow = MutableStateFlow<List<ExternalRoutineFolder>>(emptyList())
 
-    override fun observeRoutines(profileId: String, provider: IntegrationProvider?): Flow<List<ExternalRoutine>> = MutableStateFlow(
-        routines.filter { it.profileId == profileId && (provider == null || it.provider == provider) },
-    )
+    private fun publishRoutines() {
+        routinesFlow.value = routines.toList()
+    }
 
-    override fun observeFolders(profileId: String, provider: IntegrationProvider?): Flow<List<ExternalRoutineFolder>> = MutableStateFlow(
-        folders.filter { it.profileId == profileId && (provider == null || it.provider == provider) },
-    )
+    private fun publishFolders() {
+        foldersFlow.value = folders.toList()
+    }
+
+    override fun observeRoutines(profileId: String, provider: IntegrationProvider?): Flow<List<ExternalRoutine>> = routinesFlow.map { rows ->
+        rows.filter { it.profileId == profileId && (provider == null || it.provider == provider) }
+    }
+
+    override fun observeFolders(profileId: String, provider: IntegrationProvider?): Flow<List<ExternalRoutineFolder>> = foldersFlow.map { rows ->
+        rows.filter { it.profileId == profileId && (provider == null || it.provider == provider) }
+    }
 
     override suspend fun upsertRoutines(routines: List<ExternalRoutine>) {
         for (routine in routines) {
@@ -42,6 +54,7 @@ class FakeExternalRoutineRepository : ExternalRoutineRepository {
                 this.routines += routine
             }
         }
+        publishRoutines()
     }
 
     override suspend fun upsertFolders(folders: List<ExternalRoutineFolder>) {
@@ -57,32 +70,61 @@ class FakeExternalRoutineRepository : ExternalRoutineRepository {
                 this.folders += folder
             }
         }
+        publishFolders()
     }
 
     override suspend fun deleteProviderRoutines(provider: IntegrationProvider, profileId: String) {
         routines.removeAll { it.provider == provider && it.profileId == profileId }
         folders.removeAll { it.provider == provider && it.profileId == profileId }
+        publishRoutines()
+        publishFolders()
     }
 }
 
 class FakeExternalProgramRepository : ExternalProgramRepository {
     val programs = mutableListOf<ExternalProgram>()
     val stats = mutableListOf<ExternalProgramStats>()
+    private val programsFlow = MutableStateFlow<List<ExternalProgram>>(emptyList())
+    private val statsFlow = MutableStateFlow<List<ExternalProgramStats>>(emptyList())
 
-    override fun observePrograms(profileId: String, provider: IntegrationProvider?): Flow<List<ExternalProgram>> = MutableStateFlow(
-        programs.filter { it.profileId == profileId && (provider == null || it.provider == provider) },
-    )
+    private fun publishPrograms() {
+        programsFlow.value = programs.toList()
+    }
 
-    override fun observeCurrentProgram(profileId: String, provider: IntegrationProvider): Flow<ExternalProgram?> = MutableStateFlow(
-        programs.firstOrNull { it.profileId == profileId && it.provider == provider && it.isCurrent },
-    )
+    private fun publishStats() {
+        statsFlow.value = stats.toList()
+    }
 
-    override fun observeProgramStats(profileId: String, provider: IntegrationProvider?): Flow<Map<String, ExternalProgramStats>> = MutableStateFlow(
-        stats.associateBy { it.externalProgramId },
-    )
+    override fun observePrograms(profileId: String, provider: IntegrationProvider?): Flow<List<ExternalProgram>> = programsFlow.map { rows ->
+        rows.filter { it.profileId == profileId && (provider == null || it.provider == provider) }
+    }
+
+    override fun observeCurrentProgram(profileId: String, provider: IntegrationProvider): Flow<ExternalProgram?> = programsFlow.map { rows ->
+        rows.firstOrNull { it.profileId == profileId && it.provider == provider && it.isCurrent }
+    }
+
+    override fun observeProgramStats(profileId: String, provider: IntegrationProvider?): Flow<Map<String, ExternalProgramStats>> =
+        combine(programsFlow, statsFlow) { programs, stats ->
+            val visibleProgramIds = programs
+                .filter { it.profileId == profileId && (provider == null || it.provider == provider) }
+                .map { it.id }
+                .toSet()
+            stats
+                .filter { it.externalProgramId in visibleProgramIds }
+                .associateBy { it.externalProgramId }
+        }
 
     override suspend fun findProgram(provider: IntegrationProvider, externalId: String, profileId: String): ExternalProgram? =
         programs.firstOrNull { it.provider == provider && it.externalId == externalId && it.profileId == profileId }
+
+    override suspend fun findPrograms(provider: IntegrationProvider, externalIds: List<String>, profileId: String): List<ExternalProgram> {
+        val externalIdSet = externalIds.toSet()
+        return programs.filter {
+            it.provider == provider &&
+                it.externalId in externalIdSet &&
+                it.profileId == profileId
+        }
+    }
 
     override suspend fun upsertPrograms(programs: List<ExternalProgram>) {
         for (program in programs) {
@@ -97,6 +139,7 @@ class FakeExternalProgramRepository : ExternalProgramRepository {
                 this.programs += program
             }
         }
+        publishPrograms()
     }
 
     override suspend fun upsertStats(stats: List<ExternalProgramStats>) {
@@ -104,12 +147,14 @@ class FakeExternalProgramRepository : ExternalProgramRepository {
             this.stats.removeAll { it.externalProgramId == stat.externalProgramId }
             this.stats += stat
         }
+        publishStats()
     }
 
     override suspend fun updateProgramText(programId: String, scriptText: String, markNeedsSync: Boolean) {
         val index = programs.indexOfFirst { it.id == programId }
         if (index >= 0) {
             programs[index] = programs[index].copy(scriptText = scriptText, needsSync = markNeedsSync)
+            publishPrograms()
         }
     }
 
@@ -117,19 +162,26 @@ class FakeExternalProgramRepository : ExternalProgramRepository {
         val removedIds = programs.filter { it.provider == provider && it.profileId == profileId }.map { it.id }.toSet()
         programs.removeAll { it.id in removedIds }
         stats.removeAll { it.externalProgramId in removedIds }
+        publishPrograms()
+        publishStats()
     }
 }
 
 class FakeExternalMeasurementRepository : ExternalMeasurementRepository {
     val measurements = mutableListOf<ExternalBodyMeasurement>()
+    private val measurementsFlow = MutableStateFlow<List<ExternalBodyMeasurement>>(emptyList())
 
-    override fun observeMeasurements(profileId: String, provider: IntegrationProvider?): Flow<List<ExternalBodyMeasurement>> = MutableStateFlow(
-        measurements.filter { it.profileId == profileId && (provider == null || it.provider == provider) },
-    )
+    private fun publishMeasurements() {
+        measurementsFlow.value = measurements.toList()
+    }
 
-    override fun observeMeasurementsByType(profileId: String, measurementType: String): Flow<List<ExternalBodyMeasurement>> = MutableStateFlow(
-        measurements.filter { it.profileId == profileId && it.measurementType == measurementType },
-    )
+    override fun observeMeasurements(profileId: String, provider: IntegrationProvider?): Flow<List<ExternalBodyMeasurement>> = measurementsFlow.map { rows ->
+        rows.filter { it.profileId == profileId && (provider == null || it.provider == provider) }
+    }
+
+    override fun observeMeasurementsByType(profileId: String, measurementType: String): Flow<List<ExternalBodyMeasurement>> = measurementsFlow.map { rows ->
+        rows.filter { it.profileId == profileId && it.measurementType == measurementType }
+    }
 
     override suspend fun upsertMeasurements(measurements: List<ExternalBodyMeasurement>) {
         for (measurement in measurements) {
@@ -140,24 +192,31 @@ class FakeExternalMeasurementRepository : ExternalMeasurementRepository {
             }
             this.measurements += measurement
         }
+        publishMeasurements()
     }
 
     override suspend fun deleteProviderMeasurements(provider: IntegrationProvider, profileId: String) {
         measurements.removeAll { it.provider == provider && it.profileId == profileId }
+        publishMeasurements()
     }
 }
 
 class FakeExternalExerciseTemplateRepository : ExternalExerciseTemplateRepository {
     val templates = mutableListOf<ExternalExerciseTemplate>()
     val mappings = mutableListOf<ExternalExerciseTemplateMapping>()
+    private val templatesFlow = MutableStateFlow<List<ExternalExerciseTemplate>>(emptyList())
 
-    override fun observeTemplates(profileId: String, provider: IntegrationProvider?): Flow<List<ExternalExerciseTemplate>> = MutableStateFlow(
-        templates.filter { it.profileId == profileId && (provider == null || it.provider == provider) },
-    )
+    private fun publishTemplates() {
+        templatesFlow.value = templates.toList()
+    }
 
-    override fun observeTemplateCounts(profileId: String): Flow<Map<IntegrationProvider, Int>> = MutableStateFlow(
-        templates.filter { it.profileId == profileId }.groupingBy { it.provider }.eachCount(),
-    )
+    override fun observeTemplates(profileId: String, provider: IntegrationProvider?): Flow<List<ExternalExerciseTemplate>> = templatesFlow.map { rows ->
+        rows.filter { it.profileId == profileId && (provider == null || it.provider == provider) }
+    }
+
+    override fun observeTemplateCounts(profileId: String): Flow<Map<IntegrationProvider, Int>> = templatesFlow.map { rows ->
+        rows.filter { it.profileId == profileId }.groupingBy { it.provider }.eachCount()
+    }
 
     override suspend fun upsertTemplates(templates: List<ExternalExerciseTemplate>) {
         for (template in templates) {
@@ -168,6 +227,7 @@ class FakeExternalExerciseTemplateRepository : ExternalExerciseTemplateRepositor
             }
             this.templates += template
         }
+        publishTemplates()
     }
 
     override suspend fun findTemplate(provider: IntegrationProvider, externalId: String, profileId: String): ExternalExerciseTemplate? =
@@ -195,6 +255,7 @@ class FakeExternalExerciseTemplateRepository : ExternalExerciseTemplateRepositor
     override suspend fun deleteProviderTemplates(provider: IntegrationProvider, profileId: String) {
         templates.removeAll { it.provider == provider && it.profileId == profileId }
         mappings.removeAll { it.provider == provider && it.profileId == profileId }
+        publishTemplates()
     }
 }
 

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeExternalIntegrationRepositories.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeExternalIntegrationRepositories.kt
@@ -1,0 +1,221 @@
+package com.devil.phoenixproject.testutil
+
+import com.devil.phoenixproject.data.integration.ExternalExerciseTemplateRepository
+import com.devil.phoenixproject.data.integration.ExternalMeasurementRepository
+import com.devil.phoenixproject.data.integration.ExternalProgramRepository
+import com.devil.phoenixproject.data.integration.ExternalRoutineRepository
+import com.devil.phoenixproject.data.integration.IntegrationSyncCursor
+import com.devil.phoenixproject.data.integration.IntegrationSyncCursorRepository
+import com.devil.phoenixproject.domain.model.ExternalBodyMeasurement
+import com.devil.phoenixproject.domain.model.ExternalExerciseTemplate
+import com.devil.phoenixproject.domain.model.ExternalExerciseTemplateMapping
+import com.devil.phoenixproject.domain.model.ExternalProgram
+import com.devil.phoenixproject.domain.model.ExternalProgramStats
+import com.devil.phoenixproject.domain.model.ExternalRoutine
+import com.devil.phoenixproject.domain.model.ExternalRoutineFolder
+import com.devil.phoenixproject.domain.model.IntegrationProvider
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+
+class FakeExternalRoutineRepository : ExternalRoutineRepository {
+    val routines = mutableListOf<ExternalRoutine>()
+    val folders = mutableListOf<ExternalRoutineFolder>()
+
+    override fun observeRoutines(profileId: String, provider: IntegrationProvider?): Flow<List<ExternalRoutine>> = MutableStateFlow(
+        routines.filter { it.profileId == profileId && (provider == null || it.provider == provider) },
+    )
+
+    override fun observeFolders(profileId: String, provider: IntegrationProvider?): Flow<List<ExternalRoutineFolder>> = MutableStateFlow(
+        folders.filter { it.profileId == profileId && (provider == null || it.provider == provider) },
+    )
+
+    override suspend fun upsertRoutines(routines: List<ExternalRoutine>) {
+        for (routine in routines) {
+            val existing = this.routines.indexOfFirst {
+                it.provider == routine.provider &&
+                    it.externalId == routine.externalId &&
+                    it.profileId == routine.profileId
+            }
+            if (existing >= 0) {
+                this.routines[existing] = routine.copy(id = this.routines[existing].id)
+            } else {
+                this.routines += routine
+            }
+        }
+    }
+
+    override suspend fun upsertFolders(folders: List<ExternalRoutineFolder>) {
+        for (folder in folders) {
+            val existing = this.folders.indexOfFirst {
+                it.provider == folder.provider &&
+                    it.externalId == folder.externalId &&
+                    it.profileId == folder.profileId
+            }
+            if (existing >= 0) {
+                this.folders[existing] = folder.copy(id = this.folders[existing].id)
+            } else {
+                this.folders += folder
+            }
+        }
+    }
+
+    override suspend fun deleteProviderRoutines(provider: IntegrationProvider, profileId: String) {
+        routines.removeAll { it.provider == provider && it.profileId == profileId }
+        folders.removeAll { it.provider == provider && it.profileId == profileId }
+    }
+}
+
+class FakeExternalProgramRepository : ExternalProgramRepository {
+    val programs = mutableListOf<ExternalProgram>()
+    val stats = mutableListOf<ExternalProgramStats>()
+
+    override fun observePrograms(profileId: String, provider: IntegrationProvider?): Flow<List<ExternalProgram>> = MutableStateFlow(
+        programs.filter { it.profileId == profileId && (provider == null || it.provider == provider) },
+    )
+
+    override fun observeCurrentProgram(profileId: String, provider: IntegrationProvider): Flow<ExternalProgram?> = MutableStateFlow(
+        programs.firstOrNull { it.profileId == profileId && it.provider == provider && it.isCurrent },
+    )
+
+    override fun observeProgramStats(profileId: String, provider: IntegrationProvider?): Flow<Map<String, ExternalProgramStats>> = MutableStateFlow(
+        stats.associateBy { it.externalProgramId },
+    )
+
+    override suspend fun findProgram(provider: IntegrationProvider, externalId: String, profileId: String): ExternalProgram? =
+        programs.firstOrNull { it.provider == provider && it.externalId == externalId && it.profileId == profileId }
+
+    override suspend fun upsertPrograms(programs: List<ExternalProgram>) {
+        for (program in programs) {
+            val existing = this.programs.indexOfFirst {
+                it.provider == program.provider &&
+                    it.externalId == program.externalId &&
+                    it.profileId == program.profileId
+            }
+            if (existing >= 0) {
+                this.programs[existing] = program.copy(id = this.programs[existing].id)
+            } else {
+                this.programs += program
+            }
+        }
+    }
+
+    override suspend fun upsertStats(stats: List<ExternalProgramStats>) {
+        for (stat in stats) {
+            this.stats.removeAll { it.externalProgramId == stat.externalProgramId }
+            this.stats += stat
+        }
+    }
+
+    override suspend fun updateProgramText(programId: String, scriptText: String, markNeedsSync: Boolean) {
+        val index = programs.indexOfFirst { it.id == programId }
+        if (index >= 0) {
+            programs[index] = programs[index].copy(scriptText = scriptText, needsSync = markNeedsSync)
+        }
+    }
+
+    override suspend fun deleteProviderPrograms(provider: IntegrationProvider, profileId: String) {
+        val removedIds = programs.filter { it.provider == provider && it.profileId == profileId }.map { it.id }.toSet()
+        programs.removeAll { it.id in removedIds }
+        stats.removeAll { it.externalProgramId in removedIds }
+    }
+}
+
+class FakeExternalMeasurementRepository : ExternalMeasurementRepository {
+    val measurements = mutableListOf<ExternalBodyMeasurement>()
+
+    override fun observeMeasurements(profileId: String, provider: IntegrationProvider?): Flow<List<ExternalBodyMeasurement>> = MutableStateFlow(
+        measurements.filter { it.profileId == profileId && (provider == null || it.provider == provider) },
+    )
+
+    override fun observeMeasurementsByType(profileId: String, measurementType: String): Flow<List<ExternalBodyMeasurement>> = MutableStateFlow(
+        measurements.filter { it.profileId == profileId && it.measurementType == measurementType },
+    )
+
+    override suspend fun upsertMeasurements(measurements: List<ExternalBodyMeasurement>) {
+        for (measurement in measurements) {
+            this.measurements.removeAll {
+                it.provider == measurement.provider &&
+                    it.externalId == measurement.externalId &&
+                    it.profileId == measurement.profileId
+            }
+            this.measurements += measurement
+        }
+    }
+
+    override suspend fun deleteProviderMeasurements(provider: IntegrationProvider, profileId: String) {
+        measurements.removeAll { it.provider == provider && it.profileId == profileId }
+    }
+}
+
+class FakeExternalExerciseTemplateRepository : ExternalExerciseTemplateRepository {
+    val templates = mutableListOf<ExternalExerciseTemplate>()
+    val mappings = mutableListOf<ExternalExerciseTemplateMapping>()
+
+    override fun observeTemplates(profileId: String, provider: IntegrationProvider?): Flow<List<ExternalExerciseTemplate>> = MutableStateFlow(
+        templates.filter { it.profileId == profileId && (provider == null || it.provider == provider) },
+    )
+
+    override fun observeTemplateCounts(profileId: String): Flow<Map<IntegrationProvider, Int>> = MutableStateFlow(
+        templates.filter { it.profileId == profileId }.groupingBy { it.provider }.eachCount(),
+    )
+
+    override suspend fun upsertTemplates(templates: List<ExternalExerciseTemplate>) {
+        for (template in templates) {
+            this.templates.removeAll {
+                it.provider == template.provider &&
+                    it.externalId == template.externalId &&
+                    it.profileId == template.profileId
+            }
+            this.templates += template
+        }
+    }
+
+    override suspend fun findTemplate(provider: IntegrationProvider, externalId: String, profileId: String): ExternalExerciseTemplate? =
+        templates.firstOrNull { it.provider == provider && it.externalId == externalId && it.profileId == profileId }
+
+    override suspend fun upsertMapping(mapping: ExternalExerciseTemplateMapping) {
+        mappings.removeAll {
+            it.provider == mapping.provider &&
+                it.externalTemplateId == mapping.externalTemplateId &&
+                it.profileId == mapping.profileId
+        }
+        mappings += mapping
+    }
+
+    override suspend fun findMapping(
+        provider: IntegrationProvider,
+        externalTemplateId: String,
+        profileId: String,
+    ): ExternalExerciseTemplateMapping? = mappings.firstOrNull {
+        it.provider == provider &&
+            it.externalTemplateId == externalTemplateId &&
+            it.profileId == profileId
+    }
+
+    override suspend fun deleteProviderTemplates(provider: IntegrationProvider, profileId: String) {
+        templates.removeAll { it.provider == provider && it.profileId == profileId }
+        mappings.removeAll { it.provider == provider && it.profileId == profileId }
+    }
+}
+
+class FakeIntegrationSyncCursorRepository : IntegrationSyncCursorRepository {
+    val cursors = mutableListOf<IntegrationSyncCursor>()
+
+    override suspend fun getCursor(provider: IntegrationProvider, profileId: String, cursorType: String): IntegrationSyncCursor? =
+        cursors.firstOrNull {
+            it.provider == provider && it.profileId == profileId && it.cursorType == cursorType
+        }
+
+    override suspend fun upsertCursor(cursor: IntegrationSyncCursor) {
+        cursors.removeAll {
+            it.provider == cursor.provider &&
+                it.profileId == cursor.profileId &&
+                it.cursorType == cursor.cursorType
+        }
+        cursors += cursor
+    }
+
+    override suspend fun deleteProviderCursors(provider: IntegrationProvider, profileId: String) {
+        cursors.removeAll { it.provider == provider && it.profileId == profileId }
+    }
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeExternalIntegrationRepositoriesTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeExternalIntegrationRepositoriesTest.kt
@@ -1,0 +1,90 @@
+package com.devil.phoenixproject.testutil
+
+import com.devil.phoenixproject.domain.model.ExternalProgram
+import com.devil.phoenixproject.domain.model.ExternalProgramStats
+import com.devil.phoenixproject.domain.model.ExternalRoutine
+import com.devil.phoenixproject.domain.model.IntegrationProvider
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+
+class FakeExternalIntegrationRepositoriesTest {
+
+    @Test
+    fun routineObserversEmitAfterUpsert() = runTest {
+        val repository = FakeExternalRoutineRepository()
+        val emissions = mutableListOf<List<ExternalRoutine>>()
+        val job = launch {
+            repository.observeRoutines(profileId = "profile-1")
+                .take(2)
+                .toList(emissions)
+        }
+        runCurrent()
+
+        repository.upsertRoutines(
+            listOf(
+                ExternalRoutine(
+                    id = "routine-local-1",
+                    externalId = "routine-1",
+                    provider = IntegrationProvider.HEVY,
+                    title = "Upper",
+                    profileId = "profile-1",
+                ),
+            ),
+        )
+        runCurrent()
+
+        assertEquals(2, emissions.size)
+        assertEquals(emptyList(), emissions.first())
+        assertEquals("routine-1", emissions.last().single().externalId)
+        job.cancel()
+    }
+
+    @Test
+    fun programStatsObserverFiltersByProfileAndProvider() = runTest {
+        val repository = FakeExternalProgramRepository()
+        val liftosaurProgram = ExternalProgram(
+            id = "program-local-1",
+            externalId = "program-1",
+            provider = IntegrationProvider.LIFTOSAUR,
+            name = "Liftosaur",
+            profileId = "profile-1",
+        )
+        val hevyProgram = ExternalProgram(
+            id = "program-local-2",
+            externalId = "program-2",
+            provider = IntegrationProvider.HEVY,
+            name = "Hevy",
+            profileId = "profile-1",
+        )
+        val otherProfileProgram = ExternalProgram(
+            id = "program-local-3",
+            externalId = "program-3",
+            provider = IntegrationProvider.LIFTOSAUR,
+            name = "Other Profile",
+            profileId = "profile-2",
+        )
+
+        repository.upsertPrograms(listOf(liftosaurProgram, hevyProgram, otherProfileProgram))
+        repository.upsertStats(
+            listOf(
+                ExternalProgramStats(externalProgramId = liftosaurProgram.id, setCount = 10),
+                ExternalProgramStats(externalProgramId = hevyProgram.id, setCount = 20),
+                ExternalProgramStats(externalProgramId = otherProfileProgram.id, setCount = 30),
+            ),
+        )
+
+        val stats = repository.observeProgramStats(
+            profileId = "profile-1",
+            provider = IntegrationProvider.LIFTOSAUR,
+        ).first()
+
+        assertEquals(setOf(liftosaurProgram.id), stats.keys)
+        assertEquals(10, stats[liftosaurProgram.id]?.setCount)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakePortalApiClient.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakePortalApiClient.kt
@@ -3,6 +3,8 @@ package com.devil.phoenixproject.testutil
 import com.devil.phoenixproject.data.sync.GoTrueAuthResponse
 import com.devil.phoenixproject.data.sync.IntegrationSyncRequest
 import com.devil.phoenixproject.data.sync.IntegrationSyncResponse
+import com.devil.phoenixproject.data.sync.IntegrationPlaygroundSimulationRequest
+import com.devil.phoenixproject.data.sync.IntegrationPlaygroundSimulationResponse
 import com.devil.phoenixproject.data.sync.KnownEntityIds
 import com.devil.phoenixproject.data.sync.PortalApiClient
 import com.devil.phoenixproject.data.sync.PortalApiException
@@ -55,6 +57,9 @@ open class FakePortalApiClient :
     var integrationSyncResult: Result<IntegrationSyncResponse> = Result.success(
         IntegrationSyncResponse(status = "ok"),
     )
+    var playgroundSimulationResult: Result<IntegrationPlaygroundSimulationResponse> = Result.success(
+        IntegrationPlaygroundSimulationResponse(status = "ok"),
+    )
 
     // Call counters and captures
     var pushCallCount = 0
@@ -62,16 +67,19 @@ open class FakePortalApiClient :
     var signInCallCount = 0
     var signUpCallCount = 0
     var integrationSyncCallCount = 0
+    var playgroundSimulationCallCount = 0
     var lastPushPayload: PortalSyncPayload? = null
     var lastPullKnownEntityIds: KnownEntityIds? = null
     var lastPullDeviceId: String? = null
     var lastPullCursor: String? = null
     var lastPullPageSize: Int? = null
     var lastIntegrationSyncRequest: IntegrationSyncRequest? = null
+    var lastPlaygroundSimulationRequest: IntegrationPlaygroundSimulationRequest? = null
 
     // Pagination support: list of results to return for successive pull calls
     // If set, returns results from this list in order; when exhausted, falls back to pullResult
     var pullResultsQueue: MutableList<Result<PortalSyncPullResponse>>? = null
+    var integrationSyncResultsQueue: MutableList<Result<IntegrationSyncResponse>>? = null
 
     override suspend fun signIn(email: String, password: String): Result<GoTrueAuthResponse> {
         signInCallCount++
@@ -110,6 +118,14 @@ open class FakePortalApiClient :
     override suspend fun callIntegrationSync(request: IntegrationSyncRequest): Result<IntegrationSyncResponse> {
         integrationSyncCallCount++
         lastIntegrationSyncRequest = request
-        return integrationSyncResult
+        return integrationSyncResultsQueue?.removeFirstOrNull() ?: integrationSyncResult
+    }
+
+    override suspend fun callIntegrationPlaygroundSimulation(
+        request: IntegrationPlaygroundSimulationRequest,
+    ): Result<IntegrationPlaygroundSimulationResponse> {
+        playgroundSimulationCallCount++
+        lastPlaygroundSimulationRequest = request
+        return playgroundSimulationResult
     }
 }


### PR DESCRIPTION
## Summary
- Added backward-compatible mobile integration DTOs and domain models for activities, Hevy routines/folders/templates/measurements, Liftosaur programs/stats, entitlement state, cursors, and playground previews.
- Expanded SQLDelight schema and migration support for profile-scoped persistence, new integration entities, cursor tracking, and activity soft-delete handling.
- Refactored integration sync orchestration to page through multiple entity types, persist partial successes, store cursors separately, and surface entitlement/retry state.
- Added focused repositories, DI wiring, ViewModels, navigation routes, and integration screens for the new hub, routines, programs, playground, and measurement views.

## Testing
- Shared database migration verification passed.
- Shared host tests passed.
- Android unit tests passed.
- Android lint passed.
- Android debug assemble passed.