### PR TITLE
Fix dynamic % of PR routine weights and saved snapshots

### DIFF
--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModelTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModelTest.kt
@@ -5,14 +5,17 @@ import com.devil.phoenixproject.domain.model.EccentricLoad
 import com.devil.phoenixproject.domain.model.EchoLevel
 import com.devil.phoenixproject.domain.model.Exercise
 import com.devil.phoenixproject.domain.model.PRType
+import com.devil.phoenixproject.domain.model.PersonalRecord
 import com.devil.phoenixproject.domain.model.ProgramMode
 import com.devil.phoenixproject.domain.model.RoutineExercise
 import com.devil.phoenixproject.domain.model.WeightUnit
+import com.devil.phoenixproject.testutil.FakePersonalRecordRepository
 import com.devil.phoenixproject.testutil.createTestDatabase
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
@@ -165,6 +168,88 @@ class ExerciseConfigViewModelTest {
     }
 
     @Test
+    fun `global PR percent preserves custom per-set percentages`() = runTest {
+        val repository = FakePersonalRecordRepository()
+        repository.addRecord(weightPR(weight = 50f))
+        val viewModel = ExerciseConfigViewModel(repository)
+        val exercise = benchRoutineExercise(
+            id = "rex-pr-custom",
+            setReps = listOf(10, 10, 10),
+            weightPerCableKg = 5f,
+            setWeightsPerCableKg = listOf(5f, 5f, 5f),
+            usePercentOfPR = true,
+            weightPercentOfPR = 80,
+            setWeightsPercentOfPR = listOf(80, 80, 80),
+        )
+
+        viewModel.initialize(
+            exercise = exercise,
+            unit = WeightUnit.KG,
+            toDisplay = { value, _ -> value },
+            toKg = { value, _ -> value },
+        )
+        advanceUntilIdle()
+        waitForCondition { viewModel.sets.value.map { it.weightPerCable } == listOf(40f, 40f, 40f) }
+
+        viewModel.updateWeight(viewModel.sets.value.first().id, 45f)
+        assertEquals(listOf(45f, 40f, 40f), viewModel.sets.value.map { it.weightPerCable })
+
+        viewModel.onWeightPercentOfPRChange(85)
+        assertEquals(listOf(45f, 40f, 40f), viewModel.sets.value.map { it.weightPerCable })
+
+        viewModel.addSet()
+        assertEquals(listOf(45f, 40f, 40f, 42.5f), viewModel.sets.value.map { it.weightPerCable })
+
+        var saved: RoutineExercise? = null
+        viewModel.onSave { updated -> saved = updated }
+
+        assertNotNull(saved)
+        assertEquals(85, saved.weightPercentOfPR)
+        assertEquals(listOf(90, 80, 80, 85), saved.setWeightsPercentOfPR)
+        assertEquals(listOf(45f, 40f, 40f, 42.5f), saved.setWeightsPerCableKg)
+    }
+
+    @Test
+    fun `manual PR percent weight edit before PR load converts when PR becomes available`() = runTest {
+        val repository = FakePersonalRecordRepository()
+        val viewModel = ExerciseConfigViewModel(repository)
+        val exercise = benchRoutineExercise(
+            id = "rex-pr-pending",
+            setReps = listOf(10, 10),
+            weightPerCableKg = 5f,
+            setWeightsPerCableKg = listOf(5f, 5f),
+            usePercentOfPR = true,
+            weightPercentOfPR = 80,
+            setWeightsPercentOfPR = listOf(80, 80),
+        )
+
+        viewModel.initialize(
+            exercise = exercise,
+            unit = WeightUnit.KG,
+            toDisplay = { value, _ -> value },
+            toKg = { value, _ -> value },
+        )
+        advanceUntilIdle()
+        assertNull(viewModel.currentExercisePR.value)
+
+        viewModel.updateWeight(viewModel.sets.value.first().id, 25f)
+        assertEquals(listOf(25f, 5f), viewModel.sets.value.map { it.weightPerCable })
+
+        repository.addRecord(weightPR(weight = 50f))
+        viewModel.loadPRForExercise("bench-1", "Old School")
+        advanceUntilIdle()
+
+        waitForCondition { viewModel.sets.value.map { it.weightPerCable } == listOf(25f, 40f) }
+
+        var saved: RoutineExercise? = null
+        viewModel.onSave { updated -> saved = updated }
+
+        assertNotNull(saved)
+        assertEquals(listOf(50, 80), saved.setWeightsPercentOfPR)
+        assertEquals(listOf(25f, 40f), saved.setWeightsPerCableKg)
+    }
+
+    @Test
     fun `initialize reloads PR lookup when active profile changes`() = runTest {
         val database = createTestDatabase()
         val queries = database.vitruvianDatabaseQueries
@@ -250,6 +335,7 @@ class ExerciseConfigViewModelTest {
         setWeightsPerCableKg: List<Float> = emptyList(),
         usePercentOfPR: Boolean = false,
         weightPercentOfPR: Int = 80,
+        setWeightsPercentOfPR: List<Int> = emptyList(),
     ) = RoutineExercise(
         id = id,
         exercise = Exercise(
@@ -268,6 +354,20 @@ class ExerciseConfigViewModelTest {
         echoLevel = EchoLevel.HARDER,
         usePercentOfPR = usePercentOfPR,
         weightPercentOfPR = weightPercentOfPR,
+        setWeightsPercentOfPR = setWeightsPercentOfPR,
+    )
+
+    private fun weightPR(weight: Float) = PersonalRecord(
+        id = 1,
+        exerciseId = "bench-1",
+        exerciseName = "Bench Press",
+        weightPerCableKg = weight,
+        reps = 6,
+        oneRepMax = weight * 1.2f,
+        timestamp = 1_000L,
+        workoutMode = "Old School",
+        prType = PRType.MAX_WEIGHT,
+        volume = weight * 6,
     )
 
     private fun insertExercise(queries: com.devil.phoenixproject.database.VitruvianDatabaseQueries, id: String, name: String) {

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModelTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModelTest.kt
@@ -92,6 +92,79 @@ class ExerciseConfigViewModelTest {
     }
 
     @Test
+    fun `percent of PR syncs visible set weights and saves resolved snapshots`() = runTest {
+        val database = createTestDatabase()
+        val queries = database.vitruvianDatabaseQueries
+        val repository = SqlDelightPersonalRecordRepository(database)
+        val viewModel = ExerciseConfigViewModel(repository)
+        val exercise = benchRoutineExercise(
+            id = "rex-pr-sync",
+            setReps = listOf(10, 10, 10),
+            weightPerCableKg = 5f,
+            setWeightsPerCableKg = listOf(5f, 5f, 5f),
+        )
+
+        insertExercise(queries, id = "bench-1", name = "Bench Press")
+        insertWeightPR(queries, weight = 50.0)
+
+        viewModel.initialize(
+            exercise = exercise,
+            unit = WeightUnit.KG,
+            toDisplay = { value, _ -> value },
+            toKg = { value, _ -> value },
+        )
+        assertEquals(5f, viewModel.sets.value.first().weightPerCable)
+
+        waitForCondition { viewModel.currentExercisePR.value?.weightPerCableKg == 50f }
+        viewModel.onUsePercentOfPRChange(true)
+
+        assertEquals(listOf(40f, 40f, 40f), viewModel.sets.value.map { it.weightPerCable })
+        viewModel.addSet()
+        assertEquals(listOf(40f, 40f, 40f, 40f), viewModel.sets.value.map { it.weightPerCable })
+        viewModel.deleteSet(3)
+        assertEquals(listOf(40f, 40f, 40f), viewModel.sets.value.map { it.weightPerCable })
+
+        var saved: RoutineExercise? = null
+        viewModel.onSave { updated -> saved = updated }
+
+        assertNotNull(saved)
+        assertTrue(saved.usePercentOfPR)
+        assertEquals(40f, saved.weightPerCableKg)
+        assertEquals(listOf(40f, 40f, 40f), saved.setWeightsPerCableKg)
+        assertEquals(listOf(80, 80, 80), saved.setWeightsPercentOfPR)
+    }
+
+    @Test
+    fun `percent of PR uses nearest half kg rounding when syncing set weights`() = runTest {
+        val database = createTestDatabase()
+        val queries = database.vitruvianDatabaseQueries
+        val repository = SqlDelightPersonalRecordRepository(database)
+        val viewModel = ExerciseConfigViewModel(repository)
+        val exercise = benchRoutineExercise(
+            id = "rex-pr-rounding",
+            setReps = listOf(10),
+            weightPerCableKg = 5f,
+            setWeightsPerCableKg = listOf(5f),
+            usePercentOfPR = true,
+            weightPercentOfPR = 80,
+        )
+
+        insertExercise(queries, id = "bench-1", name = "Bench Press")
+        insertWeightPR(queries, weight = 47.0)
+
+        viewModel.initialize(
+            exercise = exercise,
+            unit = WeightUnit.KG,
+            toDisplay = { value, _ -> value },
+            toKg = { value, _ -> value },
+        )
+
+        waitForCondition { viewModel.sets.value.first().weightPerCable == 37.5f }
+        assertEquals(37.5f, viewModel.calculateResolvedWeight())
+        assertEquals(37.5f, viewModel.sets.value.first().weightPerCable)
+    }
+
+    @Test
     fun `initialize reloads PR lookup when active profile changes`() = runTest {
         val database = createTestDatabase()
         val queries = database.vitruvianDatabaseQueries
@@ -170,6 +243,33 @@ class ExerciseConfigViewModelTest {
         assertNull(viewModel.currentExercisePR.value)
     }
 
+    private fun benchRoutineExercise(
+        id: String,
+        setReps: List<Int?>,
+        weightPerCableKg: Float,
+        setWeightsPerCableKg: List<Float> = emptyList(),
+        usePercentOfPR: Boolean = false,
+        weightPercentOfPR: Int = 80,
+    ) = RoutineExercise(
+        id = id,
+        exercise = Exercise(
+            id = "bench-1",
+            name = "Bench Press",
+            muscleGroup = "Chest",
+            muscleGroups = "Chest",
+            equipment = "BAR",
+        ),
+        orderIndex = 0,
+        setReps = setReps,
+        weightPerCableKg = weightPerCableKg,
+        setWeightsPerCableKg = setWeightsPerCableKg,
+        programMode = ProgramMode.OldSchool,
+        eccentricLoad = EccentricLoad.LOAD_100,
+        echoLevel = EchoLevel.HARDER,
+        usePercentOfPR = usePercentOfPR,
+        weightPercentOfPR = weightPercentOfPR,
+    )
+
     private fun insertExercise(queries: com.devil.phoenixproject.database.VitruvianDatabaseQueries, id: String, name: String) {
         queries.insertExercise(
             id = id,
@@ -195,6 +295,23 @@ class ExerciseConfigViewModelTest {
             aliases = null,
             defaultCableConfig = "DOUBLE",
             one_rep_max_kg = null,
+        )
+    }
+
+    private fun insertWeightPR(queries: com.devil.phoenixproject.database.VitruvianDatabaseQueries, weight: Double) {
+        queries.insertRecord(
+            exerciseId = "bench-1",
+            exerciseName = "Bench Press",
+            weight = weight,
+            reps = 6,
+            oneRepMax = weight * 1.2,
+            achievedAt = 1_000L,
+            workoutMode = "Old School",
+            prType = PRType.MAX_WEIGHT.name,
+            volume = weight * 6,
+            phase = "COMBINED",
+            profile_id = "default",
+            cable_count = null,
         )
     }
 

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModelTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModelTest.kt
@@ -250,6 +250,45 @@ class ExerciseConfigViewModelTest {
     }
 
     @Test
+    fun `delete set while PR percent disabled keeps percentages aligned when re-enabled`() = runTest {
+        val repository = FakePersonalRecordRepository()
+        repository.addRecord(weightPR(weight = 50f))
+        val viewModel = ExerciseConfigViewModel(repository)
+        val exercise = benchRoutineExercise(
+            id = "rex-pr-delete-disabled",
+            setReps = listOf(10, 10, 10),
+            weightPerCableKg = 5f,
+            setWeightsPerCableKg = listOf(5f, 5f, 5f),
+            usePercentOfPR = true,
+            weightPercentOfPR = 80,
+            setWeightsPercentOfPR = listOf(80, 90, 100),
+        )
+
+        viewModel.initialize(
+            exercise = exercise,
+            unit = WeightUnit.KG,
+            toDisplay = { value, _ -> value },
+            toKg = { value, _ -> value },
+        )
+        advanceUntilIdle()
+        waitForCondition { viewModel.sets.value.map { it.weightPerCable } == listOf(40f, 45f, 50f) }
+
+        viewModel.onUsePercentOfPRChange(false)
+        viewModel.deleteSet(0)
+        assertEquals(listOf(45f, 50f), viewModel.sets.value.map { it.weightPerCable })
+
+        viewModel.onUsePercentOfPRChange(true)
+        assertEquals(listOf(45f, 50f), viewModel.sets.value.map { it.weightPerCable })
+
+        var saved: RoutineExercise? = null
+        viewModel.onSave { updated -> saved = updated }
+
+        assertNotNull(saved)
+        assertEquals(listOf(90, 100), saved.setWeightsPercentOfPR)
+        assertEquals(listOf(45f, 50f), saved.setWeightsPerCableKg)
+    }
+
+    @Test
     fun `initialize reloads PR lookup when active profile changes`() = runTest {
         val database = createTestDatabase()
         val queries = database.vitruvianDatabaseQueries

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModel.kt
@@ -565,8 +565,8 @@ class ExerciseConfigViewModel constructor(
         }
         val remainingSetIds = newSets.map { it.id }.toSet()
         pendingPercentOfPREditWeights.keys.retainAll(remainingSetIds)
+        setWeightsPercentOfPR = setWeightsPercentOfPR.filterIndexed { i, _ -> i != index }
         if (_usePercentOfPR.value) {
-            setWeightsPercentOfPR = setWeightsPercentOfPR.filterIndexed { i, _ -> i != index }
             syncSetWeightsToPercentOfPR()
         }
     }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModel.kt
@@ -15,6 +15,7 @@ import com.devil.phoenixproject.domain.model.WeightUnit
 import com.devil.phoenixproject.domain.model.WorkoutMode
 import com.devil.phoenixproject.domain.model.toWorkoutMode
 import com.devil.phoenixproject.util.KmpUtils
+import kotlin.math.roundToInt
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -108,6 +109,8 @@ class ExerciseConfigViewModel constructor(
 
     private val _prTypeForScaling = MutableStateFlow(PRType.MAX_WEIGHT)
     val prTypeForScaling: StateFlow<PRType> = _prTypeForScaling.asStateFlow()
+
+    private var setWeightsPercentOfPR: List<Int> = emptyList()
 
     // Warm-up sets state (Issue #30)
     private val _warmupSets = MutableStateFlow<List<WarmupSet>>(emptyList())
@@ -213,6 +216,11 @@ class ExerciseConfigViewModel constructor(
         _usePercentOfPR.value = exercise.usePercentOfPR
         _weightPercentOfPR.value = exercise.weightPercentOfPR
         _prTypeForScaling.value = exercise.prTypeForScaling
+        setWeightsPercentOfPR = normalizeSetWeightPercentages(
+            source = exercise.setWeightsPercentOfPR,
+            setCount = initialSets.size,
+            fallbackPercent = exercise.weightPercentOfPR,
+        )
 
         // Warm-up sets (Issue #30)
         _warmupSets.value = exercise.warmupSets
@@ -257,6 +265,7 @@ class ExerciseConfigViewModel constructor(
             try {
                 val pr = personalRecordRepository.getBestWeightPR(exerciseId, workoutMode, activeProfileId)
                 _currentExercisePR.value = pr
+                syncSetWeightsToPercentOfPR()
                 logDebug("Loaded PR for exercise=$exerciseId, mode=$workoutMode, profile=$activeProfileId: ${pr?.weightPerCableKg ?: "none"}")
             } catch (e: Exception) {
                 logWarning("Failed to load PR for exercise=$exerciseId, mode=$workoutMode, profile=$activeProfileId: ${e.message}")
@@ -310,10 +319,19 @@ class ExerciseConfigViewModel constructor(
     // PR percentage scaling handlers (Issue #57)
     fun onUsePercentOfPRChange(enabled: Boolean) {
         _usePercentOfPR.value = enabled
+        if (enabled) {
+            ensureSetWeightPercentages()
+            syncSetWeightsToPercentOfPR()
+        }
     }
 
     fun onWeightPercentOfPRChange(percent: Int) {
-        _weightPercentOfPR.value = percent.coerceIn(50, 120)
+        val coercedPercent = percent.coerceIn(50, 120)
+        _weightPercentOfPR.value = coercedPercent
+        if (_usePercentOfPR.value) {
+            setWeightsPercentOfPR = List(_sets.value.size) { coercedPercent }
+            syncSetWeightsToPercentOfPR()
+        }
     }
 
     fun onPRTypeForScalingChange(prType: PRType) {
@@ -400,7 +418,52 @@ class ExerciseConfigViewModel constructor(
         return (pr.weightPerCableKg * percent / 100f).roundToHalfKg()
     }
 
-    private fun Float.roundToHalfKg(): Float = (this * 2).toInt() / 2f
+    private fun Float.roundToHalfKg(): Float = (this * 2).roundToInt() / 2f
+
+    private fun normalizeSetWeightPercentages(source: List<Int>, setCount: Int, fallbackPercent: Int): List<Int> {
+        if (setCount <= 0) return emptyList()
+        val fallback = fallbackPercent.coerceIn(50, 120)
+        return List(setCount) { index ->
+            (source.getOrNull(index) ?: fallback).coerceIn(50, 120)
+        }
+    }
+
+    private fun ensureSetWeightPercentages() {
+        setWeightsPercentOfPR = normalizeSetWeightPercentages(
+            source = setWeightsPercentOfPR,
+            setCount = _sets.value.size,
+            fallbackPercent = _weightPercentOfPR.value,
+        )
+    }
+
+    private fun resolvedSetWeightsKgFromCurrentPR(): List<Float>? {
+        val pr = _currentExercisePR.value ?: return null
+        if (!_usePercentOfPR.value || pr.weightPerCableKg <= 0f) return null
+        ensureSetWeightPercentages()
+        return setWeightsPercentOfPR.map { percent ->
+            (pr.weightPerCableKg * percent / 100f).roundToHalfKg()
+        }
+    }
+
+    private fun syncSetWeightsToPercentOfPR() {
+        val resolvedWeightsKg = resolvedSetWeightsKgFromCurrentPR() ?: return
+        _sets.value = _sets.value.mapIndexed { index, set ->
+            val resolvedWeightKg = resolvedWeightsKg.getOrNull(index) ?: return@mapIndexed set
+            set.copy(weightPerCable = kgToDisplay(resolvedWeightKg, weightUnit))
+        }
+    }
+
+    private fun updateSetPercentFromDisplayWeight(setIndex: Int, displayWeight: Float) {
+        val pr = _currentExercisePR.value ?: return
+        if (!_usePercentOfPR.value || pr.weightPerCableKg <= 0f) return
+
+        ensureSetWeightPercentages()
+        val weightKg = displayToKg(displayWeight, weightUnit)
+        val percent = ((weightKg / pr.weightPerCableKg) * 100f).roundToInt().coerceIn(50, 120)
+        setWeightsPercentOfPR = setWeightsPercentOfPR.mapIndexed { index, existing ->
+            if (index == setIndex) percent else existing
+        }
+    }
 
     fun updateReps(setId: String, reps: Int?) {
         _sets.value = _sets.value.map { set ->
@@ -409,8 +472,13 @@ class ExerciseConfigViewModel constructor(
     }
 
     fun updateWeight(setId: String, weight: Float) {
+        val setIndex = _sets.value.indexOfFirst { it.id == setId }
         _sets.value = _sets.value.map { set ->
             if (set.id == setId) set.copy(weightPerCable = weight) else set
+        }
+        if (setIndex >= 0 && _usePercentOfPR.value) {
+            updateSetPercentFromDisplayWeight(setIndex, weight)
+            syncSetWeightsToPercentOfPR()
         }
     }
 
@@ -436,12 +504,21 @@ class ExerciseConfigViewModel constructor(
             restSeconds = lastSet?.restSeconds ?: 60,
         )
         _sets.value = _sets.value + newSet
+        if (_usePercentOfPR.value) {
+            val nextPercent = setWeightsPercentOfPR.lastOrNull() ?: _weightPercentOfPR.value
+            setWeightsPercentOfPR = setWeightsPercentOfPR + nextPercent
+            syncSetWeightsToPercentOfPR()
+        }
     }
 
     fun deleteSet(index: Int) {
         val newSets = _sets.value.filterIndexed { i, _ -> i != index }
             .mapIndexed { i, set -> set.copy(setNumber = i + 1) }
         _sets.value = newSets
+        if (_usePercentOfPR.value) {
+            setWeightsPercentOfPR = setWeightsPercentOfPR.filterIndexed { i, _ -> i != index }
+            syncSetWeightsToPercentOfPR()
+        }
     }
 
     fun onSave(onSaveCallback: (RoutineExercise) -> Unit) {
@@ -471,25 +548,22 @@ class ExerciseConfigViewModel constructor(
         logDebug("Rest times to save: $restTimes")
         logDebug("Weights to save: ${_sets.value.map { displayToKg(it.weightPerCable, weightUnit) }}")
 
-        val existingPercentages = originalExercise.setWeightsPercentOfPR
-        val hasCustomPercentages = existingPercentages.isNotEmpty() &&
-            existingPercentages.any { it != originalExercise.weightPercentOfPR }
         val resolvedSetWeightsPercentOfPR = if (_usePercentOfPR.value) {
-            if (hasCustomPercentages) {
-                List(_sets.value.size) { index ->
-                    existingPercentages.getOrNull(index) ?: _weightPercentOfPR.value
-                }
-            } else {
-                List(_sets.value.size) { _weightPercentOfPR.value }
-            }
+            normalizeSetWeightPercentages(
+                source = setWeightsPercentOfPR,
+                setCount = _sets.value.size,
+                fallbackPercent = _weightPercentOfPR.value,
+            )
         } else {
             emptyList()
         }
+        val resolvedSetWeightsKg = resolvedSetWeightsKgFromCurrentPR()
+            ?: _sets.value.map { displayToKg(it.weightPerCable, weightUnit) }
 
         val updatedExercise = originalExercise.copy(
             setReps = _sets.value.map { it.reps },
-            weightPerCableKg = displayToKg(_sets.value.first().weightPerCable, weightUnit),
-            setWeightsPerCableKg = _sets.value.map { displayToKg(it.weightPerCable, weightUnit) },
+            weightPerCableKg = resolvedSetWeightsKg.first(),
+            setWeightsPerCableKg = resolvedSetWeightsKg,
             programMode = _selectedMode.value.toProgramMode(),
             eccentricLoad = _eccentricLoad.value,
             echoLevel = _echoLevel.value,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModel.kt
@@ -111,6 +111,7 @@ class ExerciseConfigViewModel constructor(
     val prTypeForScaling: StateFlow<PRType> = _prTypeForScaling.asStateFlow()
 
     private var setWeightsPercentOfPR: List<Int> = emptyList()
+    private val pendingPercentOfPREditWeights = mutableMapOf<String, Float>()
 
     // Warm-up sets state (Issue #30)
     private val _warmupSets = MutableStateFlow<List<WarmupSet>>(emptyList())
@@ -216,6 +217,7 @@ class ExerciseConfigViewModel constructor(
         _usePercentOfPR.value = exercise.usePercentOfPR
         _weightPercentOfPR.value = exercise.weightPercentOfPR
         _prTypeForScaling.value = exercise.prTypeForScaling
+        pendingPercentOfPREditWeights.clear()
         setWeightsPercentOfPR = normalizeSetWeightPercentages(
             source = exercise.setWeightsPercentOfPR,
             setCount = initialSets.size,
@@ -319,6 +321,9 @@ class ExerciseConfigViewModel constructor(
     // PR percentage scaling handlers (Issue #57)
     fun onUsePercentOfPRChange(enabled: Boolean) {
         _usePercentOfPR.value = enabled
+        if (!enabled) {
+            pendingPercentOfPREditWeights.clear()
+        }
         if (enabled) {
             ensureSetWeightPercentages()
             syncSetWeightsToPercentOfPR()
@@ -326,10 +331,15 @@ class ExerciseConfigViewModel constructor(
     }
 
     fun onWeightPercentOfPRChange(percent: Int) {
+        val previousPercent = _weightPercentOfPR.value.coerceIn(50, 120)
         val coercedPercent = percent.coerceIn(50, 120)
         _weightPercentOfPR.value = coercedPercent
         if (_usePercentOfPR.value) {
-            setWeightsPercentOfPR = List(_sets.value.size) { coercedPercent }
+            ensureSetWeightPercentages()
+            if (setWeightsPercentOfPR.all { it == previousPercent }) {
+                setWeightsPercentOfPR = List(_sets.value.size) { coercedPercent }
+                pendingPercentOfPREditWeights.clear()
+            }
             syncSetWeightsToPercentOfPR()
         }
     }
@@ -439,6 +449,7 @@ class ExerciseConfigViewModel constructor(
     private fun resolvedSetWeightsKgFromCurrentPR(): List<Float>? {
         val pr = _currentExercisePR.value ?: return null
         if (!_usePercentOfPR.value || pr.weightPerCableKg <= 0f) return null
+        applyPendingPercentOfPREdits(pr)
         ensureSetWeightPercentages()
         return setWeightsPercentOfPR.map { percent ->
             (pr.weightPerCableKg * percent / 100f).roundToHalfKg()
@@ -453,16 +464,38 @@ class ExerciseConfigViewModel constructor(
         }
     }
 
-    private fun updateSetPercentFromDisplayWeight(setIndex: Int, displayWeight: Float) {
-        val pr = _currentExercisePR.value ?: return
-        if (!_usePercentOfPR.value || pr.weightPerCableKg <= 0f) return
-
-        ensureSetWeightPercentages()
+    private fun percentFromDisplayWeight(displayWeight: Float, pr: PersonalRecord): Int {
         val weightKg = displayToKg(displayWeight, weightUnit)
-        val percent = ((weightKg / pr.weightPerCableKg) * 100f).roundToInt().coerceIn(50, 120)
+        return ((weightKg / pr.weightPerCableKg) * 100f).roundToInt().coerceIn(50, 120)
+    }
+
+    private fun displayWeightFromPercent(percent: Int, pr: PersonalRecord): Float {
+        val resolvedWeightKg = (pr.weightPerCableKg * percent / 100f).roundToHalfKg()
+        return kgToDisplay(resolvedWeightKg, weightUnit)
+    }
+
+    private fun applyPendingPercentOfPREdits(pr: PersonalRecord) {
+        if (pendingPercentOfPREditWeights.isEmpty()) return
+        ensureSetWeightPercentages()
+        val setsById = _sets.value.mapIndexed { index, set -> set.id to index }.toMap()
+
+        pendingPercentOfPREditWeights.forEach { (setId, displayWeight) ->
+            val setIndex = setsById[setId] ?: return@forEach
+            val percent = percentFromDisplayWeight(displayWeight, pr)
+            setWeightsPercentOfPR = setWeightsPercentOfPR.mapIndexed { index, existing ->
+                if (index == setIndex) percent else existing
+            }
+        }
+        pendingPercentOfPREditWeights.clear()
+    }
+
+    private fun updateSetPercentFromDisplayWeight(setIndex: Int, displayWeight: Float, pr: PersonalRecord): Int {
+        ensureSetWeightPercentages()
+        val percent = percentFromDisplayWeight(displayWeight, pr)
         setWeightsPercentOfPR = setWeightsPercentOfPR.mapIndexed { index, existing ->
             if (index == setIndex) percent else existing
         }
+        return percent
     }
 
     fun updateReps(setId: String, reps: Int?) {
@@ -473,12 +506,24 @@ class ExerciseConfigViewModel constructor(
 
     fun updateWeight(setId: String, weight: Float) {
         val setIndex = _sets.value.indexOfFirst { it.id == setId }
-        _sets.value = _sets.value.map { set ->
-            if (set.id == setId) set.copy(weightPerCable = weight) else set
+        if (setIndex < 0) return
+
+        val pr = _currentExercisePR.value
+        val nextWeight = if (_usePercentOfPR.value && pr != null && pr.weightPerCableKg > 0f) {
+            pendingPercentOfPREditWeights.remove(setId)
+            val percent = updateSetPercentFromDisplayWeight(setIndex, weight, pr)
+            displayWeightFromPercent(percent, pr)
+        } else {
+            if (_usePercentOfPR.value) {
+                pendingPercentOfPREditWeights[setId] = weight
+            } else {
+                pendingPercentOfPREditWeights.remove(setId)
+            }
+            weight
         }
-        if (setIndex >= 0 && _usePercentOfPR.value) {
-            updateSetPercentFromDisplayWeight(setIndex, weight)
-            syncSetWeightsToPercentOfPR()
+
+        _sets.value = _sets.value.mapIndexed { index, set ->
+            if (index == setIndex) set.copy(weightPerCable = nextWeight) else set
         }
     }
 
@@ -505,16 +550,21 @@ class ExerciseConfigViewModel constructor(
         )
         _sets.value = _sets.value + newSet
         if (_usePercentOfPR.value) {
-            val nextPercent = setWeightsPercentOfPR.lastOrNull() ?: _weightPercentOfPR.value
-            setWeightsPercentOfPR = setWeightsPercentOfPR + nextPercent
+            setWeightsPercentOfPR = setWeightsPercentOfPR + _weightPercentOfPR.value.coerceIn(50, 120)
             syncSetWeightsToPercentOfPR()
         }
     }
 
     fun deleteSet(index: Int) {
+        val removedSetId = _sets.value.getOrNull(index)?.id
         val newSets = _sets.value.filterIndexed { i, _ -> i != index }
             .mapIndexed { i, set -> set.copy(setNumber = i + 1) }
         _sets.value = newSets
+        if (removedSetId != null) {
+            pendingPercentOfPREditWeights.remove(removedSetId)
+        }
+        val remainingSetIds = newSets.map { it.id }.toSet()
+        pendingPercentOfPREditWeights.keys.retainAll(remainingSetIds)
         if (_usePercentOfPR.value) {
             setWeightsPercentOfPR = setWeightsPercentOfPR.filterIndexed { i, _ -> i != index }
             syncSetWeightsToPercentOfPR()
@@ -548,6 +598,8 @@ class ExerciseConfigViewModel constructor(
         logDebug("Rest times to save: $restTimes")
         logDebug("Weights to save: ${_sets.value.map { displayToKg(it.weightPerCable, weightUnit) }}")
 
+        val resolvedSetWeightsKg = resolvedSetWeightsKgFromCurrentPR()
+            ?: _sets.value.map { displayToKg(it.weightPerCable, weightUnit) }
         val resolvedSetWeightsPercentOfPR = if (_usePercentOfPR.value) {
             normalizeSetWeightPercentages(
                 source = setWeightsPercentOfPR,
@@ -557,8 +609,6 @@ class ExerciseConfigViewModel constructor(
         } else {
             emptyList()
         }
-        val resolvedSetWeightsKg = resolvedSetWeightsKgFromCurrentPR()
-            ?: _sets.value.map { displayToKg(it.weightPerCable, weightUnit) }
 
         val updatedExercise = originalExercise.copy(
             setReps = _sets.value.map { it.reps },

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMRoutineFlowTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMRoutineFlowTest.kt
@@ -1,5 +1,10 @@
 package com.devil.phoenixproject.presentation.manager
 
+import com.devil.phoenixproject.domain.model.PRType
+import com.devil.phoenixproject.domain.model.PersonalRecord
+import com.devil.phoenixproject.domain.model.ProgramMode
+import com.devil.phoenixproject.domain.model.Routine
+import com.devil.phoenixproject.domain.model.RoutineExercise
 import com.devil.phoenixproject.domain.model.RoutineFlowState
 import com.devil.phoenixproject.domain.model.WorkoutState
 import com.devil.phoenixproject.testutil.DWSMTestHarness
@@ -62,6 +67,61 @@ class DWSMRoutineFlowTest {
             params.selectedExerciseId,
             "Selected exercise ID should match first exercise",
         )
+        harness.cleanup()
+    }
+
+    @Test
+    fun loadRoutine_percentOfPRResolvesStaleSnapshotWeights() = runTest {
+        val harness = DWSMTestHarness(this)
+        val exercise = TestFixtures.benchPress
+        val routine = Routine(
+            id = "routine-pr-stale",
+            name = "PR Stale Snapshot Routine",
+            exercises = listOf(
+                RoutineExercise(
+                    id = "re-pr-stale",
+                    exercise = exercise,
+                    orderIndex = 0,
+                    setReps = listOf(10, 10),
+                    weightPerCableKg = 5f,
+                    setWeightsPerCableKg = listOf(5f, 5f),
+                    programMode = ProgramMode.OldSchool,
+                    usePercentOfPR = true,
+                    weightPercentOfPR = 80,
+                    setWeightsPercentOfPR = listOf(80, 90),
+                ),
+            ),
+        )
+        harness.fakeExerciseRepo.addExercise(exercise)
+        harness.fakePRRepo.addRecord(
+            PersonalRecord(
+                id = 1,
+                exerciseId = exercise.id!!,
+                exerciseName = exercise.name,
+                weightPerCableKg = 50f,
+                reps = 6,
+                oneRepMax = 60f,
+                timestamp = 1_000L,
+                workoutMode = "Old School",
+                prType = PRType.MAX_WEIGHT,
+                volume = 300f,
+            ),
+        )
+        advanceUntilIdle()
+
+        harness.dwsm.loadRoutine(routine)
+        advanceUntilIdle()
+
+        val params = harness.dwsm.coordinator.workoutParameters.value
+        assertEquals(
+            40f,
+            params.weightPerCableKg,
+            "First set should resolve from 80% of the current PR, not stale 5kg snapshot",
+        )
+
+        val loadedExercise = harness.dwsm.coordinator.loadedRoutine.value?.exercises?.single()
+        assertNotNull(loadedExercise)
+        assertEquals(listOf(40f, 45f), loadedExercise.setWeightsPerCableKg)
         harness.cleanup()
     }
 


### PR DESCRIPTION
## Summary
- Sync `% of PR` routine set weights in the editor to the latest resolved PR values so stale `5 kg` / `11 lb` snapshots no longer leak into visible sets or warm-up preview input.
- Preserve per-set `% of PR` metadata while saving resolved absolute weights as fallback snapshots for `weightPerCableKg` and `setWeightsPerCableKg`.
- Fix half-kilogram rounding to use nearest rounding instead of truncation.
- Add regression coverage for editor syncing, rounding, and routine-load resolution against the current PR.

## Testing
- Added/updated host and common tests for `% of PR` editor sync, saved snapshot resolution, nearest-half-kg rounding, and routine load resolution from current PR.
- Verified with Gradle: `:shared:testAndroidHostTest`, `:shared:compileKotlinMetadata`, and `:shared:check`.