### PR TITLE
Align Echo and activation defaults with official app behavior

### DIFF
--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/e2e/WorkoutFlowE2ETest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/e2e/WorkoutFlowE2ETest.kt
@@ -287,8 +287,10 @@ class WorkoutFlowE2ETest {
         advanceUntilIdle()
 
         localRobot.verifyWorkoutActive()
-        // Issue #222: INIT command removed - now only CONFIG (0x04) + START (0x03)
-        kotlin.test.assertEquals(2, fakeBleRepository.commandsReceived.size)
+        // Official activation starts send CONFIG (0x04) only, without legacy START (0x03).
+        kotlin.test.assertEquals(1, fakeBleRepository.commandsReceived.size)
+        kotlin.test.assertEquals(0x04.toByte(), fakeBleRepository.commandsReceived[0][0])
+        kotlin.test.assertFalse(fakeBleRepository.commandsReceived.any { it.firstOrNull() == 0x03.toByte() })
     }
 
     @Test

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModelTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModelTest.kt
@@ -431,8 +431,10 @@ class MainViewModelTest {
         advanceUntilIdle()
 
         assertEquals(WorkoutState.Active, viewModel.workoutState.value)
-        // Issue #222: INIT command removed - now only CONFIG (0x04) + START (0x03)
-        assertEquals(2, fakeBleRepository.commandsReceived.size)
+        // Official activation starts send CONFIG (0x04) only, without legacy START (0x03).
+        assertEquals(1, fakeBleRepository.commandsReceived.size)
+        assertEquals(0x04.toByte(), fakeBleRepository.commandsReceived[0][0])
+        assertFalse(fakeBleRepository.commandsReceived.any { it.firstOrNull() == 0x03.toByte() })
     }
 
     @Test
@@ -516,7 +518,9 @@ class MainViewModelTest {
         viewModel.startWorkout(skipCountdown = true)
         advanceUntilIdle()
 
-        assertEquals(2, fakeBleRepository.commandsReceived.size)
+        assertEquals(1, fakeBleRepository.commandsReceived.size)
+        assertEquals(0x04.toByte(), fakeBleRepository.commandsReceived[0][0])
+        assertFalse(fakeBleRepository.commandsReceived.any { it.firstOrNull() == 0x03.toByte() })
 
         emitRepNotification(
             repIndex = 2,
@@ -536,7 +540,12 @@ class MainViewModelTest {
         advanceUntilIdle()
 
         assertFalse(viewModel.connectionLostDuringWorkout.value)
-        assertEquals(4, fakeBleRepository.commandsReceived.size)
+        assertEquals(2, fakeBleRepository.commandsReceived.size)
+        assertEquals(
+            listOf(0x04.toByte(), 0x04.toByte()),
+            fakeBleRepository.commandsReceived.map { it[0] },
+        )
+        assertFalse(fakeBleRepository.commandsReceived.any { it.firstOrNull() == 0x03.toByte() })
         assertEquals(0, viewModel.repCount.value.workingReps)
         assertEquals(3, viewModel.workoutParameters.value.reps)
         assertEquals(0, viewModel.workoutParameters.value.warmupReps)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/preferences/PreferencesManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/preferences/PreferencesManager.kt
@@ -40,7 +40,7 @@ data class SingleExerciseDefaults(
     fun getEchoLevel(): com.devil.phoenixproject.domain.model.EchoLevel = com.devil.phoenixproject.domain.model.EchoLevel.entries.find {
         it.levelValue == echoLevelValue
     }
-        ?: com.devil.phoenixproject.domain.model.EchoLevel.HARDER
+        ?: com.devil.phoenixproject.domain.model.EchoLevel.HARD
 
     fun toProgramMode(): com.devil.phoenixproject.domain.model.ProgramMode = when (workoutModeId) {
         0 -> com.devil.phoenixproject.domain.model.ProgramMode.OldSchool
@@ -62,7 +62,7 @@ data class JustLiftDefaults(
     val weightPerCableKg: Float = 20f,
     val weightChangePerRep: Float = 0f,
     val eccentricLoadPercentage: Int = 100,
-    val echoLevelValue: Int = 2,
+    val echoLevelValue: Int = 0,
     val stallDetectionEnabled: Boolean = true, // Stall detection auto-stop toggle
     val repCountTimingName: String = "TOP", // RepCountTiming enum name
     val restSeconds: Int = 60, // Rest timer between sets (0 = off, 5-300 in 5s increments)
@@ -77,7 +77,7 @@ data class JustLiftDefaults(
     fun getEchoLevel(): com.devil.phoenixproject.domain.model.EchoLevel = com.devil.phoenixproject.domain.model.EchoLevel.entries.find {
         it.levelValue == echoLevelValue
     }
-        ?: com.devil.phoenixproject.domain.model.EchoLevel.HARDER
+        ?: com.devil.phoenixproject.domain.model.EchoLevel.HARD
 
     fun toProgramMode(): com.devil.phoenixproject.domain.model.ProgramMode = when (workoutModeId) {
         0 -> com.devil.phoenixproject.domain.model.ProgramMode.OldSchool

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt
@@ -1002,7 +1002,7 @@ class SqlDelightSyncRepository(
                     }
 
                     val eccentricLoad = mapEccentricLoadFromDb(exRow.eccentricLoad)
-                    val echoLevel = EchoLevel.entries.getOrNull(exRow.echoLevel.toInt()) ?: EchoLevel.HARDER
+                    val echoLevel = EchoLevel.entries.getOrNull(exRow.echoLevel.toInt()) ?: EchoLevel.HARD
                     val programMode = parseProgramMode(exRow.mode)
 
                     val prTypeForScaling = try {

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepository.kt
@@ -314,7 +314,7 @@ class SqlDelightWorkoutRepository(private val db: VitruvianDatabase, private val
                 }
 
                 val eccentricLoad = mapEccentricLoadFromDb(row.eccentricLoad)
-                val echoLevel = EchoLevel.entries.getOrNull(row.echoLevel.toInt()) ?: EchoLevel.HARDER
+                val echoLevel = EchoLevel.entries.getOrNull(row.echoLevel.toInt()) ?: EchoLevel.HARD
 
                 val programMode = parseProgramMode(row.mode)
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/Models.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/Models.kt
@@ -175,8 +175,8 @@ sealed class RoutineFlowState {
 /**
  * Program modes used by Phoenix workout setup.
  *
- * Non-Echo modes start with the 96-byte activation/config frame (command 0x04),
- * followed by a START command (0x03). Echo uses its dedicated 0x4E packet.
+ * Non-Echo modes start with the 96-byte activation/config frame (command 0x04).
+ * Echo uses its dedicated 0x4E packet.
  */
 sealed class ProgramMode(val modeValue: Int, val displayName: String) {
     object OldSchool : ProgramMode(0, "Old School")

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/Routine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/Routine.kt
@@ -87,7 +87,7 @@ data class RoutineExercise(
     val programMode: ProgramMode = ProgramMode.OldSchool,
     // Echo-specific configuration
     val eccentricLoad: EccentricLoad = EccentricLoad.LOAD_100,
-    val echoLevel: EchoLevel = EchoLevel.HARDER,
+    val echoLevel: EchoLevel = EchoLevel.HARD,
     val progressionKg: Float = 0f,
     val setRestSeconds: List<Int> = emptyList(), // per-set rest times
     // Per-set echo level overrides; null entries fall back to exercise-level echoLevel

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/TemplateConverter.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/TemplateConverter.kt
@@ -180,7 +180,7 @@ class TemplateConverter(private val exerciseRepository: ExerciseRepository) {
                         },
                         weightPerCableKg = startingWeight,
                         programMode = selectedMode,
-                        echoLevel = config?.echoLevel ?: EchoLevel.HARDER,
+                        echoLevel = config?.echoLevel ?: EchoLevel.HARD,
                         eccentricLoad =
                             config?.eccentricLoadPercent?.toEccentricLoad()
                                 ?: EccentricLoad.LOAD_100,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -1581,7 +1581,7 @@ class ActiveSessionEngine(
         if (!params.isJustLift) return
 
         val eccentricLoadPct = if (params.isEchoMode) params.eccentricLoad.percentage else 100
-        val echoLevelVal = if (params.isEchoMode) params.echoLevel.levelValue else 2
+        val echoLevelVal = if (params.isEchoMode) params.echoLevel.levelValue else 0
 
         try {
             val defaults = com.devil.phoenixproject.data.preferences.JustLiftDefaults(
@@ -1620,7 +1620,7 @@ class ActiveSessionEngine(
 
         val isEchoExercise = currentExercise.programMode == ProgramMode.Echo
         val eccentricLoadPct = if (isEchoExercise) currentExercise.eccentricLoad.percentage else 100
-        val echoLevelVal = if (isEchoExercise) currentExercise.echoLevel.levelValue else 1
+        val echoLevelVal = if (isEchoExercise) currentExercise.echoLevel.levelValue else 0
 
         try {
             val setReps = currentExercise.setReps.ifEmpty { listOf(10) }
@@ -2373,6 +2373,9 @@ class ActiveSessionEngine(
                         Logger.w {
                             "BLE-ACTIVATION-VERIFY (temporary): offsets 0x48..0x5F => $activationTailDump"
                         }
+                        val eccentricUpDump = command
+                            .copyOfRange(0x48, 0x50)
+                            .joinToString(" ") { it.toUByte().toString(16).padStart(2, '0').uppercase() }
                         // Issue #390: Decode the key float values from packet bytes for readability
                         fun readFloatLE(buf: ByteArray, off: Int): Float {
                             val bits = (buf[off].toInt() and 0xFF) or
@@ -2382,8 +2385,7 @@ class ActiveSessionEngine(
                             return Float.fromBits(bits)
                         }
                         Logger.w("Issue390") {
-                            "PACKET DECODED: softMax@0x48=${readFloatLE(command, 0x48)}kg, " +
-                                "increment@0x4C=${readFloatLE(command, 0x4C)}kg, " +
+                            "PACKET DECODED: eccUpRamp@0x48..0x4F=$eccentricUpDump, " +
                                 "forceMin@0x50=${readFloatLE(command, 0x50)}kg, " +
                                 "forceMax@0x54=${readFloatLE(command, 0x54)}kg, " +
                                 "targetWeight@0x58=${readFloatLE(command, 0x58)}kg, " +
@@ -2394,19 +2396,6 @@ class ActiveSessionEngine(
                     Logger.e(e) { "Failed to send config command" }
                     coordinator._bleErrorEvents.tryEmit("Failed to send command: ${e.message}")
                     return@launch
-                }
-
-                if (!effectiveParams.isEchoMode) {
-                    delay(100)
-                    try {
-                        val startCommand = BlePacketFactory.createStartCommand()
-                        bleRepository.sendWorkoutCommand(startCommand).getOrThrow()
-                        Logger.i { "START command sent (0x03)" }
-                    } catch (e: Exception) {
-                        Logger.e(e) { "Failed to send START command" }
-                        coordinator._bleErrorEvents.tryEmit("Failed to start workout: ${e.message}")
-                        return@launch
-                    }
                 }
 
                 bleRepository.startActiveWorkoutPolling()

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/DefaultWorkoutSessionManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/DefaultWorkoutSessionManager.kt
@@ -53,7 +53,7 @@ data class JustLiftDefaults(
     val weightChangePerRep: Int, // In display units (kg or lbs based on user preference)
     val workoutModeId: Int, // 0=OldSchool, 1=Pump, 10=Echo
     val eccentricLoadPercentage: Int = 100,
-    val echoLevelValue: Int = 1, // 0=Hard, 1=Harder, 2=Hardest, 3=Epic
+    val echoLevelValue: Int = 0, // 0=Hard, 1=Harder, 2=Hardest, 3=Epic
     val stallDetectionEnabled: Boolean = true, // Stall detection auto-stop toggle
     val repCountTimingName: String = "TOP", // RepCountTiming enum name for persistence
     val restSeconds: Int = 60, // Rest timer between sets (0 = off, 5-300 in 5s increments)
@@ -90,7 +90,7 @@ data class JustLiftDefaults(
     /**
      * Get EchoLevel from stored value
      */
-    fun getEchoLevel(): EchoLevel = EchoLevel.entries.getOrElse(echoLevelValue) { EchoLevel.HARDER }
+    fun getEchoLevel(): EchoLevel = EchoLevel.entries.getOrElse(echoLevelValue) { EchoLevel.HARD }
 
     /**
      * Get RepCountTiming from stored name

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseEditBottomSheet.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseEditBottomSheet.kt
@@ -1007,7 +1007,7 @@ fun ModeSelector(
         WorkoutMode.Pump,
         WorkoutMode.TUT,
         WorkoutMode.EccentricOnly,
-        WorkoutMode.Echo(EchoLevel.HARDER),
+        WorkoutMode.Echo(EchoLevel.HARD),
     )
 
     Surface(

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/JustLiftScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/JustLiftScreen.kt
@@ -139,7 +139,7 @@ fun JustLiftScreen(navController: NavController, viewModel: MainViewModel, theme
     var weightChangePerRep by rememberSaveable { mutableStateOf(0) } // Progression/Regression value
     // Keep enum/sealed types as `remember` — they need custom Savers:
     var eccentricLoad by remember { mutableStateOf(EccentricLoad.LOAD_100) }
-    var echoLevel by remember { mutableStateOf(EchoLevel.HARDER) }
+    var echoLevel by remember { mutableStateOf(EchoLevel.HARD) }
     var repCountTiming by remember { mutableStateOf(RepCountTiming.TOP) }
     var stallDetectionEnabled by rememberSaveable { mutableStateOf(true) }
     var restSeconds by rememberSaveable { mutableStateOf(60) } // Rest timer between sets (0 = off)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SingleExerciseScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SingleExerciseScreen.kt
@@ -302,7 +302,7 @@ fun SingleExerciseScreen(
                                     setRestSeconds = listOf(60, 60, 60),
                                     programMode = ProgramMode.OldSchool,
                                     eccentricLoad = EccentricLoad.LOAD_100,
-                                    echoLevel = EchoLevel.HARDER,
+                                    echoLevel = EchoLevel.HARD,
                                 )
                             }
                             exerciseToConfig = newRoutineExercise

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModel.kt
@@ -88,7 +88,7 @@ class ExerciseConfigViewModel constructor(
     private val _eccentricLoad = MutableStateFlow(EccentricLoad.LOAD_100)
     val eccentricLoad: StateFlow<EccentricLoad> = _eccentricLoad.asStateFlow()
 
-    private val _echoLevel = MutableStateFlow(EchoLevel.HARDER)
+    private val _echoLevel = MutableStateFlow(EchoLevel.HARD)
     val echoLevel: StateFlow<EchoLevel> = _echoLevel.asStateFlow()
 
     private val _stallDetectionEnabled = MutableStateFlow(true)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/BleConstants.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/BleConstants.kt
@@ -66,28 +66,31 @@ object BleConstants {
      * Layout:
      * - 0x30-0x3F: concentric activation phase
      * - 0x40-0x4F: eccentric activation phase
-     * - 0x48-0x4B: legacy softMax for overlap firmware variants (overlaps eccentric tail)
-     * - 0x4C-0x4F: legacy increment for overlap firmware variants (overlaps eccentric tail)
+     * - 0x48-0x4F: eccentric-up ramp inside the eccentric activation phase
      * - 0x50-0x53: forceMin (0.0f)
      * - 0x54-0x57: forceMax (adjustedWeight + 10.0f — force ceiling)
      * - 0x58-0x5B: target weight (adjustedWeight — actual operating weight)
      * - 0x5C-0x5F: progression (progressionRegressionKg)
      *
-     * Firmware variants differ:
-     * - NON_OVERLAP: keep 0x48-0x4F as profile bytes and use 0x58/0x5C for active weights.
-     * - OVERLAP: write legacy softMax/increment at 0x48/0x4C after profile copy.
+     * Official activation packets keep 0x48-0x4F as the mode profile's eccentric-up
+     * ramp bytes. The active force fields live in the trailing block at 0x50-0x5F.
      *
-     * Issue #262: Firmware reads softMax (0x48) and increment (0x4C) from offsets
-     * that overlap the mode profile block (0x30-0x4F). We write these values AFTER
-     * copying the profile so they overwrite the eccentric phase's last 8 bytes.
+     * The legacy OVERLAP experiment wrote softMax/increment at 0x48/0x4C. Those
+     * aliases remain for explicit regression tests only; production packets should
+     * preserve the profile tail and use 0x58/0x5C for selected force/progression.
      */
     object ActivationPacket {
         const val SIZE = 96
         const val OFFSET_MODE_PROFILE = 0x30 // 32 bytes (concentric + eccentric phases)
 
-        // Firmware force config (overlaps end of mode profile — write AFTER profile copy)
-        const val OFFSET_SOFT_MAX = 0x48 // Weight ceiling (float LE) — caps progression
-        const val OFFSET_INCREMENT = 0x4C // Per-rep progression kg (float LE)
+        // Official profile-tail offsets.
+        const val OFFSET_ECC_UP_MIN_MMS = 0x48
+        const val OFFSET_ECC_UP_MAX_MMS = 0x4A
+        const val OFFSET_ECC_UP_RAMP = 0x4C
+
+        // Legacy OVERLAP aliases retained for explicit regression tests only.
+        const val OFFSET_SOFT_MAX = 0x48
+        const val OFFSET_INCREMENT = 0x4C
 
         // Force config block
         const val OFFSET_FORCE_MIN = 0x50 // 0.0f in activation packets

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/BlePacketFactory.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/BlePacketFactory.kt
@@ -20,7 +20,7 @@ object BlePacketFactory {
     }
 
     @Volatile
-    var defaultForceConfigVariant: ForceConfigVariant = ForceConfigVariant.OVERLAP
+    var defaultForceConfigVariant: ForceConfigVariant = ForceConfigVariant.NON_OVERLAP
 
     // ========== Little-Endian Byte Helpers ==========
 
@@ -66,8 +66,8 @@ object BlePacketFactory {
     // ========== Control Commands ==========
 
     /**
-     * Creates a START command (4 bytes).
-     * Signals the device to begin the configured workout.
+     * Creates the legacy Phoenix START command (4 bytes).
+     * Official activation-mode starts do not send this after the configuration packet.
      */
     fun createStartCommand(): ByteArray = byteArrayOf(0x03, 0x00, 0x00, 0x00)
 
@@ -117,21 +117,13 @@ object BlePacketFactory {
      * Build the 96-byte activation/program parameters frame.
      *
      * Activation modes serialize a 32-byte mode profile at 0x30-0x4F, followed by
-     * the force config block at 0x50-0x5F.
-     * - NON_OVERLAP keeps 0x48-0x4F untouched so profile bytes are preserved.
-     * - OVERLAP writes legacy softMax/increment at 0x48/0x4C when required.
+     * the force config block at 0x50-0x5F. The official app keeps these regions
+     * separate: 0x48-0x4F remains the mode profile's eccentric-up ramp, while
+     * selected force/progression live at 0x58/0x5C.
      *
-     * Issue #262: Firmware reads softMax (weight ceiling) at 0x48 and increment
-     * (per-rep progression) at 0x4C. These offsets fall within the mode profile
-     * block (0x30-0x4F), so we overwrite the last 8 bytes of the eccentric phase
-     * with the correct force config values after copying the profile.
-     *
-     * Variant override: when the profile actually copied into the packet is
-     * [ProgramMode.EccentricOnly], the [variant] argument is forced to
-     * [ForceConfigVariant.NON_OVERLAP] to preserve the eccentric-up ramp bytes
-     * at 0x48-0x4F. The override keys off the resolved profile, not
-     * `params.programMode`, so Just Lift / Echo selections (which always use
-     * the OldSchool profile) continue to honor the requested variant.
+     * The default [ForceConfigVariant.NON_OVERLAP] preserves that official layout.
+     * [ForceConfigVariant.OVERLAP] is retained only to reproduce the legacy Phoenix
+     * behavior that overwrote 0x48/0x4C after copying the profile.
      */
     fun createProgramParams(params: WorkoutParameters, variant: ForceConfigVariant = defaultForceConfigVariant): ByteArray {
         // Resolve the profile up front so the variant decision can key off it.
@@ -235,10 +227,8 @@ object BlePacketFactory {
         }
 
         if (effectiveVariant == ForceConfigVariant.OVERLAP) {
-            // Issue #262: Firmware reads softMax at 0x48 and increment at 0x4C.
-            // These overlap the last 8 bytes of the mode profile, but the firmware
-            // interprets them as force config, not mode data. Write them AFTER the
-            // profile copy so they take priority.
+            // Legacy Phoenix behavior: overwrite the profile tail with softMax
+            // and increment. Production uses NON_OVERLAP to match the official app.
             putFloatLE(frame, BleConstants.ActivationPacket.OFFSET_SOFT_MAX, softMax)
             putFloatLE(
                 frame,
@@ -270,18 +260,21 @@ object BlePacketFactory {
         }
         if (effectiveVariant == ForceConfigVariant.OVERLAP) {
             Logger.d("BlePacket") {
-                "softMax[0x48]=${readFloatLE(
+                "legacy softMax[0x48]=${readFloatLE(
                     frame,
                     BleConstants.ActivationPacket.OFFSET_SOFT_MAX,
                 )}kg, " +
-                    "increment[0x4C]=${readFloatLE(
+                    "legacy increment[0x4C]=${readFloatLE(
                         frame,
                         BleConstants.ActivationPacket.OFFSET_INCREMENT,
                     )}kg/rep"
             }
         } else {
             Logger.d("BlePacket") {
-                "non-overlap layout active (0x48..0x4F preserved as profile bytes)"
+                "official non-overlap layout active: " +
+                    "ecc.up.minMmS[0x48]=${readShortLE(frame, BleConstants.ActivationPacket.OFFSET_ECC_UP_MIN_MMS)}, " +
+                    "ecc.up.maxMmS[0x4A]=${readShortLE(frame, BleConstants.ActivationPacket.OFFSET_ECC_UP_MAX_MMS)}, " +
+                    "ecc.up.ramp[0x4C]=${readFloatLE(frame, BleConstants.ActivationPacket.OFFSET_ECC_UP_RAMP)}"
             }
         }
         Logger.d("BlePacket") {
@@ -335,7 +328,7 @@ object BlePacketFactory {
         targetReps: Int = 2,
         isJustLift: Boolean = false,
         isAMRAP: Boolean = false,
-        eccentricPct: Int = 75,
+        eccentricPct: Int = 100,
     ): ByteArray {
         // Defensive clamping: Machine hardware limit is 150% eccentric load
         // Values > 150% can cause machine faults (yellow light)
@@ -416,6 +409,12 @@ object BlePacketFactory {
             ((buffer[offset + 2].toInt() and 0xFF) shl 16) or
             ((buffer[offset + 3].toInt() and 0xFF) shl 24)
         return Float.fromBits(bits)
+    }
+
+    private fun readShortLE(buffer: ByteArray, offset: Int): Short {
+        val value = (buffer[offset].toInt() and 0xFF) or
+            ((buffer[offset + 1].toInt() and 0xFF) shl 8)
+        return value.toShort()
     }
 
     // ========== Activation Phases (Mode Profiles) ==========
@@ -532,36 +531,21 @@ object BlePacketFactory {
         // concentricDurationSeconds = 50.0 / velocity
         // concentricMaxVelocity = velocity (raw EchoVelocity enum value)
         // eccentricMaxVelocity = -200.0 (fixed in official app constructor)
-        val params = EchoParams(
+        val velocity = when (level) {
+            EchoLevel.HARD -> 50.0f
+            EchoLevel.HARDER -> 40.0f
+            EchoLevel.HARDEST -> 30.0f
+            EchoLevel.EPIC -> 15.0f
+        }
+
+        return EchoParams(
             eccentricOverload = eccentricPct,
             referenceMapBlend = 50,
             concentricDelayS = 0.1f,
             eccentricDurationSeconds = 0.0f,
             eccentricMaxVelocity = -200.0f,
-            concentricDurationSeconds = 1.0f,
-            concentricMaxVelocity = 50.0f,
+            concentricDurationSeconds = 50.0f / velocity,
+            concentricMaxVelocity = velocity,
         )
-
-        return when (level) {
-            EchoLevel.HARD -> params.copy(
-                concentricDurationSeconds = 1.0f,
-                concentricMaxVelocity = 50.0f,
-            )
-
-            EchoLevel.HARDER -> params.copy(
-                concentricDurationSeconds = 1.25f,
-                concentricMaxVelocity = 40.0f,
-            )
-
-            EchoLevel.HARDEST -> params.copy(
-                concentricDurationSeconds = 1.667f,
-                concentricMaxVelocity = 30.0f,
-            )
-
-            EchoLevel.EPIC -> params.copy(
-                concentricDurationSeconds = 3.333f,
-                concentricMaxVelocity = 15.0f,
-            )
-        }
     }
 }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/preferences/SettingsPreferencesManagerTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/preferences/SettingsPreferencesManagerTest.kt
@@ -1,5 +1,6 @@
 package com.devil.phoenixproject.data.preferences
 
+import com.devil.phoenixproject.domain.model.EchoLevel
 import com.russhwolf.settings.MapSettings
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -20,5 +21,13 @@ class SettingsPreferencesManagerTest {
         assertNull(settings.getStringOrNull("hud_preset"))
         assertEquals(15, manager.preferencesFlow.value.summaryCountdownSeconds)
         assertTrue(manager.preferencesFlow.value.enableVideoPlayback)
+    }
+
+    @Test
+    fun `just lift defaults use official Echo defaults`() {
+        val defaults = JustLiftDefaults()
+
+        assertEquals(0, defaults.echoLevelValue)
+        assertEquals(EchoLevel.HARD, defaults.getEchoLevel())
     }
 }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/RoutineTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/RoutineTest.kt
@@ -208,6 +208,14 @@ class RoutineTest {
         assertEquals(80f, weights[2]) // Falls back to base 80%
     }
 
+    @Test
+    fun routineExercise_defaultEchoSettings_matchOfficialAppDefaults() {
+        val exercise = createTestRoutineExercise(programMode = ProgramMode.Echo)
+
+        assertEquals(EchoLevel.HARD, exercise.echoLevel)
+        assertEquals(EccentricLoad.LOAD_100, exercise.eccentricLoad)
+    }
+
     // ===== Helper =====
 
     private fun createTestRoutineExercise(
@@ -222,6 +230,7 @@ class RoutineTest {
         setWeightsPercentOfPR: List<Int> = emptyList(),
         weightPerCableKg: Float = 20f,
         warmupSets: List<WarmupSet> = emptyList(),
+        programMode: ProgramMode = ProgramMode.OldSchool,
     ): RoutineExercise = RoutineExercise(
         id = id,
         exercise = Exercise(
@@ -240,5 +249,6 @@ class RoutineTest {
         weightPercentOfPR = weightPercentOfPR,
         setWeightsPercentOfPR = setWeightsPercentOfPR,
         warmupSets = warmupSets,
+        programMode = programMode,
     )
 }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMWorkoutLifecycleTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMWorkoutLifecycleTest.kt
@@ -125,7 +125,7 @@ class DWSMWorkoutLifecycleTest {
         harness.dwsm.startWorkout(skipCountdown = true)
         advanceUntilIdle()
 
-        // DWSM sends CONFIG command + START command (for non-Echo mode)
+        // DWSM sends the trainer configuration command.
         assertTrue(
             harness.fakeBleRepo.commandsReceived.isNotEmpty(),
             "Should have sent at least one BLE command (CONFIG)",
@@ -134,8 +134,14 @@ class DWSMWorkoutLifecycleTest {
     }
 
     @Test
-    fun `startWorkout uses single activation config for TUT and Eccentric Only`() = runTest {
-        val modes = listOf(ProgramMode.TUT, ProgramMode.EccentricOnly)
+    fun `startWorkout uses single activation config for non-Echo activation modes`() = runTest {
+        val modes = listOf(
+            ProgramMode.OldSchool,
+            ProgramMode.Pump,
+            ProgramMode.TUT,
+            ProgramMode.TUTBeast,
+            ProgramMode.EccentricOnly,
+        )
         for (mode in modes) {
             val harness = DWSMTestHarness(this)
             harness.fakeBleRepo.simulateConnect("Vee_Test")
@@ -151,12 +157,15 @@ class DWSMWorkoutLifecycleTest {
             harness.dwsm.startWorkout(skipCountdown = true)
             advanceUntilIdle()
 
-            assertEquals(2, harness.fakeBleRepo.commandsReceived.size, "Expected config + start for $mode")
+            assertEquals(1, harness.fakeBleRepo.commandsReceived.size, "Expected only activation config for $mode")
             assertEquals(0x04.toByte(), harness.fakeBleRepo.commandsReceived[0][0], "Expected activation packet for $mode")
-            assertEquals(0x03.toByte(), harness.fakeBleRepo.commandsReceived[1][0], "Expected start packet for $mode")
             assertFalse(
                 harness.fakeBleRepo.commandsReceived.any { it.firstOrNull() == 0x4F.toByte() },
                 "Workout start should not send a regular packet for $mode",
+            )
+            assertFalse(
+                harness.fakeBleRepo.commandsReceived.any { it.firstOrNull() == 0x03.toByte() },
+                "Activation workout start should not send legacy 0x03 start packet for $mode",
             )
             harness.cleanup()
         }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/util/BleConstantsTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/util/BleConstantsTest.kt
@@ -61,10 +61,16 @@ class BleConstantsTest {
 
     @Test
     fun `activation packet force config offsets match firmware layout`() {
-        // Firmware force config (overlaps eccentric phase tail)
+        // Official eccentric-up profile tail.
+        assertEquals(0x48, BleConstants.ActivationPacket.OFFSET_ECC_UP_MIN_MMS)
+        assertEquals(0x4A, BleConstants.ActivationPacket.OFFSET_ECC_UP_MAX_MMS)
+        assertEquals(0x4C, BleConstants.ActivationPacket.OFFSET_ECC_UP_RAMP)
+
+        // Legacy OVERLAP aliases kept only for explicit regression tests.
         assertEquals(0x48, BleConstants.ActivationPacket.OFFSET_SOFT_MAX)
         assertEquals(0x4C, BleConstants.ActivationPacket.OFFSET_INCREMENT)
-        // Protocol force config block
+
+        // Official force config block.
         assertEquals(0x50, BleConstants.ActivationPacket.OFFSET_FORCE_MIN)
         assertEquals(0x54, BleConstants.ActivationPacket.OFFSET_FORCE_MAX)
         assertEquals(0x58, BleConstants.ActivationPacket.OFFSET_TARGET_WEIGHT)

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/util/BlePacketFactoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/util/BlePacketFactoryTest.kt
@@ -246,7 +246,7 @@ class BlePacketFactoryTest {
     }
 
     @Test
-    fun `createProgramParams writes softMax at firmware offset 0x48`() {
+    fun `legacy OVERLAP variant writes softMax at offset 0x48`() {
         val weight = 50f
         val params = WorkoutParameters(
             programMode = ProgramMode.OldSchool,
@@ -259,12 +259,12 @@ class BlePacketFactoryTest {
             variant = BlePacketFactory.ForceConfigVariant.OVERLAP,
         )
 
-        // Firmware reads softMax from 0x48 (Issue #262)
+        // Legacy OVERLAP behavior writes softMax over the profile tail.
         assertEquals(weight, readFloatLE(packet, BleConstants.ActivationPacket.OFFSET_SOFT_MAX))
     }
 
     @Test
-    fun `createProgramParams writes increment at firmware offset 0x4C`() {
+    fun `legacy OVERLAP variant writes increment at offset 0x4C`() {
         val progression = 2.5f
         val params = WorkoutParameters(
             programMode = ProgramMode.OldSchool,
@@ -278,7 +278,7 @@ class BlePacketFactoryTest {
             variant = BlePacketFactory.ForceConfigVariant.OVERLAP,
         )
 
-        // Firmware reads increment from 0x4C (Issue #262)
+        // Legacy OVERLAP behavior writes increment over the profile tail.
         assertEquals(progression, readFloatLE(packet, BleConstants.ActivationPacket.OFFSET_INCREMENT))
         // Verify LE encoding: 2.5f = 0x40200000 -> LE bytes [0x00, 0x00, 0x20, 0x40]
         assertEquals(0x00.toByte(), packet[0x4C])
@@ -323,7 +323,7 @@ class BlePacketFactoryTest {
     }
 
     @Test
-    fun `createProgramParams AMRAP writes selected per-cable softMax at 0x48`() {
+    fun `legacy OVERLAP AMRAP writes selected per-cable softMax at 0x48`() {
         val params = WorkoutParameters(
             programMode = ProgramMode.OldSchool,
             reps = 10,
@@ -342,7 +342,7 @@ class BlePacketFactoryTest {
     }
 
     @Test
-    fun `createProgramParams Just Lift writes selected per-cable softMax at 0x48`() {
+    fun `legacy OVERLAP Just Lift writes selected per-cable softMax at 0x48`() {
         val params = WorkoutParameters(
             programMode = ProgramMode.OldSchool,
             reps = 10,
@@ -425,7 +425,7 @@ class BlePacketFactoryTest {
             variant = BlePacketFactory.ForceConfigVariant.OVERLAP,
         )
 
-        // Firmware force config (0x48-0x4F)
+        // Legacy OVERLAP force config (0x48-0x4F)
         assertEquals(40.0f, readFloatLE(packet, 0x48)) // softMax = weightPerCableKg
         assertEquals(3.0f, readFloatLE(packet, 0x4C)) // increment = progression
 
@@ -583,6 +583,17 @@ class BlePacketFactoryTest {
 
         assertEquals(32, packet.size)
         assertEquals(0x4E.toByte(), packet[0])
+    }
+
+    @Test
+    fun `createEchoControl defaults match official app RepConfig defaults`() {
+        val packet = BlePacketFactory.createEchoControl(EchoLevel.HARD)
+
+        assertEquals(3.toByte(), packet[0x04], "default romRepCount")
+        assertEquals(2.toByte(), packet[0x05], "default target reps")
+        assertEquals(100, readUShortLE(packet, 0x08), "default eccentricOverload")
+        assertEquals(1.0f, readFloatLE(packet, 0x10), "default HARD duration")
+        assertEquals(50.0f, readFloatLE(packet, 0x14), "default HARD velocity")
     }
 
     // ========== Color Scheme Tests ==========
@@ -748,8 +759,8 @@ class BlePacketFactoryTest {
     fun `Echo HARDEST packet has correct velocity parameters`() {
         val packet = BlePacketFactory.createEchoControl(EchoLevel.HARDEST, eccentricPct = 100)
 
-        // HARDEST = velocity 30, duration = 50/30 = 1.667s
-        assertEquals(1.667f, readFloatLE(packet, 0x10), "concentricDurationSeconds (50/30)")
+        // HARDEST = velocity 30, duration = 50/30 = 1.6666666s
+        assertEquals(50.0f / 30.0f, readFloatLE(packet, 0x10), "concentricDurationSeconds (50/30)")
         assertEquals(30.0f, readFloatLE(packet, 0x14), "concentricMaxVelocity (HARDEST=30)")
         assertEquals(-200.0f, readFloatLE(packet, 0x1C), "eccentricMaxVelocity")
     }
@@ -758,8 +769,8 @@ class BlePacketFactoryTest {
     fun `Echo EPIC packet has correct velocity parameters`() {
         val packet = BlePacketFactory.createEchoControl(EchoLevel.EPIC, eccentricPct = 100)
 
-        // EPIC = velocity 15, duration = 50/15 = 3.333s
-        assertEquals(3.333f, readFloatLE(packet, 0x10), "concentricDurationSeconds (50/15)")
+        // EPIC = velocity 15, duration = 50/15 = 3.3333333s
+        assertEquals(50.0f / 15.0f, readFloatLE(packet, 0x10), "concentricDurationSeconds (50/15)")
         assertEquals(15.0f, readFloatLE(packet, 0x14), "concentricMaxVelocity (EPIC=15)")
         assertEquals(-200.0f, readFloatLE(packet, 0x1C), "eccentricMaxVelocity")
     }
@@ -847,11 +858,8 @@ class BlePacketFactoryTest {
             reps = 10,
             weightPerCableKg = 50f,
         )
-        // Use NON_OVERLAP to test raw profile bytes at 0x48-0x4F without force config overwrite
-        val packet = BlePacketFactory.createProgramParams(
-            params,
-            variant = BlePacketFactory.ForceConfigVariant.NON_OVERLAP,
-        )
+        // Default production layout must preserve 0x48-0x4F as the profile tail.
+        val packet = BlePacketFactory.createProgramParams(params)
 
         // Concentric down ramp: C1507d(0, 20, 3.0f)
         assertEquals(0.toShort(), readShortLE(packet, 0x30), "conc.down.minMmS")
@@ -939,11 +947,8 @@ class BlePacketFactoryTest {
             reps = 10,
             weightPerCableKg = 30f,
         )
-        // Use NON_OVERLAP to test raw profile bytes at 0x48-0x4F without force config overwrite
-        val packet = BlePacketFactory.createProgramParams(
-            params,
-            variant = BlePacketFactory.ForceConfigVariant.NON_OVERLAP,
-        )
+        // Default production layout must preserve 0x48-0x4F as the profile tail.
+        val packet = BlePacketFactory.createProgramParams(params)
 
         // Concentric down ramp: C1507d(50, 450, 10.0f)
         assertEquals(50.toShort(), readShortLE(packet, 0x30), "conc.down.minMmS")
@@ -1030,11 +1035,8 @@ class BlePacketFactoryTest {
             reps = 8,
             weightPerCableKg = 40f,
         )
-        // Use NON_OVERLAP to test raw profile bytes at 0x48-0x4F without force config overwrite
-        val packet = BlePacketFactory.createProgramParams(
-            params,
-            variant = BlePacketFactory.ForceConfigVariant.NON_OVERLAP,
-        )
+        // Default production layout must preserve 0x48-0x4F as the profile tail.
+        val packet = BlePacketFactory.createProgramParams(params)
 
         // Concentric down ramp: C1507d(250, 350, 7.0f)
         assertEquals(250.toShort(), readShortLE(packet, 0x30), "conc.down.minMmS")
@@ -1128,11 +1130,8 @@ class BlePacketFactoryTest {
             reps = 6,
             weightPerCableKg = 60f,
         )
-        // Use NON_OVERLAP to test raw profile bytes at 0x48-0x4F without force config overwrite
-        val packet = BlePacketFactory.createProgramParams(
-            params,
-            variant = BlePacketFactory.ForceConfigVariant.NON_OVERLAP,
-        )
+        // Default production layout must preserve 0x48-0x4F as the profile tail.
+        val packet = BlePacketFactory.createProgramParams(params)
 
         // Concentric down ramp: C1507d(50, 550, 50.0f)
         assertEquals(50.toShort(), readShortLE(packet, 0x30), "conc.down.minMmS")
@@ -1322,11 +1321,8 @@ class BlePacketFactoryTest {
             reps = 6,
             weightPerCableKg = 70f,
         )
-        // Use NON_OVERLAP to test raw profile bytes at 0x48-0x4F without force config overwrite
-        val packet = BlePacketFactory.createProgramParams(
-            params,
-            variant = BlePacketFactory.ForceConfigVariant.NON_OVERLAP,
-        )
+        // Default production layout must preserve 0x48-0x4F as the profile tail.
+        val packet = BlePacketFactory.createProgramParams(params)
 
         // Concentric down ramp: C1507d(150, 250, 7.0f)
         assertEquals(150.toShort(), readShortLE(packet, 0x30), "conc.down.minMmS")
@@ -1382,11 +1378,10 @@ class BlePacketFactoryTest {
         assertEquals(96, packet.size, "Packet must be 96 bytes")
         assertEquals(0x04.toByte(), packet[0], "Command byte must be ACTIVATION (0x04)")
 
-        // OVERLAP offsets (0x48-0x4F) — firmware force config
-        val softMax = readFloatLE(packet, BleConstants.ActivationPacket.OFFSET_SOFT_MAX)
-        val increment = readFloatLE(packet, BleConstants.ActivationPacket.OFFSET_INCREMENT)
-        assertEquals(weightPerCableKg, softMax, "softMax at 0x48 must be weightPerCableKg (80kg)")
-        assertEquals(progressionKg, increment, "increment at 0x4C must be progressionKg (4.535929kg)")
+        // Default production layout preserves the OldSchool eccentric-up profile tail.
+        assertEquals((-260).toShort(), readShortLE(packet, 0x48), "OldSchool ecc.up.minMmS at 0x48")
+        assertEquals((-110).toShort(), readShortLE(packet, 0x4A), "OldSchool ecc.up.maxMmS at 0x4A")
+        assertEquals(0.0f, readFloatLE(packet, 0x4C), "OldSchool ecc.up.ramp at 0x4C")
 
         // Protocol force config (0x50-0x5F)
         val forceMax = weightPerCableKg + 10.0f
@@ -1410,11 +1405,6 @@ class BlePacketFactoryTest {
 
         // Verify the weight is NOT near-zero (the actual bug symptom)
         assertTrue(
-            softMax > 10f,
-            "Issue #390: softMax ($softMax kg) must not be near-zero. " +
-                "Expected 80kg for calf raise at 80% of PR.",
-        )
-        assertTrue(
             readFloatLE(packet, 0x58) > 10f,
             "Issue #390: targetWeight must not be near-zero. " +
                 "Expected 80kg for first set of calf raise.",
@@ -1436,16 +1426,17 @@ class BlePacketFactoryTest {
         val packet = BlePacketFactory.createProgramParams(params)
 
         assertEquals(96, packet.size)
-        assertEquals(1.5f, readFloatLE(packet, 0x48), "softMax = weightPerCableKg even if low")
-        assertEquals(0.5f, readFloatLE(packet, 0x4C), "increment = progressionKg")
+        assertEquals((-260).toShort(), readShortLE(packet, 0x48), "OldSchool ecc.up.minMmS preserved")
+        assertEquals(0.0f, readFloatLE(packet, 0x4C), "OldSchool ecc.up.ramp preserved")
         assertEquals(1.5f, readFloatLE(packet, 0x58), "targetWeight = selected weight")
+        assertEquals(0.5f, readFloatLE(packet, 0x5C), "progression = progressionKg")
         assertEquals(11.5f, readFloatLE(packet, 0x54), "forceMax = selected weight + 10")
     }
 
     @Test
-    fun `issue390 AMRAP mode keeps softMax at selected per-cable weight`() {
+    fun `issue390 AMRAP mode keeps target weight at selected per-cable weight`() {
         // AMRAP uses reps=0xFF for unlimited reps. The force controller still
-        // receives the selected per-cable force as softMax.
+        // receives the selected per-cable force in the official trailing force block.
         val params = WorkoutParameters(
             programMode = ProgramMode.OldSchool,
             reps = 10,
@@ -1456,16 +1447,15 @@ class BlePacketFactoryTest {
 
         val packet = BlePacketFactory.createProgramParams(params)
 
-        assertEquals(40.0f, readFloatLE(packet, 0x48), "AMRAP softMax uses selected per-cable weight")
-        assertEquals(0.907f, readFloatLE(packet, 0x4C), "AMRAP increment still uses progressionKg")
-
-        // TargetWeight stays anchored to the selected force; progression is
-        // carried separately by the increment/progression fields.
+        assertEquals(0xFF.toByte(), packet[0x04], "AMRAP reps marker")
+        assertEquals((-260).toShort(), readShortLE(packet, 0x48), "AMRAP preserves OldSchool ecc.up.minMmS")
+        assertEquals(0.0f, readFloatLE(packet, 0x4C), "AMRAP preserves OldSchool ecc.up.ramp")
         assertEquals(40.0f, readFloatLE(packet, 0x58), "AMRAP targetWeight uses selected weight")
+        assertEquals(0.907f, readFloatLE(packet, 0x5C), "AMRAP progression uses progressionKg")
     }
 
     @Test
-    fun `issue390 JustLift mode keeps softMax at selected per-cable weight`() {
+    fun `issue390 JustLift mode keeps target weight at selected per-cable weight`() {
         val params = WorkoutParameters(
             programMode = ProgramMode.OldSchool,
             reps = 10,
@@ -1475,6 +1465,9 @@ class BlePacketFactoryTest {
 
         val packet = BlePacketFactory.createProgramParams(params)
 
-        assertEquals(40.0f, readFloatLE(packet, 0x48), "JustLift softMax uses selected per-cable weight")
+        assertEquals(0xFF.toByte(), packet[0x04], "JustLift reps marker")
+        assertEquals((-260).toShort(), readShortLE(packet, 0x48), "JustLift preserves OldSchool ecc.up.minMmS")
+        assertEquals(0.0f, readFloatLE(packet, 0x4C), "JustLift preserves OldSchool ecc.up.ramp")
+        assertEquals(40.0f, readFloatLE(packet, 0x58), "JustLift targetWeight uses selected weight")
     }
 }


### PR DESCRIPTION
## Summary
- Switched activation packets to the official non-overlap layout by default so Eccentric Only preserves the profile tail instead of being overwritten by legacy force fields.
- Removed the legacy post-config `0x03` start packet for activation modes.
- Corrected Echo defaults and fallback handling to use the official `HARD` level and `100%` eccentric overload.
- Fixed Echo duration generation to use the official `50.0 / velocity` calculation, including HARDEST and EPIC precision.
- Added regression coverage for Echo packet defaults, Eccentric Only parity, and non-Echo workout lifecycle behavior.

## Testing
- `:shared:testAndroidHostTest` for `BlePacketFactoryTest`, `RoutineTest`, `SettingsPreferencesManagerTest`, and `DWSMWorkoutLifecycleTest` passed.
- `:shared:compileKotlinIosArm64` passed.
- `git diff --check` passed.