### PR TITLE
Add Recent Activity replay links to Single Exercise

### DIFF
--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -610,6 +610,7 @@
     <string name="cd_toggle_theme">Toggle theme (current: %1$s)</string>
     <string name="cd_workouts">Workouts</string>
     <string name="cd_disconnect">Disconnect</string>
+    <string name="single_exercise_unavailable">Exercise is no longer available</string>
 
     <!-- ==================== Voice Emergency Stop (Issue #141) ==================== -->
     <string name="settings_voice_stop_title">Voice Emergency Stop</string>

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/navigation/NavGraph.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/navigation/NavGraph.kt
@@ -107,6 +107,22 @@ fun NavGraph(
                 )
             }
 
+            // Single Exercise screen - reopen a recent activity exercise for another set
+            composable(
+                route = NavigationRoutes.SingleExerciseForExercise.route,
+                arguments = listOf(navArgument("exerciseId") { type = NavType.StringType }),
+            ) { backStackEntry ->
+                val exerciseId = backStackEntry.arguments?.read { getStringOrNull("exerciseId") }
+
+                SingleExerciseScreen(
+                    navController = navController,
+                    viewModel = viewModel,
+                    exerciseRepository = exerciseRepository,
+                    themeMode = themeMode,
+                    initialExerciseId = exerciseId,
+                )
+            }
+
             // Daily Routines screen - pre-built routines
             composable(NavigationRoutes.DailyRoutines.route) {
                 DailyRoutinesScreen(

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/navigation/NavigationRoutes.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/navigation/NavigationRoutes.kt
@@ -8,6 +8,9 @@ sealed class NavigationRoutes(val route: String) {
     object Home : NavigationRoutes("home")
     object JustLift : NavigationRoutes("just_lift")
     object SingleExercise : NavigationRoutes("single_exercise")
+    object SingleExerciseForExercise : NavigationRoutes("single_exercise/{exerciseId}") {
+        fun createRoute(exerciseId: String) = "single_exercise/${exerciseId.encodeRouteSegment()}"
+    }
     object DailyRoutines : NavigationRoutes("daily_routines")
     object RoutineOverview : NavigationRoutes("routine_overview")
     object SetReady : NavigationRoutes("set_ready")

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/EnhancedMainScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/EnhancedMainScreen.kt
@@ -196,7 +196,7 @@ fun EnhancedMainScreen(
     val isWorkoutsRoute = remember(currentRoute) {
         currentRoute == NavigationRoutes.Home.route ||
             currentRoute == NavigationRoutes.JustLift.route ||
-            currentRoute == NavigationRoutes.SingleExercise.route ||
+            currentRoute.startsWith(NavigationRoutes.SingleExercise.route) ||
             currentRoute == NavigationRoutes.DailyRoutines.route ||
             currentRoute == NavigationRoutes.ActiveWorkout.route ||
             currentRoute == NavigationRoutes.TrainingCycles.route ||
@@ -870,7 +870,7 @@ private fun getScreenTitle(route: String, routineName: String = "", exerciseName
 
     route == NavigationRoutes.JustLift.route -> "Just Lift"
 
-    route == NavigationRoutes.SingleExercise.route -> "Single Exercise"
+    route.startsWith(NavigationRoutes.SingleExercise.route) -> "Single Exercise"
 
     // Routine flow (dynamic - uses routine name)
     route == NavigationRoutes.RoutineOverview.route -> routineName.ifEmpty { "Routine" }
@@ -907,7 +907,7 @@ private fun getCompactScreenTitle(route: String, title: String): String = when {
     route == NavigationRoutes.DailyRoutines.route -> "Routines"
     route == NavigationRoutes.TrainingCycles.route -> "Cycles"
     route == NavigationRoutes.SmartInsights.route -> "Insights"
-    route == NavigationRoutes.SingleExercise.route -> "Exercise"
+    route.startsWith(NavigationRoutes.SingleExercise.route) -> "Exercise"
     route.startsWith("cycle_editor") -> "Cycle"
     route.startsWith("cycleReview") -> "Review"
     route.startsWith("routine_editor") -> "Edit"

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/EnhancedMainScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/EnhancedMainScreen.kt
@@ -196,7 +196,7 @@ fun EnhancedMainScreen(
     val isWorkoutsRoute = remember(currentRoute) {
         currentRoute == NavigationRoutes.Home.route ||
             currentRoute == NavigationRoutes.JustLift.route ||
-            currentRoute.startsWith(NavigationRoutes.SingleExercise.route) ||
+            isSingleExerciseRoute(currentRoute) ||
             currentRoute == NavigationRoutes.DailyRoutines.route ||
             currentRoute == NavigationRoutes.ActiveWorkout.route ||
             currentRoute == NavigationRoutes.TrainingCycles.route ||
@@ -854,6 +854,10 @@ private fun ConnectionStatusIndicator(
  * Get the screen title based on the current route.
  * Supports dynamic titles for routine, exercise, and cycle flows.
  */
+private fun isSingleExerciseRoute(route: String): Boolean =
+    route == NavigationRoutes.SingleExercise.route ||
+        route.startsWith("${NavigationRoutes.SingleExercise.route}/")
+
 private fun getScreenTitle(route: String, routineName: String = "", exerciseName: String = "", cycleName: String = ""): String = when {
     // Main tabs (static titles)
     route == NavigationRoutes.Home.route -> "Choose Your Workout"
@@ -870,7 +874,7 @@ private fun getScreenTitle(route: String, routineName: String = "", exerciseName
 
     route == NavigationRoutes.JustLift.route -> "Just Lift"
 
-    route.startsWith(NavigationRoutes.SingleExercise.route) -> "Single Exercise"
+    isSingleExerciseRoute(route) -> "Single Exercise"
 
     // Routine flow (dynamic - uses routine name)
     route == NavigationRoutes.RoutineOverview.route -> routineName.ifEmpty { "Routine" }
@@ -907,7 +911,7 @@ private fun getCompactScreenTitle(route: String, title: String): String = when {
     route == NavigationRoutes.DailyRoutines.route -> "Routines"
     route == NavigationRoutes.TrainingCycles.route -> "Cycles"
     route == NavigationRoutes.SmartInsights.route -> "Insights"
-    route.startsWith(NavigationRoutes.SingleExercise.route) -> "Exercise"
+    isSingleExerciseRoute(route) -> "Exercise"
     route.startsWith("cycle_editor") -> "Cycle"
     route.startsWith("cycleReview") -> "Review"
     route.startsWith("routine_editor") -> "Edit"

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/HomeScreen.kt
@@ -203,7 +203,13 @@ fun HomeScreen(navController: NavController, viewModel: MainViewModel) {
                         color = MaterialTheme.colorScheme.onSurface,
                         modifier = Modifier.padding(bottom = 8.dp),
                     )
-                    RecentActivitySummary(recentSessions, weightUnit)
+                    RecentActivitySummary(
+                        history = recentSessions,
+                        weightUnit = weightUnit,
+                        onExerciseClick = { exerciseId ->
+                            navController.navigate(NavigationRoutes.SingleExerciseForExercise.createRoute(exerciseId))
+                        },
+                    )
                 }
             }
         }
@@ -536,7 +542,11 @@ private fun ComplianceDot(letter: String, isActive: Boolean, isToday: Boolean) {
 }
 
 @Composable
-private fun RecentActivitySummary(history: List<WorkoutSession>, weightUnit: WeightUnit = WeightUnit.KG) {
+private fun RecentActivitySummary(
+    history: List<WorkoutSession>,
+    weightUnit: WeightUnit = WeightUnit.KG,
+    onExerciseClick: (String) -> Unit,
+) {
     if (history.isEmpty()) {
         Text(
             "No recent workouts yet.",
@@ -546,47 +556,81 @@ private fun RecentActivitySummary(history: List<WorkoutSession>, weightUnit: Wei
     } else {
         Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
             history.take(2).forEach { session ->
-                Surface(
-                    color = MaterialTheme.colorScheme.surfaceContainer,
-                    shape = RoundedCornerShape(12.dp),
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    Row(
-                        modifier = Modifier.padding(12.dp),
-                        verticalAlignment = Alignment.CenterVertically,
+                val replayExerciseId = session.replayExerciseId()
+                if (replayExerciseId != null) {
+                    Surface(
+                        onClick = { onExerciseClick(replayExerciseId) },
+                        color = MaterialTheme.colorScheme.surfaceContainer,
+                        shape = RoundedCornerShape(12.dp),
+                        modifier = Modifier.fillMaxWidth(),
                     ) {
-                        Box(
-                            modifier = Modifier
-                                .size(8.dp)
-                                .clip(CircleShape)
-                                .background(MaterialTheme.colorScheme.primary),
+                        RecentActivityRowContent(
+                            session = session,
+                            weightUnit = weightUnit,
+                            showChevron = true,
                         )
-                        Spacer(Modifier.width(12.dp))
-                        Column(modifier = Modifier.weight(1f)) {
-                            val displayWeight = WeightDisplayFormatter.formatDisplayWeight(
-                                session.weightPerCableKg,
-                                session.displayMultiplier ?: session.cableCount,
-                                weightUnit,
-                            )
-                            val unitLabel = if (weightUnit == WeightUnit.LB) "lbs" else "kg"
-                            Text(
-                                session.exerciseName ?: "Workout Session",
-                                style = MaterialTheme.typography.labelLarge,
-                                fontWeight = FontWeight.SemiBold,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                            )
-                            Text(
-                                "${session.workingReps} reps • $displayWeight $unitLabel",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                            )
-                        }
+                    }
+                } else {
+                    Surface(
+                        color = MaterialTheme.colorScheme.surfaceContainer,
+                        shape = RoundedCornerShape(12.dp),
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        RecentActivityRowContent(
+                            session = session,
+                            weightUnit = weightUnit,
+                            showChevron = false,
+                        )
                     }
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun RecentActivityRowContent(session: WorkoutSession, weightUnit: WeightUnit, showChevron: Boolean) {
+    Row(
+        modifier = Modifier.padding(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(8.dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.primary),
+        )
+        Spacer(Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            val displayWeight = WeightDisplayFormatter.formatDisplayWeight(
+                session.weightPerCableKg,
+                session.displayMultiplier ?: session.cableCount,
+                weightUnit,
+            )
+            val unitLabel = if (weightUnit == WeightUnit.LB) "lbs" else "kg"
+            Text(
+                session.exerciseName ?: "Workout Session",
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                "${session.workingReps} reps • $displayWeight $unitLabel",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        if (showChevron) {
+            Spacer(Modifier.width(8.dp))
+            Icon(
+                Icons.Default.ChevronRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(18.dp),
+            )
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RecentActivityReplay.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RecentActivityReplay.kt
@@ -1,0 +1,7 @@
+package com.devil.phoenixproject.presentation.screen
+
+import com.devil.phoenixproject.domain.model.WorkoutSession
+
+internal fun WorkoutSession.replayExerciseId(): String? = exerciseId
+    ?.trim()
+    ?.takeIf { it.isNotEmpty() }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SingleExerciseScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SingleExerciseScreen.kt
@@ -44,6 +44,9 @@ import com.devil.phoenixproject.presentation.viewmodel.MainViewModel
 import com.devil.phoenixproject.ui.theme.ThemeMode
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.getString
+import vitruvianprojectphoenix.shared.generated.resources.Res
+import vitruvianprojectphoenix.shared.generated.resources.single_exercise_unavailable
 
 /**
  * Single Exercise screen - allows user to pick and configure a single exercise
@@ -70,10 +73,11 @@ fun SingleExerciseScreen(
     var isLoadingDefaults by remember { mutableStateOf(false) }
     var missingInitialExerciseMessage by remember { mutableStateOf<String?>(null) }
     var initialExerciseHandled by remember(initialExerciseId) { mutableStateOf(false) }
+    var loadingRequestId by remember { mutableStateOf(0) }
     val snackbarHostState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
 
-    // Track current loading job to cancel on rapid selection changes
+    // Track current loading request to cancel and ignore stale rapid selections.
     var loadingJob by remember { mutableStateOf<Job?>(null) }
 
     // Local state for picker
@@ -141,6 +145,8 @@ fun SingleExerciseScreen(
 
         // Cancel any in-progress loading to prevent race conditions
         loadingJob?.cancel()
+        val requestId = loadingRequestId + 1
+        loadingRequestId = requestId
 
         // Set loading state to prevent showing dialog before defaults are loaded
         isLoadingDefaults = true
@@ -152,30 +158,31 @@ fun SingleExerciseScreen(
                     viewModel.getSingleExerciseDefaults(exerciseId)
                 }
 
-                exerciseToConfig = buildSingleExerciseRoutineExercise(
-                    exercise = exercise,
-                    savedDefaults = savedDefaults,
-                )
+                if (loadingRequestId == requestId) {
+                    exerciseToConfig = buildSingleExerciseRoutineExercise(
+                        exercise = exercise,
+                        savedDefaults = savedDefaults,
+                    )
+                }
             } finally {
-                isLoadingDefaults = false
+                if (loadingRequestId == requestId) {
+                    isLoadingDefaults = false
+                }
             }
         }
     }
 
-    // Trigger import
-    LaunchedEffect(Unit) {
-        exerciseRepository.importExercises()
-    }
-
+    // Trigger import before resolving a direct Recent Activity exercise link.
     LaunchedEffect(initialExerciseId) {
+        exerciseRepository.importExercises()
+
         val exerciseId = initialExerciseId?.trim()?.takeIf { it.isNotEmpty() } ?: return@LaunchedEffect
         if (initialExerciseHandled) return@LaunchedEffect
         initialExerciseHandled = true
 
-        exerciseRepository.importExercises()
         val exercise = exerciseRepository.getExerciseById(exerciseId)
         if (exercise == null) {
-            missingInitialExerciseMessage = "Exercise is no longer available"
+            missingInitialExerciseMessage = getString(Res.string.single_exercise_unavailable)
             return@LaunchedEffect
         }
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SingleExerciseScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SingleExerciseScreen.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -21,6 +23,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavController
 import co.touchlab.kermit.Logger
+import com.devil.phoenixproject.data.preferences.SingleExerciseDefaults
 import com.devil.phoenixproject.data.repository.ExerciseRepository
 import com.devil.phoenixproject.domain.model.EccentricLoad
 import com.devil.phoenixproject.domain.model.EchoLevel
@@ -53,6 +56,7 @@ fun SingleExerciseScreen(
     viewModel: MainViewModel,
     exerciseRepository: ExerciseRepository,
     themeMode: ThemeMode,
+    initialExerciseId: String? = null,
 ) {
     val weightUnit by viewModel.weightUnit.collectAsState()
     val enableVideoPlayback by viewModel.enableVideoPlayback.collectAsState()
@@ -64,6 +68,9 @@ fun SingleExerciseScreen(
 
     var exerciseToConfig by remember { mutableStateOf<RoutineExercise?>(null) }
     var isLoadingDefaults by remember { mutableStateOf(false) }
+    var missingInitialExerciseMessage by remember { mutableStateOf<String?>(null) }
+    var initialExerciseHandled by remember(initialExerciseId) { mutableStateOf(false) }
+    val snackbarHostState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
 
     // Track current loading job to cancel on rapid selection changes
@@ -129,9 +136,56 @@ fun SingleExerciseScreen(
     val customExerciseCount by exerciseRepository.getCustomExercises().collectAsState(initial = emptyList())
     val customCount = customExerciseCount.size
 
+    fun openExerciseConfig(selectedExercise: Exercise) {
+        val exercise = selectedExercise.toSingleExerciseConfigModel()
+
+        // Cancel any in-progress loading to prevent race conditions
+        loadingJob?.cancel()
+
+        // Set loading state to prevent showing dialog before defaults are loaded
+        isLoadingDefaults = true
+
+        // Load saved defaults for this exercise asynchronously
+        loadingJob = coroutineScope.launch {
+            try {
+                val savedDefaults = selectedExercise.id?.let { exerciseId ->
+                    viewModel.getSingleExerciseDefaults(exerciseId)
+                }
+
+                exerciseToConfig = buildSingleExerciseRoutineExercise(
+                    exercise = exercise,
+                    savedDefaults = savedDefaults,
+                )
+            } finally {
+                isLoadingDefaults = false
+            }
+        }
+    }
+
     // Trigger import
     LaunchedEffect(Unit) {
         exerciseRepository.importExercises()
+    }
+
+    LaunchedEffect(initialExerciseId) {
+        val exerciseId = initialExerciseId?.trim()?.takeIf { it.isNotEmpty() } ?: return@LaunchedEffect
+        if (initialExerciseHandled) return@LaunchedEffect
+        initialExerciseHandled = true
+
+        exerciseRepository.importExercises()
+        val exercise = exerciseRepository.getExerciseById(exerciseId)
+        if (exercise == null) {
+            missingInitialExerciseMessage = "Exercise is no longer available"
+            return@LaunchedEffect
+        }
+
+        openExerciseConfig(exercise)
+    }
+
+    LaunchedEffect(missingInitialExerciseMessage) {
+        val message = missingInitialExerciseMessage ?: return@LaunchedEffect
+        snackbarHostState.showSnackbar(message)
+        missingInitialExerciseMessage = null
     }
 
     // Set global title
@@ -192,6 +246,7 @@ fun SingleExerciseScreen(
 
     Scaffold(
         contentWindowInsets = WindowInsets.navigationBars,
+        snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { padding ->
         Box(modifier = Modifier.padding(padding)) {
             // Always show the picker content as the background
@@ -251,65 +306,7 @@ fun SingleExerciseScreen(
                     }
                 },
                 onExerciseSelected = { selectedExercise ->
-                    val exercise = Exercise(
-                        name = selectedExercise.name,
-                        muscleGroup = selectedExercise.muscleGroups.split(",").firstOrNull()?.trim() ?: "Full Body",
-                        muscleGroups = selectedExercise.muscleGroups,
-                        equipment = selectedExercise.equipment,
-                        id = selectedExercise.id,
-                    )
-
-                    // Cancel any in-progress loading to prevent race conditions
-                    loadingJob?.cancel()
-
-                    // Set loading state to prevent showing dialog before defaults are loaded
-                    isLoadingDefaults = true
-
-                    // Load saved defaults for this exercise asynchronously
-                    loadingJob = coroutineScope.launch {
-                        try {
-                            val savedDefaults = selectedExercise.id?.let { exerciseId ->
-                                viewModel.getSingleExerciseDefaults(exerciseId)
-                            }
-
-                            val newRoutineExercise = if (savedDefaults != null) {
-                                // Apply saved defaults
-                                RoutineExercise(
-                                    id = generateUUID(),
-                                    exercise = exercise,
-                                    orderIndex = 0,
-                                    setReps = savedDefaults.setReps,
-                                    weightPerCableKg = savedDefaults.weightPerCableKg,
-                                    setWeightsPerCableKg = savedDefaults.setWeightsPerCableKg,
-                                    progressionKg = savedDefaults.progressionKg,
-                                    setRestSeconds = savedDefaults.setRestSeconds,
-                                    programMode = savedDefaults.toProgramMode(),
-                                    eccentricLoad = savedDefaults.getEccentricLoad(),
-                                    echoLevel = savedDefaults.getEchoLevel(),
-                                    duration = savedDefaults.duration.takeIf { it > 0 },
-                                    isAMRAP = savedDefaults.isAMRAP,
-                                    perSetRestTime = savedDefaults.perSetRestTime,
-                                )
-                            } else {
-                                // No saved defaults - use system defaults
-                                RoutineExercise(
-                                    id = generateUUID(),
-                                    exercise = exercise,
-                                    orderIndex = 0,
-                                    setReps = listOf(10, 10, 10),
-                                    weightPerCableKg = 20f,
-                                    progressionKg = 0f,
-                                    setRestSeconds = listOf(60, 60, 60),
-                                    programMode = ProgramMode.OldSchool,
-                                    eccentricLoad = EccentricLoad.LOAD_100,
-                                    echoLevel = EchoLevel.HARD,
-                                )
-                            }
-                            exerciseToConfig = newRoutineExercise
-                        } finally {
-                            isLoadingDefaults = false
-                        }
-                    }
+                    openExerciseConfig(selectedExercise)
                 },
                 exerciseRepository = exerciseRepository,
                 enableVideoPlayback = enableVideoPlayback,
@@ -396,4 +393,47 @@ fun SingleExerciseScreen(
             )
         }
     }
+}
+
+private fun Exercise.toSingleExerciseConfigModel(): Exercise = Exercise(
+    name = name,
+    muscleGroup = muscleGroups.split(",").firstOrNull()?.trim() ?: "Full Body",
+    muscleGroups = muscleGroups,
+    equipment = equipment,
+    id = id,
+)
+
+private fun buildSingleExerciseRoutineExercise(
+    exercise: Exercise,
+    savedDefaults: SingleExerciseDefaults?,
+): RoutineExercise = if (savedDefaults != null) {
+    RoutineExercise(
+        id = generateUUID(),
+        exercise = exercise,
+        orderIndex = 0,
+        setReps = savedDefaults.setReps,
+        weightPerCableKg = savedDefaults.weightPerCableKg,
+        setWeightsPerCableKg = savedDefaults.setWeightsPerCableKg,
+        progressionKg = savedDefaults.progressionKg,
+        setRestSeconds = savedDefaults.setRestSeconds,
+        programMode = savedDefaults.toProgramMode(),
+        eccentricLoad = savedDefaults.getEccentricLoad(),
+        echoLevel = savedDefaults.getEchoLevel(),
+        duration = savedDefaults.duration.takeIf { it > 0 },
+        isAMRAP = savedDefaults.isAMRAP,
+        perSetRestTime = savedDefaults.perSetRestTime,
+    )
+} else {
+    RoutineExercise(
+        id = generateUUID(),
+        exercise = exercise,
+        orderIndex = 0,
+        setReps = listOf(10, 10, 10),
+        weightPerCableKg = 20f,
+        progressionKg = 0f,
+        setRestSeconds = listOf(60, 60, 60),
+        programMode = ProgramMode.OldSchool,
+        eccentricLoad = EccentricLoad.LOAD_100,
+        echoLevel = EchoLevel.HARD,
+    )
 }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/navigation/NavigationRoutesTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/navigation/NavigationRoutesTest.kt
@@ -1,0 +1,22 @@
+package com.devil.phoenixproject.presentation.navigation
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class NavigationRoutesTest {
+    @Test
+    fun singleExerciseForExerciseRoute_preservesNormalExerciseIds() {
+        assertEquals(
+            "single_exercise/bench-press_1.2~custom",
+            NavigationRoutes.SingleExerciseForExercise.createRoute("bench-press_1.2~custom"),
+        )
+    }
+
+    @Test
+    fun singleExerciseForExerciseRoute_percentEncodesSpecialCharacters() {
+        assertEquals(
+            "single_exercise/exercise%2Fwith%20space%3F",
+            NavigationRoutes.SingleExerciseForExercise.createRoute("exercise/with space?"),
+        )
+    }
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/screen/RecentActivityReplayTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/screen/RecentActivityReplayTest.kt
@@ -1,0 +1,29 @@
+package com.devil.phoenixproject.presentation.screen
+
+import com.devil.phoenixproject.domain.model.WorkoutSession
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class RecentActivityReplayTest {
+    @Test
+    fun replayExerciseId_returnsNonBlankExerciseId() {
+        val session = WorkoutSession(exerciseId = "bench-press")
+
+        assertEquals("bench-press", session.replayExerciseId())
+    }
+
+    @Test
+    fun replayExerciseId_returnsNullForBlankExerciseId() {
+        val session = WorkoutSession(exerciseId = "   ")
+
+        assertNull(session.replayExerciseId())
+    }
+
+    @Test
+    fun replayExerciseId_returnsNullForMissingExerciseId() {
+        val session = WorkoutSession(exerciseId = null)
+
+        assertNull(session.replayExerciseId())
+    }
+}


### PR DESCRIPTION
## Summary
- Added a parameterized `SingleExerciseForExercise` route so Recent Activity entries can reopen the matching exercise setup flow.
- Made tappable Recent Activity rows on the home screen deep-link back into Single Exercise with the config sheet preloaded.
- Kept the top bar and workout-route handling aligned for the new `single_exercise/{exerciseId}` route.
- Added focused tests for route encoding and replay eligibility.

## Testing
- `:shared:testAndroidHostTest` passed, including the new navigation and replay helper tests.
- `:androidApp:assembleDebug` passed.
- `spotlessCheck` was blocked by pre-existing formatting violations in unrelated files, so it did not pass end to end.