### PR TITLE
fix: warm-up sets must not inherit per-rep weight progression (#481)

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -2259,11 +2259,30 @@ class ActiveSessionEngine(
                     coordinator._workoutParameters.value = warmupOverrideParams
                 }
 
-                val bleParams = if (isTimedCableExercise) {
-                    Logger.d { "Duration cable: overriding isAMRAP=true for BLE command (prevents machine rep limit)" }
-                    warmupOverrideParams.copy(isAMRAP = true)
-                } else {
-                    warmupOverrideParams
+                val bleParams = run {
+                    val base = if (isTimedCableExercise) {
+                        Logger.d { "Duration cable: overriding isAMRAP=true for BLE command (prevents machine rep limit)" }
+                        warmupOverrideParams.copy(isAMRAP = true)
+                    } else {
+                        warmupOverrideParams
+                    }
+                    // Issue #481: Variable warm-up sets must never carry the working-set's
+                    // per-rep weight progression to the machine — the firmware applies the
+                    // increment to every rep, including warm-up reps. The warm-up override
+                    // (inline above and buildWarmupOverrideParams) intentionally inherits
+                    // progressionRegressionKg so that _workoutParameters retains the working
+                    // value for the warm-up→working transition (handleSetCompletion restores
+                    // weight/reps but NOT progression). So zero it here for the BLE packet
+                    // ONLY, leaving persisted state intact. Covers both the inline override
+                    // and the interrupted-workout recovery replay (skipVariableWarmupOverride).
+                    val sendingWarmupSet = hasVariableWarmupOverrideApplied ||
+                        (skipVariableWarmupOverride && isInWarmupPhase)
+                    if (sendingWarmupSet && base.progressionRegressionKg != 0f) {
+                        Logger.d { "Issue #481: zeroing per-rep progression for warm-up BLE packet (was ${base.progressionRegressionKg}kg)" }
+                        base.copy(progressionRegressionKg = 0f)
+                    } else {
+                        base
+                    }
                 }
 
                 // Issue #390: Diagnostic logging for weight tracing from routine → BLE

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/WarmupProgressionTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/WarmupProgressionTest.kt
@@ -1,0 +1,150 @@
+package com.devil.phoenixproject.presentation.manager
+
+import com.devil.phoenixproject.domain.model.ProgramMode
+import com.devil.phoenixproject.domain.model.Routine
+import com.devil.phoenixproject.domain.model.RoutineExercise
+import com.devil.phoenixproject.domain.model.WarmupSet
+import com.devil.phoenixproject.testutil.DWSMTestHarness
+import com.devil.phoenixproject.testutil.TestFixtures
+import com.devil.phoenixproject.util.BleConstants
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Issue #481: When an exercise has variable warm-up sets AND "weight change per rep"
+ * (progression) is configured for the working sets, the warm-up sets must NOT inherit
+ * that per-rep progression on the machine — warm-up weight should stay flat.
+ *
+ * Regression guard: zeroing progression for warm-up must not leak into the working set
+ * that follows (the working set must still send the configured progression to the machine).
+ */
+class WarmupProgressionTest {
+
+    private val workingWeightKg = 40f
+    private val warmupPercent = 50
+    private val progressionKg = 2f
+
+    /** Read a little-endian float from a byte array at the given offset. */
+    private fun readFloatLE(buffer: ByteArray, offset: Int): Float {
+        val bits = (buffer[offset].toInt() and 0xFF) or
+            ((buffer[offset + 1].toInt() and 0xFF) shl 8) or
+            ((buffer[offset + 2].toInt() and 0xFF) shl 16) or
+            ((buffer[offset + 3].toInt() and 0xFF) shl 24)
+        return Float.fromBits(bits)
+    }
+
+    /** First activation (0x04) packet captured by the fake BLE repo. */
+    private fun DWSMTestHarness.firstActivationPacket(): ByteArray =
+        fakeBleRepo.commandsReceived.first { it.firstOrNull() == 0x04.toByte() }
+
+    private fun warmupRoutine(): Routine {
+        val exercise = RoutineExercise(
+            id = "warmup-progression-ex",
+            exercise = TestFixtures.benchPress, // equipment "BAR" => cable (non-bodyweight)
+            orderIndex = 0,
+            setReps = listOf(8),
+            weightPerCableKg = workingWeightKg,
+            setWeightsPerCableKg = listOf(workingWeightKg),
+            programMode = ProgramMode.OldSchool,
+            progressionKg = progressionKg,
+            warmupSets = listOf(WarmupSet(reps = 5, percentOfWorking = warmupPercent)),
+        )
+        return Routine(
+            id = "warmup-progression-routine",
+            name = "Warm-up Progression Routine",
+            exercises = listOf(exercise),
+        )
+    }
+
+    @Test
+    fun `warm-up set does not send per-rep progression to the machine`() = runTest {
+        val harness = DWSMTestHarness(this)
+        val routine = warmupRoutine()
+        routine.exercises.forEach { harness.fakeExerciseRepo.addExercise(it.exercise) }
+        harness.fakeBleRepo.simulateConnect("Vee_Test")
+
+        harness.dwsm.loadRoutine(routine)
+        advanceUntilIdle()
+
+        // Sanity: routine load should have entered the warm-up phase.
+        assertEquals(
+            0,
+            harness.coordinator.currentWarmupSetIndex.value,
+            "Routine with warmupSets should start in warm-up phase",
+        )
+
+        harness.fakeBleRepo.commandsReceived.clear()
+        harness.dwsm.startWorkout(skipCountdown = true)
+        advanceUntilIdle()
+
+        val warmupPacket = harness.firstActivationPacket()
+
+        // Confirms the warm-up override actually fired (50% of 40kg = 20kg).
+        assertEquals(
+            workingWeightKg * warmupPercent / 100f,
+            readFloatLE(warmupPacket, BleConstants.ActivationPacket.OFFSET_TARGET_WEIGHT),
+            "Warm-up set should send warm-up weight (50% of working)",
+        )
+
+        // The bug: warm-up must NOT carry the working-set per-rep progression.
+        assertEquals(
+            0f,
+            readFloatLE(warmupPacket, BleConstants.ActivationPacket.OFFSET_PROGRESSION),
+            "Issue #481: warm-up set must send 0 per-rep progression",
+        )
+
+        harness.cleanup()
+    }
+
+    @Test
+    fun `working set after warm-up retains configured per-rep progression`() = runTest {
+        val harness = DWSMTestHarness(this)
+        val routine = warmupRoutine()
+        routine.exercises.forEach { harness.fakeExerciseRepo.addExercise(it.exercise) }
+        harness.fakeBleRepo.simulateConnect("Vee_Test")
+
+        harness.dwsm.loadRoutine(routine)
+        advanceUntilIdle()
+
+        // Start (and implicitly send) the single warm-up set.
+        harness.dwsm.startWorkout(skipCountdown = true)
+        advanceUntilIdle()
+        assertTrue(
+            harness.fakeBleRepo.commandsReceived.any { it.firstOrNull() == 0x04.toByte() },
+            "Warm-up set should have sent an activation packet",
+        )
+
+        // Complete the warm-up set -> transition to the working set.
+        harness.fakeBleRepo.commandsReceived.clear()
+        harness.activeSessionEngine.handleSetCompletion()
+        advanceUntilIdle()
+
+        // Warm-up phase should be over.
+        assertEquals(
+            -1,
+            harness.coordinator.currentWarmupSetIndex.value,
+            "Single warm-up set should transition to the working phase",
+        )
+
+        val workingPacket = harness.firstActivationPacket()
+
+        // Working weight restored (no warm-up override).
+        assertEquals(
+            workingWeightKg,
+            readFloatLE(workingPacket, BleConstants.ActivationPacket.OFFSET_TARGET_WEIGHT),
+            "Working set should send full working weight",
+        )
+
+        // Regression guard: zeroing warm-up progression must not break working-set progression.
+        assertEquals(
+            progressionKg,
+            readFloatLE(workingPacket, BleConstants.ActivationPacket.OFFSET_PROGRESSION),
+            "Issue #481: working set must still send configured per-rep progression",
+        )
+
+        harness.cleanup()
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #481. When an exercise has variable warm-up sets **and** per-rep weight progression ("weight change per rep") configured for working sets, the machine was applying the progression to warm-up reps too.

## Root cause
The warm-up override in `ActiveSessionEngine.startWorkout` (the inline `effectiveParams.copy(...)` and `buildWarmupOverrideParams`) overrides weight/reps/warmupReps/isAMRAP but **inherits** `progressionRegressionKg` from the working-set params. That value flows into `bleParams` → `BlePacketFactory.createProgramParams` → activation packet offset `0x5C`, and the firmware applies the increment to every warm-up rep.

## Why not the originally-suggested fix
The issue suggested zeroing `progressionRegressionKg` in the two override sites. Tracing the data flow shows that would introduce a **worse regression**: the override is written back into `coordinator._workoutParameters.value`, and the warm-up→working transition (`handleSetCompletion`) restores only weight/reps/warmupReps — so a zeroed progression would carry forward and silently kill the **working** set's progression.

## The fix
Zero `progressionRegressionKg` only when building `bleParams`, gated on actually sending a warm-up packet (`hasVariableWarmupOverrideApplied || (skipVariableWarmupOverride && isInWarmupPhase)`):
- Sends 0 progression to the machine for warm-up sets — covers both the inline path and interrupted-workout recovery replay.
- Leaves `_workoutParameters.value` holding the working value, so the working-set transition still sends the configured progression.
- Skips the out-of-bounds warm-up-index fall-through edge case (which resolves to a working set).

## Tests
New `WarmupProgressionTest` inspects the real activation-packet bytes at offset `0x5C`:
- Warm-up set sends **0** progression (the bug) — and warm-up weight (50% of working) confirms the override fired.
- Working set after warm-up **retains** the configured progression (regression guard).

Confirmed RED before the fix (`expected:<0.0> but was:<2.0>`), GREEN after. Full shared suite: **1806 tests, 0 failures**.