### PR TITLE
fix: prevent Analytics history crash on non-finite weight values

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/KmpUtils.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/KmpUtils.kt
@@ -214,6 +214,14 @@ object KmpUtils {
      * @return Formatted string
      */
     fun formatFloat(value: Float, decimals: Int): String {
+        // Guard against non-finite values: kotlin.math.roundToInt() throws
+        // IllegalArgumentException("Cannot round NaN value.") on NaN, which would
+        // crash any screen that formats a corrupt/missing metric (e.g. a workout
+        // history entry with a NaN weight). Treat non-finite as 0 for display.
+        if (!value.isFinite()) {
+            return if (decimals <= 0) "0" else "0.${"".padStart(decimals, '0')}"
+        }
+
         if (decimals <= 0) {
             return value.roundToInt().toString()
         }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/KmpUtils.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/KmpUtils.kt
@@ -219,7 +219,7 @@ object KmpUtils {
         // crash any screen that formats a corrupt/missing metric (e.g. a workout
         // history entry with a NaN weight). Treat non-finite as 0 for display.
         if (!value.isFinite()) {
-            return if (decimals <= 0) "0" else "0.${"".padStart(decimals, '0')}"
+            return if (decimals <= 0) "0" else "0.${"0".repeat(decimals)}"
         }
 
         if (decimals <= 0) {

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/util/KmpUtilsTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/util/KmpUtilsTest.kt
@@ -1,0 +1,46 @@
+package com.devil.phoenixproject.util
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Tests for KmpUtils.formatFloat, focused on the non-finite guard.
+ *
+ * Regression: a workout-history entry holding a NaN weight/force value caused
+ * the Analytics > History tab to crash on scroll, because kotlin.math.roundToInt()
+ * throws IllegalArgumentException("Cannot round NaN value.") when fed NaN. The
+ * formatter now treats non-finite values as 0 so the UI degrades gracefully
+ * instead of crashing.
+ */
+class KmpUtilsTest {
+
+    @Test
+    fun formatFloat_nan_withDecimals_returnsZeroNoThrow() {
+        assertEquals("0.0", KmpUtils.formatFloat(Float.NaN, 1))
+        assertEquals("0.00", KmpUtils.formatFloat(Float.NaN, 2))
+    }
+
+    @Test
+    fun formatFloat_nan_zeroDecimals_returnsZeroNoThrow() {
+        assertEquals("0", KmpUtils.formatFloat(Float.NaN, 0))
+    }
+
+    @Test
+    fun formatFloat_infinity_returnsZeroNoThrow() {
+        assertEquals("0", KmpUtils.formatFloat(Float.POSITIVE_INFINITY, 0))
+        assertEquals("0.0", KmpUtils.formatFloat(Float.NEGATIVE_INFINITY, 1))
+    }
+
+    @Test
+    fun formatFloat_finiteValues_unchanged() {
+        assertEquals("10", KmpUtils.formatFloat(10f, 0))
+        assertEquals("10.5", KmpUtils.formatFloat(10.5f, 1))
+        assertEquals("3.14", KmpUtils.formatFloat(3.14159f, 2))
+    }
+
+    @Test
+    fun formatFloat_extensionAndDouble_handleNonFinite() {
+        assertEquals("0.0", Float.NaN.format(1))
+        assertEquals("0.0", Double.NaN.format(1))
+    }
+}


### PR DESCRIPTION
## Root Cause Analysis

The Analytics > History tab crashes when scrolling reaches a specific workout-history entry. The crash is repeatable and tied to particular entries because it is **data-driven**, not position-driven.

**The chain:**
1. Every history card renders an always-visible "Measured Peak" weight line (`HistoryTab.kt:366`, `:935`).
2. That value flows through `WeightDisplayFormatter.formatDisplayWeight` → `Float.format(1)` → `KmpUtils.formatFloat`.
3. `formatFloat` calls `kotlin.math.roundToInt()` (`KmpUtils.kt:218`, `:224`), which **throws `IllegalArgumentException("Cannot round NaN value.")`** when fed a `NaN`.
4. An entry whose stored `heaviestLiftKg`/`weightPerCableKg` (or other metric) is non-finite therefore crashes the app the instant its card scrolls into view.

The `display % 1f == 0f` integer-branch guard in `formatDisplayWeight` is `false` for `NaN`, so the value always routes into the throwing `roundToInt` path. (`Infinity` doesn't throw in `roundToInt` but is equally invalid for display.)

## Fix

Harden `KmpUtils.formatFloat` — the central formatting chokepoint used app-wide — to detect non-finite input via `isFinite()` and return a zeroed display string (`"0"`, `"0.0"`, …) instead of crashing. This fixes the reported scroll crash for every affected entry and prevents the entire class of non-finite-metric crashes elsewhere in the UI.

## Tests

Added `KmpUtilsTest` covering:
- `NaN` with zero and multiple decimals
- `Infinity` (positive/negative)
- Finite values unchanged (regression guard)
- `Float`/`Double` `.format()` extensions

`commonMain` and `commonTest` compile cleanly across shared targets. Test execution was not possible in this environment (no Android SDK / no macOS runtime), but compilation of the common source sets validates the change.

https://claude.ai/code/session_01Kh6qWrLjm2EYhrwMAYwHri

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kh6qWrLjm2EYhrwMAYwHri)_