### PR TITLE
Fix Analytics History crash from duplicate LazyColumn keys.

### DIFF
--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/manager/HistoryManagerTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/manager/HistoryManagerTest.kt
@@ -43,6 +43,59 @@ class HistoryManagerTest {
     }
 
     @Test
+    fun `history lazy column keys stay unique when standalone session id matches grouped routineSessionId`() = runTest {
+        val collisionId = "dd283eb8-d6d9-4ff0-b9af-50969e583b4f"
+        val managerScope = CoroutineScope(coroutineContext + SupervisorJob())
+        try {
+            val manager =
+                HistoryManager(
+                    fakeWorkoutRepository,
+                    fakePersonalRecordRepository,
+                    fakeUserProfileRepository,
+                    managerScope,
+                )
+            var latestHistory: List<HistoryItem>? = null
+            val collectJob = launch {
+                manager.groupedWorkoutHistory.collect { latestHistory = it }
+            }
+            advanceUntilIdle()
+
+            // Original standalone workout (local BLE capture)
+            fakeWorkoutRepository.addSession(
+                WorkoutSession(
+                    id = collisionId,
+                    timestamp = 1_000L,
+                    routineSessionId = null,
+                    totalReps = 10,
+                    duration = 60L,
+                ),
+            )
+            // Pulled portal copy: exercise row references same portal session id as routineSessionId
+            fakeWorkoutRepository.addSession(
+                WorkoutSession(
+                    id = "portal-exercise-row-1",
+                    timestamp = 1_000L,
+                    routineSessionId = collisionId,
+                    routineName = "Synced Workout",
+                    totalReps = 10,
+                    duration = 60L,
+                ),
+            )
+            advanceUntilIdle()
+
+            val historyItems = assertNotNull(latestHistory)
+            val keys = historyItems.map { historyItemLazyColumnKey(it) }
+            val duplicateKeys = keys.groupingBy { it }.eachCount().filter { it.value > 1 }
+
+            assertEquals(emptyList(), duplicateKeys.keys.toList())
+            assertEquals(2, historyItems.size)
+            collectJob.cancel()
+        } finally {
+            managerScope.cancel()
+        }
+    }
+
+    @Test
     fun `groupedWorkoutHistory groups routine sessions and keeps singles separate`() = runTest {
         val managerScope = CoroutineScope(coroutineContext + SupervisorJob())
         try {

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/manager/HistoryManagerTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/manager/HistoryManagerTest.kt
@@ -84,7 +84,7 @@ class HistoryManagerTest {
             advanceUntilIdle()
 
             val historyItems = assertNotNull(latestHistory)
-            val keys = historyItems.map { historyItemLazyColumnKey(it) }
+            val keys = historyItems.map { it.lazyColumnKey }
             val duplicateKeys = keys.groupingBy { it }.eachCount().filter { it.value > 1 }
 
             assertEquals(emptyList(), duplicateKeys.keys.toList())

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/HistoryManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/HistoryManager.kt
@@ -42,6 +42,12 @@ data class GroupedRoutineHistoryItem(
     override val timestamp: Long,
 ) : HistoryItem()
 
+/** LazyColumn key used by [HistoryTab]; prefixed by item type to avoid id/routineSessionId collisions. */
+fun historyItemLazyColumnKey(item: HistoryItem): String = when (item) {
+    is SingleSessionHistoryItem -> "single:${item.session.id}"
+    is GroupedRoutineHistoryItem -> "routine:${item.routineSessionId}"
+}
+
 /**
  * Manages workout history and personal records display.
  * Extracted from MainViewModel — pure read-only computed flows.

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/HistoryManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/HistoryManager.kt
@@ -43,10 +43,11 @@ data class GroupedRoutineHistoryItem(
 ) : HistoryItem()
 
 /** LazyColumn key used by [HistoryTab]; prefixed by item type to avoid id/routineSessionId collisions. */
-fun historyItemLazyColumnKey(item: HistoryItem): String = when (item) {
-    is SingleSessionHistoryItem -> "single:${item.session.id}"
-    is GroupedRoutineHistoryItem -> "routine:${item.routineSessionId}"
-}
+val HistoryItem.lazyColumnKey: String
+    get() = when (this) {
+        is SingleSessionHistoryItem -> "single:${session.id}"
+        is GroupedRoutineHistoryItem -> "routine:$routineSessionId"
+    }
 
 /**
  * Manages workout history and personal records display.

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/HistoryTab.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/HistoryTab.kt
@@ -73,6 +73,7 @@ import com.devil.phoenixproject.presentation.components.RepReplayCard
 import com.devil.phoenixproject.presentation.components.charts.HistoryTimePeriod
 import com.devil.phoenixproject.presentation.manager.HistoryItem
 import com.devil.phoenixproject.ui.theme.Spacing
+import com.devil.phoenixproject.presentation.manager.historyItemLazyColumnKey
 import com.devil.phoenixproject.util.KmpUtils
 import kotlinx.coroutines.launch
 import kotlinx.datetime.DateTimeUnit
@@ -175,10 +176,7 @@ fun HistoryTab(
                 verticalArrangement = Arrangement.spacedBy(Spacing.small),
             ) {
                 items(filteredHistory.size, key = { index ->
-                    when (val item = filteredHistory[index]) {
-                        is com.devil.phoenixproject.presentation.manager.SingleSessionHistoryItem -> item.session.id
-                        is com.devil.phoenixproject.presentation.manager.GroupedRoutineHistoryItem -> item.routineSessionId
-                    }
+                    historyItemLazyColumnKey(filteredHistory[index])
                 }) { index ->
                     when (val item = filteredHistory[index]) {
                         is com.devil.phoenixproject.presentation.manager.SingleSessionHistoryItem -> {

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/HistoryTab.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/HistoryTab.kt
@@ -73,7 +73,7 @@ import com.devil.phoenixproject.presentation.components.RepReplayCard
 import com.devil.phoenixproject.presentation.components.charts.HistoryTimePeriod
 import com.devil.phoenixproject.presentation.manager.HistoryItem
 import com.devil.phoenixproject.ui.theme.Spacing
-import com.devil.phoenixproject.presentation.manager.historyItemLazyColumnKey
+import com.devil.phoenixproject.presentation.manager.lazyColumnKey
 import com.devil.phoenixproject.util.KmpUtils
 import kotlinx.coroutines.launch
 import kotlinx.datetime.DateTimeUnit


### PR DESCRIPTION
Prefix single vs grouped history item keys so synced standalone session IDs cannot collide with grouped routineSessionId values when scrolling the History tab.