### PR TITLE
feat: 1RM parity Phase 1 — canonical hybrid estimate + sync field

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,12 @@ Uses multiplatform-settings with Keychain backend (`KeychainSettings`) for secur
 - Automatically migrates from legacy NSUserDefaults on first access
 - Requires iOS Keychain capability in entitlements
 
+### 1RM Estimate Parity (PARITY-CRITICAL)
+- Canonical formula: hybrid — Brzycki `w*36/(37-reps)` for reps <= 10, Epley `w*(1+reps/30)` for reps > 10. Continuous at reps == 10.
+- Single implementation: `OneRepMaxCalculator.estimate()` (`util/Constants.kt`). All 1RM estimates (UI display, PR storage, cycle reporting) route through it — never reimplement the formula.
+- Mobile computes the estimate per exercise-session (per-cable kg) and ships it as `PortalExerciseDto.estimatedOneRepMaxKg`. The portal stores it verbatim in `exercise_progress.estimated_1rm_kg` and recomputes (same hybrid) ONLY when the field is absent (legacy payloads). Mirror any change in the phoenix-portal counterpart.
+- Max-weight PRs (`personal_records`) are a SEPARATE metric from the estimated 1RM — do not relabel one as the other.
+
 ## The Daem0n's Covenant (v6.6.6 - Enforced)
 
 This project is bound to Daem0n for persistent AI memory. **The covenant is ENFORCED at the protocol layer** - mutating tools block with `COMMUNION_REQUIRED` or `COUNSEL_REQUIRED` errors until proper rituals are observed.

--- a/docs/superpowers/plans/2026-05-30-1rm-parity-mobile.md
+++ b/docs/superpowers/plans/2026-05-30-1rm-parity-mobile.md
@@ -1,0 +1,414 @@
+# 1RM Parity (Mobile) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the mobile app the single source of truth for the estimated 1RM number — compute it once with a canonical hybrid formula and ship it to the portal in the sync payload.
+
+**Architecture:** Add a hybrid (Brzycki ≤10 reps, Epley >10) estimator to `OneRepMaxCalculator`, replace the two duplicated hardcoded Epley copies with it, then add a per-exercise `estimatedOneRepMaxKg` field to the push DTO and populate it in `PortalSyncAdapter`. The portal stores this value verbatim (its plan).
+
+**Tech Stack:** Kotlin Multiplatform, kotlinx.serialization, kotlin.test, Gradle.
+
+**Counterpart:** `phoenix-portal` plan `docs/superpowers/plans/2026-05-30-1rm-parity-portal.md`. The wire field is backward compatible (optional), so either side can deploy first; the portal falls back to recomputing when the field is absent.
+
+**Scope:** This plan is **Phase 1 (parity)** only. Phase 2 (manual-input + assessment persistence) is outlined at the end and gets its own plan after Phase 1 lands.
+
+---
+
+## File Structure
+
+| File | Change | Responsibility |
+|---|---|---|
+| `shared/src/commonMain/kotlin/com/devil/phoenixproject/util/Constants.kt` | Modify `OneRepMaxCalculator` (lines 98-107) | Canonical 1RM formulas: `epley`, `brzycki`, `estimate` (hybrid) |
+| `shared/src/commonTest/kotlin/com/devil/phoenixproject/util/OneRepMaxCalculatorTest.kt` | Create | Unit tests for the formulas |
+| `shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseDetailScreen.kt` | Modify private `calculateOneRepMax` (lines 755-758) | Delegate to canonical calculator |
+| `shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExercisesTab.kt` | Modify private `calculateOneRepMax` (lines 340-344) | Delegate to canonical calculator |
+| `shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncDtos.kt` | Modify `PortalExerciseDto` (lines 79-87) | Add `estimatedOneRepMaxKg` wire field |
+| `shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapter.kt` | Modify `buildPortalExerciseWithTelemetry` (lines 276-284) | Populate `estimatedOneRepMaxKg` |
+| `shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapterTest.kt` | Modify (add test) | Assert the field is populated with the hybrid value |
+| `CLAUDE.md` (repo root) | Modify | Document the hybrid as a parity-critical constant |
+
+---
+
+## Task 1: Canonical hybrid in `OneRepMaxCalculator`
+
+**Files:**
+- Modify: `shared/src/commonMain/kotlin/com/devil/phoenixproject/util/Constants.kt:98-107`
+- Test: `shared/src/commonTest/kotlin/com/devil/phoenixproject/util/OneRepMaxCalculatorTest.kt` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `shared/src/commonTest/kotlin/com/devil/phoenixproject/util/OneRepMaxCalculatorTest.kt`:
+
+```kotlin
+package com.devil.phoenixproject.util
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class OneRepMaxCalculatorTest {
+
+    private val tol = 0.01f
+
+    @Test
+    fun `epley matches formula for multi-rep sets`() {
+        // 100 * (1 + 10/30) = 133.333
+        assertEquals(133.33f, OneRepMaxCalculator.epley(100f, 10), tol)
+    }
+
+    @Test
+    fun `epley returns weight for single rep and zero for invalid`() {
+        assertEquals(100f, OneRepMaxCalculator.epley(100f, 1), tol)
+        assertEquals(0f, OneRepMaxCalculator.epley(100f, 0), tol)
+    }
+
+    @Test
+    fun `brzycki matches formula for low reps`() {
+        // 100 * 36 / (37 - 5) = 112.5
+        assertEquals(112.5f, OneRepMaxCalculator.brzycki(100f, 5), tol)
+    }
+
+    @Test
+    fun `estimate uses brzycki at or below ten reps`() {
+        // 100 * 36 / 32 = 112.5
+        assertEquals(112.5f, OneRepMaxCalculator.estimate(100f, 5), tol)
+    }
+
+    @Test
+    fun `estimate is continuous at the ten rep boundary`() {
+        // Brzycki(10) = 100*36/27 = 133.333 == Epley(10) = 100*(1+10/30)
+        assertEquals(133.33f, OneRepMaxCalculator.estimate(100f, 10), tol)
+    }
+
+    @Test
+    fun `estimate uses epley above ten reps`() {
+        // 100 * (1 + 11/30) = 136.667
+        assertEquals(136.67f, OneRepMaxCalculator.estimate(100f, 11), tol)
+    }
+
+    @Test
+    fun `estimate handles single rep and invalid inputs`() {
+        assertEquals(100f, OneRepMaxCalculator.estimate(100f, 1), tol)
+        assertEquals(0f, OneRepMaxCalculator.estimate(100f, 0), tol)
+        assertEquals(0f, OneRepMaxCalculator.estimate(0f, 5), tol)
+    }
+
+    @Test
+    fun `estimate never evaluates an unsafe brzycki denominator`() {
+        // reps > 10 always routes to Epley, so 37 - reps is never <= 0
+        assertEquals(100f * (1f + 40f / 30f), OneRepMaxCalculator.estimate(100f, 40), tol)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :shared:testDebugUnitTest --tests "com.devil.phoenixproject.util.OneRepMaxCalculatorTest"`
+Expected: FAIL — `brzycki` and `estimate` are unresolved references.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `Constants.kt`, replace the `OneRepMaxCalculator` object (lines 98-107) with:
+
+```kotlin
+/**
+ * Estimated one-rep max calculators.
+ *
+ * PARITY-CRITICAL: `estimate()` is the canonical cross-stack 1RM formula.
+ * Mobile computes it and ships it to the portal (per-cable kg). The portal
+ * MUST NOT use a different formula — see the monorepo parity doctrine.
+ */
+object OneRepMaxCalculator {
+    /** Epley: weight * (1 + reps/30). Robust for any rep count. */
+    fun epley(weight: Float, reps: Int): Float {
+        if (reps <= 0) return 0f
+        if (reps == 1) return weight
+        return weight * (1f + reps / 30f)
+    }
+
+    /** Brzycki: weight * 36 / (37 - reps). Accurate for low reps; invalid for reps >= 37. */
+    fun brzycki(weight: Float, reps: Int): Float {
+        if (reps <= 0) return 0f
+        if (reps == 1) return weight
+        if (reps >= 37) return 0f
+        return weight * (36f / (37f - reps))
+    }
+
+    /**
+     * Canonical hybrid estimate: Brzycki for reps <= 10, Epley for reps > 10.
+     * Continuous at reps == 10 (both yield weight * 1.3333).
+     */
+    fun estimate(weight: Float, reps: Int): Float {
+        if (weight <= 0f || reps <= 0) return 0f
+        if (reps == 1) return weight
+        return if (reps <= 10) weight * (36f / (37f - reps))
+        else weight * (1f + reps / 30f)
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :shared:testDebugUnitTest --tests "com.devil.phoenixproject.util.OneRepMaxCalculatorTest"`
+Expected: PASS (8 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shared/src/commonMain/kotlin/com/devil/phoenixproject/util/Constants.kt \
+        shared/src/commonTest/kotlin/com/devil/phoenixproject/util/OneRepMaxCalculatorTest.kt
+git commit -m "feat: add canonical hybrid 1RM estimator (Brzycki<=10, Epley>10)"
+```
+
+---
+
+## Task 2: Dedupe `ExerciseDetailScreen.calculateOneRepMax`
+
+**Files:**
+- Modify: `shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseDetailScreen.kt:755-758`
+
+This is a refactor verified by compilation + Task 1's tests (the math is now centralized). It also fixes a latent bug: the old `reps <= 0` branch returned `weight` instead of `0`.
+
+- [ ] **Step 1: Replace the duplicated private function body**
+
+Replace lines 755-758:
+
+```kotlin
+private fun calculateOneRepMax(weight: Float, reps: Int): Float {
+    if (reps <= 0) return weight
+    if (reps == 1) return weight
+    return weight * (1 + 0.0333f * reps)
+}
+```
+
+with a delegation to the canonical calculator:
+
+```kotlin
+private fun calculateOneRepMax(weight: Float, reps: Int): Float =
+    OneRepMaxCalculator.estimate(weight, reps)
+```
+
+- [ ] **Step 2: Add the import if missing**
+
+Ensure the file imports the calculator (add near the other `com.devil.phoenixproject.util` imports):
+
+```kotlin
+import com.devil.phoenixproject.util.OneRepMaxCalculator
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `./gradlew :shared:compileDebugKotlinAndroid`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseDetailScreen.kt
+git commit -m "refactor: use canonical 1RM estimator in ExerciseDetailScreen"
+```
+
+---
+
+## Task 3: Dedupe `ExercisesTab.calculateOneRepMax`
+
+**Files:**
+- Modify: `shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExercisesTab.kt:340-344`
+
+`ExercisesTab` computes 1RM on **display** weight (`weightPerCableKg * displayLoadMultiplier()`) via `calculateBestOneRepMax`; that call site is unchanged — only the formula is centralized.
+
+- [ ] **Step 1: Replace the duplicated private function body**
+
+Replace lines 340-344:
+
+```kotlin
+private fun calculateOneRepMax(weight: Float, reps: Int): Float {
+    if (reps <= 0) return weight
+    if (reps == 1) return weight
+    return weight * (1 + 0.0333f * reps)
+}
+```
+
+with:
+
+```kotlin
+private fun calculateOneRepMax(weight: Float, reps: Int): Float =
+    OneRepMaxCalculator.estimate(weight, reps)
+```
+
+- [ ] **Step 2: Add the import if missing**
+
+```kotlin
+import com.devil.phoenixproject.util.OneRepMaxCalculator
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `./gradlew :shared:compileDebugKotlinAndroid`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExercisesTab.kt
+git commit -m "refactor: use canonical 1RM estimator in ExercisesTab"
+```
+
+> **Note (deferred):** Making `ExercisesTab` display the *stored* `Exercise.one_rep_max_kg` instead of recomputing requires the repository to surface that column on `ExerciseSummary`. The stored column is only populated by assessment/PR-sync until Phase 2 wires manual-input persistence, so this read-consistency change is sequenced into the Phase 2 plan.
+
+---
+
+## Task 4: Add and populate `estimatedOneRepMaxKg` on the push DTO
+
+**Files:**
+- Modify: `shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncDtos.kt:79-87`
+- Modify: `shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapter.kt:276-284`
+- Test: `shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapterTest.kt` (add a test)
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test inside `class PortalSyncAdapterTest` (it uses the existing `makeSessionWithReps` helper and `toPortalWorkoutSessions` entry point already used in the file):
+
+```kotlin
+    @Test
+    fun `exercise dto carries hybrid estimated 1RM per cable`() {
+        // 60 kg per cable x 5 reps -> Brzycki: 60 * 36 / 32 = 67.5
+        val sessions = listOf(
+            makeSessionWithReps(
+                sessionId = "s1",
+                routineSessionId = null,
+                exerciseName = "Bench Press",
+                weightPerCableKg = 60f,
+                totalReps = 5,
+            ),
+        )
+
+        val result = PortalSyncAdapter.toPortalWorkoutSessions(sessions, "user-1")
+
+        val estimate = result[0].exercises[0].estimatedOneRepMaxKg
+        assertNotNull(estimate)
+        assertTrue(abs(estimate - 67.5f) < 0.01f, "expected 67.5, got $estimate")
+    }
+```
+
+> If `makeSessionWithReps` does not already accept `weightPerCableKg`/`totalReps` params, extend that test helper (defined later in the same file) to set `WorkoutSession.weightPerCableKg` and `WorkoutSession.totalReps`; do not change production code for the helper.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :shared:testDebugUnitTest --tests "com.devil.phoenixproject.data.sync.PortalSyncAdapterTest"`
+Expected: FAIL — `estimatedOneRepMaxKg` is an unresolved reference on `PortalExerciseDto`.
+
+- [ ] **Step 3a: Add the field to `PortalExerciseDto`**
+
+In `PortalSyncDtos.kt`, replace `PortalExerciseDto` (lines 79-87) with:
+
+```kotlin
+@Serializable
+data class PortalExerciseDto(
+    val id: String,
+    val sessionId: String,
+    val exerciseId: String? = null,    // exercise_catalog.id for identity preservation (#404)
+    val name: String,
+    val muscleGroup: String = "General",
+    val orderIndex: Int = 0,
+    /**
+     * Canonical estimated 1RM (per-cable kg) for this exercise in this session.
+     * Mobile is the source of truth (see OneRepMaxCalculator.estimate). The
+     * portal stores this verbatim in exercise_progress.estimated_1rm_kg and
+     * only recomputes when this field is absent (legacy payloads).
+     */
+    val estimatedOneRepMaxKg: Float? = null,
+    val sets: List<PortalSetDto> = emptyList(),
+)
+```
+
+- [ ] **Step 3b: Populate it in the adapter**
+
+In `PortalSyncAdapter.kt`, replace the `PortalExerciseDto(...)` construction (lines 276-284) with:
+
+```kotlin
+        val exercise = PortalExerciseDto(
+            id = exerciseId,
+            sessionId = portalSessionId,
+            exerciseId = session.exerciseId, // Catalog exercise ID for identity preservation (#404)
+            name = session.exerciseName ?: "Unknown Exercise",
+            muscleGroup = swr.muscleGroup,
+            orderIndex = orderIndex,
+            // Per-cable estimate from this exercise's single set; matches the
+            // set's weightKg (per-cable). Portal applies its x2 display transform.
+            estimatedOneRepMaxKg = OneRepMaxCalculator.estimate(
+                session.weightPerCableKg,
+                session.totalReps,
+            ),
+            sets = listOf(set),
+        )
+```
+
+Add the import at the top of `PortalSyncAdapter.kt` if missing:
+
+```kotlin
+import com.devil.phoenixproject.util.OneRepMaxCalculator
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :shared:testDebugUnitTest --tests "com.devil.phoenixproject.data.sync.PortalSyncAdapterTest"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncDtos.kt \
+        shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapter.kt \
+        shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapterTest.kt
+git commit -m "feat: ship canonical estimated 1RM per exercise in sync payload"
+```
+
+---
+
+## Task 5: Document the parity constant
+
+**Files:**
+- Modify: `CLAUDE.md` (repo root) — under the sync/parity guidance.
+
+- [ ] **Step 1: Add a parity note**
+
+Append to the sync section of `CLAUDE.md`:
+
+```markdown
+### 1RM Estimate Parity (PARITY-CRITICAL)
+- Canonical formula: hybrid — Brzycki `w*36/(37-reps)` for reps <= 10, Epley `w*(1+reps/30)` for reps > 10. Continuous at reps == 10.
+- Single implementation: `OneRepMaxCalculator.estimate()` (`util/Constants.kt`).
+- Mobile computes the estimate per exercise-session (per-cable kg) and ships it as `PortalExerciseDto.estimatedOneRepMaxKg`. The portal stores it verbatim in `exercise_progress.estimated_1rm_kg` and recomputes (same hybrid) ONLY when the field is absent (legacy payloads).
+- Max-weight PRs (`personal_records`) are a separate metric from the estimated 1RM — do not relabel one as the other.
+```
+
+- [ ] **Step 2: Run the full mobile unit suite**
+
+Run: `./gradlew :androidApp:testDebugUnitTest :shared:testDebugUnitTest`
+Expected: BUILD SUCCESSFUL, all tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: document canonical 1RM estimate as a parity constant"
+```
+
+---
+
+## Phase 2 (outline — gets its own plan after Phase 1 lands)
+
+Not implemented here; requires reading `TrainingCyclesScreen.kt` (manual-input confirm handler) and `ResolveRoutineWeightsUseCase.kt` first. Scope:
+
+1. **Persist manual 1RM input:** on `OneRepMaxInputScreen` confirm, call `exerciseRepository.updateOneRepMax()` for each entered exercise (wire in `TrainingCyclesScreen`), so the value survives beyond cycle creation.
+2. **Assessment feeds scaling:** make `ResolveRoutineWeightsUseCase` fall back to `Exercise.one_rep_max_kg` when no matching PR exists (leaning option (a) from the spec; alternative (b) is a synthetic PR).
+3. **`ExercisesTab` reads stored 1RM** (deferred from Task 3) once the column is reliably populated.
+4. Tests for each input path.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Hybrid formula (Task 1) ✓; dedupe both copies (Tasks 2, 3) ✓; wire field + populate (Task 4) ✓; parity doc (Task 5) ✓; Phase 2 input-path persistence — outlined for follow-up per the phased decision ✓.
+- **Placeholder scan:** No TBD/TODO; all code blocks concrete. The `makeSessionWithReps` extension note is a conditional instruction, not a placeholder.
+- **Type consistency:** `OneRepMaxCalculator.estimate(weight: Float, reps: Int): Float` used identically in Tasks 1-4; `PortalExerciseDto.estimatedOneRepMaxKg: Float?` defined in Task 4 Step 3a and read in the Task 4 test.

--- a/docs/superpowers/specs/2026-05-30-1rm-parity-mobile-design.md
+++ b/docs/superpowers/specs/2026-05-30-1rm-parity-mobile-design.md
@@ -1,0 +1,86 @@
+# 1RM Feature — Parity & Full Functionality (Mobile, Project-Phoenix-MP)
+
+- **Date:** 2026-05-30
+- **Repo:** Project-Phoenix-MP (Kotlin Multiplatform)
+- **Counterpart spec:** `phoenix-portal/docs/superpowers/specs/2026-05-30-1rm-parity-portal-design.md` (must land together — shared sync contract)
+- **Definition of done:** (1) the 1RM number agrees everywhere; (2) every 1RM input path persists
+- **Sequencing:** Phase 1 correctness/parity first; Phase 2 input-path persistence as a follow-up increment
+
+---
+
+## Problem statement
+
+"1RM" currently resolves to **three incompatible numbers** across the stack, and the mobile-computed estimate is dropped at the sync boundary. Mobile is the BLE-authoritative source of workout data, so it should own the canonical 1RM estimate.
+
+### Verified findings (mobile-relevant, confirmed by direct inspection)
+- Mobile UI/local PR uses **Epley** `w·(1+reps/30)` via `OneRepMaxCalculator.epley` (`Constants.kt:102-106`).
+- The portal independently recomputes **Brzycki** server-side and **Epley** client-side → numbers never match.
+- Set-level PR hint sends `isPr`, `prType` (`MAX_WEIGHT`/`MAX_VOLUME`), `prPhase`, `prVolume` but **no 1RM estimate** (`PortalSyncAdapter.kt:261-264`).
+- Mobile's Epley `oneRepMax` exists on a DTO (`SyncModels.kt:88`) but the push path ignores it → the estimate never reaches the portal.
+- Duplicate hardcoded Epley in `ExerciseDetailScreen.kt:755-758` (`w*(1+0.0333f*reps)`); minor bug: `reps<=0` returns `weight` (should be `0`).
+
+### Reported-but-unverified (confirm during implementation)
+- A second hardcoded Epley in `ExercisesTab.kt` (audit cited line 419, but the file is 366 lines — line wrong; existence to confirm).
+- `ExercisesTab` recomputing from sessions instead of reading stored `Exercise.one_rep_max_kg`.
+- Manual `OneRepMaxInputScreen` values never persisted (Phase 2 target).
+- VBT Assessment never creating a PersonalRecord / not feeding routine scaling (Phase 2 target).
+
+### What works (must not regress)
+`OneRepMaxCalculator.epley`; VBT `AssessmentEngine` (OLS regression, R², tested); PR→Exercise sync for COMBINED phase; `ResolveRoutineWeightsUseCase` percentage resolution; 2× per-cable weight handling; DB schema (columns/queries exist).
+
+---
+
+## Architecture: mobile owns the canonical estimate
+
+### Canonical formula (hybrid, single definition — lives here on mobile)
+```
+estimate1RM(weight, reps):
+  if weight <= 0 || reps <= 0  -> 0
+  if reps == 1                 -> weight
+  if reps <= 10                -> weight * (36 / (37 - reps))   // Brzycki
+  else                         -> weight * (1 + reps / 30)      // Epley
+```
+Continuous at reps = 10 (Brzycki `36/27` = Epley `1+10/30` = 1.3333). Document as a parity-critical constant in CLAUDE.md.
+
+### Two distinct metrics (do not conflate)
+- **Max Weight PR** = heaviest weight lifted (already correct in sync). Keep labeled as max-weight.
+- **Estimated 1RM** = the hybrid estimate. Mobile is source of truth; ships it to the portal.
+
+### Shared sync contract (must match the portal spec exactly)
+- New optional field `estimatedOneRepMaxKg: Float?` on the exercise/set sync DTO in `SyncModels.kt`.
+- Per-cable kg (consistent with the existing weight convention; portal applies its 2× display multiplier).
+- Computed per exercise-session as the **best estimate across valid sets** (reps ≥ 1, weight > 0). The hybrid removes the need for the old server-side reps 1–12 clamp.
+- Backward compatible: portal falls back to the same hybrid server-side only when the field is absent (legacy payloads).
+
+---
+
+## Phase 1 — Correctness / Parity (mobile tasks)
+1. `OneRepMaxCalculator` (`Constants.kt`): add `brzycki(weight, reps)` and `estimate(weight, reps)` (hybrid); keep `epley()`.
+2. Replace hardcoded Epley in `ExerciseDetailScreen.kt:755-758` with `OneRepMaxCalculator.estimate()`; fix `reps<=0` → `0`.
+3. Confirm/dedupe any `ExercisesTab` 1RM copy to use the calculator; have it read stored `Exercise.one_rep_max_kg` where appropriate.
+4. Add `estimatedOneRepMaxKg` to the sync DTO (`SyncModels.kt`); have `PortalSyncAdapter` compute and populate it per exercise-session.
+
+### Tests
+- Unit tests for the hybrid: boundaries reps = 1 / 10 / 11 / high / ≤ 0; weight ≤ 0.
+- Adapter test: `estimatedOneRepMaxKg` populated correctly (best-across-valid-sets).
+- Verify: `./gradlew :androidApp:testDebugUnitTest`.
+
+---
+
+## Phase 2 — Input-path persistence (mobile tasks)
+1. **Manual `OneRepMaxInputScreen`:** on confirm, persist to `Exercise.one_rep_max_kg` via `exerciseRepository.updateOneRepMax()` (wire in `TrainingCyclesScreen`) — not just transient cycle state.
+2. **VBT Assessment → routine scaling:** make the assessment 1RM feed `ResolveRoutineWeightsUseCase`.
+   - **Open sub-decision (resolve at Phase 2 start):** (a) `ResolveRoutineWeightsUseCase` falls back to `Exercise.one_rep_max_kg` when no matching PR exists, or (b) assessment writes a synthetic PR. **Leaning (a).**
+3. Tests for both input paths.
+
+---
+
+## Risks / open items
+- Wire-contract change must land together with the portal spec (CLAUDE.md parity rule). Backward compatible via the absent-field server fallback.
+- `ExercisesTab` specifics unverified — confirm before editing.
+- Phase 2 assessment→scaling has the open (a)/(b) sub-decision.
+
+## Out of scope (not selected)
+- "Tested vs. estimated" 1RM as a user-facing distinction feature.
+- "Edit 1RM from everywhere" beyond Phase 2 manual-input persistence.
+- User-selectable formula choice.

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/migration/MigrationManagerTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/migration/MigrationManagerTest.kt
@@ -394,7 +394,7 @@ class MigrationManagerTest {
         assertEquals(500.0, volumePr.volume)
         assertEquals(2, repairedRecords.size)
         assertEquals(
-            OneRepMaxCalculator.epley(60f, 10).toDouble(),
+            OneRepMaxCalculator.estimate(60f, 10).toDouble(),
             exercise?.one_rep_max_kg,
         )
     }

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightPersonalRecordRepositoryTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightPersonalRecordRepositoryTest.kt
@@ -72,7 +72,9 @@ class SqlDelightPersonalRecordRepositoryTest {
         assertEquals(50f, volumePr?.weightPerCableKg)
         assertEquals(250f, volumePr?.volume)
         assertEquals(
-            OneRepMaxCalculator.epley(60f, 5).toDouble(),
+            // Canonical hybrid: reps=5 ≤ 10 → Brzycki = 60 × 36/(37-5) = 67.5
+            // (was epley(60,5)=70.0; updated to reflect OneRepMaxCalculator.estimate)
+            OneRepMaxCalculator.estimate(60f, 5).toDouble(),
             exercise?.one_rep_max_kg,
         )
     }

--- a/shared/src/androidMain/kotlin/com/devil/phoenixproject/util/CsvExporter.android.kt
+++ b/shared/src/androidMain/kotlin/com/devil/phoenixproject/util/CsvExporter.android.kt
@@ -201,8 +201,6 @@ class AndroidCsvExporter(private val context: Context) : CsvExporter {
         value
     }
 
-    private fun calculateOneRM(weight: Float, reps: Int): Float {
-        // Brzycki formula: 1RM = weight * (36 / (37 - reps))
-        return if (reps >= 37) weight else weight * (36f / (37f - reps))
-    }
+    private fun calculateOneRM(weight: Float, reps: Int): Float =
+        OneRepMaxCalculator.estimate(weight, reps)
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightPersonalRecordRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightPersonalRecordRepository.kt
@@ -271,7 +271,7 @@ class SqlDelightPersonalRecordRepository(private val db: VitruvianDatabase) : Pe
         val canonicalWorkoutMode = normalizeWorkoutModeKey(workoutMode)
         val volumeForWeightPR = weightPRWeightPerCableKg * reps
         val volumeForVolumePR = volumePRWeightPerCableKg * reps
-        val estimatedOneRepMax = OneRepMaxCalculator.epley(weightPRWeightPerCableKg, reps)
+        val estimatedOneRepMax = OneRepMaxCalculator.estimate(weightPRWeightPerCableKg, reps)
         val phaseName = phase.name
 
         // Issue #319: Log the profile context being used

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepository.kt
@@ -888,7 +888,7 @@ class SqlDelightWorkoutRepository(private val db: VitruvianDatabase, private val
 
             if (!isNewWeightPR && !isNewVolumePR) return@withContext
 
-            val oneRepMax = OneRepMaxCalculator.epley(weightKg, reps)
+            val oneRepMax = OneRepMaxCalculator.estimate(weightKg, reps)
 
             if (isNewWeightPR) {
                 queries.upsertPR(

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapter.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapter.kt
@@ -11,6 +11,7 @@ import com.devil.phoenixproject.domain.model.TrainingCycle
 import com.devil.phoenixproject.domain.model.WorkoutSession
 import com.devil.phoenixproject.domain.model.generateUUID
 import com.devil.phoenixproject.util.KmpUtils.currentTimeMillis
+import com.devil.phoenixproject.util.OneRepMaxCalculator
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.builtins.nullable
@@ -280,6 +281,12 @@ object PortalSyncAdapter {
             name = session.exerciseName ?: "Unknown Exercise",
             muscleGroup = swr.muscleGroup,
             orderIndex = orderIndex,
+            // Per-cable estimate from this exercise's single set; matches the
+            // set's weightKg (per-cable). Portal applies its x2 display transform.
+            estimatedOneRepMaxKg = OneRepMaxCalculator.estimate(
+                session.weightPerCableKg,
+                session.totalReps,
+            ),
             sets = listOf(set),
         )
         return ExerciseWithTelemetry(exercise, telemetry)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapter.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapter.kt
@@ -283,10 +283,12 @@ object PortalSyncAdapter {
             orderIndex = orderIndex,
             // Per-cable estimate from this exercise's single set; matches the
             // set's weightKg (per-cable). Portal applies its x2 display transform.
+            // null when there is no meaningful estimate (0-rep/0-weight) so the
+            // portal treats the field as absent and falls back, per the DTO doc.
             estimatedOneRepMaxKg = OneRepMaxCalculator.estimate(
                 session.weightPerCableKg,
                 session.totalReps,
-            ),
+            ).takeIf { it > 0f },
             sets = listOf(set),
         )
         return ExerciseWithTelemetry(exercise, telemetry)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapter.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapter.kt
@@ -287,7 +287,7 @@ object PortalSyncAdapter {
             // portal treats the field as absent and falls back, per the DTO doc.
             estimatedOneRepMaxKg = OneRepMaxCalculator.estimate(
                 session.weightPerCableKg,
-                session.totalReps,
+                session.workingReps,
             ).takeIf { it > 0f },
             sets = listOf(set),
         )

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncDtos.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncDtos.kt
@@ -83,6 +83,13 @@ data class PortalExerciseDto(
     val name: String,
     val muscleGroup: String = "General",
     val orderIndex: Int = 0,
+    /**
+     * Canonical estimated 1RM (per-cable kg) for this exercise in this session.
+     * Mobile is the source of truth (see OneRepMaxCalculator.estimate). The
+     * portal stores this verbatim in exercise_progress.estimated_1rm_kg and
+     * only recomputes when this field is absent (legacy payloads).
+     */
+    val estimatedOneRepMaxKg: Float? = null,
     val sets: List<PortalSetDto> = emptyList(),
 )
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/TrainingCycleModels.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/TrainingCycleModels.kt
@@ -389,9 +389,9 @@ data class CompletedSet(
     val completedAt: Long,
 ) {
     /**
-     * Calculate estimated 1RM using Epley formula.
+     * Calculate estimated 1RM using canonical hybrid formula (Brzycki ≤10 reps, Epley >10 reps).
      */
-    fun estimatedOneRepMax(): Float = OneRepMaxCalculator.epley(actualWeightKg, actualReps)
+    fun estimatedOneRepMax(): Float = OneRepMaxCalculator.estimate(actualWeightKg, actualReps)
 
     /**
      * Calculate volume (weight × reps).

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseDetailScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseDetailScreen.kt
@@ -41,6 +41,7 @@ import com.devil.phoenixproject.ui.theme.Spacing
 import com.devil.phoenixproject.ui.theme.ThemeMode
 import com.devil.phoenixproject.ui.theme.screenBackgroundBrush
 import com.devil.phoenixproject.util.KmpUtils
+import com.devil.phoenixproject.util.OneRepMaxCalculator
 import org.jetbrains.compose.resources.stringResource
 import vitruvianprojectphoenix.shared.generated.resources.*
 import vitruvianprojectphoenix.shared.generated.resources.Res
@@ -752,11 +753,8 @@ private enum class TimeRange(val label: String) {
     ALL("All"),
 }
 
-private fun calculateOneRepMax(weight: Float, reps: Int): Float {
-    if (reps <= 0) return weight
-    if (reps == 1) return weight
-    return weight * (1 + 0.0333f * reps)
-}
+private fun calculateOneRepMax(weight: Float, reps: Int): Float =
+    OneRepMaxCalculator.estimate(weight, reps)
 
 private fun formatDuration(durationMs: Long): String {
     val minutes = durationMs / 60000

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExercisesTab.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExercisesTab.kt
@@ -21,6 +21,7 @@ import com.devil.phoenixproject.domain.model.WorkoutSession
 import com.devil.phoenixproject.domain.model.displayLoadMultiplier
 import com.devil.phoenixproject.ui.theme.Spacing
 import com.devil.phoenixproject.util.KmpUtils
+import com.devil.phoenixproject.util.OneRepMaxCalculator
 import org.jetbrains.compose.resources.stringResource
 import vitruvianprojectphoenix.shared.generated.resources.*
 import vitruvianprojectphoenix.shared.generated.resources.Res
@@ -335,13 +336,10 @@ private fun formatRelativeTime(timestamp: Long): String {
 }
 
 /**
- * Epley formula for estimated one-rep max
+ * Estimated one-rep max using canonical hybrid formula (Brzycki ≤10 reps, Epley >10 reps).
  */
-private fun calculateOneRepMax(weight: Float, reps: Int): Float {
-    if (reps <= 0) return weight
-    if (reps == 1) return weight
-    return weight * (1 + 0.0333f * reps)
-}
+private fun calculateOneRepMax(weight: Float, reps: Int): Float =
+    OneRepMaxCalculator.estimate(weight, reps)
 
 /**
  * Get best 1RM from a list of sessions

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/Constants.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/Constants.kt
@@ -94,15 +94,36 @@ object UnitConverter {
 
 /**
  * Estimated one-rep max calculators.
+ *
+ * PARITY-CRITICAL: `estimate()` is the canonical cross-stack 1RM formula.
+ * Mobile computes it and ships it to the portal (per-cable kg). The portal
+ * MUST NOT use a different formula — see the monorepo parity doctrine.
  */
 object OneRepMaxCalculator {
-    /**
-     * Calculate estimated 1RM using Epley formula.
-     */
+    /** Epley: weight * (1 + reps/30). Robust for any rep count. */
     fun epley(weight: Float, reps: Int): Float {
         if (reps <= 0) return 0f
         if (reps == 1) return weight
         return weight * (1f + reps / 30f)
+    }
+
+    /** Brzycki: weight * 36 / (37 - reps). Accurate for low reps; invalid for reps >= 37. */
+    fun brzycki(weight: Float, reps: Int): Float {
+        if (reps <= 0) return 0f
+        if (reps == 1) return weight
+        if (reps >= 37) return 0f
+        return weight * (36f / (37f - reps))
+    }
+
+    /**
+     * Canonical hybrid estimate: Brzycki for reps <= 10, Epley for reps > 10.
+     * Continuous at reps == 10 (both yield weight * 1.3333).
+     */
+    fun estimate(weight: Float, reps: Int): Float {
+        if (weight <= 0f || reps <= 0) return 0f
+        if (reps == 1) return weight
+        return if (reps <= 10) weight * (36f / (37f - reps))
+        else weight * (1f + reps / 30f)
     }
 }
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/Constants.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/Constants.kt
@@ -100,7 +100,7 @@ object UnitConverter {
  * MUST NOT use a different formula — see the monorepo parity doctrine.
  */
 object OneRepMaxCalculator {
-    /** Epley: weight * (1 + reps/30). Robust for any rep count. */
+    /** Epley: weight * (1 + reps/30). Linear estimate; tends to overestimate at very high rep counts (>20). */
     fun epley(weight: Float, reps: Int): Float {
         if (reps <= 0) return 0f
         if (reps == 1) return weight
@@ -109,7 +109,7 @@ object OneRepMaxCalculator {
 
     /** Brzycki: weight * 36 / (37 - reps). Accurate for low reps; invalid for reps >= 37. */
     fun brzycki(weight: Float, reps: Int): Float {
-        if (reps <= 0) return 0f
+        if (weight <= 0f || reps <= 0) return 0f
         if (reps == 1) return weight
         if (reps >= 37) return 0f
         return weight * (36f / (37f - reps))
@@ -122,8 +122,7 @@ object OneRepMaxCalculator {
     fun estimate(weight: Float, reps: Int): Float {
         if (weight <= 0f || reps <= 0) return 0f
         if (reps == 1) return weight
-        return if (reps <= 10) weight * (36f / (37f - reps))
-        else weight * (1f + reps / 30f)
+        return if (reps <= 10) brzycki(weight, reps) else epley(weight, reps)
     }
 }
 

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapterTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapterTest.kt
@@ -983,7 +983,9 @@ class PortalSyncAdapterTest {
                 exerciseName = "Bench Press",
                 weightPerCableKg = 60f,
                 totalReps = 5,
-            ),
+            ).let { swr ->
+                swr.copy(session = swr.session.copy(workingReps = 5))
+            }
         )
 
         val result = PortalSyncAdapter.toPortalWorkoutSessions(sessions, "user-1")

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapterTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapterTest.kt
@@ -971,6 +971,28 @@ class PortalSyncAdapterTest {
         assertFloatEquals(500f, result[0].totalVolume)
     }
 
+    // ========== Estimated 1RM in sync payload (Task 4) ==========
+
+    @Test
+    fun `exercise dto carries hybrid estimated 1RM per cable`() {
+        // 60 kg per cable x 5 reps -> Brzycki: 60 * 36 / 32 = 67.5
+        val sessions = listOf(
+            makeSessionWithReps(
+                sessionId = "s1",
+                routineSessionId = null,
+                exerciseName = "Bench Press",
+                weightPerCableKg = 60f,
+                totalReps = 5,
+            ),
+        )
+
+        val result = PortalSyncAdapter.toPortalWorkoutSessions(sessions, "user-1")
+
+        val estimate = result[0].exercises[0].estimatedOneRepMaxKg
+        assertNotNull(estimate)
+        assertTrue(abs(estimate - 67.5f) < 0.01f, "expected 67.5, got $estimate")
+    }
+
     // ========== Factory Helpers ==========
 
     private fun makeSessionWithReps(

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/TrainingCycleModelsTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/TrainingCycleModelsTest.kt
@@ -94,7 +94,7 @@ class TrainingCycleModelsTest {
     }
 
     @Test
-    fun `CompletedSet estimatedOneRepMax uses Epley formula`() {
+    fun `CompletedSet estimatedOneRepMax uses canonical hybrid formula`() {
         val set = CompletedSet(
             id = "set-1",
             sessionId = "session-1",
@@ -109,7 +109,9 @@ class TrainingCycleModelsTest {
         )
 
         val estimated = set.estimatedOneRepMax()
-        assertEquals(116.65f, estimated, absoluteTolerance = 0.1f)
+        // Canonical hybrid: reps=5 ≤ 10 → Brzycki = 100 × 36/(37-5) = 100 × 36/32 = 112.5
+        // (was 116.65 under raw Epley; updated to reflect OneRepMaxCalculator.estimate)
+        assertEquals(112.5f, estimated, absoluteTolerance = 0.1f)
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/util/OneRepMaxCalculatorTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/util/OneRepMaxCalculatorTest.kt
@@ -1,0 +1,58 @@
+package com.devil.phoenixproject.util
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class OneRepMaxCalculatorTest {
+
+    private val tol = 0.01f
+
+    @Test
+    fun `epley matches formula for multi-rep sets`() {
+        // 100 * (1 + 10/30) = 133.333
+        assertEquals(133.33f, OneRepMaxCalculator.epley(100f, 10), tol)
+    }
+
+    @Test
+    fun `epley returns weight for single rep and zero for invalid`() {
+        assertEquals(100f, OneRepMaxCalculator.epley(100f, 1), tol)
+        assertEquals(0f, OneRepMaxCalculator.epley(100f, 0), tol)
+    }
+
+    @Test
+    fun `brzycki matches formula for low reps`() {
+        // 100 * 36 / (37 - 5) = 112.5
+        assertEquals(112.5f, OneRepMaxCalculator.brzycki(100f, 5), tol)
+    }
+
+    @Test
+    fun `estimate uses brzycki at or below ten reps`() {
+        // 100 * 36 / 32 = 112.5
+        assertEquals(112.5f, OneRepMaxCalculator.estimate(100f, 5), tol)
+    }
+
+    @Test
+    fun `estimate is continuous at the ten rep boundary`() {
+        // Brzycki(10) = 100*36/27 = 133.333 == Epley(10) = 100*(1+10/30)
+        assertEquals(133.33f, OneRepMaxCalculator.estimate(100f, 10), tol)
+    }
+
+    @Test
+    fun `estimate uses epley above ten reps`() {
+        // 100 * (1 + 11/30) = 136.667
+        assertEquals(136.67f, OneRepMaxCalculator.estimate(100f, 11), tol)
+    }
+
+    @Test
+    fun `estimate handles single rep and invalid inputs`() {
+        assertEquals(100f, OneRepMaxCalculator.estimate(100f, 1), tol)
+        assertEquals(0f, OneRepMaxCalculator.estimate(100f, 0), tol)
+        assertEquals(0f, OneRepMaxCalculator.estimate(0f, 5), tol)
+    }
+
+    @Test
+    fun `estimate never evaluates an unsafe brzycki denominator`() {
+        // reps > 10 always routes to Epley, so 37 - reps is never <= 0
+        assertEquals(100f * (1f + 40f / 30f), OneRepMaxCalculator.estimate(100f, 40), tol)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/util/OneRepMaxCalculatorTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/util/OneRepMaxCalculatorTest.kt
@@ -55,4 +55,11 @@ class OneRepMaxCalculatorTest {
         // reps > 10 always routes to Epley, so 37 - reps is never <= 0
         assertEquals(100f * (1f + 40f / 30f), OneRepMaxCalculator.estimate(100f, 40), tol)
     }
+
+    @Test
+    fun `brzycki returns zero for invalid weight and out-of-range reps`() {
+        assertEquals(0f, OneRepMaxCalculator.brzycki(100f, 0), tol)
+        assertEquals(0f, OneRepMaxCalculator.brzycki(100f, 37), tol)
+        assertEquals(0f, OneRepMaxCalculator.brzycki(-10f, 5), tol)
+    }
 }

--- a/shared/src/iosMain/kotlin/com/devil/phoenixproject/util/CsvExporter.ios.kt
+++ b/shared/src/iosMain/kotlin/com/devil/phoenixproject/util/CsvExporter.ios.kt
@@ -24,9 +24,10 @@ class IosCsvExporter : CsvExporter {
     private val fileManager = NSFileManager.defaultManager
 
     /**
-     * Calculate estimated 1RM using Brzycki formula
+     * Calculate estimated 1RM using the canonical hybrid (OneRepMaxCalculator.estimate).
      */
-    private fun calculateOneRM(weight: Float, reps: Int): Float = if (reps <= 1) weight else weight * (36f / (37f - reps))
+    private fun calculateOneRM(weight: Float, reps: Int): Float =
+        OneRepMaxCalculator.estimate(weight, reps)
 
     override fun exportPersonalRecords(
         personalRecords: List<PersonalRecord>,


### PR DESCRIPTION
## Summary
- Add canonical hybrid 1RM estimator (Brzycki reps<=10, Epley reps>10) in \OneRepMaxCalculator.estimate()\ and route all production call sites through it
- Ship \stimatedOneRepMaxKg\ per exercise in the mobile sync payload; portal stores it verbatim (counterpart PR required)
- Fix CSV export to use the same hybrid formula; document parity constant in CLAUDE.md

## Test plan
- [x] \./gradlew :shared:testAndroidHostTest\
- [x] \./gradlew :androidApp:testDebugUnitTest\
- [ ] Manual: complete a workout, sync, confirm portal exercise progress chart matches mobile estimate
- [ ] Land together with phoenix-portal \docs/1rm-parity-spec\ PR (shared wire contract)

Made with [Cursor](https://cursor.com)