### PR TITLE
fix: resolve unresolved reference breaking all release builds

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/HistoryTab.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/HistoryTab.kt
@@ -176,7 +176,7 @@ fun HistoryTab(
                 verticalArrangement = Arrangement.spacedBy(Spacing.small),
             ) {
                 items(filteredHistory.size, key = { index ->
-                    historyItemLazyColumnKey(filteredHistory[index])
+                    filteredHistory[index].lazyColumnKey
                 }) { index ->
                     when (val item = filteredHistory[index]) {
                         is com.devil.phoenixproject.presentation.manager.SingleSessionHistoryItem -> {


### PR DESCRIPTION
## Problem
All four release workflows on `main` (Android AAB, Android APK, iOS IPA, iOS TestFlight) fail at the Kotlin compile step with:

```
HistoryTab.kt:179:21 Unresolved reference 'historyItemLazyColumnKey'
```

Because the error is in `commonMain`, it breaks both `:shared:compileAndroidMain` and `:shared:compileKotlinIosArm64`, taking down every platform identically.

## Root cause
PR #485 (`86a5a809`) refactored the History LazyColumn key into the extension property `HistoryItem.lazyColumnKey` (in `HistoryManager.kt`) and added the correct import to `HistoryTab.kt`, but left the call site invoking a **function** named `historyItemLazyColumnKey(...)` that never existed — a bad GitHub-suggestion merge. It never compiled.

Note: CI on #485 *did* fail (`Unit Tests` + `Lint Check` red); it was merged over failing checks because `main` has no branch protection.

## Fix
One line — use the extension property at the call site:
```kotlin
- historyItemLazyColumnKey(filteredHistory[index])
+ filteredHistory[index].lazyColumnKey
```

The original key-collision fix from #485 (prefixing `single:`/`routine:`) is preserved.

## Verification
`./gradlew :shared:compileAndroidMain` passes locally (the exact task that failed in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)