### PR TITLE
fix(audio): sound system reliability — iOS drops, final rep, REST_ENDING, buffer

### DIFF
--- a/.cursor/settings.json
+++ b/.cursor/settings.json
@@ -1,0 +1,7 @@
+{
+  "plugins": {
+    "superpowers": {
+      "enabled": true
+    }
+  }
+}

--- a/.cursor/settings.json
+++ b/.cursor/settings.json
@@ -1,7 +1,0 @@
-{
-  "plugins": {
-    "superpowers": {
-      "enabled": true
-    }
-  }
-}

--- a/shared/src/androidMain/kotlin/com/devil/phoenixproject/presentation/components/HapticFeedbackEffect.android.kt
+++ b/shared/src/androidMain/kotlin/com/devil/phoenixproject/presentation/components/HapticFeedbackEffect.android.kt
@@ -36,9 +36,6 @@ actual fun HapticFeedbackEffect(hapticEvents: SharedFlow<HapticEvent>) {
         }
     }
 
-    // Track which sounds are loaded and ready to play
-    val loadedSounds = remember { mutableSetOf<Int>() }
-
     // Create SoundPool for audio feedback. USAGE_MEDIA keeps cues on STREAM_MUSIC,
     // matching Spotify mix behavior and foreground hardware volume buttons.
     val soundPool = remember {
@@ -47,13 +44,7 @@ actual fun HapticFeedbackEffect(hapticEvents: SharedFlow<HapticEvent>) {
             .setAudioAttributes(
                 buildCueAudioAttributes(),
             )
-            .build().apply {
-                setOnLoadCompleteListener { _, sampleId, status ->
-                    if (status == 0) {
-                        loadedSounds.add(sampleId)
-                    }
-                }
-            }
+            .build()
     }
 
     // Load sounds from static shared-module raw resource IDs so release shrinking
@@ -93,7 +84,7 @@ actual fun HapticFeedbackEffect(hapticEvents: SharedFlow<HapticEvent>) {
     LaunchedEffect(hapticEvents) {
         hapticEvents.collect { event ->
             playHapticFeedback(vibrator, event)
-            playSound(event, soundPool, soundIds, badgeSoundIds, prSoundIds, repCountSoundIds, countdownTickSoundId, loadedSounds, context)
+            playSound(event, soundPool, soundIds, badgeSoundIds, prSoundIds, repCountSoundIds, countdownTickSoundId, context)
         }
     }
 
@@ -126,7 +117,6 @@ private fun playSound(
     prSoundIds: List<Int>,
     repCountSoundIds: List<Int>,
     countdownTickSoundId: Int?,
-    loadedSounds: Set<Int>,
     context: Context,
 ) {
     // ERROR event has no sound

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -3811,7 +3811,8 @@ class ActiveSessionEngine(
                     }
 
                     // Emit REST_ENDING when timer completes (gated by beepsEnabled)
-                    if (remainingSeconds <= 0 && lastRenderedSecond > 0) {
+                    if (remainingSeconds <= 0 && lastTickedSecond != 0) {
+                        lastTickedSecond = 0
                         val prefs = settingsManager.userPreferences.value
                         if (prefs.beepsEnabled) {
                             coordinator._hapticEvents.emit(HapticEvent.REST_ENDING)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -3810,6 +3810,14 @@ class ActiveSessionEngine(
                         )
                     }
 
+                    // Emit REST_ENDING when timer completes (gated by beepsEnabled)
+                    if (remainingSeconds <= 0 && lastRenderedSecond > 0) {
+                        val prefs = settingsManager.userPreferences.value
+                        if (prefs.beepsEnabled) {
+                            coordinator._hapticEvents.emit(HapticEvent.REST_ENDING)
+                        }
+                    }
+
                     if (remainingSeconds <= 0 && autoplay && !coordinator._isRestPaused.value) break
 
                     delay(100)
@@ -3873,7 +3881,13 @@ class ActiveSessionEngine(
                         lastRenderedSecond = remaining
                     }
 
-                    if (remaining <= 0) break
+                    if (remaining <= 0) {
+                        val prefs = settingsManager.userPreferences.value
+                        if (prefs.beepsEnabled) {
+                            coordinator._hapticEvents.emit(HapticEvent.REST_ENDING)
+                        }
+                        break
+                    }
 
                     delay(100)
                 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -217,9 +217,10 @@ class ActiveSessionEngine(
                                 params.reps > 0 && repNumber >= params.reps
                             if (prefs.audioRepCountEnabled && repNumber in 1..25) {
                                 coordinator._hapticEvents.emit(HapticEvent.REP_COUNT_ANNOUNCED(repNumber))
-                            } else if (prefs.repSoundEnabled && isFinalRep) {
+                            }
+                            if (isFinalRep && prefs.repSoundEnabled) {
                                 coordinator._hapticEvents.emit(HapticEvent.FINAL_REP)
-                            } else if (prefs.repSoundEnabled) {
+                            } else if (!prefs.audioRepCountEnabled && prefs.repSoundEnabled) {
                                 coordinator._hapticEvents.emit(HapticEvent.REP_COMPLETED)
                             }
                         }
@@ -235,9 +236,10 @@ class ActiveSessionEngine(
                                 params.reps > 0 && event.workingCount >= params.reps
                             if (prefs.audioRepCountEnabled && event.workingCount in 1..25) {
                                 coordinator._hapticEvents.emit(HapticEvent.REP_COUNT_ANNOUNCED(event.workingCount))
-                            } else if (prefs.repSoundEnabled && isFinalRep) {
+                            }
+                            if (isFinalRep && prefs.repSoundEnabled) {
                                 coordinator._hapticEvents.emit(HapticEvent.FINAL_REP)
-                            } else if (prefs.repSoundEnabled) {
+                            } else if (!prefs.audioRepCountEnabled && prefs.repSoundEnabled) {
                                 coordinator._hapticEvents.emit(HapticEvent.REP_COMPLETED)
                             }
                         }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/DefaultWorkoutSessionManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/DefaultWorkoutSessionManager.kt
@@ -154,8 +154,8 @@ class DefaultWorkoutSessionManager(
     private val scope: CoroutineScope,
     private val elapsedRealtimeProvider: () -> Long = ::elapsedRealtimeMillis,
     private val _hapticEvents: MutableSharedFlow<HapticEvent> = MutableSharedFlow(
-        extraBufferCapacity = 10,
-        onBufferOverflow = kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST,
+        extraBufferCapacity = 32,
+        onBufferOverflow = kotlinx.coroutines.channels.BufferOverflow.SUSPEND,
     ),
 ) : WorkoutStateProvider {
     private val isIosPlatform = getPlatform().name.startsWith("iOS")

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutCoordinator.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutCoordinator.kt
@@ -40,8 +40,8 @@ import kotlin.concurrent.Volatile
  */
 class WorkoutCoordinator(
     internal val _hapticEvents: MutableSharedFlow<HapticEvent> = MutableSharedFlow(
-        extraBufferCapacity = 10,
-        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+        extraBufferCapacity = 32,
+        onBufferOverflow = BufferOverflow.SUSPEND,
     ),
     private val velocityLossThresholdPercent: Float = 20f,
     autoEndOnVelocityLoss: Boolean = false,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/HistoryTab.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/HistoryTab.kt
@@ -176,7 +176,7 @@ fun HistoryTab(
                 verticalArrangement = Arrangement.spacedBy(Spacing.small),
             ) {
                 items(filteredHistory.size, key = { index ->
-                    historyItemLazyColumnKey(filteredHistory[index])
+                    filteredHistory[index].lazyColumnKey
                 }) { index ->
                     when (val item = filteredHistory[index]) {
                         is com.devil.phoenixproject.presentation.manager.SingleSessionHistoryItem -> {

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
@@ -93,8 +93,8 @@ class MainViewModel constructor(
 
     // Shared haptic events flow - created here, passed to both GamificationManager and WorkoutSessionManager
     private val _hapticEvents = MutableSharedFlow<HapticEvent>(
-        extraBufferCapacity = 10,
-        onBufferOverflow = kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST,
+        extraBufferCapacity = 32,
+        onBufferOverflow = kotlinx.coroutines.channels.BufferOverflow.SUSPEND,
     )
 
     // === Phase 1b: SettingsManager (extracted from this class) ===

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/HapticEventAudioTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/HapticEventAudioTest.kt
@@ -367,7 +367,7 @@ class AudioPreferenceGateTest {
         }
         if (isFinalRep && repSoundEnabled) {
             events.add(HapticEvent.FINAL_REP)
-        } else if (!audioRepCountEnabled && repSoundEnabled) {
+        } else if ((!audioRepCountEnabled || repNumber !in 1..25) && repSoundEnabled) {
             events.add(HapticEvent.REP_COMPLETED)
         }
         return events

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/HapticEventAudioTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/HapticEventAudioTest.kt
@@ -329,6 +329,27 @@ class AudioPreferenceGateTest {
         assertEquals(HapticEvent.FINAL_REP, event)
     }
 
+    @Test
+    fun `REST_ENDING gated by beepsEnabled only`() {
+        // REST_ENDING fires when rest timer completes (reaches 0).
+        // Gated by beepsEnabled (the general audio cue toggle), NOT countdownBeepsEnabled.
+        data class GateState(val beepsEnabled: Boolean)
+
+        val cases = listOf(
+            GateState(true) to true,
+            GateState(false) to false,
+        )
+
+        for ((state, expected) in cases) {
+            val shouldEmit = state.beepsEnabled
+            assertEquals(
+                expected,
+                shouldEmit,
+                "beepsEnabled=${state.beepsEnabled}",
+            )
+        }
+    }
+
     /**
      * Returns the LIST of HapticEvents that would be emitted for a working rep.
      * Unlike selectWorkingRepEvent (single event), this models dual-emission

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/HapticEventAudioTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/HapticEventAudioTest.kt
@@ -328,4 +328,64 @@ class AudioPreferenceGateTest {
         )
         assertEquals(HapticEvent.FINAL_REP, event)
     }
+
+    /**
+     * Returns the LIST of HapticEvents that would be emitted for a working rep.
+     * Unlike selectWorkingRepEvent (single event), this models dual-emission
+     * on the final rep when voice counting is active.
+     */
+    private fun selectWorkingRepEvents(
+        audioRepCountEnabled: Boolean,
+        repSoundEnabled: Boolean,
+        repNumber: Int,
+        isFinalRep: Boolean,
+    ): List<HapticEvent> {
+        val events = mutableListOf<HapticEvent>()
+        if (audioRepCountEnabled && repNumber in 1..25) {
+            events.add(HapticEvent.REP_COUNT_ANNOUNCED(repNumber))
+        }
+        if (isFinalRep && repSoundEnabled) {
+            events.add(HapticEvent.FINAL_REP)
+        } else if (!audioRepCountEnabled && repSoundEnabled) {
+            events.add(HapticEvent.REP_COMPLETED)
+        }
+        return events
+    }
+
+    @Test
+    fun `final rep with audioRepCount emits BOTH announced AND final_rep`() {
+        val events = selectWorkingRepEvents(
+            audioRepCountEnabled = true,
+            repSoundEnabled = true,
+            repNumber = 10,
+            isFinalRep = true,
+        )
+        assertEquals(2, events.size, "Final rep with voice counting should emit 2 events")
+        assertTrue(events[0] is HapticEvent.REP_COUNT_ANNOUNCED, "First event should be rep count")
+        assertEquals(HapticEvent.FINAL_REP, events[1], "Second event should be FINAL_REP")
+    }
+
+    @Test
+    fun `non-final rep with audioRepCount emits only announced`() {
+        val events = selectWorkingRepEvents(
+            audioRepCountEnabled = true,
+            repSoundEnabled = true,
+            repNumber = 5,
+            isFinalRep = false,
+        )
+        assertEquals(1, events.size)
+        assertTrue(events[0] is HapticEvent.REP_COUNT_ANNOUNCED)
+    }
+
+    @Test
+    fun `final rep without audioRepCount emits only FINAL_REP`() {
+        val events = selectWorkingRepEvents(
+            audioRepCountEnabled = false,
+            repSoundEnabled = true,
+            repNumber = 10,
+            isFinalRep = true,
+        )
+        assertEquals(1, events.size)
+        assertEquals(HapticEvent.FINAL_REP, events[0])
+    }
 }

--- a/shared/src/iosMain/kotlin/com/devil/phoenixproject/presentation/components/HapticFeedbackEffect.ios.kt
+++ b/shared/src/iosMain/kotlin/com/devil/phoenixproject/presentation/components/HapticFeedbackEffect.ios.kt
@@ -9,7 +9,6 @@ import androidx.compose.runtime.remember
 import co.touchlab.kermit.Logger
 import com.devil.phoenixproject.domain.model.HapticEvent
 import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.collectLatest
 import platform.AVFAudio.AVAudioPlayer
 import platform.AVFAudio.AVAudioSession
 import platform.AVFAudio.AVAudioSessionCategoryAmbient
@@ -45,7 +44,7 @@ actual fun HapticFeedbackEffect(hapticEvents: SharedFlow<HapticEvent>) {
     }
 
     LaunchedEffect(hapticEvents) {
-        hapticEvents.collectLatest { event ->
+        hapticEvents.collect { event ->
             // Play haptic feedback
             playHapticFeedback(event)
             // Play sound (if available)


### PR DESCRIPTION
## Summary

- **iOS collectLatest → collect**: Fixes the primary cause of dropped sounds during rapid rep counting — iOS was cancelling in-flight audio handlers when new haptic events arrived.
- **FINAL_REP dual emission**: When voice counting is enabled, the last rep now plays both the spoken number and the distinct final-rep alert (boopbeepbeep), instead of only the spoken number.
- **REST_ENDING wired up**: Emits the restover sound once when routine rest or Just Lift egg timer reaches zero (gated by beepsEnabled).
- **Android dead code removal**: Removes unused loadedSounds tracking from SoundPool — fallback via play() return value already handles unloaded samples.
- **SharedFlow buffer**: Increases haptic event buffer from 10 to 32 and switches from DROP_OLDEST to SUSPEND to prevent silent event loss during rapid workout transitions.
- **Bonus fix**: HistoryTab lazyColumnKey unresolved reference (pre-existing compile break).

## Test plan

- [x] :shared:allTests — PASS
- [x] :androidApp:testDebugUnitTest — PASS
- [x] :shared:testAndroidHostTest (HapticFeedbackAudioRoutingGuardTest, 4 tests) — PASS
- [x] :androidApp:assembleDebug — BUILD SUCCESSFUL
- [ ] Manual: rapid rep counting on iOS with voice count enabled — all numbers audible
- [ ] Manual: final rep with voice count — spoken number + distinct final-rep sound
- [ ] Manual: rest timer completion — restover sound plays when beeps enabled

Made with [Cursor](https://cursor.com)