### PR TITLE
Add mobile duplicate push payload guards

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/SyncManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/SyncManager.kt
@@ -12,6 +12,7 @@ import com.devil.phoenixproject.data.repository.UserProfileRepository
 import com.devil.phoenixproject.domain.model.CharacterClass
 import com.devil.phoenixproject.domain.model.IntegrationProvider
 import com.devil.phoenixproject.domain.model.RpgProfile
+import com.devil.phoenixproject.domain.model.WorkoutSession
 import com.devil.phoenixproject.domain.model.currentTimeMillis
 import com.devil.phoenixproject.domain.premium.RpgAttributeEngine
 import com.devil.phoenixproject.getPlatform
@@ -406,9 +407,12 @@ class SyncManager(
         // earlier-batch sessions to be missed by the re-query.
         val stampTime = currentTimeMillis()
         val activeProfileId = userProfileRepository.activeProfile.value?.id ?: "default"
-        val pushedSessions = syncRepository.getWorkoutSessionsModifiedSince(
-            prePushLastSync,
-            activeProfileId,
+        val pushedSessions = dedupeWorkoutSessionsById(
+            syncRepository.getWorkoutSessionsModifiedSince(
+                prePushLastSync,
+                activeProfileId,
+            ),
+            context = "Post-push stamping",
         )
         pushedSessions.forEach { session ->
             syncRepository.updateSessionTimestamp(session.id, stampTime)
@@ -531,7 +535,10 @@ class SyncManager(
         val activeProfileId = userProfileRepository.activeProfile.value?.id ?: "default"
 
         // 1. Gather workout sessions as full domain objects (profile-scoped to prevent cross-profile leak)
-        val sessions = syncRepository.getWorkoutSessionsModifiedSince(lastSync, activeProfileId)
+        val sessions = dedupeWorkoutSessionsById(
+            syncRepository.getWorkoutSessionsModifiedSince(lastSync, activeProfileId),
+            context = "Push payload",
+        )
 
         // 2. Fetch full PRs with type/phase/volume metadata (GAP 2 fix), profile-scoped
         val recentPRs = syncRepository.getFullPRsModifiedSince(lastSync, activeProfileId)
@@ -795,6 +802,7 @@ class SyncManager(
                 allProfiles = profileDtos,
                 externalActivities = externalActivityDtos,
             )
+            rejectDuplicatePushPayloadKeys(payload)?.let { return it }
             val result = apiClient.pushPortalPayload(payload)
             if (result.isFailure) return result
             lastResponse = result.getOrThrow()
@@ -844,6 +852,7 @@ class SyncManager(
                     externalActivities = if (isLastBatch) externalActivityDtos else emptyList(),
                 )
 
+                rejectDuplicatePushPayloadKeys(payload)?.let { return it }
                 val result = apiClient.pushPortalPayload(payload)
                 if (result.isFailure) {
                     val error = result.exceptionOrNull()
@@ -1432,6 +1441,100 @@ class SyncManager(
             isIosPlatform -> "ios"
             else -> "android"
         }
+    }
+
+    private fun dedupeWorkoutSessionsById(
+        sessions: List<WorkoutSession>,
+        context: String,
+    ): List<WorkoutSession> {
+        if (sessions.size < 2) return sessions
+
+        val countsById = sessions.groupingBy { it.id }.eachCount()
+        val duplicateCounts = countsById.filterValues { count -> count > 1 }
+        if (duplicateCounts.isEmpty()) return sessions
+
+        val seen = mutableSetOf<String>()
+        val deduped = sessions.filter { session -> seen.add(session.id) }
+        val sample = duplicateCounts.entries
+            .take(10)
+            .joinToString { (id, count) -> "$id x$count" }
+        val suffix = if (duplicateCounts.size > 10) ", ..." else ""
+        Logger.w("SyncManager") {
+            "$context: dropped ${sessions.size - deduped.size} duplicate workout session row(s) " +
+                "before portal sync; duplicate IDs/counts=[$sample$suffix]"
+        }
+        return deduped
+    }
+
+    private fun rejectDuplicatePushPayloadKeys(
+        payload: PortalSyncPayload,
+    ): Result<PortalSyncPushResponse>? {
+        val duplicate = findPushPayloadDuplicateKeys(payload).firstOrNull() ?: return null
+        val message = duplicate.toExceptionMessage()
+        Logger.e("SyncManager") { message }
+        return Result.failure(PortalApiException(message, null, 400))
+    }
+}
+
+internal data class PushPayloadDuplicateKeys(
+    val table: String,
+    val ids: List<String>,
+) {
+    fun toExceptionMessage(): String =
+        "Duplicate IDs in local push payload: $table contains duplicate key(s): ${ids.joinToString()}"
+}
+
+internal fun findPushPayloadDuplicateKeys(
+    payload: PortalSyncPayload,
+): List<PushPayloadDuplicateKeys> {
+    val reports = mutableListOf<PushPayloadDuplicateKeys>()
+
+    reports.addDuplicateKeys(
+        table = "workout_sessions",
+        values = payload.sessions.map { session -> session.id },
+    )
+    reports.addDuplicateKeys(
+        table = "exercises",
+        values = payload.sessions.flatMap { session ->
+            session.exercises.map { exercise -> exercise.id }
+        },
+    )
+    reports.addDuplicateKeys(
+        table = "sets",
+        values = payload.sessions.flatMap { session ->
+            session.exercises.flatMap { exercise -> exercise.sets.map { set -> set.id } }
+        },
+    )
+    reports.addDuplicateKeys(
+        table = "rep_summaries",
+        values = payload.sessions.flatMap { session ->
+            session.exercises.flatMap { exercise ->
+                exercise.sets.flatMap { set -> set.repSummaries.map { rep -> rep.id } }
+            }
+        },
+    )
+    reports.addDuplicateKeys(
+        table = "rep_telemetry",
+        values = payload.telemetry.map { telemetry -> telemetry.id },
+    )
+
+    return reports
+}
+
+private fun MutableList<PushPayloadDuplicateKeys>.addDuplicateKeys(
+    table: String,
+    values: List<String>,
+) {
+    val seen = mutableSetOf<String>()
+    val duplicates = linkedSetOf<String>()
+    values.forEach { value ->
+        val normalized = value.lowercase()
+        if (normalized.isNotBlank() && !seen.add(normalized)) {
+            duplicates.add(value)
+        }
+    }
+    if (duplicates.isNotEmpty()) {
+        add(PushPayloadDuplicateKeys(table, duplicates.toList()))
     }
 }
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/SyncManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/SyncManager.kt
@@ -1449,12 +1449,12 @@ class SyncManager(
     ): List<WorkoutSession> {
         if (sessions.size < 2) return sessions
 
-        val countsById = sessions.groupingBy { it.id }.eachCount()
+        val countsById = sessions.groupingBy { it.id.lowercase() }.eachCount()
         val duplicateCounts = countsById.filterValues { count -> count > 1 }
         if (duplicateCounts.isEmpty()) return sessions
 
         val seen = mutableSetOf<String>()
-        val deduped = sessions.filter { session -> seen.add(session.id) }
+        val deduped = sessions.filter { session -> seen.add(session.id.lowercase()) }
         val sample = duplicateCounts.entries
             .take(10)
             .joinToString { (id, count) -> "$id x$count" }
@@ -1492,6 +1492,14 @@ internal fun findPushPayloadDuplicateKeys(
     reports.addDuplicateKeys(
         table = "workout_sessions",
         values = payload.sessions.map { session -> session.id },
+    )
+    reports.addDuplicateKeys(
+        table = "routines",
+        values = payload.routines.map { routine -> routine.id },
+    )
+    reports.addDuplicateKeys(
+        table = "training_cycles",
+        values = payload.cycles.map { cycle -> cycle.id },
     )
     reports.addDuplicateKeys(
         table = "exercises",

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/PortalPushLimitsTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/PortalPushLimitsTest.kt
@@ -458,7 +458,7 @@ class PortalPushLimitsTest {
     }
 
     @Test
-    fun findPushPayloadDuplicateKeysReportsAllPortalPushTablesCaseInsensitive() {
+    fun findPushPayloadDuplicateKeysReportsConfiguredPortalPushTablesCaseInsensitive() {
         val firstSession = PortalWorkoutSessionDto(
             id = "session-a",
             userId = "user-123",
@@ -507,6 +507,22 @@ class PortalPushLimitsTest {
             deviceId = "device-1",
             lastSync = 0L,
             sessions = listOf(firstSession, secondSession),
+            routines = listOf(
+                PortalRoutineSyncDto(id = "routine-a", userId = "user-123", name = "Routine A"),
+                PortalRoutineSyncDto(id = "ROUTINE-A", userId = "user-123", name = "Routine B"),
+            ),
+            cycles = listOf(
+                PortalTrainingCycleSyncDto(
+                    id = "cycle-a",
+                    userId = "user-123",
+                    name = "Cycle A",
+                ),
+                PortalTrainingCycleSyncDto(
+                    id = "CYCLE-A",
+                    userId = "user-123",
+                    name = "Cycle B",
+                ),
+            ),
             telemetry = listOf(
                 PortalRepTelemetryDto(id = "telemetry-a", setId = "set-a", timestampMs = 1L),
                 PortalRepTelemetryDto(id = "TELEMETRY-A", setId = "SET-A", timestampMs = 2L),
@@ -516,14 +532,24 @@ class PortalPushLimitsTest {
         val duplicates = findPushPayloadDuplicateKeys(payload)
 
         assertEquals(
-            listOf("workout_sessions", "exercises", "sets", "rep_summaries", "rep_telemetry"),
+            listOf(
+                "workout_sessions",
+                "routines",
+                "training_cycles",
+                "exercises",
+                "sets",
+                "rep_summaries",
+                "rep_telemetry",
+            ),
             duplicates.map { duplicate -> duplicate.table },
         )
         assertEquals(listOf("SESSION-A"), duplicates[0].ids)
-        assertEquals(listOf("EXERCISE-A"), duplicates[1].ids)
-        assertEquals(listOf("SET-A"), duplicates[2].ids)
-        assertEquals(listOf("REP-A"), duplicates[3].ids)
-        assertEquals(listOf("TELEMETRY-A"), duplicates[4].ids)
+        assertEquals(listOf("ROUTINE-A"), duplicates[1].ids)
+        assertEquals(listOf("CYCLE-A"), duplicates[2].ids)
+        assertEquals(listOf("EXERCISE-A"), duplicates[3].ids)
+        assertEquals(listOf("SET-A"), duplicates[4].ids)
+        assertEquals(listOf("REP-A"), duplicates[5].ids)
+        assertEquals(listOf("TELEMETRY-A"), duplicates[6].ids)
     }
 
     private fun stubPortalSession(id: String) = PortalWorkoutSessionDto(

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/PortalPushLimitsTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/PortalPushLimitsTest.kt
@@ -457,6 +457,75 @@ class PortalPushLimitsTest {
         assertTrue(batches[0].isEmpty())
     }
 
+    @Test
+    fun findPushPayloadDuplicateKeysReportsAllPortalPushTablesCaseInsensitive() {
+        val firstSession = PortalWorkoutSessionDto(
+            id = "session-a",
+            userId = "user-123",
+            startedAt = "2026-03-02T12:00:00Z",
+            exercises = listOf(
+                PortalExerciseDto(
+                    id = "exercise-a",
+                    sessionId = "session-a",
+                    name = "Bench Press",
+                    sets = listOf(
+                        PortalSetDto(
+                            id = "set-a",
+                            exerciseId = "exercise-a",
+                            setNumber = 1,
+                            repSummaries = listOf(
+                                PortalRepSummaryDto(
+                                    id = "rep-a",
+                                    setId = "set-a",
+                                    repNumber = 1,
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        val secondSession = firstSession.copy(
+            id = "SESSION-A",
+            exercises = listOf(
+                firstSession.exercises.single().copy(
+                    id = "EXERCISE-A",
+                    sets = listOf(
+                        firstSession.exercises.single().sets.single().copy(
+                            id = "SET-A",
+                            repSummaries = listOf(
+                                firstSession.exercises.single().sets.single().repSummaries
+                                    .single()
+                                    .copy(id = "REP-A"),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        val payload = PortalSyncPayload(
+            deviceId = "device-1",
+            lastSync = 0L,
+            sessions = listOf(firstSession, secondSession),
+            telemetry = listOf(
+                PortalRepTelemetryDto(id = "telemetry-a", setId = "set-a", timestampMs = 1L),
+                PortalRepTelemetryDto(id = "TELEMETRY-A", setId = "SET-A", timestampMs = 2L),
+            ),
+        )
+
+        val duplicates = findPushPayloadDuplicateKeys(payload)
+
+        assertEquals(
+            listOf("workout_sessions", "exercises", "sets", "rep_summaries", "rep_telemetry"),
+            duplicates.map { duplicate -> duplicate.table },
+        )
+        assertEquals(listOf("SESSION-A"), duplicates[0].ids)
+        assertEquals(listOf("EXERCISE-A"), duplicates[1].ids)
+        assertEquals(listOf("SET-A"), duplicates[2].ids)
+        assertEquals(listOf("REP-A"), duplicates[3].ids)
+        assertEquals(listOf("TELEMETRY-A"), duplicates[4].ids)
+    }
+
     private fun stubPortalSession(id: String) = PortalWorkoutSessionDto(
         id = id,
         userId = "user-123",

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapterTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapterTest.kt
@@ -214,6 +214,18 @@ class PortalSyncAdapterTest {
     }
 
     @Test
+    fun `exercise id remains stable from workout session id`() {
+        val sessionId = "773e35b1-57be-42f8-9d64-69d127cadd3c"
+        val swr = makeSessionWithReps(sessionId = sessionId)
+
+        val result = PortalSyncAdapter.toPortalWorkoutSessions(listOf(swr), "user-1")
+
+        val exercise = result.single().exercises.single()
+        assertEquals(sessionId, exercise.id)
+        assertEquals(sessionId, exercise.sets.single().exerciseId)
+    }
+
+    @Test
     fun `exercise contains one set with correct weight and reps`() {
         val swr = makeSessionWithReps(
             weightPerCableKg = 30f,

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/SyncManagerTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/SyncManagerTest.kt
@@ -3,6 +3,7 @@ package com.devil.phoenixproject.data.sync
 import com.devil.phoenixproject.data.repository.SubscriptionStatus
 import com.devil.phoenixproject.domain.model.ExternalActivity
 import com.devil.phoenixproject.domain.model.IntegrationProvider
+import com.devil.phoenixproject.domain.model.Routine
 import com.devil.phoenixproject.domain.model.WorkoutSession
 import com.devil.phoenixproject.testutil.FakeExternalActivityRepository
 import com.devil.phoenixproject.testutil.FakeGamificationRepository
@@ -245,6 +246,7 @@ class SyncManagerTest {
             exerciseName = "Bench Press",
         )
         val duplicateSession = firstSession.copy(
+            id = sessionId.uppercase(),
             timestamp = 2000L,
             reps = 12,
             totalReps = 12,
@@ -279,23 +281,13 @@ class SyncManagerTest {
     }
 
     @Test
-    fun syncFailsBeforePushWhenPortalPayloadHasDuplicateNestedExerciseIds() = runTest {
+    fun syncFailsBeforePushWhenPortalPayloadHasDuplicateRoutineIds() = runTest {
         setupAuthenticated()
-        val lowerId = "8db61128-c19d-48dc-a05e-ade968afa87e"
-        val upperId = lowerId.uppercase()
-        fakeSyncRepo.workoutSessionsToReturn = listOf(
-            makeWorkoutSession(
-                id = lowerId,
-                timestamp = 1000L,
-                exerciseName = "Bench Press",
-                routineSessionId = "routine-run-1",
-            ),
-            makeWorkoutSession(
-                id = upperId,
-                timestamp = 2000L,
-                exerciseName = "Row",
-                routineSessionId = "routine-run-1",
-            ),
+        val routineId = "8db61128-c19d-48dc-a05e-ade968afa87e"
+        val upperId = routineId.uppercase()
+        fakeSyncRepo.routinesToReturn = listOf(
+            makeRoutine(id = routineId, name = "Strength A"),
+            makeRoutine(id = upperId, name = "Strength B"),
         )
         val manager = createManager()
 
@@ -306,12 +298,12 @@ class SyncManagerTest {
         assertIs<PortalApiException>(error)
         assertEquals(400, error.statusCode)
         assertTrue(
-            error.message.orEmpty().contains("exercises contains duplicate key(s): $upperId"),
-            "Local preflight should name the duplicate nested exercise key",
+            error.message.orEmpty().contains("routines contains duplicate key(s): $upperId"),
+            "Local preflight should name the duplicate routine key",
         )
         val state = manager.syncState.value
         assertIs<SyncState.Error>(state)
-        assertTrue(state.message.contains("Duplicate IDs in local push payload: exercises"))
+        assertTrue(state.message.contains("Duplicate IDs in local push payload: routines"))
         assertEquals(0, fakeApi.pushCallCount, "Payload with duplicate keys should not be pushed")
         assertEquals(0, fakeApi.pullCallCount, "Failed push preflight should not start pull")
         assertNull(fakeApi.lastPushPayload, "No doomed payload should be sent")
@@ -1116,6 +1108,15 @@ class SyncManagerTest {
         exerciseId = "exercise-$id",
         exerciseName = exerciseName,
         routineSessionId = routineSessionId,
+        profileId = "default",
+    )
+
+    private fun makeRoutine(
+        id: String,
+        name: String,
+    ) = Routine(
+        id = id,
+        name = name,
         profileId = "default",
     )
 }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/SyncManagerTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/SyncManagerTest.kt
@@ -3,6 +3,7 @@ package com.devil.phoenixproject.data.sync
 import com.devil.phoenixproject.data.repository.SubscriptionStatus
 import com.devil.phoenixproject.domain.model.ExternalActivity
 import com.devil.phoenixproject.domain.model.IntegrationProvider
+import com.devil.phoenixproject.domain.model.WorkoutSession
 import com.devil.phoenixproject.testutil.FakeExternalActivityRepository
 import com.devil.phoenixproject.testutil.FakeGamificationRepository
 import com.devil.phoenixproject.testutil.FakePortalApiClient
@@ -230,6 +231,95 @@ class SyncManagerTest {
         assertTrue(payload.sessions.isEmpty(), "Sessions should be empty")
         assertTrue(payload.routines.isEmpty(), "Routines should be empty")
         assertEquals(1, fakeApi.pushCallCount, "Push should still be called even with empty data")
+    }
+
+    @Test
+    fun syncDeduplicatesDuplicateWorkoutSessionIdsBeforePush() = runTest {
+        setupAuthenticated()
+        val sessionId = "773e35b1-57be-42f8-9d64-69d127cadd3c"
+        val firstSession = makeWorkoutSession(
+            id = sessionId,
+            timestamp = 1000L,
+            reps = 8,
+            totalReps = 8,
+            exerciseName = "Bench Press",
+        )
+        val duplicateSession = firstSession.copy(
+            timestamp = 2000L,
+            reps = 12,
+            totalReps = 12,
+            exerciseName = "Duplicate Bench Press",
+        )
+        fakeSyncRepo.workoutSessionsToReturn = listOf(firstSession, duplicateSession)
+        fakeApi.pushResult = Result.success(
+            PortalSyncPushResponse(syncTime = "2026-03-02T12:00:00Z"),
+        )
+        val manager = createManager()
+
+        val result = manager.sync()
+
+        assertTrue(result.isSuccess)
+        assertEquals(1, fakeApi.pushCallCount)
+        val payload = fakeApi.lastPushPayload
+        assertNotNull(payload, "Push payload should be captured")
+        assertEquals(1, payload.sessions.size, "Duplicate session IDs should be sent once")
+        val pushedSession = payload.sessions.single()
+        assertEquals(sessionId, pushedSession.id)
+        assertEquals(sessionId, pushedSession.exercises.single().id)
+        assertEquals(
+            8,
+            pushedSession.exercises.single().sets.single().actualReps,
+            "The first repository row should win deterministically",
+        )
+        assertEquals(
+            listOf(sessionId),
+            fakeSyncRepo.updateSessionTimestampCalls,
+            "Post-push timestamp stamping should run once for the deduped session",
+        )
+    }
+
+    @Test
+    fun syncFailsBeforePushWhenPortalPayloadHasDuplicateNestedExerciseIds() = runTest {
+        setupAuthenticated()
+        val lowerId = "8db61128-c19d-48dc-a05e-ade968afa87e"
+        val upperId = lowerId.uppercase()
+        fakeSyncRepo.workoutSessionsToReturn = listOf(
+            makeWorkoutSession(
+                id = lowerId,
+                timestamp = 1000L,
+                exerciseName = "Bench Press",
+                routineSessionId = "routine-run-1",
+            ),
+            makeWorkoutSession(
+                id = upperId,
+                timestamp = 2000L,
+                exerciseName = "Row",
+                routineSessionId = "routine-run-1",
+            ),
+        )
+        val manager = createManager()
+
+        val result = manager.sync()
+
+        assertTrue(result.isFailure)
+        val error = result.exceptionOrNull()
+        assertIs<PortalApiException>(error)
+        assertEquals(400, error.statusCode)
+        assertTrue(
+            error.message.orEmpty().contains("exercises contains duplicate key(s): $upperId"),
+            "Local preflight should name the duplicate nested exercise key",
+        )
+        val state = manager.syncState.value
+        assertIs<SyncState.Error>(state)
+        assertTrue(state.message.contains("Duplicate IDs in local push payload: exercises"))
+        assertEquals(0, fakeApi.pushCallCount, "Payload with duplicate keys should not be pushed")
+        assertEquals(0, fakeApi.pullCallCount, "Failed push preflight should not start pull")
+        assertNull(fakeApi.lastPushPayload, "No doomed payload should be sent")
+        assertTrue(
+            fakeSyncRepo.updateSessionTimestampCalls.isEmpty(),
+            "Local validation failures must not stamp sessions as synced",
+        )
+        assertEquals(0L, tokenStorage.getLastSyncTimestamp())
     }
 
     @Test
@@ -1007,4 +1097,25 @@ class SyncManagerTest {
             "Session returned by server (session-2) should be converted and merged into local database",
         )
     }
+
+    private fun makeWorkoutSession(
+        id: String,
+        timestamp: Long,
+        reps: Int = 10,
+        totalReps: Int = 10,
+        exerciseName: String = "Test Exercise",
+        routineSessionId: String? = null,
+    ) = WorkoutSession(
+        id = id,
+        timestamp = timestamp,
+        mode = "OldSchool",
+        reps = reps,
+        weightPerCableKg = 20f,
+        duration = 60_000L,
+        totalReps = totalReps,
+        exerciseId = "exercise-$id",
+        exerciseName = exerciseName,
+        routineSessionId = routineSessionId,
+        profileId = "default",
+    )
 }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeSyncRepository.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeSyncRepository.kt
@@ -124,8 +124,10 @@ class FakeSyncRepository : SyncRepository {
     // === Post-Push Stamping ===
 
     var updatedSessionTimestamps: MutableMap<String, Long> = mutableMapOf()
+    var updateSessionTimestampCalls: MutableList<String> = mutableListOf()
 
     override suspend fun updateSessionTimestamp(sessionId: String, timestamp: Long) {
+        updateSessionTimestampCalls += sessionId
         updatedSessionTimestamps[sessionId] = timestamp
     }
 


### PR DESCRIPTION
## Summary
- Deduplicate repeated `WorkoutSession.id` values before building portal push payloads and before post-push timestamp stamping.
- Add a local duplicate-key preflight for `workout_sessions`, `exercises`, `sets`, `rep_summaries`, and `rep_telemetry` that fails fast with `PortalApiException` instead of sending a doomed request.
- Add regression coverage for exact duplicate session rows, nested duplicate exercise IDs, and stable adapter ID mapping.

## Testing
- `:shared:testAndroidHostTest --tests com.devil.phoenixproject.data.sync.SyncManagerTest`
- `:shared:testAndroidHostTest --tests com.devil.phoenixproject.data.sync.PortalPushLimitsTest`
- `:shared:validateSchemaManifest :shared:testAndroidHostTest`