### PR TITLE
Add personal record sync and PR feedback UI

### DIFF
--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepositoryTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepositoryTest.kt
@@ -4,6 +4,7 @@ import com.devil.phoenixproject.data.sync.PersonalRecordSyncDto
 import com.devil.phoenixproject.data.sync.RoutineSyncDto
 import com.devil.phoenixproject.data.sync.WorkoutSessionSyncDto
 import com.devil.phoenixproject.domain.model.PRType
+import com.devil.phoenixproject.domain.model.PersonalRecord
 import com.devil.phoenixproject.domain.model.WorkoutPhase
 import com.devil.phoenixproject.testutil.FakeUserProfileRepository
 import com.devil.phoenixproject.testutil.createTestDatabase
@@ -91,6 +92,31 @@ class SqlDelightSyncRepositoryTest {
     }
 
     @Test
+    fun `getFullPRsModifiedSince preserves profile id and cable count`() = runTest {
+        database.vitruvianDatabaseQueries.insertRecord(
+            exerciseId = "deadlift",
+            exerciseName = "Deadlift",
+            weight = 85.0,
+            reps = 5L,
+            oneRepMax = 99.17,
+            achievedAt = 1_700_000_000_000L,
+            workoutMode = "OldSchool",
+            prType = PRType.MAX_WEIGHT.name,
+            volume = 425.0,
+            phase = WorkoutPhase.CONCENTRIC.name,
+            profile_id = "active-profile",
+            cable_count = 2L,
+        )
+
+        val records = repository.getFullPRsModifiedSince(0L, "active-profile")
+
+        val record = assertNotNull(records.singleOrNull())
+        assertEquals("active-profile", record.profileId)
+        assertEquals(2, record.cableCount)
+        assertEquals(WorkoutPhase.CONCENTRIC, record.phase)
+    }
+
+    @Test
     fun `getExerciseMuscleGroup resolves by id then name and is null for unknown`() = runTest {
         // Seed one catalog exercise. Positional args follow the insertExercise
         // column order: id, name, displayName, description, created, muscleGroup,
@@ -161,11 +187,15 @@ class SqlDelightSyncRepositoryTest {
             cableCount = 2,
         )
 
-        val firstBackfillCount = repository.backfillPhaseSpecificPRs("active-profile")
-        val secondBackfillCount = repository.backfillPhaseSpecificPRs("active-profile")
+        val firstBackfill = repository.backfillPhaseSpecificPRs("active-profile")
+        val secondBackfill = repository.backfillPhaseSpecificPRs(
+            profileId = "active-profile",
+            fromSessionTimestamp = firstBackfill.maxScannedSessionTimestamp ?: 0L,
+        )
 
-        assertEquals(2, firstBackfillCount, "Only the missing eccentric weight and volume PRs should be created")
-        assertEquals(0, secondBackfillCount, "Backfill should be idempotent")
+        assertEquals(2, firstBackfill.changedRows, "Only the missing eccentric weight and volume PRs should be created")
+        assertEquals(1_700_000_000_000L, firstBackfill.maxScannedSessionTimestamp)
+        assertEquals(0, secondBackfill.changedRows, "Backfill should be idempotent")
         val concentricWeight = database.vitruvianDatabaseQueries.selectPR(
             exerciseId = "bicep-curl",
             workoutMode = "Old School",
@@ -199,6 +229,79 @@ class SqlDelightSyncRepositoryTest {
         assertEquals(1500.0, concentricVolume.volume)
         assertEquals(42.0, eccentricWeight.weight)
         assertEquals(336.0, eccentricVolume.volume)
+    }
+
+    @Test
+    fun `findSessionIdsForPersonalRecords resolves sessions outside delta batch`() = runTest {
+        insertHistoricalSession(
+            id = "historical-bicep-curl",
+            timestamp = 1_700_000_000_000L,
+            exerciseId = "bicep-curl",
+            exerciseName = "Bicep Curl",
+            workingReps = 8,
+            peakConcentricA = 20.0,
+            peakConcentricB = 18.0,
+            peakEccentricA = 42.0,
+            peakEccentricB = 39.0,
+            profileId = "active-profile",
+        )
+        insertHistoricalSession(
+            id = "other-profile-session",
+            timestamp = 1_700_000_000_000L,
+            exerciseId = "bicep-curl",
+            exerciseName = "Bicep Curl",
+            workingReps = 8,
+            peakConcentricA = 25.0,
+            peakConcentricB = 23.0,
+            peakEccentricA = 45.0,
+            peakEccentricB = 41.0,
+            profileId = "other-profile",
+        )
+        val record = PersonalRecord(
+            exerciseId = "bicep-curl",
+            exerciseName = "Bicep Curl",
+            weightPerCableKg = 42f,
+            reps = 8,
+            oneRepMax = 42f,
+            timestamp = 1_700_000_000_000L,
+            workoutMode = "OldSchool",
+            prType = PRType.MAX_WEIGHT,
+            volume = 336f,
+            phase = WorkoutPhase.ECCENTRIC,
+            profileId = "active-profile",
+        )
+
+        val sessionIds = repository.findSessionIdsForPersonalRecords(listOf(record), "active-profile")
+
+        assertEquals(
+            mapOf("bicep-curl:1700000000000" to "historical-bicep-curl"),
+            sessionIds,
+        )
+    }
+
+    @Test
+    fun `backfillPhaseSpecificPRs checkpoints even when no sessions have phase metrics`() = runTest {
+        insertHistoricalSession(
+            id = "no-phase-metrics",
+            timestamp = 1_700_000_000_000L,
+            exerciseId = "bicep-curl",
+            exerciseName = "Bicep Curl",
+            workingReps = 8,
+            peakConcentricA = null,
+            peakConcentricB = null,
+            peakEccentricA = null,
+            peakEccentricB = null,
+            profileId = "active-profile",
+        )
+
+        val backfill = repository.backfillPhaseSpecificPRs("active-profile")
+
+        assertEquals(0, backfill.changedRows)
+        assertEquals(
+            1_700_000_000_000L,
+            backfill.maxScannedSessionTimestamp,
+            "A profile with no phase metrics should still advance the checkpoint",
+        )
     }
 
     @Test

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepositoryTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepositoryTest.kt
@@ -4,6 +4,7 @@ import com.devil.phoenixproject.data.sync.PersonalRecordSyncDto
 import com.devil.phoenixproject.data.sync.RoutineSyncDto
 import com.devil.phoenixproject.data.sync.WorkoutSessionSyncDto
 import com.devil.phoenixproject.domain.model.PRType
+import com.devil.phoenixproject.domain.model.WorkoutPhase
 import com.devil.phoenixproject.testutil.FakeUserProfileRepository
 import com.devil.phoenixproject.testutil.createTestDatabase
 import kotlinx.coroutines.test.runTest
@@ -135,6 +136,72 @@ class SqlDelightSyncRepositoryTest {
     }
 
     @Test
+    fun `backfillPhaseSpecificPRs creates phase records and preserves better existing phase PRs`() = runTest {
+        insertHistoricalSession(
+            id = "historical-bicep-curl",
+            timestamp = 1_700_000_000_000,
+            exerciseId = "bicep-curl",
+            exerciseName = "Bicep Curl",
+            workingReps = 8,
+            peakConcentricA = 20.0,
+            peakConcentricB = 18.0,
+            peakEccentricA = 42.0,
+            peakEccentricB = 39.0,
+            profileId = "active-profile",
+        )
+        val prRepository = SqlDelightPersonalRecordRepository(database)
+        prRepository.updatePhaseSpecificPRs(
+            exerciseId = "bicep-curl",
+            workoutMode = "Old School",
+            timestamp = 1_600_000_000_000,
+            reps = 50,
+            peakConcentricForceKg = 30f,
+            peakEccentricForceKg = 0f,
+            profileId = "active-profile",
+            cableCount = 2,
+        )
+
+        val firstBackfillCount = repository.backfillPhaseSpecificPRs("active-profile")
+        val secondBackfillCount = repository.backfillPhaseSpecificPRs("active-profile")
+
+        assertEquals(2, firstBackfillCount, "Only the missing eccentric weight and volume PRs should be created")
+        assertEquals(0, secondBackfillCount, "Backfill should be idempotent")
+        val concentricWeight = database.vitruvianDatabaseQueries.selectPR(
+            exerciseId = "bicep-curl",
+            workoutMode = "Old School",
+            prType = PRType.MAX_WEIGHT.name,
+            phase = WorkoutPhase.CONCENTRIC.name,
+            profileId = "active-profile",
+        ).executeAsOne()
+        val concentricVolume = database.vitruvianDatabaseQueries.selectPR(
+            exerciseId = "bicep-curl",
+            workoutMode = "Old School",
+            prType = PRType.MAX_VOLUME.name,
+            phase = WorkoutPhase.CONCENTRIC.name,
+            profileId = "active-profile",
+        ).executeAsOne()
+        val eccentricWeight = database.vitruvianDatabaseQueries.selectPR(
+            exerciseId = "bicep-curl",
+            workoutMode = "Old School",
+            prType = PRType.MAX_WEIGHT.name,
+            phase = WorkoutPhase.ECCENTRIC.name,
+            profileId = "active-profile",
+        ).executeAsOne()
+        val eccentricVolume = database.vitruvianDatabaseQueries.selectPR(
+            exerciseId = "bicep-curl",
+            workoutMode = "Old School",
+            prType = PRType.MAX_VOLUME.name,
+            phase = WorkoutPhase.ECCENTRIC.name,
+            profileId = "active-profile",
+        ).executeAsOne()
+
+        assertEquals(30.0, concentricWeight.weight)
+        assertEquals(1500.0, concentricVolume.volume)
+        assertEquals(42.0, eccentricWeight.weight)
+        assertEquals(336.0, eccentricVolume.volume)
+    }
+
+    @Test
     fun `mergeRoutines uses active profile id`() = runTest {
         repository.mergeRoutines(
             routines = listOf(
@@ -155,5 +222,69 @@ class SqlDelightSyncRepositoryTest {
 
         assertNotNull(routine)
         assertEquals("active-profile", routine.profile_id)
+    }
+
+    private fun insertHistoricalSession(
+        id: String,
+        timestamp: Long,
+        exerciseId: String,
+        exerciseName: String,
+        workingReps: Long,
+        peakConcentricA: Double?,
+        peakConcentricB: Double?,
+        peakEccentricA: Double?,
+        peakEccentricB: Double?,
+        profileId: String,
+    ) {
+        database.vitruvianDatabaseQueries.insertSession(
+            id = id,
+            timestamp = timestamp,
+            mode = "OldSchool",
+            targetReps = workingReps,
+            weightPerCableKg = 20.0,
+            progressionKg = 0.0,
+            duration = 60_000L,
+            totalReps = workingReps,
+            warmupReps = 0L,
+            workingReps = workingReps,
+            isJustLift = 0L,
+            stopAtTop = 0L,
+            eccentricLoad = 100L,
+            echoLevel = 1L,
+            exerciseId = exerciseId,
+            exerciseName = exerciseName,
+            routineSessionId = null,
+            routineName = null,
+            safetyFlags = 0L,
+            deloadWarningCount = 0L,
+            romViolationCount = 0L,
+            spotterActivations = 0L,
+            peakForceConcentricA = peakConcentricA,
+            peakForceConcentricB = peakConcentricB,
+            peakForceEccentricA = peakEccentricA,
+            peakForceEccentricB = peakEccentricB,
+            avgForceConcentricA = null,
+            avgForceConcentricB = null,
+            avgForceEccentricA = null,
+            avgForceEccentricB = null,
+            heaviestLiftKg = null,
+            totalVolumeKg = null,
+            cableCount = 2L,
+            estimatedCalories = null,
+            warmupAvgWeightKg = null,
+            workingAvgWeightKg = null,
+            burnoutAvgWeightKg = null,
+            peakWeightKg = null,
+            rpe = null,
+            routineId = null,
+            avgMcvMmS = null,
+            avgAsymmetryPercent = null,
+            totalVelocityLossPercent = null,
+            dominantSide = null,
+            strengthProfile = null,
+            formScore = null,
+            profile_id = profileId,
+            display_multiplier = 2L,
+        )
     }
 }

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModelTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModelTest.kt
@@ -9,6 +9,7 @@ import com.devil.phoenixproject.domain.model.PersonalRecord
 import com.devil.phoenixproject.domain.model.ProgramMode
 import com.devil.phoenixproject.domain.model.RoutineExercise
 import com.devil.phoenixproject.domain.model.WeightUnit
+import com.devil.phoenixproject.domain.model.WorkoutPhase
 import com.devil.phoenixproject.presentation.screen.shouldShowCableOnlyExerciseControls
 import com.devil.phoenixproject.presentation.screen.shouldShowStopAtTopToggle
 import com.devil.phoenixproject.testutil.FakePersonalRecordRepository
@@ -395,6 +396,36 @@ class ExerciseConfigViewModelTest {
         assertNull(viewModel.currentExercisePR.value)
     }
 
+    @Test
+    fun `initialize uses concentric PR for normal workout setup and ignores higher eccentric PR`() = runTest {
+        val database = createTestDatabase()
+        val queries = database.vitruvianDatabaseQueries
+        val repository = SqlDelightPersonalRecordRepository(database)
+        val viewModel = ExerciseConfigViewModel(repository)
+        val exercise = benchRoutineExercise(
+            id = "rex-phase",
+            setReps = listOf(10),
+            weightPerCableKg = 20f,
+        )
+
+        insertExercise(queries, id = "bench-1", name = "Bench Press")
+        insertWeightPR(queries, weight = 35.0, phase = WorkoutPhase.COMBINED)
+        insertWeightPR(queries, weight = 45.0, phase = WorkoutPhase.CONCENTRIC)
+        insertWeightPR(queries, weight = 90.0, phase = WorkoutPhase.ECCENTRIC)
+
+        viewModel.initialize(
+            exercise = exercise,
+            unit = WeightUnit.KG,
+            toDisplay = { value, _ -> value },
+            toKg = { value, _ -> value },
+            profileId = "default",
+        )
+
+        waitForCondition { viewModel.currentExercisePR.value?.weightPerCableKg == 45f }
+        assertEquals(WorkoutPhase.CONCENTRIC, viewModel.currentExercisePR.value?.phase)
+        assertEquals(45f, viewModel.currentExercisePR.value?.weightPerCableKg)
+    }
+
     private fun benchRoutineExercise(
         id: String,
         setReps: List<Int?>,
@@ -465,7 +496,11 @@ class ExerciseConfigViewModelTest {
         )
     }
 
-    private fun insertWeightPR(queries: com.devil.phoenixproject.database.VitruvianDatabaseQueries, weight: Double) {
+    private fun insertWeightPR(
+        queries: com.devil.phoenixproject.database.VitruvianDatabaseQueries,
+        weight: Double,
+        phase: WorkoutPhase = WorkoutPhase.COMBINED,
+    ) {
         queries.insertRecord(
             exerciseId = "bench-1",
             exerciseName = "Bench Press",
@@ -476,7 +511,7 @@ class ExerciseConfigViewModelTest {
             workoutMode = "Old School",
             prType = PRType.MAX_WEIGHT.name,
             volume = weight * 6,
-            phase = "COMBINED",
+            phase = phase.name,
             profile_id = "default",
             cable_count = null,
         )

--- a/shared/src/androidMain/kotlin/com/devil/phoenixproject/util/CsvExporter.android.kt
+++ b/shared/src/androidMain/kotlin/com/devil/phoenixproject/util/CsvExporter.android.kt
@@ -39,7 +39,7 @@ class AndroidCsvExporter(private val context: Context) : CsvExporter {
 
         FileWriter(file).use { writer ->
             // Header
-            writer.appendLine("Exercise,Weight,Reps,Date,Mode,1RM")
+            writer.appendLine("Exercise,Phase,Weight,Reps,Date,Mode,1RM")
 
             // Data rows
             personalRecords.sortedByDescending { it.timestamp }.forEach { pr ->
@@ -49,7 +49,7 @@ class AndroidCsvExporter(private val context: Context) : CsvExporter {
                 val oneRM = calculateOneRM(pr.weightPerCableKg, pr.reps)
 
                 writer.appendLine(
-                    "${escapeCsv(exerciseName)},$weight,${pr.reps},$date,${pr.workoutMode},${String.format(Locale.US, "%.1f", oneRM)}",
+                    "${escapeCsv(exerciseName)},${pr.phase.name},$weight,${pr.reps},$date,${pr.workoutMode},${String.format(Locale.US, "%.1f", oneRM)}",
                 )
             }
         }
@@ -126,7 +126,7 @@ class AndroidCsvExporter(private val context: Context) : CsvExporter {
 
         FileWriter(file).use { writer ->
             // Header
-            writer.appendLine("Exercise,Date,Weight,Reps,Mode,1RM,Progress From Previous")
+            writer.appendLine("Exercise,Phase,Date,Weight,Reps,Mode,1RM,Progress From Previous")
 
             grouped.forEach { (exerciseId, records) ->
                 val exerciseName = exerciseNames[exerciseId] ?: "Unknown"
@@ -144,7 +144,7 @@ class AndroidCsvExporter(private val context: Context) : CsvExporter {
                     writer.appendLine(
                         "${escapeCsv(
                             exerciseName,
-                        )},$date,$weight,${pr.reps},${pr.workoutMode},${String.format(Locale.US, "%.1f", oneRM)},$progress",
+                        )},${pr.phase.name},$date,$weight,${pr.reps},${pr.workoutMode},${String.format(Locale.US, "%.1f", oneRM)},$progress",
                     )
 
                     previousWeight = pr.weightPerCableKg

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/PersonalRecordRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/PersonalRecordRepository.kt
@@ -106,7 +106,11 @@ interface PersonalRecordRepository {
      * @param profileId Profile to filter by
      * @return PersonalRecord with highest weight, or null if no PR exists
      */
-    suspend fun getBestWeightPR(exerciseId: String, profileId: String): PersonalRecord?
+    suspend fun getBestWeightPR(
+        exerciseId: String,
+        profileId: String,
+        phase: WorkoutPhase = WorkoutPhase.COMBINED,
+    ): PersonalRecord?
 
     /**
      * Get the best volume PR for an exercise across all modes
@@ -114,7 +118,11 @@ interface PersonalRecordRepository {
      * @param profileId Profile to filter by
      * @return PersonalRecord with highest volume (weight × reps), or null if no PR exists
      */
-    suspend fun getBestVolumePR(exerciseId: String, profileId: String): PersonalRecord?
+    suspend fun getBestVolumePR(
+        exerciseId: String,
+        profileId: String,
+        phase: WorkoutPhase = WorkoutPhase.COMBINED,
+    ): PersonalRecord?
 
     /**
      * Get the best weight PR for an exercise in a specific mode
@@ -123,7 +131,12 @@ interface PersonalRecordRepository {
      * @param profileId Profile to filter by
      * @return PersonalRecord with highest weight for this mode, or null if no PR exists
      */
-    suspend fun getBestWeightPR(exerciseId: String, workoutMode: String, profileId: String): PersonalRecord?
+    suspend fun getBestWeightPR(
+        exerciseId: String,
+        workoutMode: String,
+        profileId: String,
+        phase: WorkoutPhase = WorkoutPhase.COMBINED,
+    ): PersonalRecord?
 
     /**
      * Get the best volume PR for an exercise in a specific mode
@@ -132,7 +145,12 @@ interface PersonalRecordRepository {
      * @param profileId Profile to filter by
      * @return PersonalRecord with highest volume for this mode, or null if no PR exists
      */
-    suspend fun getBestVolumePR(exerciseId: String, workoutMode: String, profileId: String): PersonalRecord?
+    suspend fun getBestVolumePR(
+        exerciseId: String,
+        workoutMode: String,
+        profileId: String,
+        phase: WorkoutPhase = WorkoutPhase.COMBINED,
+    ): PersonalRecord?
 
     /**
      * Get all PRs for an exercise (all modes) for display
@@ -207,7 +225,7 @@ interface PersonalRecordRepository {
      * @param reps Number of reps completed
      * @param peakConcentricForceKg Peak force during concentric phase (per cable, kg)
      * @param peakEccentricForceKg Peak force during eccentric phase (per cable, kg)
-     * @return List of phases where PRs were broken (can be empty, one, or both)
+     * @return List of phase/type pairs where PRs were broken
      */
     suspend fun updatePhaseSpecificPRs(
         exerciseId: String,
@@ -218,8 +236,13 @@ interface PersonalRecordRepository {
         peakEccentricForceKg: Float,
         profileId: String,
         cableCount: Int? = null,
-    ): Result<List<WorkoutPhase>>
+    ): Result<List<PhasePRBreak>>
 }
+
+data class PhasePRBreak(
+    val phase: WorkoutPhase,
+    val prType: PRType,
+)
 
 fun normalizeWorkoutModeKey(workoutMode: String): String {
     val trimmed = workoutMode.trim()
@@ -235,4 +258,37 @@ fun normalizeWorkoutModeKey(workoutMode: String): String {
         trimmed.equals("Eccentric Only", ignoreCase = true) -> "Eccentric Only"
         else -> trimmed
     }
+}
+
+fun preferredPRPhaseForWorkoutMode(workoutMode: String): WorkoutPhase = when (normalizeWorkoutModeKey(workoutMode)) {
+    "Eccentric Only" -> WorkoutPhase.ECCENTRIC
+    else -> WorkoutPhase.CONCENTRIC
+}
+
+suspend fun PersonalRecordRepository.getBestWeightPRForWorkoutMode(
+    exerciseId: String,
+    workoutMode: String,
+    profileId: String,
+): PersonalRecord? {
+    val preferredPhase = preferredPRPhaseForWorkoutMode(workoutMode)
+    return getBestWeightPR(exerciseId, workoutMode, profileId, preferredPhase)
+        ?: if (preferredPhase != WorkoutPhase.COMBINED) {
+            getBestWeightPR(exerciseId, workoutMode, profileId, WorkoutPhase.COMBINED)
+        } else {
+            null
+        }
+}
+
+suspend fun PersonalRecordRepository.getBestVolumePRForWorkoutMode(
+    exerciseId: String,
+    workoutMode: String,
+    profileId: String,
+): PersonalRecord? {
+    val preferredPhase = preferredPRPhaseForWorkoutMode(workoutMode)
+    return getBestVolumePR(exerciseId, workoutMode, profileId, preferredPhase)
+        ?: if (preferredPhase != WorkoutPhase.COMBINED) {
+            getBestVolumePR(exerciseId, workoutMode, profileId, WorkoutPhase.COMBINED)
+        } else {
+            null
+        }
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightPersonalRecordRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightPersonalRecordRepository.kt
@@ -132,27 +132,27 @@ class SqlDelightPersonalRecordRepository(private val db: VitruvianDatabase) : Pe
             .maxByOrNull { it.volume }
     }
 
-    override suspend fun getBestWeightPR(exerciseId: String, profileId: String): PersonalRecord? = withContext(Dispatchers.IO) {
+    override suspend fun getBestWeightPR(exerciseId: String, profileId: String, phase: WorkoutPhase): PersonalRecord? = withContext(Dispatchers.IO) {
         recordsForExercise(exerciseId, profileId)
-            .filter { it.prType == PRType.MAX_WEIGHT }
+            .filter { it.prType == PRType.MAX_WEIGHT && it.phase == phase }
             .maxByOrNull { it.weightPerCableKg }
     }
 
-    override suspend fun getBestVolumePR(exerciseId: String, profileId: String): PersonalRecord? = withContext(Dispatchers.IO) {
+    override suspend fun getBestVolumePR(exerciseId: String, profileId: String, phase: WorkoutPhase): PersonalRecord? = withContext(Dispatchers.IO) {
         recordsForExercise(exerciseId, profileId)
-            .filter { it.prType == PRType.MAX_VOLUME }
+            .filter { it.prType == PRType.MAX_VOLUME && it.phase == phase }
             .maxByOrNull { it.volume }
     }
 
-    override suspend fun getBestWeightPR(exerciseId: String, workoutMode: String, profileId: String): PersonalRecord? = withContext(Dispatchers.IO) {
+    override suspend fun getBestWeightPR(exerciseId: String, workoutMode: String, profileId: String, phase: WorkoutPhase): PersonalRecord? = withContext(Dispatchers.IO) {
         recordsForMode(exerciseId, workoutMode, profileId)
-            .filter { it.prType == PRType.MAX_WEIGHT }
+            .filter { it.prType == PRType.MAX_WEIGHT && it.phase == phase }
             .maxByOrNull { it.weightPerCableKg }
     }
 
-    override suspend fun getBestVolumePR(exerciseId: String, workoutMode: String, profileId: String): PersonalRecord? = withContext(Dispatchers.IO) {
+    override suspend fun getBestVolumePR(exerciseId: String, workoutMode: String, profileId: String, phase: WorkoutPhase): PersonalRecord? = withContext(Dispatchers.IO) {
         recordsForMode(exerciseId, workoutMode, profileId)
-            .filter { it.prType == PRType.MAX_VOLUME }
+            .filter { it.prType == PRType.MAX_VOLUME && it.phase == phase }
             .maxByOrNull { it.volume }
     }
 
@@ -202,9 +202,9 @@ class SqlDelightPersonalRecordRepository(private val db: VitruvianDatabase) : Pe
         peakEccentricForceKg: Float,
         profileId: String,
         cableCount: Int?,
-    ): Result<List<WorkoutPhase>> = withContext(Dispatchers.IO) {
+    ): Result<List<PhasePRBreak>> = withContext(Dispatchers.IO) {
         try {
-            val brokenPhases = mutableListOf<WorkoutPhase>()
+            val brokenPhasePRs = mutableListOf<PhasePRBreak>()
 
             // Check concentric PR (peak force during lifting)
             if (peakConcentricForceKg > 0f) {
@@ -219,7 +219,7 @@ class SqlDelightPersonalRecordRepository(private val db: VitruvianDatabase) : Pe
                     profileId = profileId,
                     cableCount = cableCount,
                 )
-                if (broken.isNotEmpty()) brokenPhases.add(WorkoutPhase.CONCENTRIC)
+                brokenPhasePRs.addAll(broken.map { PhasePRBreak(WorkoutPhase.CONCENTRIC, it) })
             }
 
             // Check eccentric PR (peak force during lowering)
@@ -235,10 +235,10 @@ class SqlDelightPersonalRecordRepository(private val db: VitruvianDatabase) : Pe
                     profileId = profileId,
                     cableCount = cableCount,
                 )
-                if (broken.isNotEmpty()) brokenPhases.add(WorkoutPhase.ECCENTRIC)
+                brokenPhasePRs.addAll(broken.map { PhasePRBreak(WorkoutPhase.ECCENTRIC, it) })
             }
 
-            Result.success(brokenPhases)
+            Result.success(brokenPhasePRs)
         } catch (e: Exception) {
             Result.failure(e)
         }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt
@@ -48,6 +48,9 @@ class SqlDelightSyncRepository(
     private val queries = db.vitruvianDatabaseQueries
     private val json = Json { ignoreUnknownKeys = true }
 
+    private fun personalRecordSessionKey(exerciseId: String, timestamp: Long): String =
+        "$exerciseId:$timestamp"
+
     // === Push Operations ===
 
     override suspend fun getSessionsModifiedSince(timestamp: Long, profileId: String): List<WorkoutSessionSyncDto> = withContext(Dispatchers.IO) {
@@ -1363,16 +1366,31 @@ class SqlDelightSyncRepository(
                     "ECCENTRIC" -> WorkoutPhase.ECCENTRIC
                     else -> WorkoutPhase.COMBINED
                 },
+                profileId = row.profile_id,
+                cableCount = row.cable_count?.toInt(),
             )
         }
     }
 
-    override suspend fun backfillPhaseSpecificPRs(profileId: String): Int = withContext(Dispatchers.IO) {
+    override suspend fun backfillPhaseSpecificPRs(
+        profileId: String,
+        fromSessionTimestamp: Long,
+    ): PhasePRBackfillResult = withContext(Dispatchers.IO) {
         val prRepository = SqlDelightPersonalRecordRepository(db)
-        val sessions = getWorkoutSessionsModifiedSince(0L, profileId)
+        val sessions = queries.selectSessionsForPhasePRBackfill(
+            fromSessionTimestamp = fromSessionTimestamp,
+            profileId = profileId,
+            mapper = ::mapToWorkoutSession,
+        ).executeAsList()
         var changedRows = 0
+        var maxScannedSessionTimestamp: Long? = null
+        var hadFailure = false
 
         for (session in sessions) {
+            maxScannedSessionTimestamp = maxOf(
+                maxScannedSessionTimestamp ?: session.timestamp,
+                session.timestamp,
+            )
             val exerciseId = session.exerciseId?.takeIf { it.isNotBlank() } ?: continue
             val reps = when {
                 session.workingReps > 0 -> session.workingReps
@@ -1402,6 +1420,7 @@ class SqlDelightSyncRepository(
                 cableCount = session.displayMultiplier ?: session.cableCount,
             )
             changedRows += result.getOrElse { error ->
+                hadFailure = true
                 Logger.e(error) {
                     "Phase PR backfill failed for session=${session.id}, exercise=$exerciseId, profile=${session.profileId}"
                 }
@@ -1409,7 +1428,37 @@ class SqlDelightSyncRepository(
             }.size
         }
 
-        changedRows
+        val checkpointTimestamp = maxScannedSessionTimestamp
+            ?: queries.selectLatestSessionForPhasePRBackfill(
+                fromSessionTimestamp = fromSessionTimestamp,
+                profileId = profileId,
+                mapper = ::mapToWorkoutSession,
+            ).executeAsOneOrNull()
+                ?.timestamp
+
+        PhasePRBackfillResult(
+            changedRows = changedRows,
+            maxScannedSessionTimestamp = checkpointTimestamp.takeUnless { hadFailure },
+        )
+    }
+
+    override suspend fun findSessionIdsForPersonalRecords(
+        records: List<PersonalRecord>,
+        profileId: String,
+    ): Map<String, String> = withContext(Dispatchers.IO) {
+        if (records.isEmpty()) return@withContext emptyMap()
+
+        records
+            .distinctBy { record -> personalRecordSessionKey(record.exerciseId, record.timestamp) }
+            .mapNotNull { record ->
+                val sessionId = queries.selectSessionIdForPersonalRecord(
+                    exerciseId = record.exerciseId,
+                    timestamp = record.timestamp,
+                    profileId = profileId,
+                ).executeAsOneOrNull()
+                sessionId?.let { personalRecordSessionKey(record.exerciseId, record.timestamp) to it }
+            }
+            .toMap()
     }
 
     override suspend fun getPhaseStatisticsForSessions(sessionIds: List<String>): List<com.devil.phoenixproject.database.PhaseStatistics> {

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt
@@ -1367,6 +1367,51 @@ class SqlDelightSyncRepository(
         }
     }
 
+    override suspend fun backfillPhaseSpecificPRs(profileId: String): Int = withContext(Dispatchers.IO) {
+        val prRepository = SqlDelightPersonalRecordRepository(db)
+        val sessions = getWorkoutSessionsModifiedSince(0L, profileId)
+        var changedRows = 0
+
+        for (session in sessions) {
+            val exerciseId = session.exerciseId?.takeIf { it.isNotBlank() } ?: continue
+            val reps = when {
+                session.workingReps > 0 -> session.workingReps
+                session.totalReps > 0 -> session.totalReps
+                else -> 0
+            }
+            if (reps <= 0) continue
+
+            val peakConcentric = maxOf(
+                session.peakForceConcentricA ?: 0f,
+                session.peakForceConcentricB ?: 0f,
+            )
+            val peakEccentric = maxOf(
+                session.peakForceEccentricA ?: 0f,
+                session.peakForceEccentricB ?: 0f,
+            )
+            if (peakConcentric <= 0f && peakEccentric <= 0f) continue
+
+            val result = prRepository.updatePhaseSpecificPRs(
+                exerciseId = exerciseId,
+                workoutMode = session.mode,
+                timestamp = session.timestamp,
+                reps = reps,
+                peakConcentricForceKg = peakConcentric,
+                peakEccentricForceKg = peakEccentric,
+                profileId = session.profileId,
+                cableCount = session.displayMultiplier ?: session.cableCount,
+            )
+            changedRows += result.getOrElse { error ->
+                Logger.e(error) {
+                    "Phase PR backfill failed for session=${session.id}, exercise=$exerciseId, profile=${session.profileId}"
+                }
+                emptyList()
+            }.size
+        }
+
+        changedRows
+    }
+
     override suspend fun getPhaseStatisticsForSessions(sessionIds: List<String>): List<com.devil.phoenixproject.database.PhaseStatistics> {
         if (sessionIds.isEmpty()) return emptyList()
         return withContext(Dispatchers.IO) {

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SyncRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SyncRepository.kt
@@ -14,6 +14,11 @@ import com.devil.phoenixproject.domain.model.PersonalRecord
 import com.devil.phoenixproject.domain.model.Routine
 import com.devil.phoenixproject.domain.model.WorkoutSession
 
+data class PhasePRBackfillResult(
+    val changedRows: Int,
+    val maxScannedSessionTimestamp: Long? = null,
+)
+
 /**
  * Repository interface for sync operations.
  * Provides methods to get local changes for push and merge remote changes from pull.
@@ -94,9 +99,21 @@ interface SyncRepository {
      * Idempotently backfill phase-specific PRs from historical sessions that
      * have tagged exercises and saved concentric/eccentric force metrics.
      *
-     * @return number of phase/type PR rows created or improved.
+     * @return phase PR change count and the newest scanned session timestamp for checkpointing.
      */
-    suspend fun backfillPhaseSpecificPRs(profileId: String = "default"): Int = 0
+    suspend fun backfillPhaseSpecificPRs(
+        profileId: String = "default",
+        fromSessionTimestamp: Long = 0L,
+    ): PhasePRBackfillResult = PhasePRBackfillResult(changedRows = 0)
+
+    /**
+     * Resolve local workout session IDs for dedicated PR rows whose source
+     * sessions may not be included in the current modified-since push batch.
+     */
+    suspend fun findSessionIdsForPersonalRecords(
+        records: List<PersonalRecord>,
+        profileId: String = "default",
+    ): Map<String, String> = emptyMap()
 
     /**
      * Get phase statistics for the given session IDs.

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SyncRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SyncRepository.kt
@@ -91,6 +91,14 @@ interface SyncRepository {
     suspend fun getFullPRsModifiedSince(timestamp: Long, profileId: String = "default"): List<PersonalRecord>
 
     /**
+     * Idempotently backfill phase-specific PRs from historical sessions that
+     * have tagged exercises and saved concentric/eccentric force metrics.
+     *
+     * @return number of phase/type PR rows created or improved.
+     */
+    suspend fun backfillPhaseSpecificPRs(profileId: String = "default"): Int = 0
+
+    /**
      * Get phase statistics for the given session IDs.
      * Returns SQLDelight PhaseStatistics rows for conversion to portal DTOs.
      */

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapter.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapter.kt
@@ -2,12 +2,14 @@ package com.devil.phoenixproject.data.sync
 
 import com.devil.phoenixproject.domain.model.CycleProgress
 import com.devil.phoenixproject.domain.model.CycleProgression
+import com.devil.phoenixproject.domain.model.PRType
 import com.devil.phoenixproject.domain.model.PersonalRecord
 import com.devil.phoenixproject.domain.model.ProgramMode
 import com.devil.phoenixproject.domain.model.RepMetricData
 import com.devil.phoenixproject.domain.model.Routine
 import com.devil.phoenixproject.domain.model.SupersetColors
 import com.devil.phoenixproject.domain.model.TrainingCycle
+import com.devil.phoenixproject.domain.model.WorkoutPhase
 import com.devil.phoenixproject.domain.model.WorkoutSession
 import com.devil.phoenixproject.domain.model.generateUUID
 import com.devil.phoenixproject.util.KmpUtils.currentTimeMillis
@@ -44,6 +46,7 @@ object PortalSyncAdapter {
         val repBiomechanics: List<RepBiomechanicsData> = emptyList(),
         val muscleGroup: String = "General",
         val isPr: Boolean = false,
+        val prRecords: List<PersonalRecord> = emptyList(),
         val prRecord: PersonalRecord? = null, // Carries PR metadata (type, phase, volume)
     )
 
@@ -257,7 +260,7 @@ object PortalSyncAdapter {
         }
 
         // One mobile session = one "set" in portal (the entire exercise execution)
-        val pr = swr.prRecord
+        val pr = swr.prRecord ?: swr.prRecords.legacySetPrHint()
         val set = PortalSetDto(
             id = setId,
             exerciseId = exerciseId,
@@ -266,7 +269,7 @@ object PortalSyncAdapter {
             actualReps = session.totalReps,
             weightKg = session.weightPerCableKg,
             rpe = session.rpe,
-            isPr = swr.isPr,
+            isPr = swr.isPr || swr.prRecords.isNotEmpty(),
             prType = pr?.prType?.name, // "MAX_WEIGHT" or "MAX_VOLUME"
             prPhase = pr?.phase?.name, // "COMBINED", "CONCENTRIC", "ECCENTRIC"
             prVolume = if (pr?.prType?.name == "MAX_VOLUME") pr.volume else null,
@@ -293,6 +296,40 @@ object PortalSyncAdapter {
         )
         return ExerciseWithTelemetry(exercise, telemetry)
     }
+
+    fun toPortalPersonalRecord(
+        record: PersonalRecord,
+        sessionId: String?,
+        muscleGroup: String,
+    ): PortalPersonalRecordDto {
+        val value = if (record.prType == PRType.MAX_VOLUME) {
+            record.volume
+        } else {
+            record.weightPerCableKg
+        }
+        return PortalPersonalRecordDto(
+            exerciseName = record.exerciseName.ifBlank { record.exerciseId },
+            exerciseId = record.exerciseId,
+            muscleGroup = muscleGroup.ifBlank { "General" },
+            recordType = record.prType.name,
+            value = value,
+            volume = record.volume.takeIf { record.prType == PRType.MAX_VOLUME },
+            weightKg = record.weightPerCableKg,
+            reps = record.reps,
+            workoutPhase = record.phase.name,
+            sessionId = sessionId,
+            achievedAt = epochToIso8601(record.timestamp),
+            updatedAt = epochToIso8601(currentTimeMillis()),
+            localProfileId = record.profileId,
+            workoutMode = PortalMappings.workoutModeToSync(record.workoutMode),
+        )
+    }
+
+    private fun List<PersonalRecord>.legacySetPrHint(): PersonalRecord? =
+        firstOrNull { it.phase == WorkoutPhase.CONCENTRIC && it.prType == PRType.MAX_WEIGHT }
+            ?: firstOrNull { it.phase == WorkoutPhase.COMBINED && it.prType == PRType.MAX_WEIGHT }
+            ?: firstOrNull { it.prType == PRType.MAX_WEIGHT }
+            ?: firstOrNull()
 
     // ─── Rep Data Mapping ───────────────────────────────────────────
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncDtos.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncDtos.kt
@@ -480,6 +480,33 @@ data class ExternalActivityAckDto(
     val updatedAt: String? = null,
 )
 
+/**
+ * Dedicated mobile -> portal personal record row.
+ *
+ * The portal treats this top-level list as authoritative when present and
+ * falls back to set-level `isPr` hints only for older clients. Mobile does not
+ * send its local Long primary key because the portal schema accepts only UUIDs
+ * for `id`; dedupe is by exercise, achievedAt, recordType, workoutPhase, and
+ * localProfileId.
+ */
+@Serializable
+data class PortalPersonalRecordDto(
+    val exerciseName: String,
+    val exerciseId: String? = null,
+    val muscleGroup: String = "General",
+    val recordType: String,
+    val value: Float? = null,
+    val volume: Float? = null,
+    val weightKg: Float? = null,
+    val reps: Int? = null,
+    val workoutPhase: String,
+    val sessionId: String? = null,
+    val achievedAt: String,
+    val updatedAt: String? = null,
+    val localProfileId: String? = null,
+    val workoutMode: String? = null,
+)
+
 // ─── Composite Sync Payload ─────────────────────────────────────────
 
 /**
@@ -511,6 +538,8 @@ data class PortalSyncPayload(
     val allProfiles: List<LocalProfileDto>? = null,
     // External integration activities (paid users only)
     val externalActivities: List<ExternalActivitySyncDto> = emptyList(),
+    // Dedicated personal_records rows; authoritative over legacy set PR hints.
+    val personalRecords: List<PortalPersonalRecordDto> = emptyList(),
 )
 
 // ─── External Activities (Integration sync) ──────────────────────────

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalTokenStorage.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalTokenStorage.kt
@@ -61,6 +61,7 @@ class PortalTokenStorage(private val settings: Settings) {
         private const val KEY_REFRESH_TOKEN = "portal_refresh_token"
         private const val KEY_EXPIRES_AT = "portal_token_expires_at"
         private const val KEY_LAST_SYNC = "portal_last_sync_timestamp"
+        private const val KEY_PHASE_PR_BACKFILL_CHECKPOINT_PREFIX = "portal_phase_pr_backfill_checkpoint_"
         private const val KEY_DEVICE_ID = "portal_device_id"
         private const val KEY_STORAGE_VERIFIED = "portal_storage_verified"
     }
@@ -175,6 +176,13 @@ class PortalTokenStorage(private val settings: Settings) {
         settings[KEY_LAST_SYNC] = timestamp
     }
 
+    fun getPhasePRBackfillCheckpoint(profileId: String): Long =
+        settings[phasePRBackfillCheckpointKey(profileId), 0L]
+
+    fun setPhasePRBackfillCheckpoint(profileId: String, timestamp: Long) {
+        settings[phasePRBackfillCheckpointKey(profileId)] = timestamp
+    }
+
     fun updatePremiumStatus(isPremium: Boolean) {
         settings[KEY_IS_PREMIUM] = isPremium
         _currentUser.value = _currentUser.value?.copy(isPremium = isPremium)
@@ -249,5 +257,10 @@ class PortalTokenStorage(private val settings: Settings) {
     private fun generateDeviceId(): String {
         // Generate a stable device identifier using multiplatform UUID
         return generateUUID()
+    }
+
+    private fun phasePRBackfillCheckpointKey(profileId: String): String {
+        val normalizedProfileId = profileId.trim().ifBlank { "default" }
+        return "$KEY_PHASE_PR_BACKFILL_CHECKPOINT_PREFIX$normalizedProfileId"
     }
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/SyncManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/SyncManager.kt
@@ -155,6 +155,9 @@ class SyncManager(
             "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
             RegexOption.IGNORE_CASE,
         )
+
+        private fun personalRecordSessionKey(exerciseId: String, timestamp: Long): String =
+            "$exerciseId:$timestamp"
     }
 
     /**
@@ -534,10 +537,17 @@ class SyncManager(
         val platform = getPlatformName()
         val activeProfileId = userProfileRepository.activeProfile.value?.id ?: "default"
 
-        val phaseBackfillCount = syncRepository.backfillPhaseSpecificPRs(activeProfileId)
-        if (phaseBackfillCount > 0) {
+        val phaseBackfillCheckpoint = tokenStorage.getPhasePRBackfillCheckpoint(activeProfileId)
+        val phaseBackfillResult = syncRepository.backfillPhaseSpecificPRs(
+            profileId = activeProfileId,
+            fromSessionTimestamp = phaseBackfillCheckpoint,
+        )
+        phaseBackfillResult.maxScannedSessionTimestamp?.let { maxScannedTimestamp ->
+            tokenStorage.setPhasePRBackfillCheckpoint(activeProfileId, maxScannedTimestamp)
+        }
+        if (phaseBackfillResult.changedRows > 0) {
             Logger.i("SyncManager") {
-                "Backfilled $phaseBackfillCount phase-specific PR row(s) before portal push"
+                "Backfilled ${phaseBackfillResult.changedRows} phase-specific PR row(s) before portal push"
             }
         }
 
@@ -549,16 +559,30 @@ class SyncManager(
 
         // 2. Fetch full PRs with type/phase/volume metadata (GAP 2 fix), profile-scoped
         val recentPRs = syncRepository.getFullPRsModifiedSince(lastSync, activeProfileId)
-        val prBySessionKey = recentPRs.groupBy { pr -> "${pr.exerciseId}:${pr.timestamp}" }
-        val sessionIdByPrKey = sessions.associate { session ->
-            "${session.exerciseId}:${session.timestamp}" to session.id
+        val prBySessionKey = recentPRs.groupBy { pr ->
+            personalRecordSessionKey(pr.exerciseId, pr.timestamp)
         }
+        val sessionIdByDeltaPrKey = sessions.mapNotNull { session ->
+            val exerciseId = session.exerciseId?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+            personalRecordSessionKey(exerciseId, session.timestamp) to session.id
+        }.toMap()
+        val missingSessionRecords = recentPRs.filter { pr ->
+            personalRecordSessionKey(pr.exerciseId, pr.timestamp) !in sessionIdByDeltaPrKey
+        }
+        val historicalSessionIdByPrKey = if (missingSessionRecords.isEmpty()) {
+            emptyMap()
+        } else {
+            syncRepository.findSessionIdsForPersonalRecords(missingSessionRecords, activeProfileId)
+        }
+        val sessionIdByPrKey = sessionIdByDeltaPrKey + historicalSessionIdByPrKey
 
         // 3. Build SessionWithReps (fetch rep metrics per session, detect PRs, attach PR metadata)
         val sessionsWithReps = sessions.map { session ->
             val repMetrics = repMetricRepository.getRepMetrics(session.id)
-            val sessionKey = "${session.exerciseId}:${session.timestamp}"
-            val prRecords = prBySessionKey[sessionKey] ?: emptyList()
+            val sessionKey = session.exerciseId
+                ?.takeIf { it.isNotBlank() }
+                ?.let { exerciseId -> personalRecordSessionKey(exerciseId, session.timestamp) }
+            val prRecords = sessionKey?.let { prBySessionKey[it] } ?: emptyList()
 
             // Resolve the real muscle group from the exercise catalog instead of
             // hardcoding "General". Sessions don't carry a muscle group, so look it
@@ -577,7 +601,7 @@ class SyncManager(
             )
         }
         val personalRecordDtos = recentPRs.map { pr ->
-            val sessionKey = "${pr.exerciseId}:${pr.timestamp}"
+            val sessionKey = personalRecordSessionKey(pr.exerciseId, pr.timestamp)
             val muscleGroup =
                 syncRepository.getExerciseMuscleGroup(pr.exerciseId, pr.exerciseName)
                     ?: "General"

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/SyncManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/SyncManager.kt
@@ -534,6 +534,13 @@ class SyncManager(
         val platform = getPlatformName()
         val activeProfileId = userProfileRepository.activeProfile.value?.id ?: "default"
 
+        val phaseBackfillCount = syncRepository.backfillPhaseSpecificPRs(activeProfileId)
+        if (phaseBackfillCount > 0) {
+            Logger.i("SyncManager") {
+                "Backfilled $phaseBackfillCount phase-specific PR row(s) before portal push"
+            }
+        }
+
         // 1. Gather workout sessions as full domain objects (profile-scoped to prevent cross-profile leak)
         val sessions = dedupeWorkoutSessionsById(
             syncRepository.getWorkoutSessionsModifiedSince(lastSync, activeProfileId),
@@ -542,13 +549,16 @@ class SyncManager(
 
         // 2. Fetch full PRs with type/phase/volume metadata (GAP 2 fix), profile-scoped
         val recentPRs = syncRepository.getFullPRsModifiedSince(lastSync, activeProfileId)
-        val prBySessionKey = recentPRs.associateBy { pr -> "${pr.exerciseId}:${pr.timestamp}" }
+        val prBySessionKey = recentPRs.groupBy { pr -> "${pr.exerciseId}:${pr.timestamp}" }
+        val sessionIdByPrKey = sessions.associate { session ->
+            "${session.exerciseId}:${session.timestamp}" to session.id
+        }
 
         // 3. Build SessionWithReps (fetch rep metrics per session, detect PRs, attach PR metadata)
         val sessionsWithReps = sessions.map { session ->
             val repMetrics = repMetricRepository.getRepMetrics(session.id)
             val sessionKey = "${session.exerciseId}:${session.timestamp}"
-            val prRecord = prBySessionKey[sessionKey]
+            val prRecords = prBySessionKey[sessionKey] ?: emptyList()
 
             // Resolve the real muscle group from the exercise catalog instead of
             // hardcoding "General". Sessions don't carry a muscle group, so look it
@@ -562,8 +572,19 @@ class SyncManager(
                 session = session,
                 repMetrics = repMetrics,
                 muscleGroup = muscleGroup,
-                isPr = prRecord != null,
-                prRecord = prRecord,
+                isPr = prRecords.isNotEmpty(),
+                prRecords = prRecords,
+            )
+        }
+        val personalRecordDtos = recentPRs.map { pr ->
+            val sessionKey = "${pr.exerciseId}:${pr.timestamp}"
+            val muscleGroup =
+                syncRepository.getExerciseMuscleGroup(pr.exerciseId, pr.exerciseName)
+                    ?: "General"
+            PortalSyncAdapter.toPortalPersonalRecord(
+                record = pr,
+                sessionId = sessionIdByPrKey[sessionKey],
+                muscleGroup = muscleGroup,
             )
         }
 
@@ -779,6 +800,7 @@ class SyncManager(
                 "${effectiveTelemetry.size} telemetry points, " +
                 "${routineDtos.size} routines, ${cycleDtos.size} cycles, " +
                 "${customExerciseDtos.size} custom exercises, " +
+                "${personalRecordDtos.size} personal records, " +
                 "${phaseStatsBySessionId.size} sessions with phase stats, " +
                 "${assessmentDtos.size} assessments"
         }
@@ -807,6 +829,7 @@ class SyncManager(
                 profileName = activeProfile?.name,
                 allProfiles = profileDtos,
                 externalActivities = externalActivityDtos,
+                personalRecords = personalRecordDtos,
             )
             rejectDuplicatePushPayloadKeys(payload)?.let { return it }
             val result = apiClient.pushPortalPayload(payload)
@@ -857,6 +880,7 @@ class SyncManager(
                     profileName = activeProfile?.name,
                     allProfiles = if (isLastBatch) profileDtos else null,
                     externalActivities = if (isLastBatch) externalActivityDtos else emptyList(),
+                    personalRecords = if (isLastBatch) personalRecordDtos else emptyList(),
                 )
 
                 rejectDuplicatePushPayloadKeys(payload)?.let { return it }
@@ -1535,6 +1559,20 @@ internal fun findPushPayloadDuplicateKeys(
     reports.addDuplicateKeys(
         table = "rep_telemetry",
         values = payload.telemetry.map { telemetry -> telemetry.id },
+    )
+    reports.addDuplicateKeys(
+        table = "personal_records",
+        values = payload.personalRecords.map { record ->
+            val exerciseKey = record.exerciseId?.let { "id:$it" }
+                ?: "name:${record.exerciseName}"
+            listOf(
+                record.localProfileId ?: "__no_profile__",
+                exerciseKey,
+                record.achievedAt,
+                record.recordType,
+                record.workoutPhase,
+            ).joinToString("|")
+        },
     )
 
     return reports

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/Models.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/Models.kt
@@ -654,6 +654,7 @@ data class PRCelebrationEvent(
     val workoutMode: String,
     val brokenPRTypes: List<PRType> = listOf(PRType.MAX_WEIGHT),
     val cableCount: Int? = null,
+    val phaseLabel: String = "Combined",
 ) {
     val isWeightPR: Boolean get() = PRType.MAX_WEIGHT in brokenPRTypes
     val isVolumePR: Boolean get() = PRType.MAX_VOLUME in brokenPRTypes

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/ResolveRoutineWeightsUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/ResolveRoutineWeightsUseCase.kt
@@ -2,6 +2,8 @@ package com.devil.phoenixproject.domain.usecase
 
 import com.devil.phoenixproject.data.repository.ExerciseRepository
 import com.devil.phoenixproject.data.repository.PersonalRecordRepository
+import com.devil.phoenixproject.data.repository.getBestVolumePRForWorkoutMode
+import com.devil.phoenixproject.data.repository.getBestWeightPRForWorkoutMode
 import com.devil.phoenixproject.domain.model.PRType
 import com.devil.phoenixproject.domain.model.ProgramMode
 import com.devil.phoenixproject.domain.model.RoutineExercise
@@ -51,13 +53,13 @@ class ResolveRoutineWeightsUseCase(
 
         // Lookup PR for this exercise filtered by mode and profile
         val pr = when (exercise.prTypeForScaling) {
-            PRType.MAX_WEIGHT -> prRepository.getBestWeightPR(
+            PRType.MAX_WEIGHT -> prRepository.getBestWeightPRForWorkoutMode(
                 exerciseId,
                 mode.displayName,
                 profileId,
             )
 
-            PRType.MAX_VOLUME -> prRepository.getBestVolumePR(
+            PRType.MAX_VOLUME -> prRepository.getBestVolumePRForWorkoutMode(
                 exerciseId,
                 mode.displayName,
                 profileId,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/DashboardComponents.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/DashboardComponents.kt
@@ -21,8 +21,10 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.devil.phoenixproject.domain.model.PRType
 import com.devil.phoenixproject.domain.model.PersonalRecord
 import com.devil.phoenixproject.domain.model.WeightUnit
+import com.devil.phoenixproject.domain.model.WorkoutPhase
 import com.devil.phoenixproject.domain.model.WorkoutSession
 import com.devil.phoenixproject.domain.model.effectiveTotalVolumeKg
 import com.devil.phoenixproject.domain.model.currentTimeMillis
@@ -368,7 +370,7 @@ private fun PRListItem(
                     maxLines = 1,
                 )
                 Text(
-                    text = "${pr.reps} reps • ${KmpUtils.formatTimestamp(
+                    text = "${pr.phase.displayLabel()} ${pr.prType.displayLabel()} • ${pr.reps} reps • ${KmpUtils.formatTimestamp(
                         pr.timestamp,
                         "MMM dd, yyyy",
                     )}",
@@ -525,7 +527,7 @@ private fun TopExerciseItem(
                         maxLines = 1,
                     )
                     Text(
-                        text = "${pr.reps} reps",
+                        text = "${pr.phase.displayLabel()} • ${pr.reps} reps",
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
@@ -543,6 +545,17 @@ private fun TopExerciseItem(
             )
         }
     }
+}
+
+private fun WorkoutPhase.displayLabel(): String = when (this) {
+    WorkoutPhase.CONCENTRIC -> "Concentric"
+    WorkoutPhase.ECCENTRIC -> "Eccentric"
+    WorkoutPhase.COMBINED -> "Combined"
+}
+
+private fun PRType.displayLabel(): String = when (this) {
+    PRType.MAX_WEIGHT -> "Weight"
+    PRType.MAX_VOLUME -> "Volume"
 }
 
 /**

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/PRCelebrationAnimation.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/PRCelebrationAnimation.kt
@@ -39,6 +39,7 @@ fun PRCelebrationDialog(
     exerciseName: String,
     weight: String,
     workoutMode: String? = null,
+    phaseLabel: String? = null,
     onDismiss: () -> Unit,
     onSoundTrigger: () -> Unit = {},
 ) {
@@ -66,12 +67,18 @@ fun PRCelebrationDialog(
             exerciseName = exerciseName,
             weight = weight,
             workoutMode = workoutMode,
+            phaseLabel = phaseLabel,
         )
     }
 }
 
 @Composable
-private fun PRCelebrationContent(exerciseName: String, weight: String, workoutMode: String? = null) {
+private fun PRCelebrationContent(
+    exerciseName: String,
+    weight: String,
+    workoutMode: String? = null,
+    phaseLabel: String? = null,
+) {
     // Animation states
     val infiniteTransition = rememberInfiniteTransition(label = "celebration")
 
@@ -139,6 +146,15 @@ private fun PRCelebrationContent(exerciseName: String, weight: String, workoutMo
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.onSurface,
             )
+
+            phaseLabel?.takeIf { it.isNotBlank() }?.let { label ->
+                Text(
+                    "$label phase",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
 
             // Weight achieved
             Surface(

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/PRIndicator.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/PRIndicator.kt
@@ -29,7 +29,12 @@ import androidx.compose.ui.unit.dp
  * @param modifier Modifier for the composable
  */
 @Composable
-fun PRIndicator(currentWeight: Float, prWeight: Float?, modifier: Modifier = Modifier) {
+fun PRIndicator(
+    currentWeight: Float,
+    prWeight: Float?,
+    modifier: Modifier = Modifier,
+    phaseLabel: String? = null,
+) {
     if (prWeight == null || prWeight <= 0) {
         Text(
             text = "No PR",
@@ -51,7 +56,7 @@ fun PRIndicator(currentWeight: Float, prWeight: Float?, modifier: Modifier = Mod
         horizontalArrangement = Arrangement.Center,
     ) {
         Text(
-            text = "$percentage% PR",
+            text = "$percentage% PR${phaseLabel?.let { " · $it" } ?: ""}",
             style = MaterialTheme.typography.labelMedium,
             color = when {
                 isAbovePR -> MaterialTheme.colorScheme.primary

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/WeightStepper.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/WeightStepper.kt
@@ -47,6 +47,7 @@ fun WeightStepper(
     step: Float = 2.5f,
     label: String = "Weight",
     prWeight: Float? = null,
+    prPhaseLabel: String? = null,
 ) {
     Column(modifier = modifier) {
         // Header row with label and PR indicator
@@ -67,6 +68,7 @@ fun WeightStepper(
                 PRIndicator(
                     currentWeight = weight,
                     prWeight = prWeight,
+                    phaseLabel = prPhaseLabel,
                 )
             }
         }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/GamificationManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/GamificationManager.kt
@@ -4,6 +4,7 @@ import co.touchlab.kermit.Logger
 import com.devil.phoenixproject.data.local.BadgeDefinitions
 import com.devil.phoenixproject.data.repository.ExerciseRepository
 import com.devil.phoenixproject.data.repository.GamificationRepository
+import com.devil.phoenixproject.data.repository.PhasePRBreak
 import com.devil.phoenixproject.data.repository.PersonalRecordRepository
 import com.devil.phoenixproject.domain.model.Badge
 import com.devil.phoenixproject.domain.model.BadgeRequirement
@@ -11,6 +12,7 @@ import com.devil.phoenixproject.domain.model.HapticEvent
 import com.devil.phoenixproject.domain.model.PRCelebrationEvent
 import com.devil.phoenixproject.domain.model.PRType
 import com.devil.phoenixproject.domain.model.ProgramMode
+import com.devil.phoenixproject.domain.model.WorkoutPhase
 import com.devil.phoenixproject.domain.model.currentTimeMillis
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -143,6 +145,7 @@ class GamificationManager(
                     }
 
                     // Check phase-specific PRs (Issue #111)
+                    var phasePRBreaks = emptyList<PhasePRBreak>()
                     if (peakConcentricForceKg > 0f || peakEccentricForceKg > 0f) {
                         personalRecordRepository.updatePhaseSpecificPRs(
                             exerciseId = exId,
@@ -153,7 +156,14 @@ class GamificationManager(
                             peakEccentricForceKg = peakEccentricForceKg,
                             profileId = effectiveProfileId,
                             cableCount = cableCount,
-                        ).onFailure { e ->
+                        ).onSuccess { breaks ->
+                            phasePRBreaks = breaks
+                            if (breaks.isNotEmpty()) {
+                                Logger.i {
+                                    "PR_TRACK: SUCCESS — New phase PR(s) broken: $breaks for exercise=$exId, mode=$workoutMode, profile=$effectiveProfileId"
+                                }
+                            }
+                        }.onFailure { e ->
                             Logger.e { "PR_TRACK: Error updating phase-specific PRs: ${e.message}" }
                         }
                     }
@@ -161,30 +171,41 @@ class GamificationManager(
                     // Only celebrate if gamification is enabled and an actual PR was broken
                     if (gamificationEnabled.value) {
                         result.onSuccess { brokenPRs ->
-                            if (brokenPRs.isNotEmpty()) {
+                            val celebrationPRTypes = brokenPRs.ifEmpty {
+                                phasePRBreaks.map { it.prType }.distinct()
+                            }
+                            if (celebrationPRTypes.isNotEmpty()) {
                                 hasCelebrationSound = true // PR dialog will play sound via callback
                                 val prTypeDescription = when {
-                                    brokenPRs.contains(PRType.MAX_WEIGHT) &&
-                                        brokenPRs.contains(PRType.MAX_VOLUME) -> "Weight & Volume"
+                                    celebrationPRTypes.contains(PRType.MAX_WEIGHT) &&
+                                        celebrationPRTypes.contains(PRType.MAX_VOLUME) -> "Weight & Volume"
 
-                                    brokenPRs.contains(PRType.MAX_WEIGHT) -> "Weight"
+                                    celebrationPRTypes.contains(PRType.MAX_WEIGHT) -> "Weight"
 
-                                    brokenPRs.contains(PRType.MAX_VOLUME) -> "Volume"
+                                    celebrationPRTypes.contains(PRType.MAX_VOLUME) -> "Volume"
 
                                     else -> ""
+                                }
+                                val phaseLabel = phasePRBreaks.celebrationPhaseLabel()
+                                val celebrationWeight = when {
+                                    brokenPRs.isNotEmpty() -> achievedWeightKg
+                                    phasePRBreaks.singlePhaseOrNull() == WorkoutPhase.ECCENTRIC -> peakEccentricForceKg
+                                    phasePRBreaks.singlePhaseOrNull() == WorkoutPhase.CONCENTRIC -> peakConcentricForceKg
+                                    else -> maxOf(peakConcentricForceKg, peakEccentricForceKg, achievedWeightKg)
                                 }
                                 _prCelebrationEvent.emit(
                                     PRCelebrationEvent(
                                         exerciseName = exercise?.name ?: "Unknown Exercise",
-                                        weightPerCableKg = achievedWeightKg,
+                                        weightPerCableKg = celebrationWeight,
                                         reps = workingReps,
                                         workoutMode = workoutMode,
-                                        brokenPRTypes = brokenPRs,
+                                        brokenPRTypes = celebrationPRTypes,
                                         cableCount = cableCount,
+                                        phaseLabel = phaseLabel,
                                     ),
                                 )
                                 Logger.i {
-                                    "NEW PR ($prTypeDescription): ${exercise?.name} - $achievedWeightKg kg x $workingReps reps in $workoutMode mode (profile=$effectiveProfileId)"
+                                    "NEW $phaseLabel PR ($prTypeDescription): ${exercise?.name} - $celebrationWeight kg x $workingReps reps in $workoutMode mode (profile=$effectiveProfileId)"
                                 }
                             }
                         }
@@ -293,4 +314,14 @@ class GamificationManager(
         if (!gamificationEnabled.value) return
         scope.launch { hapticEvents.emit(HapticEvent.PERSONAL_RECORD) }
     }
+}
+
+private fun List<PhasePRBreak>.singlePhaseOrNull(): WorkoutPhase? =
+    map { it.phase }.distinct().singleOrNull()
+
+private fun List<PhasePRBreak>.celebrationPhaseLabel(): String = when {
+    isEmpty() -> "Combined"
+    singlePhaseOrNull() == WorkoutPhase.CONCENTRIC -> "Concentric"
+    singlePhaseOrNull() == WorkoutPhase.ECCENTRIC -> "Eccentric"
+    else -> "Concentric + Eccentric"
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ActiveWorkoutScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ActiveWorkoutScreen.kt
@@ -562,6 +562,7 @@ fun ActiveWorkoutScreen(navController: NavController, viewModel: MainViewModel, 
                 weightUnit,
             )} × ${event.reps} reps",
             workoutMode = event.workoutMode,
+            phaseLabel = event.phaseLabel,
             onDismiss = { prCelebrationEvent = null },
             onSoundTrigger = { viewModel.emitPRSound() },
         )

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseEditBottomSheet.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseEditBottomSheet.kt
@@ -75,6 +75,7 @@ import com.devil.phoenixproject.domain.model.RepCountTiming
 import com.devil.phoenixproject.domain.model.RoutineExercise
 import com.devil.phoenixproject.domain.model.WarmupSet
 import com.devil.phoenixproject.domain.model.WeightUnit
+import com.devil.phoenixproject.domain.model.WorkoutPhase
 import com.devil.phoenixproject.domain.model.WorkoutMode
 import com.devil.phoenixproject.presentation.components.CompactNumberPicker
 import com.devil.phoenixproject.presentation.components.ProgressionSlider
@@ -292,7 +293,7 @@ fun ExerciseEditBottomSheet(
                                 )
                                 Column {
                                     Text(
-                                        "Personal Record",
+                                        "${pr.phase.displayLabel()} Personal Record",
                                         style = MaterialTheme.typography.labelMedium,
                                         fontWeight = FontWeight.Bold,
                                         color = MaterialTheme.colorScheme.onPrimaryContainer,
@@ -1244,7 +1245,7 @@ fun WeightConfigurationCard(
                     )
                     Text(
                         text = if (currentExercisePR != null) {
-                            "Scale weight based on your personal record"
+                            "Scale weight based on your ${currentExercisePR.phase.displayLabel().lowercase()} personal record"
                         } else {
                             "No PR set for this exercise"
                         },
@@ -1274,7 +1275,7 @@ fun WeightConfigurationCard(
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Text(
-                        text = "$weightPercentOfPR% of PR",
+                        text = "$weightPercentOfPR% of ${currentExercisePR.phase.displayLabel()} PR",
                         style = MaterialTheme.typography.titleLarge,
                         fontWeight = FontWeight.Bold,
                         color = MaterialTheme.colorScheme.primary,
@@ -1633,4 +1634,10 @@ private fun WarmupSetRow(
             }
         }
     }
+}
+
+private fun WorkoutPhase.displayLabel(): String = when (this) {
+    WorkoutPhase.CONCENTRIC -> "Concentric"
+    WorkoutPhase.ECCENTRIC -> "Eccentric"
+    WorkoutPhase.COMBINED -> "Combined"
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseEditBottomSheet.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseEditBottomSheet.kt
@@ -1244,9 +1244,9 @@ fun WeightConfigurationCard(
                         color = if (usePercentOfPR) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface,
                     )
                     Text(
-                        text = if (currentExercisePR != null) {
-                            "Scale weight based on your ${currentExercisePR.phase.displayLabel().lowercase()} personal record"
-                        } else {
+                        text = currentExercisePR?.let { pr ->
+                            "Scale weight based on your ${pr.phase.displayLabel().lowercase()} personal record"
+                        } ?: run {
                             "No PR set for this exercise"
                         },
                         style = MaterialTheme.typography.bodySmall,
@@ -1261,11 +1261,12 @@ fun WeightConfigurationCard(
             }
 
             // Show percentage controls when toggle is ON and PR exists
-            if (usePercentOfPR && currentExercisePR != null) {
+            val prForScaling = currentExercisePR
+            if (usePercentOfPR && prForScaling != null) {
                 Spacer(modifier = Modifier.height(Spacing.medium))
 
                 // Calculate resolved weight
-                val resolvedWeight = (currentExercisePR.weightPerCableKg * weightPercentOfPR / 100f)
+                val resolvedWeight = (prForScaling.weightPerCableKg * weightPercentOfPR / 100f)
                     .let { (it * 2).roundToInt() / 2f } // Round to 0.5kg
 
                 // Display current percentage and resolved weight
@@ -1275,7 +1276,7 @@ fun WeightConfigurationCard(
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Text(
-                        text = "$weightPercentOfPR% of ${currentExercisePR.phase.displayLabel()} PR",
+                        text = "$weightPercentOfPR% of ${prForScaling.phase.displayLabel()} PR",
                         style = MaterialTheme.typography.titleLarge,
                         fontWeight = FontWeight.Bold,
                         color = MaterialTheme.colorScheme.primary,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
 import com.devil.phoenixproject.data.repository.PersonalRecordRepository
+import com.devil.phoenixproject.data.repository.getBestWeightPRForWorkoutMode
 import com.devil.phoenixproject.domain.model.EccentricLoad
 import com.devil.phoenixproject.domain.model.EchoLevel
 import com.devil.phoenixproject.domain.model.PRType
@@ -265,7 +266,7 @@ class ExerciseConfigViewModel constructor(
         }
         viewModelScope.launch {
             try {
-                val pr = personalRecordRepository.getBestWeightPR(exerciseId, workoutMode, activeProfileId)
+                val pr = personalRecordRepository.getBestWeightPRForWorkoutMode(exerciseId, workoutMode, activeProfileId)
                 _currentExercisePR.value = pr
                 syncSetWeightsToPercentOfPR()
                 logDebug("Loaded PR for exercise=$exerciseId, mode=$workoutMode, profile=$activeProfileId: ${pr?.weightPerCableKg ?: "none"}")

--- a/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
+++ b/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
@@ -554,6 +554,39 @@ SELECT id FROM WorkoutSession;
 selectRecentSessions:
 SELECT * FROM WorkoutSession WHERE profile_id = :profileId ORDER BY timestamp DESC LIMIT :limit;
 
+selectSessionsForPhasePRBackfill:
+SELECT * FROM WorkoutSession
+WHERE profile_id = :profileId
+AND timestamp >= :fromSessionTimestamp
+AND deletedAt IS NULL
+AND exerciseId IS NOT NULL
+AND exerciseId != ''
+AND (workingReps > 0 OR totalReps > 0)
+AND (
+    COALESCE(peakForceConcentricA, 0) > 0
+    OR COALESCE(peakForceConcentricB, 0) > 0
+    OR COALESCE(peakForceEccentricA, 0) > 0
+    OR COALESCE(peakForceEccentricB, 0) > 0
+)
+ORDER BY timestamp ASC;
+
+selectLatestSessionForPhasePRBackfill:
+SELECT * FROM WorkoutSession
+WHERE profile_id = :profileId
+AND timestamp >= :fromSessionTimestamp
+AND deletedAt IS NULL
+ORDER BY timestamp DESC
+LIMIT 1;
+
+selectSessionIdForPersonalRecord:
+SELECT id FROM WorkoutSession
+WHERE exerciseId = :exerciseId
+AND timestamp = :timestamp
+AND profile_id = :profileId
+AND deletedAt IS NULL
+ORDER BY updatedAt DESC, id ASC
+LIMIT 1;
+
 insertSession:
 INSERT INTO WorkoutSession (
     id, timestamp, mode, targetReps, weightPerCableKg, progressionKg,

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/repository/PersonalRecordRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/repository/PersonalRecordRepositoryTest.kt
@@ -2,6 +2,7 @@ package com.devil.phoenixproject.data.repository
 
 import com.devil.phoenixproject.domain.model.PRType
 import com.devil.phoenixproject.domain.model.PersonalRecord
+import com.devil.phoenixproject.domain.model.WorkoutPhase
 import com.devil.phoenixproject.testutil.FakePersonalRecordRepository
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -290,6 +291,129 @@ class PersonalRecordRepositoryTest {
         val bestVolumePR = repository.getBestVolumePR(exerciseId, profileId)
         assertNotNull(bestVolumePR)
         assertEquals(450f, bestVolumePR.volume)
+    }
+
+    @Test
+    fun `unphased best weight lookup ignores stronger eccentric PR`() = runTest {
+        repository.addRecord(
+            PersonalRecord(
+                id = 1,
+                exerciseId = exerciseId,
+                exerciseName = exerciseName,
+                weightPerCableKg = 35f,
+                reps = 8,
+                oneRepMax = 45f,
+                timestamp = 1_000L,
+                workoutMode = "Old School",
+                prType = PRType.MAX_WEIGHT,
+                volume = 280f,
+                phase = WorkoutPhase.COMBINED,
+            ),
+        )
+        repository.addRecord(
+            PersonalRecord(
+                id = 2,
+                exerciseId = exerciseId,
+                exerciseName = exerciseName,
+                weightPerCableKg = 80f,
+                reps = 4,
+                oneRepMax = 90f,
+                timestamp = 2_000L,
+                workoutMode = "Old School",
+                prType = PRType.MAX_WEIGHT,
+                volume = 320f,
+                phase = WorkoutPhase.ECCENTRIC,
+            ),
+        )
+
+        val bestWeightPR = repository.getBestWeightPR(exerciseId, "OldSchool", profileId)
+
+        assertNotNull(bestWeightPR)
+        assertEquals(WorkoutPhase.COMBINED, bestWeightPR.phase)
+        assertEquals(35f, bestWeightPR.weightPerCableKg)
+    }
+
+    @Test
+    fun `phase-aware lookup falls back from concentric to combined but never eccentric`() = runTest {
+        repository.addRecord(
+            PersonalRecord(
+                id = 1,
+                exerciseId = exerciseId,
+                exerciseName = exerciseName,
+                weightPerCableKg = 35f,
+                reps = 8,
+                oneRepMax = 45f,
+                timestamp = 1_000L,
+                workoutMode = "Old School",
+                prType = PRType.MAX_WEIGHT,
+                volume = 280f,
+                phase = WorkoutPhase.COMBINED,
+            ),
+        )
+        repository.addRecord(
+            PersonalRecord(
+                id = 2,
+                exerciseId = exerciseId,
+                exerciseName = exerciseName,
+                weightPerCableKg = 80f,
+                reps = 4,
+                oneRepMax = 90f,
+                timestamp = 2_000L,
+                workoutMode = "Old School",
+                prType = PRType.MAX_WEIGHT,
+                volume = 320f,
+                phase = WorkoutPhase.ECCENTRIC,
+            ),
+        )
+
+        val startupPR = repository.getBestWeightPRForWorkoutMode(exerciseId, "OldSchool", profileId)
+        val eccentricOnlyPR = repository.getBestWeightPRForWorkoutMode(exerciseId, "EccentricOnly", profileId)
+
+        assertNotNull(startupPR)
+        assertEquals(WorkoutPhase.COMBINED, startupPR.phase)
+        assertEquals(35f, startupPR.weightPerCableKg)
+        assertNull(eccentricOnlyPR, "Eccentric Only must not borrow a PR from a different workout mode")
+    }
+
+    @Test
+    fun `phase-specific update records weight and volume breaks for each phase`() = runTest {
+        val result = repository.updatePhaseSpecificPRs(
+            exerciseId = exerciseId,
+            workoutMode = "OldSchool",
+            timestamp = 1_000L,
+            reps = 5,
+            peakConcentricForceKg = 30f,
+            peakEccentricForceKg = 60f,
+            profileId = profileId,
+        ).getOrThrow()
+
+        assertEquals(
+            setOf(
+                WorkoutPhase.CONCENTRIC to PRType.MAX_WEIGHT,
+                WorkoutPhase.CONCENTRIC to PRType.MAX_VOLUME,
+                WorkoutPhase.ECCENTRIC to PRType.MAX_WEIGHT,
+                WorkoutPhase.ECCENTRIC to PRType.MAX_VOLUME,
+            ),
+            result.map { it.phase to it.prType }.toSet(),
+        )
+        assertEquals(
+            30f,
+            repository.getBestWeightPR(
+                exerciseId,
+                "OldSchool",
+                profileId,
+                phase = WorkoutPhase.CONCENTRIC,
+            )?.weightPerCableKg,
+        )
+        assertEquals(
+            60f,
+            repository.getBestWeightPR(
+                exerciseId,
+                "OldSchool",
+                profileId,
+                phase = WorkoutPhase.ECCENTRIC,
+            )?.weightPerCableKg,
+        )
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/SyncManagerTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/SyncManagerTest.kt
@@ -4,8 +4,11 @@ import com.devil.phoenixproject.data.repository.SubscriptionStatus
 import com.devil.phoenixproject.domain.model.Exercise
 import com.devil.phoenixproject.domain.model.ExternalActivity
 import com.devil.phoenixproject.domain.model.IntegrationProvider
+import com.devil.phoenixproject.domain.model.PRType
+import com.devil.phoenixproject.domain.model.PersonalRecord
 import com.devil.phoenixproject.domain.model.Routine
 import com.devil.phoenixproject.domain.model.RoutineExercise
+import com.devil.phoenixproject.domain.model.WorkoutPhase
 import com.devil.phoenixproject.domain.model.WorkoutSession
 import com.devil.phoenixproject.testutil.FakeExternalActivityRepository
 import com.devil.phoenixproject.testutil.FakeGamificationRepository
@@ -170,6 +173,27 @@ class SyncManagerTest {
     }
 
     @Test
+    fun syncBackfillsPhaseSpecificPRsBeforeCollectingPushRecords() = runTest {
+        setupAuthenticated()
+        fakeSyncRepo.phaseBackfillBreaksToReturn = 2
+        fakeApi.pushResult = Result.success(
+            PortalSyncPushResponse(syncTime = "2026-03-02T12:00:00Z"),
+        )
+        val manager = createManager()
+
+        val result = manager.sync()
+
+        assertTrue(result.isSuccess)
+        assertEquals(
+            listOf("backfillPhaseSpecificPRs", "getFullPRsModifiedSince"),
+            fakeSyncRepo.callLog.filter {
+                it == "backfillPhaseSpecificPRs" || it == "getFullPRsModifiedSince"
+            },
+            "Historical phase PR backfill must run before building the dedicated PR payload",
+        )
+    }
+
+    @Test
     fun syncSendsCorrectPayloadWithDeviceIdAndPlatform() = runTest {
         setupAuthenticated()
         fakeApi.pushResult = Result.success(
@@ -282,6 +306,91 @@ class SyncManagerTest {
             listOf(sessionId),
             fakeSyncRepo.updateSessionTimestampCalls,
             "Post-push timestamp stamping should run once for the deduped session",
+        )
+    }
+
+    @Test
+    fun syncPushesAllPhaseSpecificPersonalRecordsForSameExerciseTimestamp() = runTest {
+        setupAuthenticated()
+        val exerciseId = "bicep-curl"
+        val timestamp = 1_740_916_800_000L
+        fakeSyncRepo.workoutSessionsToReturn = listOf(
+            makeWorkoutSession(
+                id = "session-phase-pr",
+                timestamp = timestamp,
+                reps = 8,
+                totalReps = 8,
+                exerciseId = exerciseId,
+                exerciseName = "Bicep Curl",
+            ),
+        )
+        fakeSyncRepo.fullPRsToReturn = listOf(
+            makePersonalRecord(
+                id = 1,
+                exerciseId = exerciseId,
+                exerciseName = "Bicep Curl",
+                weightPerCableKg = 20f,
+                reps = 8,
+                timestamp = timestamp,
+                prType = PRType.MAX_WEIGHT,
+                phase = WorkoutPhase.CONCENTRIC,
+            ),
+            makePersonalRecord(
+                id = 2,
+                exerciseId = exerciseId,
+                exerciseName = "Bicep Curl",
+                weightPerCableKg = 42f,
+                reps = 8,
+                timestamp = timestamp,
+                prType = PRType.MAX_WEIGHT,
+                phase = WorkoutPhase.ECCENTRIC,
+            ),
+            makePersonalRecord(
+                id = 3,
+                exerciseId = exerciseId,
+                exerciseName = "Bicep Curl",
+                weightPerCableKg = 20f,
+                reps = 8,
+                timestamp = timestamp,
+                prType = PRType.MAX_VOLUME,
+                phase = WorkoutPhase.CONCENTRIC,
+                volume = 160f,
+            ),
+            makePersonalRecord(
+                id = 4,
+                exerciseId = exerciseId,
+                exerciseName = "Bicep Curl",
+                weightPerCableKg = 42f,
+                reps = 8,
+                timestamp = timestamp,
+                prType = PRType.MAX_VOLUME,
+                phase = WorkoutPhase.ECCENTRIC,
+                volume = 336f,
+            ),
+        )
+        fakeApi.pushResult = Result.success(
+            PortalSyncPushResponse(syncTime = "2026-03-02T12:00:00Z"),
+        )
+        val manager = createManager()
+
+        val result = manager.sync()
+
+        assertTrue(result.isSuccess)
+        val payload = assertNotNull(fakeApi.lastPushPayload, "Push payload should be captured")
+        assertEquals(
+            setOf(
+                WorkoutPhase.CONCENTRIC.name to PRType.MAX_WEIGHT.name,
+                WorkoutPhase.ECCENTRIC.name to PRType.MAX_WEIGHT.name,
+                WorkoutPhase.CONCENTRIC.name to PRType.MAX_VOLUME.name,
+                WorkoutPhase.ECCENTRIC.name to PRType.MAX_VOLUME.name,
+            ),
+            payload.personalRecords.map { it.workoutPhase to it.recordType }.toSet(),
+            "Dedicated PR payload rows should preserve phase and PR type instead of collapsing by timestamp",
+        )
+        assertEquals(
+            WorkoutPhase.CONCENTRIC.name,
+            payload.sessions.single().exercises.single().sets.single().prPhase,
+            "Legacy set-level hint should prefer the normal concentric weight PR when present",
         )
     }
 
@@ -1156,6 +1265,7 @@ class SyncManagerTest {
         timestamp: Long,
         reps: Int = 10,
         totalReps: Int = 10,
+        exerciseId: String = "exercise-$id",
         exerciseName: String = "Test Exercise",
         routineSessionId: String? = null,
     ) = WorkoutSession(
@@ -1166,10 +1276,36 @@ class SyncManagerTest {
         weightPerCableKg = 20f,
         duration = 60_000L,
         totalReps = totalReps,
-        exerciseId = "exercise-$id",
+        exerciseId = exerciseId,
         exerciseName = exerciseName,
         routineSessionId = routineSessionId,
         profileId = "default",
+    )
+
+    private fun makePersonalRecord(
+        id: Long,
+        exerciseId: String,
+        exerciseName: String,
+        weightPerCableKg: Float,
+        reps: Int,
+        timestamp: Long,
+        prType: PRType,
+        phase: WorkoutPhase,
+        volume: Float = weightPerCableKg * reps,
+    ) = PersonalRecord(
+        id = id,
+        exerciseId = exerciseId,
+        exerciseName = exerciseName,
+        weightPerCableKg = weightPerCableKg,
+        reps = reps,
+        oneRepMax = weightPerCableKg,
+        timestamp = timestamp,
+        workoutMode = "OldSchool",
+        prType = prType,
+        volume = volume,
+        phase = phase,
+        profileId = "default",
+        cableCount = 2,
     )
 
     private fun makeRoutine(

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/SyncManagerTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/SyncManagerTest.kt
@@ -1,5 +1,6 @@
 package com.devil.phoenixproject.data.sync
 
+import com.devil.phoenixproject.data.repository.PhasePRBackfillResult
 import com.devil.phoenixproject.data.repository.SubscriptionStatus
 import com.devil.phoenixproject.domain.model.Exercise
 import com.devil.phoenixproject.domain.model.ExternalActivity
@@ -175,7 +176,10 @@ class SyncManagerTest {
     @Test
     fun syncBackfillsPhaseSpecificPRsBeforeCollectingPushRecords() = runTest {
         setupAuthenticated()
-        fakeSyncRepo.phaseBackfillBreaksToReturn = 2
+        fakeSyncRepo.phaseBackfillResultToReturn = PhasePRBackfillResult(
+            changedRows = 2,
+            maxScannedSessionTimestamp = 1_700_000_000_000L,
+        )
         fakeApi.pushResult = Result.success(
             PortalSyncPushResponse(syncTime = "2026-03-02T12:00:00Z"),
         )
@@ -190,6 +194,40 @@ class SyncManagerTest {
                 it == "backfillPhaseSpecificPRs" || it == "getFullPRsModifiedSince"
             },
             "Historical phase PR backfill must run before building the dedicated PR payload",
+        )
+        assertEquals(0L, fakeSyncRepo.lastPhaseBackfillFromTimestamp)
+        assertEquals(
+            1_700_000_000_000L,
+            tokenStorage.getPhasePRBackfillCheckpoint("default"),
+            "Successful backfill progress should be checkpointed by profile",
+        )
+    }
+
+    @Test
+    fun syncUsesStoredPhasePRBackfillCheckpoint() = runTest {
+        setupAuthenticated()
+        tokenStorage.setPhasePRBackfillCheckpoint("default", 1_700_000_000_000L)
+        fakeSyncRepo.phaseBackfillResultToReturn = PhasePRBackfillResult(
+            changedRows = 0,
+            maxScannedSessionTimestamp = 1_700_000_100_000L,
+        )
+        fakeApi.pushResult = Result.success(
+            PortalSyncPushResponse(syncTime = "2026-03-02T12:00:00Z"),
+        )
+        val manager = createManager()
+
+        val result = manager.sync()
+
+        assertTrue(result.isSuccess)
+        assertEquals(
+            1_700_000_000_000L,
+            fakeSyncRepo.lastPhaseBackfillFromTimestamp,
+            "Backfill should resume from the stored checkpoint instead of scanning from zero",
+        )
+        assertEquals(
+            1_700_000_100_000L,
+            tokenStorage.getPhasePRBackfillCheckpoint("default"),
+            "Backfill checkpoint should advance to the newest scanned session",
         )
     }
 
@@ -392,6 +430,37 @@ class SyncManagerTest {
             payload.sessions.single().exercises.single().sets.single().prPhase,
             "Legacy set-level hint should prefer the normal concentric weight PR when present",
         )
+    }
+
+    @Test
+    fun syncResolvesSessionIdForDedicatedPROutsideDeltaSessionBatch() = runTest {
+        setupAuthenticated()
+        val exerciseId = "bicep-curl"
+        val timestamp = 1_740_916_800_000L
+        val sessionKey = "$exerciseId:$timestamp"
+        val pr = makePersonalRecord(
+            id = 42,
+            exerciseId = exerciseId,
+            exerciseName = "Bicep Curl",
+            weightPerCableKg = 42f,
+            reps = 8,
+            timestamp = timestamp,
+            prType = PRType.MAX_WEIGHT,
+            phase = WorkoutPhase.ECCENTRIC,
+        )
+        fakeSyncRepo.fullPRsToReturn = listOf(pr)
+        fakeSyncRepo.sessionIdsForPersonalRecordsToReturn = mapOf(sessionKey to "historical-session")
+        fakeApi.pushResult = Result.success(
+            PortalSyncPushResponse(syncTime = "2026-03-02T12:00:00Z"),
+        )
+        val manager = createManager()
+
+        val result = manager.sync()
+
+        assertTrue(result.isSuccess)
+        val payload = assertNotNull(fakeApi.lastPushPayload, "Push payload should be captured")
+        assertEquals("historical-session", payload.personalRecords.single().sessionId)
+        assertEquals(listOf(pr), fakeSyncRepo.lastSessionIdPersonalRecords)
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/ResolveRoutineWeightsUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/ResolveRoutineWeightsUseCaseTest.kt
@@ -5,6 +5,7 @@ import com.devil.phoenixproject.domain.model.PRType
 import com.devil.phoenixproject.domain.model.PersonalRecord
 import com.devil.phoenixproject.domain.model.ProgramMode
 import com.devil.phoenixproject.domain.model.RoutineExercise
+import com.devil.phoenixproject.domain.model.WorkoutPhase
 import com.devil.phoenixproject.testutil.FakeExerciseRepository
 import com.devil.phoenixproject.testutil.FakePersonalRecordRepository
 import kotlin.test.BeforeTest
@@ -527,6 +528,64 @@ class ResolveRoutineWeightsUseCaseTest {
     }
 
     @Test
+    fun `normal mode percent of PR uses concentric PR instead of stronger eccentric PR`() = runTest {
+        prRepository.addRecord(
+            phaseRecord(id = 1, mode = "Old School", phase = WorkoutPhase.COMBINED, weight = 35f),
+        )
+        prRepository.addRecord(
+            phaseRecord(id = 2, mode = "Old School", phase = WorkoutPhase.CONCENTRIC, weight = 45f),
+        )
+        prRepository.addRecord(
+            phaseRecord(id = 3, mode = "Old School", phase = WorkoutPhase.ECCENTRIC, weight = 90f),
+        )
+
+        val routineExercise = RoutineExercise(
+            id = "routine-ex-phase",
+            exercise = testExercise,
+            orderIndex = 0,
+            weightPerCableKg = 30f,
+            usePercentOfPR = true,
+            weightPercentOfPR = 100,
+            prTypeForScaling = PRType.MAX_WEIGHT,
+            programMode = ProgramMode.OldSchool,
+        )
+
+        val result = useCase(routineExercise)
+
+        assertEquals(45f, result.baseWeight)
+        assertEquals(45f, result.usedPR)
+    }
+
+    @Test
+    fun `eccentric only percent of PR uses eccentric phase PR`() = runTest {
+        prRepository.addRecord(
+            phaseRecord(id = 1, mode = "Eccentric Only", phase = WorkoutPhase.COMBINED, weight = 35f),
+        )
+        prRepository.addRecord(
+            phaseRecord(id = 2, mode = "Eccentric Only", phase = WorkoutPhase.CONCENTRIC, weight = 45f),
+        )
+        prRepository.addRecord(
+            phaseRecord(id = 3, mode = "Eccentric Only", phase = WorkoutPhase.ECCENTRIC, weight = 90f),
+        )
+
+        val routineExercise = RoutineExercise(
+            id = "routine-ex-eccentric",
+            exercise = testExercise,
+            orderIndex = 0,
+            weightPerCableKg = 30f,
+            usePercentOfPR = true,
+            weightPercentOfPR = 100,
+            prTypeForScaling = PRType.MAX_WEIGHT,
+            programMode = ProgramMode.EccentricOnly,
+        )
+
+        val result = useCase(routineExercise)
+
+        assertEquals(90f, result.baseWeight)
+        assertEquals(90f, result.usedPR)
+    }
+
+    @Test
     fun `set weights default to base percentage when no per-set percentages defined`() = runTest {
         // Given: Exercise uses PR percentage for base weight, but no per-set percentages
         prRepository.addRecord(
@@ -571,3 +630,17 @@ class ResolveRoutineWeightsUseCaseTest {
         }
     }
 }
+
+private fun phaseRecord(id: Long, mode: String, phase: WorkoutPhase, weight: Float) = PersonalRecord(
+    id = id,
+    exerciseId = "bench-press",
+    exerciseName = "Bench Press",
+    weightPerCableKg = weight,
+    reps = 10,
+    oneRepMax = weight * 1.2f,
+    timestamp = 1_000L + id,
+    workoutMode = mode,
+    prType = PRType.MAX_WEIGHT,
+    volume = weight * 10,
+    phase = phase,
+)

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakePersonalRecordRepository.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakePersonalRecordRepository.kt
@@ -1,6 +1,7 @@
 package com.devil.phoenixproject.testutil
 
 import com.devil.phoenixproject.data.repository.PersonalRecordRepository
+import com.devil.phoenixproject.data.repository.PhasePRBreak
 import com.devil.phoenixproject.data.repository.normalizeWorkoutModeKey
 import com.devil.phoenixproject.domain.model.PRType
 import com.devil.phoenixproject.domain.model.PersonalRecord
@@ -32,7 +33,7 @@ class FakePersonalRecordRepository : PersonalRecordRepository {
 
     // Test control methods
     fun addRecord(record: PersonalRecord) {
-        val key = "${record.exerciseId}-${normalizeWorkoutModeKey(record.workoutMode)}-${record.prType}"
+        val key = recordKey(record.exerciseId, record.workoutMode, record.prType, record.phase, record.profileId)
         records[key] = record
         updateRecordsFlow()
     }
@@ -88,7 +89,7 @@ class FakePersonalRecordRepository : PersonalRecordRepository {
         updateCalls.add(UpdateCall(exerciseId, weightPerCableKg, weightPerCableKg, reps, workoutMode, timestamp))
 
         val normalizedMode = normalizeWorkoutModeKey(workoutMode)
-        val key = "$exerciseId-$normalizedMode-${PRType.MAX_VOLUME}"
+        val key = recordKey(exerciseId, normalizedMode, PRType.MAX_VOLUME, WorkoutPhase.COMBINED, profileId)
         val existing = records[key]
         val newVolume = weightPerCableKg * reps
 
@@ -104,6 +105,9 @@ class FakePersonalRecordRepository : PersonalRecordRepository {
                 workoutMode = workoutMode,
                 prType = PRType.MAX_VOLUME,
                 volume = newVolume,
+                phase = WorkoutPhase.COMBINED,
+                profileId = profileId,
+                cableCount = cableCount,
             )
             updateRecordsFlow()
             Result.success(true)
@@ -116,7 +120,8 @@ class FakePersonalRecordRepository : PersonalRecordRepository {
         .filter {
             it.exerciseId == exerciseId &&
                 normalizeWorkoutModeKey(it.workoutMode) == normalizeWorkoutModeKey(workoutMode) &&
-                it.prType == PRType.MAX_WEIGHT
+                it.prType == PRType.MAX_WEIGHT &&
+                it.phase == WorkoutPhase.COMBINED
         }
         .maxByOrNull { it.weightPerCableKg }
 
@@ -124,31 +129,34 @@ class FakePersonalRecordRepository : PersonalRecordRepository {
         .filter {
             it.exerciseId == exerciseId &&
                 normalizeWorkoutModeKey(it.workoutMode) == normalizeWorkoutModeKey(workoutMode) &&
-                it.prType == PRType.MAX_VOLUME
+                it.prType == PRType.MAX_VOLUME &&
+                it.phase == WorkoutPhase.COMBINED
         }
         .maxByOrNull { it.volume }
 
-    override suspend fun getBestWeightPR(exerciseId: String, profileId: String): PersonalRecord? = records.values
-        .filter { it.exerciseId == exerciseId && it.prType == PRType.MAX_WEIGHT }
+    override suspend fun getBestWeightPR(exerciseId: String, profileId: String, phase: WorkoutPhase): PersonalRecord? = records.values
+        .filter { it.exerciseId == exerciseId && it.prType == PRType.MAX_WEIGHT && it.phase == phase }
         .maxByOrNull { it.weightPerCableKg }
 
-    override suspend fun getBestVolumePR(exerciseId: String, profileId: String): PersonalRecord? = records.values
-        .filter { it.exerciseId == exerciseId && it.prType == PRType.MAX_VOLUME }
+    override suspend fun getBestVolumePR(exerciseId: String, profileId: String, phase: WorkoutPhase): PersonalRecord? = records.values
+        .filter { it.exerciseId == exerciseId && it.prType == PRType.MAX_VOLUME && it.phase == phase }
         .maxByOrNull { it.volume }
 
-    override suspend fun getBestWeightPR(exerciseId: String, workoutMode: String, profileId: String): PersonalRecord? = records.values
+    override suspend fun getBestWeightPR(exerciseId: String, workoutMode: String, profileId: String, phase: WorkoutPhase): PersonalRecord? = records.values
         .filter {
             it.exerciseId == exerciseId &&
                 normalizeWorkoutModeKey(it.workoutMode) == normalizeWorkoutModeKey(workoutMode) &&
-                it.prType == PRType.MAX_WEIGHT
+                it.prType == PRType.MAX_WEIGHT &&
+                it.phase == phase
         }
         .maxByOrNull { it.weightPerCableKg }
 
-    override suspend fun getBestVolumePR(exerciseId: String, workoutMode: String, profileId: String): PersonalRecord? = records.values
+    override suspend fun getBestVolumePR(exerciseId: String, workoutMode: String, profileId: String, phase: WorkoutPhase): PersonalRecord? = records.values
         .filter {
             it.exerciseId == exerciseId &&
                 normalizeWorkoutModeKey(it.workoutMode) == normalizeWorkoutModeKey(workoutMode) &&
-                it.prType == PRType.MAX_VOLUME
+                it.prType == PRType.MAX_VOLUME &&
+                it.phase == phase
         }
         .maxByOrNull { it.volume }
 
@@ -184,7 +192,7 @@ class FakePersonalRecordRepository : PersonalRecordRepository {
         val newOneRepMax = calculateOneRepMax(weightPRWeightPerCableKg, reps)
 
         // Check weight PR
-        val weightKey = "$exerciseId-$normalizedMode-${PRType.MAX_WEIGHT}"
+        val weightKey = recordKey(exerciseId, normalizedMode, PRType.MAX_WEIGHT, WorkoutPhase.COMBINED, profileId)
         val existingWeightPR = records[weightKey]
         if (existingWeightPR == null || weightPRWeightPerCableKg > existingWeightPR.weightPerCableKg) {
             records[weightKey] = PersonalRecord(
@@ -198,12 +206,15 @@ class FakePersonalRecordRepository : PersonalRecordRepository {
                 workoutMode = workoutMode,
                 prType = PRType.MAX_WEIGHT,
                 volume = weightPRVolume,
+                phase = WorkoutPhase.COMBINED,
+                profileId = profileId,
+                cableCount = cableCount,
             )
             brokenPRs.add(PRType.MAX_WEIGHT)
         }
 
         // Check volume PR
-        val volumeKey = "$exerciseId-$normalizedMode-${PRType.MAX_VOLUME}"
+        val volumeKey = recordKey(exerciseId, normalizedMode, PRType.MAX_VOLUME, WorkoutPhase.COMBINED, profileId)
         val existingVolumePR = records[volumeKey]
         if (existingVolumePR == null || newVolumePRVolume > existingVolumePR.volume) {
             records[volumeKey] = PersonalRecord(
@@ -217,6 +228,9 @@ class FakePersonalRecordRepository : PersonalRecordRepository {
                 workoutMode = workoutMode,
                 prType = PRType.MAX_VOLUME,
                 volume = newVolumePRVolume,
+                phase = WorkoutPhase.COMBINED,
+                profileId = profileId,
+                cableCount = cableCount,
             )
             brokenPRs.add(PRType.MAX_VOLUME)
         }
@@ -234,52 +248,110 @@ class FakePersonalRecordRepository : PersonalRecordRepository {
         peakEccentricForceKg: Float,
         profileId: String,
         cableCount: Int?,
-    ): Result<List<WorkoutPhase>> {
-        val brokenPhases = mutableListOf<WorkoutPhase>()
+    ): Result<List<PhasePRBreak>> {
+        val brokenPRs = mutableListOf<PhasePRBreak>()
 
         if (peakConcentricForceKg > 0f) {
-            val key = "$exerciseId-$workoutMode-${PRType.MAX_WEIGHT}-CONCENTRIC"
-            val existing = records[key]
-            if (existing == null || peakConcentricForceKg > existing.weightPerCableKg) {
-                records[key] = PersonalRecord(
-                    id = records.size.toLong(),
+            brokenPRs.addAll(
+                updatePhasePRs(
                     exerciseId = exerciseId,
-                    exerciseName = exerciseId,
-                    weightPerCableKg = peakConcentricForceKg,
-                    reps = reps,
-                    oneRepMax = calculateOneRepMax(peakConcentricForceKg * 2, reps),
-                    timestamp = timestamp,
                     workoutMode = workoutMode,
-                    prType = PRType.MAX_WEIGHT,
-                    volume = peakConcentricForceKg * reps,
+                    timestamp = timestamp,
+                    reps = reps,
+                    weightPerCableKg = peakConcentricForceKg,
                     phase = WorkoutPhase.CONCENTRIC,
-                )
-                brokenPhases.add(WorkoutPhase.CONCENTRIC)
-            }
+                    profileId = profileId,
+                    cableCount = cableCount,
+                ),
+            )
         }
 
         if (peakEccentricForceKg > 0f) {
-            val key = "$exerciseId-$workoutMode-${PRType.MAX_WEIGHT}-ECCENTRIC"
-            val existing = records[key]
-            if (existing == null || peakEccentricForceKg > existing.weightPerCableKg) {
-                records[key] = PersonalRecord(
-                    id = records.size.toLong(),
+            brokenPRs.addAll(
+                updatePhasePRs(
                     exerciseId = exerciseId,
-                    exerciseName = exerciseId,
-                    weightPerCableKg = peakEccentricForceKg,
-                    reps = reps,
-                    oneRepMax = calculateOneRepMax(peakEccentricForceKg * 2, reps),
-                    timestamp = timestamp,
                     workoutMode = workoutMode,
-                    prType = PRType.MAX_WEIGHT,
-                    volume = peakEccentricForceKg * reps,
+                    timestamp = timestamp,
+                    reps = reps,
+                    weightPerCableKg = peakEccentricForceKg,
                     phase = WorkoutPhase.ECCENTRIC,
-                )
-                brokenPhases.add(WorkoutPhase.ECCENTRIC)
-            }
+                    profileId = profileId,
+                    cableCount = cableCount,
+                ),
+            )
         }
 
         updateRecordsFlow()
-        return Result.success(brokenPhases)
+        return Result.success(brokenPRs)
+    }
+
+    private fun updatePhasePRs(
+        exerciseId: String,
+        workoutMode: String,
+        timestamp: Long,
+        reps: Int,
+        weightPerCableKg: Float,
+        phase: WorkoutPhase,
+        profileId: String,
+        cableCount: Int?,
+    ): List<PhasePRBreak> {
+        val broken = mutableListOf<PhasePRBreak>()
+        val normalizedMode = normalizeWorkoutModeKey(workoutMode)
+        val volume = weightPerCableKg * reps
+        val oneRepMax = calculateOneRepMax(weightPerCableKg, reps)
+
+        val weightKey = recordKey(exerciseId, normalizedMode, PRType.MAX_WEIGHT, phase, profileId)
+        val existingWeight = records[weightKey]
+        if (existingWeight == null || weightPerCableKg > existingWeight.weightPerCableKg) {
+            records[weightKey] = PersonalRecord(
+                id = existingWeight?.id ?: records.size.toLong(),
+                exerciseId = exerciseId,
+                exerciseName = existingWeight?.exerciseName ?: exerciseId,
+                weightPerCableKg = weightPerCableKg,
+                reps = reps,
+                oneRepMax = oneRepMax,
+                timestamp = timestamp,
+                workoutMode = normalizedMode,
+                prType = PRType.MAX_WEIGHT,
+                volume = volume,
+                phase = phase,
+                profileId = profileId,
+                cableCount = cableCount,
+            )
+            broken.add(PhasePRBreak(phase, PRType.MAX_WEIGHT))
+        }
+
+        val volumeKey = recordKey(exerciseId, normalizedMode, PRType.MAX_VOLUME, phase, profileId)
+        val existingVolume = records[volumeKey]
+        if (existingVolume == null || volume > existingVolume.volume) {
+            records[volumeKey] = PersonalRecord(
+                id = existingVolume?.id ?: records.size.toLong(),
+                exerciseId = exerciseId,
+                exerciseName = existingVolume?.exerciseName ?: exerciseId,
+                weightPerCableKg = weightPerCableKg,
+                reps = reps,
+                oneRepMax = oneRepMax,
+                timestamp = timestamp,
+                workoutMode = normalizedMode,
+                prType = PRType.MAX_VOLUME,
+                volume = volume,
+                phase = phase,
+                profileId = profileId,
+                cableCount = cableCount,
+            )
+            broken.add(PhasePRBreak(phase, PRType.MAX_VOLUME))
+        }
+
+        return broken
+    }
+
+    private fun recordKey(
+        exerciseId: String,
+        workoutMode: String,
+        prType: PRType,
+        phase: WorkoutPhase,
+        profileId: String,
+    ): String {
+        return "$exerciseId-${normalizeWorkoutModeKey(workoutMode)}-$prType-$phase-$profileId"
     }
 }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeSyncRepository.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeSyncRepository.kt
@@ -25,8 +25,11 @@ class FakeSyncRepository : SyncRepository {
 
     // === Configurable return values for push ===
 
+    val callLog: MutableList<String> = mutableListOf()
     var workoutSessionsToReturn: List<WorkoutSession> = emptyList()
     var prsToReturn: List<PersonalRecordSyncDto> = emptyList()
+    var fullPRsToReturn: List<PersonalRecord> = emptyList()
+    var phaseBackfillBreaksToReturn: Int = 0
     var routinesToReturn: List<Routine> = emptyList()
     var gamificationStatsToReturn: GamificationStatsSyncDto? = null
 
@@ -161,7 +164,15 @@ class FakeSyncRepository : SyncRepository {
 
     override suspend fun getFullCyclesForSync(profileId: String): List<CycleWithContext> = cyclesToReturn
 
-    override suspend fun getFullPRsModifiedSince(timestamp: Long, profileId: String): List<PersonalRecord> = emptyList()
+    override suspend fun getFullPRsModifiedSince(timestamp: Long, profileId: String): List<PersonalRecord> {
+        callLog += "getFullPRsModifiedSince"
+        return fullPRsToReturn
+    }
+
+    override suspend fun backfillPhaseSpecificPRs(profileId: String): Int {
+        callLog += "backfillPhaseSpecificPRs"
+        return phaseBackfillBreaksToReturn
+    }
 
     override suspend fun getPhaseStatisticsForSessions(sessionIds: List<String>): List<PhaseStatistics> = emptyList()
 

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeSyncRepository.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeSyncRepository.kt
@@ -1,5 +1,6 @@
 package com.devil.phoenixproject.testutil
 
+import com.devil.phoenixproject.data.repository.PhasePRBackfillResult
 import com.devil.phoenixproject.data.repository.SyncRepository
 import com.devil.phoenixproject.data.sync.CustomExerciseSyncDto
 import com.devil.phoenixproject.data.sync.EarnedBadgeSyncDto
@@ -29,7 +30,10 @@ class FakeSyncRepository : SyncRepository {
     var workoutSessionsToReturn: List<WorkoutSession> = emptyList()
     var prsToReturn: List<PersonalRecordSyncDto> = emptyList()
     var fullPRsToReturn: List<PersonalRecord> = emptyList()
-    var phaseBackfillBreaksToReturn: Int = 0
+    var phaseBackfillResultToReturn: PhasePRBackfillResult = PhasePRBackfillResult(changedRows = 0)
+    var lastPhaseBackfillFromTimestamp: Long? = null
+    var sessionIdsForPersonalRecordsToReturn: Map<String, String> = emptyMap()
+    var lastSessionIdPersonalRecords: List<PersonalRecord> = emptyList()
     var routinesToReturn: List<Routine> = emptyList()
     var gamificationStatsToReturn: GamificationStatsSyncDto? = null
 
@@ -169,9 +173,22 @@ class FakeSyncRepository : SyncRepository {
         return fullPRsToReturn
     }
 
-    override suspend fun backfillPhaseSpecificPRs(profileId: String): Int {
+    override suspend fun backfillPhaseSpecificPRs(
+        profileId: String,
+        fromSessionTimestamp: Long,
+    ): PhasePRBackfillResult {
         callLog += "backfillPhaseSpecificPRs"
-        return phaseBackfillBreaksToReturn
+        lastPhaseBackfillFromTimestamp = fromSessionTimestamp
+        return phaseBackfillResultToReturn
+    }
+
+    override suspend fun findSessionIdsForPersonalRecords(
+        records: List<PersonalRecord>,
+        profileId: String,
+    ): Map<String, String> {
+        callLog += "findSessionIdsForPersonalRecords"
+        lastSessionIdPersonalRecords = records
+        return sessionIdsForPersonalRecordsToReturn
     }
 
     override suspend fun getPhaseStatisticsForSessions(sessionIds: List<String>): List<PhaseStatistics> = emptyList()

--- a/shared/src/iosMain/kotlin/com/devil/phoenixproject/util/CsvExporter.ios.kt
+++ b/shared/src/iosMain/kotlin/com/devil/phoenixproject/util/CsvExporter.ios.kt
@@ -36,14 +36,14 @@ class IosCsvExporter : CsvExporter {
         formatWeight: (Float, WeightUnit) -> String,
     ): Result<String> = try {
         val csv = buildString {
-            appendLine("Exercise,Weight (${weightUnit.name}),Reps,1RM,Date")
+            appendLine("Exercise,Phase,Weight (${weightUnit.name}),Reps,1RM,Date")
             personalRecords.forEach { pr ->
                 val exerciseName = exerciseNames[pr.exerciseId] ?: pr.exerciseId
                 val formattedWeight = formatWeight(pr.weightPerCableKg, weightUnit)
                 val oneRM = calculateOneRM(pr.weightPerCableKg, pr.reps)
                 val formattedOneRM = formatWeight(oneRM, weightUnit)
                 val date = KmpUtils.formatTimestamp(pr.timestamp, "yyyy-MM-dd")
-                appendLine("\"$exerciseName\",$formattedWeight,${pr.reps},$formattedOneRM,$date")
+                appendLine("\"$exerciseName\",${pr.phase.name},$formattedWeight,${pr.reps},$formattedOneRM,$date")
             }
         }
 
@@ -101,7 +101,7 @@ class IosCsvExporter : CsvExporter {
         val grouped = personalRecords.groupBy { it.exerciseId }
 
         val csv = buildString {
-            appendLine("Exercise,Date,Weight (${weightUnit.name}),Reps,1RM,Improvement")
+            appendLine("Exercise,Phase,Date,Weight (${weightUnit.name}),Reps,1RM,Improvement")
 
             grouped.forEach { (exerciseId, prs) ->
                 val exerciseName = exerciseNames[exerciseId] ?: exerciseId
@@ -122,7 +122,7 @@ class IosCsvExporter : CsvExporter {
                     }
                     previousOneRM = oneRM
 
-                    appendLine("\"$exerciseName\",$date,$formattedWeight,${pr.reps},$formattedOneRM,$improvement")
+                    appendLine("\"$exerciseName\",${pr.phase.name},$date,$formattedWeight,${pr.reps},$formattedOneRM,$improvement")
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Add personal record synchronization through the sync layer and portal DTOs
- Update routine weight resolution, exercise config, and workout UI to surface PR-driven feedback
- Add platform CSV exporter support and expand repository, sync, and view-model coverage

## Testing
- Unit tests updated for personal record repositories, sync manager, and routine weight resolution
- UI-oriented test coverage updated for exercise config and sync-related behavior