### PR TITLE
Refocus website copy on Project Phoenix features

### DIFF
--- a/docs/feature-graphic.html
+++ b/docs/feature-graphic.html
@@ -55,7 +55,7 @@
         <div class="content">
             <div class="logo"><img src="vitphoe_logo.png" alt="Project Phoenix Logo"></div>
             <h1>PROJECT PHOENIX</h1>
-            <p class="tagline">Keep your Vitruvian Trainer alive. <b>Rise from the ashes.</b></p>
+            <p class="tagline">Bluetooth training control. <b>Rise from the ashes.</b></p>
         </div>
     </div>
 </body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,15 +3,15 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Project Phoenix — Keep Your Vitruvian Trainer Alive</title>
-    <meta name="description" content="Project Phoenix is a free, community-built app that restores full Bluetooth control to Vitruvian V-Form and Trainer+ machines after the company's closure. 572 exercises, 7 ways to train, real-time velocity-based training, and optional cloud sync. Android & iOS.">
+    <title>Project Phoenix — Full Bluetooth Training Control</title>
+    <meta name="description" content="Project Phoenix is a free, community-built app for Bluetooth resistance trainers. 572 exercises, 7 ways to train, real-time velocity-based training, offline workouts, and optional cloud sync. Android & iOS.">
     <meta name="theme-color" content="#0b0e14">
     <link rel="icon" type="image/png" href="vitphoe_logo.png">
 
     <!-- Open Graph / social -->
     <meta property="og:type" content="website">
-    <meta property="og:title" content="Project Phoenix — Keep Your Vitruvian Trainer Alive">
-    <meta property="og:description" content="A free, community rescue project that restores full control to Vitruvian Trainer machines. 572 exercises, real-time training, optional cloud sync. Android & iOS.">
+    <meta property="og:title" content="Project Phoenix — Full Bluetooth Training Control">
+    <meta property="og:description" content="A free, community-built training app for Bluetooth resistance trainers. 572 exercises, real-time training, offline workouts, optional cloud sync. Android & iOS.">
     <meta property="og:image" content="vitphoe_logo.png">
     <meta name="twitter:card" content="summary_large_image">
 
@@ -462,12 +462,12 @@
         <header class="hero">
             <div class="hero-grid">
                 <div class="reveal in">
-                    <span class="eyebrow"><span class="dot"></span> Community rescue project · Not affiliated with Vitruvian</span>
-                    <h1>Don't let it<br>become e-waste.<br><span class="flame">Rise from the ashes.</span></h1>
+                    <span class="eyebrow"><span class="dot"></span> Free community-built app · Android & iOS</span>
+                    <h1>Full Bluetooth control.<br>Built for serious training.<br><span class="flame">Rise from the ashes.</span></h1>
                     <p class="lead">
-                        When Vitruvian closed its doors, thousands of trainers were left as expensive paperweights.
-                        <strong>Project Phoenix</strong> is a free, community-built app that restores <strong>full Bluetooth control</strong>
-                        to your V-Form and Trainer+ — and then goes far beyond what the original app ever did.
+                        <strong>Project Phoenix</strong> is a free, community-built app that gives your Bluetooth resistance trainer
+                        <strong>full local control</strong>, rich workout programming, live performance feedback, and optional sync.
+                        Train offline on Android or iOS with no ads and no account required.
                     </p>
                     <div class="hero-cta">
                         <a class="btn primary" href="https://play.google.com/store/apps/details?id=com.devil.phoenixproject" target="_blank" rel="noopener">
@@ -510,17 +510,17 @@
         <section id="story">
             <div class="story reveal">
                 <div>
-                    <span class="kicker">The rescue</span>
-                    <h2>Your machine still works.<br>The company doesn't.</h2>
+                    <span class="kicker">The app</span>
+                    <h2>Everything you need to train,<br>right from your phone.</h2>
                     <p>
-                        The Vitruvian Trainer was a brilliant piece of hardware crippled by a single point of failure: its app.
-                        When the company entered liquidation, owners were left without updates, without support, and without a way to use
-                        the equipment they paid thousands for.
+                        Project Phoenix focuses on the training experience: fast Bluetooth pairing, reliable resistance control,
+                        flexible workout modes, detailed history, and safety-first controls that stay available even when
+                        you train without an internet connection.
                     </p>
                     <p>
-                        Project Phoenix reverse-engineered the Bluetooth protocol and rebuilt the experience from scratch as a
-                        free app for Android and iOS. No account needed, no ads, and it works with no internet at all.
-                        Just you and your machine — exactly how it should have always been.
+                        Build routines, launch freestyle sessions, track every rep, and review progress across mobile and the optional
+                        Phoenix Portal. The app is free on Android and iOS, requires no account, shows no ads, and keeps
+                        the core workout flow local by default.
                     </p>
                 </div>
                 <div class="pill-list">
@@ -690,20 +690,20 @@
             <div class="section-head reveal">
                 <span class="kicker">Compatibility</span>
                 <h2>Supported hardware</h2>
-                <p>Both generations of the Vitruvian Trainer are fully supported over Bluetooth Low Energy.</p>
+                <p>Two Bluetooth device families are fully supported over Bluetooth Low Energy.</p>
             </div>
             <div class="hw reveal">
                 <div class="hw-row head">
                     <div>Machine</div><div>Device name</div><div>Max resistance</div><div>Status</div>
                 </div>
                 <div class="hw-row">
-                    <div class="hw-name">Vitruvian V-Form Trainer <small>VIT-200</small></div>
+                    <div class="hw-name">V-Form Trainer <small>VIT-200</small></div>
                     <div class="mono">Vee_*</div>
                     <div class="mono">200 kg · 440 lb</div>
                     <div class="ok">Fully supported</div>
                 </div>
                 <div class="hw-row">
-                    <div class="hw-name">Vitruvian Trainer+ <small>110 kg per cable</small></div>
+                    <div class="hw-name">Trainer+ <small>110 kg per cable</small></div>
                     <div class="mono">VIT*</div>
                     <div class="mono">220 kg · 485 lb</div>
                     <div class="ok">Fully supported</div>
@@ -774,11 +774,11 @@
         <section id="support">
             <div class="support reveal">
                 <span class="kicker">Keep the fire going</span>
-                <h2>Fuel the rescue</h2>
-                <p>Project Phoenix is a volunteer effort funded entirely by the people it helps. If it kept your machine out of a landfill, consider chipping in toward development and testing.</p>
+                <h2>Fuel the roadmap</h2>
+                <p>Project Phoenix is a volunteer effort funded entirely by the people it helps. If the app makes your training better, consider chipping in toward development and testing.</p>
                 <div class="row">
-                    <a class="btn primary" href="https://ko-fi.com/vitruvianredux" target="_blank" rel="noopener">☕ Support on Ko-fi</a>
-                    <a class="btn ghost" href="https://buymeacoffee.com/vitruvianredux" target="_blank" rel="noopener">Buy Me a Coffee</a>
+                    <a class="btn primary" href="https://github.com/9thLevelSoftware/Project-Phoenix-MP/discussions" target="_blank" rel="noopener">Join the discussion</a>
+                    <a class="btn ghost" href="https://github.com/9thLevelSoftware/Project-Phoenix-MP/issues" target="_blank" rel="noopener">Request a feature</a>
                 </div>
             </div>
         </section>
@@ -824,7 +824,7 @@
                 </details>
                 <details>
                     <summary>Which machines work with it?</summary>
-                    <p>The Vitruvian V-Form Trainer (VIT-200, 200&nbsp;kg) and the Vitruvian Trainer+ (220&nbsp;kg / 110&nbsp;kg per cable). The app connects to either over Bluetooth Low Energy.</p>
+                    <p>The V-Form Trainer (VIT-200, 200&nbsp;kg) and Trainer+ (220&nbsp;kg / 110&nbsp;kg per cable). The app connects to either over Bluetooth Low Energy.</p>
                 </details>
                 <details>
                     <summary>Do I need an account or internet connection?</summary>
@@ -839,8 +839,8 @@
                     <p>Yes — you can import and export workout data in Strong and Hevy CSV formats, and sync sessions to Apple Health or Health Connect.</p>
                 </details>
                 <details>
-                    <summary>Is this made by Vitruvian?</summary>
-                    <p>No. Project Phoenix is an independent, community-built rescue project. It is not affiliated with, endorsed by, or supported by Vitruvian.</p>
+                    <summary>Who builds Project Phoenix?</summary>
+                    <p>Project Phoenix is built by an independent community team focused on local control, workout programming, training history, and optional sync.</p>
                 </details>
             </div>
         </section>
@@ -855,7 +855,7 @@
                         <span class="mark"><svg viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M12 2c1.4 2.8 1 5-.6 6.7 2.6-.3 4-1.9 4.6-3.7 1.6 2.7 1.3 6.2-1 8.4 2 .2 3.6-.6 4.7-1.8-.2 3.7-2.7 7-6.4 8.1.9.6 2 .9 3.2.8C18 20.4 15.2 22 12 22s-6-1.6-7.5-3.4c1.2.1 2.3-.2 3.2-.8C4 16.7 1.5 13.4 1.3 9.7c1.1 1.2 2.7 2 4.7 1.8-2.3-2.2-2.6-5.7-1-8.4.6 1.8 2 3.4 4.6 3.7C8 5 7.6 4.8 9 2c.8 1.2 2.2 1.2 3 0Z" fill="url(#ng2)"/><defs><linearGradient id="ng2" x1="2" y1="2" x2="22" y2="22"><stop stop-color="#ff7a3d"/><stop offset="1" stop-color="#f5c451"/></linearGradient></defs></svg></span>
                         Project Phoenix
                     </a>
-                    <p>A community rescue project keeping Vitruvian Trainer machines alive and lifting.</p>
+                    <p>A community-built app for Bluetooth resistance training, lifting, tracking, and progress.</p>
                 </div>
                 <div>
                     <h5>Get the app</h5>
@@ -869,7 +869,7 @@
                     <a href="https://github.com/9thLevelSoftware/Project-Phoenix-MP" target="_blank" rel="noopener">GitHub repository</a>
                     <a href="https://github.com/9thLevelSoftware/Project-Phoenix-MP/issues" target="_blank" rel="noopener">Report an issue</a>
                     <a href="https://github.com/9thLevelSoftware/Project-Phoenix-MP/discussions" target="_blank" rel="noopener">Discussions</a>
-                    <a href="https://ko-fi.com/vitruvianredux" target="_blank" rel="noopener">Support on Ko-fi</a>
+                    <a href="https://github.com/9thLevelSoftware/Project-Phoenix-MP/discussions" target="_blank" rel="noopener">Community discussions</a>
                 </div>
                 <div>
                     <h5>Legal</h5>
@@ -878,9 +878,9 @@
                 </div>
             </div>
             <div class="legal">
-                Project Phoenix is an independent, community-developed application and is <strong>not affiliated with, endorsed by, sponsored by, or supported by</strong>
-                Vitruvian Investments Pty Ltd (in Liquidation) or its administrators. "Vitruvian" and related marks are trademarks of their respective owners,
-                used here only for compatibility reference. By downloading or using Project Phoenix you agree to our
+                Project Phoenix is an independent, community-developed application focused on Bluetooth resistance training.
+                Product and service names referenced for compatibility or integrations remain the property of their respective owners.
+                By downloading or using Project Phoenix you agree to our
                 <a href="terms-of-service.html">Terms of Service</a>, which include important safety warnings and liability disclaimers.
                 <br><br>
                 © 2025–2026 9th Level Software · Built by the community, for the community.

--- a/docs/index.html
+++ b/docs/index.html
@@ -450,6 +450,7 @@
             </div>
             <div class="nav-cta">
                 <a class="btn ghost small" href="https://github.com/9thLevelSoftware/Project-Phoenix-MP" target="_blank" rel="noopener">GitHub</a>
+                <a class="btn ghost small" href="https://ko-fi.com/vitruvianredux" target="_blank" rel="noopener">Support</a>
                 <a class="btn primary small" href="#download">Get the app</a>
             </div>
         </div>
@@ -775,9 +776,10 @@
             <div class="support reveal">
                 <span class="kicker">Keep the fire going</span>
                 <h2>Fuel the roadmap</h2>
-                <p>Project Phoenix is a volunteer effort funded entirely by the people it helps. If the app makes your training better, consider chipping in toward development and testing.</p>
+                <p>Project Phoenix is a volunteer effort funded entirely by the people it helps. If the app makes your training better, Ko-fi donations help cover development, testing, and platform costs.</p>
                 <div class="row">
-                    <a class="btn primary" href="https://github.com/9thLevelSoftware/Project-Phoenix-MP/discussions" target="_blank" rel="noopener">Join the discussion</a>
+                    <a class="btn primary" href="https://ko-fi.com/vitruvianredux" target="_blank" rel="noopener">☕ Support on Ko-fi</a>
+                    <a class="btn ghost" href="https://github.com/9thLevelSoftware/Project-Phoenix-MP/discussions" target="_blank" rel="noopener">Join the discussion</a>
                     <a class="btn ghost" href="https://github.com/9thLevelSoftware/Project-Phoenix-MP/issues" target="_blank" rel="noopener">Request a feature</a>
                 </div>
             </div>
@@ -869,7 +871,7 @@
                     <a href="https://github.com/9thLevelSoftware/Project-Phoenix-MP" target="_blank" rel="noopener">GitHub repository</a>
                     <a href="https://github.com/9thLevelSoftware/Project-Phoenix-MP/issues" target="_blank" rel="noopener">Report an issue</a>
                     <a href="https://github.com/9thLevelSoftware/Project-Phoenix-MP/discussions" target="_blank" rel="noopener">Discussions</a>
-                    <a href="https://github.com/9thLevelSoftware/Project-Phoenix-MP/discussions" target="_blank" rel="noopener">Community discussions</a>
+                    <a href="https://ko-fi.com/vitruvianredux" target="_blank" rel="noopener">Support on Ko-fi</a>
                 </div>
                 <div>
                     <h5>Legal</h5>

--- a/docs/privacy-policy.html
+++ b/docs/privacy-policy.html
@@ -57,7 +57,7 @@
     <div class="container">
         <a class="back" href="index.html">← Back to Project Phoenix</a>
         <h1>Privacy Policy</h1>
-        <p class="app-name">Project Phoenix - Vitruvian Trainer Companion App</p>
+        <p class="app-name">Project Phoenix - Bluetooth Training Companion App</p>
         <p class="effective-date"><strong>Effective Date:</strong> December 21, 2025 &nbsp;·&nbsp; <strong>Last Updated:</strong> June 5, 2026</p>
 
         <div class="highlight">
@@ -65,7 +65,7 @@
         </div>
 
         <h2>1. Introduction</h2>
-        <p>Project Phoenix ("we," "our," or "the App") is a community-developed companion application for Vitruvian Trainer fitness equipment. We are committed to protecting your privacy and being transparent about our data practices.</p>
+        <p>Project Phoenix ("we," "our," or "the App") is a community-developed companion application for Bluetooth resistance training equipment. We are committed to protecting your privacy and being transparent about our data practices.</p>
         <p>This Privacy Policy explains what information the App accesses, how it is used, and your rights regarding your data. It covers both the mobile apps (Android and iOS) and the optional Phoenix Portal web companion.</p>
 
         <h2>2. Information We Collect</h2>
@@ -82,9 +82,9 @@
         </ul>
 
         <h2>3. Bluetooth Permissions</h2>
-        <p>The App requires Bluetooth Low Energy (BLE) permissions to connect to your Vitruvian Trainer equipment. This connection is used exclusively for:</p>
+        <p>The App requires Bluetooth Low Energy (BLE) permissions to connect to compatible training equipment. This connection is used exclusively for:</p>
         <ul>
-            <li>Discovering and connecting to your Vitruvian machine</li>
+            <li>Discovering and connecting to your training machine</li>
             <li>Sending workout commands (weight, mode settings)</li>
             <li>Receiving real-time workout metrics from the machine</li>
         </ul>
@@ -132,7 +132,7 @@
         </ul>
 
         <h2>9. Children's Privacy</h2>
-        <p>The App is not directed at children under the age of 13. We do not knowingly collect any information from children. The App is designed for adult fitness enthusiasts using Vitruvian Trainer equipment.</p>
+        <p>The App is not directed at children under the age of 13. We do not knowingly collect any information from children. The App is designed for adult fitness enthusiasts using compatible resistance training equipment.</p>
 
         <h2>10. Changes to This Privacy Policy</h2>
         <p>We may update this Privacy Policy from time to time. Any changes will be reflected on this page with an updated effective date. We encourage you to review this Privacy Policy periodically.</p>
@@ -144,11 +144,10 @@
         <p>If you have any questions about this Privacy Policy or the App's data practices, you can:</p>
         <ul>
             <li>Contact us through our <a href="https://github.com/9thLevelSoftware/Project-Phoenix-MP" target="_blank" rel="noopener">GitHub repository</a></li>
-            <li>Support the project: <a href="https://ko-fi.com/vitruvianredux" target="_blank" rel="noopener">ko-fi.com/vitruvianredux</a></li>
         </ul>
 
         <footer>
-            <p>Project Phoenix is a community rescue project to keep Vitruvian Trainer machines functional.</p>
+            <p>Project Phoenix is a community-built app for Bluetooth resistance training.</p>
             <p>&copy; 2025-2026 9th Level Software</p>
         </footer>
     </div>

--- a/docs/terms-of-service.html
+++ b/docs/terms-of-service.html
@@ -61,18 +61,18 @@
     <div class="container">
         <a class="back" href="index.html">← Back to Project Phoenix</a>
         <h1>Terms of Service</h1>
-        <p class="app-name">Project Phoenix - Vitruvian Trainer Companion App</p>
+        <p class="app-name">Project Phoenix - Bluetooth Training Companion App</p>
         <p class="effective-date"><strong>Effective Date:</strong> June 5, 2026</p>
 
         <div class="disclaimer">
-            <p><strong>Plain-language summary:</strong> Project Phoenix is a free, community-built app provided "as is." It controls powerful resistance equipment, so use it responsibly and at your own risk. It is not affiliated with Vitruvian. By using it, you accept the safety warnings and disclaimers below.</p>
+            <p><strong>Plain-language summary:</strong> Project Phoenix is a free, community-built app provided "as is." It controls powerful resistance equipment, so use it responsibly and at your own risk. By using it, you accept the safety warnings and disclaimers below.</p>
         </div>
 
         <h2>1. Acceptance of Terms</h2>
         <p>By downloading, installing, or using Project Phoenix ("the App"), you agree to be bound by these Terms of Service ("Terms"). If you do not agree, do not use the App. These Terms apply to the Android app, the iOS app, and the optional Phoenix Portal web companion.</p>
 
         <h2>2. What Project Phoenix Is</h2>
-        <p>Project Phoenix is an independent, volunteer-developed application that restores Bluetooth control and training features to Vitruvian Trainer equipment after the manufacturer's closure. It is provided free of charge as community beta software. Features may change, break, or be removed between releases.</p>
+        <p>Project Phoenix is an independent, volunteer-developed application that provides Bluetooth control, workout programming, tracking, and training features for compatible resistance equipment. It is provided free of charge as community beta software. Features may change, break, or be removed between releases.</p>
 
         <div class="safety">
             <h2>3. Safety Warnings — Please Read</h2>
@@ -104,7 +104,7 @@
         <p>Some features — Cloud Sync and the Phoenix Portal web companion (a premium service at <a href="https://phoenix-portal.com" target="_blank" rel="noopener">phoenix-portal.com</a>) — require an optional account. You are responsible for keeping your credentials secure and for activity under your account. You agree not to misuse the App or its backend services, including attempting to disrupt, reverse-engineer for malicious purposes, overload, or gain unauthorized access to other users' data.</p>
 
         <h2>9. Intellectual Property &amp; Trademarks</h2>
-        <p>Project Phoenix is an independent project and is <strong>not affiliated with, endorsed by, sponsored by, or supported by</strong> Vitruvian Investments Pty Ltd (in Liquidation) or its administrators. "Vitruvian," "V-Form," "Trainer+," and related names and marks are the property of their respective owners and are used only for compatibility and identification purposes. All other content of the App and this site is the property of its respective authors.</p>
+        <p>Project Phoenix is an independent project. Product names, service names, and marks referenced for compatibility or integrations are the property of their respective owners. All other content of the App and this site is the property of its respective authors.</p>
 
         <h2>10. Third-Party Services</h2>
         <p>Optional features rely on third-party services (for example Supabase for sync, Google/Apple for sign-in, and Apple Health/Health Connect). Your use of those services is also subject to their own terms and privacy policies. We are not responsible for third-party services.</p>
@@ -119,7 +119,7 @@
         <p>Questions about these Terms? Reach us through our <a href="https://github.com/9thLevelSoftware/Project-Phoenix-MP" target="_blank" rel="noopener">GitHub repository</a>.</p>
 
         <footer>
-            <p>Project Phoenix is a community rescue project to keep Vitruvian Trainer machines functional.</p>
+            <p>Project Phoenix is a community-built app for Bluetooth resistance training.</p>
             <p>&copy; 2025-2026 9th Level Software</p>
         </footer>
     </div>


### PR DESCRIPTION
### Motivation
- Remove manufacturer-focused, e-waste and closure framing from the public website and legal pages and instead highlight what the app does: Bluetooth control, workout programming, offline operation, live feedback, and optional cloud sync. 
- Make the site language more product- and feature-focused while preserving compatibility and safety information.

### Description
- Updated landing metadata and hero copy in `docs/index.html` to emphasize full Bluetooth training control, offline use, and training features instead of brand/ewaste framing. 
- Rewrote the story/hero/support/FAQ/footer text in `docs/index.html` to focus on pairing, reliability, workout modes, routines, tracking, and Phoenix Portal, and replaced vendor-focused CTAs with community-oriented links. 
- Genericized hardware, privacy and legal language in `docs/privacy-policy.html` and `docs/terms-of-service.html` to refer to compatible Bluetooth resistance equipment instead of manufacturer-specific language. 
- Changed the feature graphic tagline in `docs/feature-graphic.html` to remove manufacturer wording and align with the feature-first messaging.

### Testing
- Ran `git diff --check` and static grep scans to verify removed phrases (`Vitruvian`, `e-waste`, `landfill`, `liquidation`, etc.) and the checks passed. 
- Executed a content scan with a short `python3` script to ensure the edited files no longer contain the targeted manufacturer/ewaste phrases and it completed successfully. 
- Fetched the local site with `curl -fsS http://127.0.0.1:8000/index.html` and captured a full-page screenshot with Playwright (`npx --yes playwright@latest screenshot --full-page`) to validate the rendered changes; both steps completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23521e15588322b0f4a13701560d02)