### PR TITLE
Add TV remote navigation for sliders and editable fields

### DIFF
--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/util/PlatformInputModeAndroidTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/util/PlatformInputModeAndroidTest.kt
@@ -1,0 +1,42 @@
+package com.devil.phoenixproject.presentation.util
+
+import android.content.res.Configuration
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PlatformInputModeAndroidTest {
+
+    @Test
+    fun televisionUiModeUsesTvRemoteInputMode() {
+        assertTrue(
+            isTvRemoteInputMode(
+                uiModeType = Configuration.UI_MODE_TYPE_TELEVISION,
+                touchscreen = Configuration.TOUCHSCREEN_FINGER,
+                navigation = Configuration.NAVIGATION_NONAV,
+            ),
+        )
+    }
+
+    @Test
+    fun noTouchDpadUsesTvRemoteInputMode() {
+        assertTrue(
+            isTvRemoteInputMode(
+                uiModeType = Configuration.UI_MODE_TYPE_NORMAL,
+                touchscreen = Configuration.TOUCHSCREEN_NOTOUCH,
+                navigation = Configuration.NAVIGATION_DPAD,
+            ),
+        )
+    }
+
+    @Test
+    fun touchscreenPhoneDoesNotUseTvRemoteInputMode() {
+        assertFalse(
+            isTvRemoteInputMode(
+                uiModeType = Configuration.UI_MODE_TYPE_NORMAL,
+                touchscreen = Configuration.TOUCHSCREEN_FINGER,
+                navigation = Configuration.NAVIGATION_NONAV,
+            ),
+        )
+    }
+}

--- a/shared/src/androidMain/kotlin/com/devil/phoenixproject/presentation/util/PlatformInputMode.android.kt
+++ b/shared/src/androidMain/kotlin/com/devil/phoenixproject/presentation/util/PlatformInputMode.android.kt
@@ -1,0 +1,30 @@
+package com.devil.phoenixproject.presentation.util
+
+import android.content.res.Configuration
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+
+@Composable
+actual fun rememberIsTvRemoteInputMode(): Boolean {
+    val configuration = LocalContext.current.resources.configuration
+    val uiModeType = configuration.uiMode and Configuration.UI_MODE_TYPE_MASK
+    return remember(uiModeType, configuration.touchscreen, configuration.navigation) {
+        isTvRemoteInputMode(
+            uiModeType = uiModeType,
+            touchscreen = configuration.touchscreen,
+            navigation = configuration.navigation,
+        )
+    }
+}
+
+internal fun isTvRemoteInputMode(
+    uiModeType: Int,
+    touchscreen: Int,
+    navigation: Int,
+): Boolean {
+    val isTelevision = uiModeType == Configuration.UI_MODE_TYPE_TELEVISION
+    val isNoTouchDpad = touchscreen == Configuration.TOUCHSCREEN_NOTOUCH &&
+        navigation == Configuration.NAVIGATION_DPAD
+    return isTelevision || isNoTouchDpad
+}

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/BulkWeightAdjustDialog.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/BulkWeightAdjustDialog.kt
@@ -20,7 +20,6 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
@@ -332,7 +331,7 @@ private fun PercentageModeContent(
         Spacer(Modifier.height(8.dp))
 
         // Custom percentage input
-        OutlinedTextField(
+        ConfirmEditTextField(
             value = percentValue,
             onValueChange = onCustomValueChange,
             modifier = Modifier.fillMaxWidth(),
@@ -353,7 +352,7 @@ private fun AbsoluteModeContent(
     onValueChange: (String) -> Unit,
     unitLabel: String,
 ) {
-    OutlinedTextField(
+    ConfirmEditTextField(
         value = absoluteValue,
         onValueChange = onValueChange,
         modifier = Modifier.fillMaxWidth(),

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/ConfirmEditTextField.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/ConfirmEditTextField.kt
@@ -24,8 +24,7 @@ import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import com.devil.phoenixproject.presentation.util.rememberIsTvRemoteInputMode
 
-class ConfirmEditTextFieldState(isTvRemoteInputMode: Boolean) {
-    var isTvRemoteInputMode by mutableStateOf(isTvRemoteInputMode)
+class ConfirmEditTextFieldState(val isTvRemoteInputMode: Boolean) {
     var isEditing by mutableStateOf(false)
         private set
 
@@ -70,8 +69,7 @@ fun ConfirmEditTextField(
     colors: TextFieldColors = OutlinedTextFieldDefaults.colors(),
 ) {
     val isTvRemoteInputMode = rememberIsTvRemoteInputMode()
-    val state = remember { ConfirmEditTextFieldState(isTvRemoteInputMode) }
-    state.isTvRemoteInputMode = isTvRemoteInputMode
+    val state = remember(isTvRemoteInputMode) { ConfirmEditTextFieldState(isTvRemoteInputMode) }
 
     val focusRequester = remember { FocusRequester() }
     val keyboardController = LocalSoftwareKeyboardController.current
@@ -83,11 +81,17 @@ fun ConfirmEditTextField(
         }
     }
 
-    val effectiveModifier = if (isTvRemoteInputMode) {
-        modifier
-            .focusRequester(focusRequester)
-            .onFocusChanged { state.onFocusChanged(it.isFocused) }
-            .onPreviewKeyEvent { event ->
+    val effectiveModifier = modifier
+        .focusRequester(focusRequester)
+        .onFocusChanged {
+            if (isTvRemoteInputMode) {
+                state.onFocusChanged(it.isFocused)
+            }
+        }
+        .onPreviewKeyEvent { event ->
+            if (!isTvRemoteInputMode) {
+                false
+            } else {
                 if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
                 when (event.key) {
                     Key.Enter,
@@ -109,9 +113,7 @@ fun ConfirmEditTextField(
                     else -> false
                 }
             }
-    } else {
-        modifier
-    }
+        }
 
     OutlinedTextField(
         value = value,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/ConfirmEditTextField.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/ConfirmEditTextField.kt
@@ -1,0 +1,134 @@
+package com.devil.phoenixproject.presentation.components
+
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.TextFieldColors
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import com.devil.phoenixproject.presentation.util.rememberIsTvRemoteInputMode
+
+class ConfirmEditTextFieldState(isTvRemoteInputMode: Boolean) {
+    var isTvRemoteInputMode by mutableStateOf(isTvRemoteInputMode)
+    var isEditing by mutableStateOf(false)
+        private set
+
+    fun onFocusChanged(isFocused: Boolean) {
+        if (!isFocused) {
+            isEditing = false
+        }
+    }
+
+    fun onConfirmKey(): Boolean {
+        if (!isTvRemoteInputMode || isEditing) return false
+        isEditing = true
+        return true
+    }
+
+    fun onDismissEditing(): Boolean {
+        if (!isTvRemoteInputMode || !isEditing) return false
+        isEditing = false
+        return true
+    }
+
+    fun effectiveReadOnly(originalReadOnly: Boolean): Boolean = originalReadOnly || (isTvRemoteInputMode && !isEditing)
+}
+
+@Composable
+fun ConfirmEditTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    readOnly: Boolean = false,
+    label: @Composable (() -> Unit)? = null,
+    placeholder: @Composable (() -> Unit)? = null,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    suffix: @Composable (() -> Unit)? = null,
+    isError: Boolean = false,
+    singleLine: Boolean = false,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    shape: Shape = OutlinedTextFieldDefaults.shape,
+    colors: TextFieldColors = OutlinedTextFieldDefaults.colors(),
+) {
+    val isTvRemoteInputMode = rememberIsTvRemoteInputMode()
+    val state = remember { ConfirmEditTextFieldState(isTvRemoteInputMode) }
+    state.isTvRemoteInputMode = isTvRemoteInputMode
+
+    val focusRequester = remember { FocusRequester() }
+    val keyboardController = LocalSoftwareKeyboardController.current
+
+    LaunchedEffect(isTvRemoteInputMode, state.isEditing) {
+        if (isTvRemoteInputMode && state.isEditing) {
+            focusRequester.requestFocus()
+            keyboardController?.show()
+        }
+    }
+
+    val effectiveModifier = if (isTvRemoteInputMode) {
+        modifier
+            .focusRequester(focusRequester)
+            .onFocusChanged { state.onFocusChanged(it.isFocused) }
+            .onPreviewKeyEvent { event ->
+                if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
+                when (event.key) {
+                    Key.Enter,
+                    Key.NumPadEnter,
+                    Key.DirectionCenter,
+                    -> state.onConfirmKey()
+
+                    Key.Back,
+                    Key.Escape,
+                    -> {
+                        if (state.onDismissEditing()) {
+                            keyboardController?.hide()
+                            true
+                        } else {
+                            false
+                        }
+                    }
+
+                    else -> false
+                }
+            }
+    } else {
+        modifier
+    }
+
+    OutlinedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        modifier = effectiveModifier,
+        enabled = enabled,
+        readOnly = state.effectiveReadOnly(readOnly),
+        label = label,
+        placeholder = placeholder,
+        leadingIcon = leadingIcon,
+        trailingIcon = trailingIcon,
+        suffix = suffix,
+        isError = isError,
+        singleLine = singleLine,
+        keyboardOptions = keyboardOptions,
+        keyboardActions = keyboardActions,
+        shape = shape,
+        colors = colors,
+    )
+}

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/CreateExerciseDialog.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/CreateExerciseDialog.kt
@@ -100,7 +100,7 @@ fun CreateExerciseDialog(
                     Spacer(modifier = Modifier.height(Spacing.medium))
 
                     // Exercise Name
-                    OutlinedTextField(
+                    ConfirmEditTextField(
                         value = name,
                         onValueChange = {
                             name = it

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/ExerciseConfigModal.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/ExerciseConfigModal.kt
@@ -424,7 +424,7 @@ private fun EccentricSlider(percent: Int, onPercentChange: (Int) -> Unit, label:
 
         Spacer(modifier = Modifier.height(Spacing.small))
 
-        Slider(
+        ExpressiveSlider(
             value = percent.toFloat(),
             onValueChange = { onPercentChange(it.toInt()) },
             valueRange = 100f..150f,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/ExercisePicker.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/ExercisePicker.kt
@@ -33,7 +33,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -463,7 +462,7 @@ fun ExercisePickerContent(
             }
 
             // Search field (floating style)
-            OutlinedTextField(
+            ConfirmEditTextField(
                 value = searchQuery,
                 onValueChange = onSearchQueryChange,
                 modifier = Modifier

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/ExpressiveComponents.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/ExpressiveComponents.kt
@@ -16,6 +16,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.devil.phoenixproject.presentation.util.rememberIsTvRemoteInputMode
+import com.devil.phoenixproject.presentation.util.tvSliderKeys
 
 /**
  * A Material 3 Expressive Card wrapper.
@@ -72,14 +74,28 @@ fun ExpressiveSlider(
     valueRange: ClosedFloatingPointRange<Float>,
     modifier: Modifier = Modifier,
     steps: Int = 0,
+    enabled: Boolean = true,
+    remoteStep: Float? = null,
     onValueChangeFinished: (() -> Unit)? = null,
     trackColor: Color = MaterialTheme.colorScheme.onSurface,
     thumbColor: Color = MaterialTheme.colorScheme.onSurface,
 ) {
+    val isTvRemoteInputMode = rememberIsTvRemoteInputMode()
+
     Slider(
         value = value,
         onValueChange = onValueChange,
-        modifier = modifier,
+        modifier = modifier.tvSliderKeys(
+            value = value,
+            onValueChange = onValueChange,
+            valueRange = valueRange,
+            steps = steps,
+            explicitStep = remoteStep,
+            enabled = enabled,
+            isTvRemoteInputMode = isTvRemoteInputMode,
+            onValueChangeFinished = onValueChangeFinished,
+        ),
+        enabled = enabled,
         valueRange = valueRange,
         steps = steps,
         onValueChangeFinished = onValueChangeFinished,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/MiniExercisePickerDialog.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/MiniExercisePickerDialog.kt
@@ -21,7 +21,6 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -81,7 +80,7 @@ fun MiniExercisePickerDialog(
                     .fillMaxWidth()
                     .heightIn(max = 520.dp),
             ) {
-                OutlinedTextField(
+                ConfirmEditTextField(
                     value = searchQuery,
                     onValueChange = { searchQuery = it },
                     label = { Text(stringResource(Res.string.search_exercises_short)) },

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/RpeSlider.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/RpeSlider.kt
@@ -212,15 +212,13 @@ fun RpeSlider(selectedRpe: Int, onRpeSelected: (Int) -> Unit, onDismiss: () -> U
             Spacer(Modifier.height(Spacing.medium))
 
             // Slider
-            Slider(
+            ExpressiveSlider(
                 value = sliderValue,
                 onValueChange = { sliderValue = it },
                 valueRange = 6f..10f,
                 steps = 3,
-                colors = SliderDefaults.colors(
-                    thumbColor = getRpeColor(sliderValue.roundToInt()),
-                    activeTrackColor = getRpeColor(sliderValue.roundToInt()),
-                ),
+                thumbColor = getRpeColor(sliderValue.roundToInt()),
+                trackColor = getRpeColor(sliderValue.roundToInt()),
                 modifier = Modifier.fillMaxWidth(),
             )
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/SliderWithButtons.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/SliderWithButtons.kt
@@ -160,6 +160,8 @@ fun SliderWithButtons(
                 },
                 valueRange = valueRange,
                 steps = sliderSteps,
+                enabled = enabled,
+                remoteStep = step,
                 modifier = Modifier.weight(1f),
             )
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/WeightAdjustmentControls.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/WeightAdjustmentControls.kt
@@ -391,7 +391,7 @@ private fun WeightPickerDialog(
 
                 // Slider for weight selection (operates in display units for better UX)
                 val displayWeight = if (isLbs) UnitConverter.kgToLb(selectedWeightKg) else selectedWeightKg
-                Slider(
+                ExpressiveSlider(
                     value = displayWeight,
                     onValueChange = { displayValue ->
                         // Convert back to kg and round to machine increment (0.5kg)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/cycle/ProgressionSettingsSheet.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/cycle/ProgressionSettingsSheet.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.devil.phoenixproject.domain.model.CycleProgression
+import com.devil.phoenixproject.presentation.components.ExpressiveSlider
 import org.jetbrains.compose.resources.stringResource
 import vitruvianprojectphoenix.shared.generated.resources.*
 import vitruvianprojectphoenix.shared.generated.resources.Res
@@ -104,7 +105,7 @@ fun ProgressionSettingsSheet(
                         .padding(start = 48.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Slider(
+                    ExpressiveSlider(
                         value = weightPercent,
                         onValueChange = { weightPercent = it },
                         valueRange = 0.5f..10f,
@@ -167,7 +168,7 @@ fun ProgressionSettingsSheet(
                         .padding(start = 48.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Slider(
+                    ExpressiveSlider(
                         value = eccentricPercent.toFloat(),
                         onValueChange = { eccentricPercent = it.toInt() },
                         valueRange = 1f..20f,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseEditBottomSheet.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseEditBottomSheet.kt
@@ -45,7 +45,6 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
-import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -78,6 +77,7 @@ import com.devil.phoenixproject.domain.model.WeightUnit
 import com.devil.phoenixproject.domain.model.WorkoutMode
 import com.devil.phoenixproject.domain.model.WorkoutPhase
 import com.devil.phoenixproject.presentation.components.CompactNumberPicker
+import com.devil.phoenixproject.presentation.components.ExpressiveSlider
 import com.devil.phoenixproject.presentation.components.ProgressionSlider
 import com.devil.phoenixproject.presentation.components.VideoPlayer
 import com.devil.phoenixproject.presentation.viewmodel.ExerciseConfigViewModel
@@ -618,7 +618,7 @@ fun ExerciseEditBottomSheet(
                                 fontWeight = FontWeight.Bold,
                                 modifier = Modifier.padding(bottom = Spacing.extraSmall),
                             )
-                            Slider(
+                            ExpressiveSlider(
                                 value = rest.toFloat(),
                                 onValueChange = { viewModel.onRestChange(it.toInt()) },
                                 valueRange = 0f..300f,
@@ -994,7 +994,7 @@ fun SetRow(
                     fontWeight = FontWeight.Bold,
                     modifier = Modifier.padding(bottom = Spacing.extraSmall),
                 )
-                Slider(
+                ExpressiveSlider(
                     value = setConfig.restSeconds.toFloat(),
                     onValueChange = { onRestChange(it.toInt()) },
                     valueRange = 0f..300f,
@@ -1290,7 +1290,7 @@ fun WeightConfigurationCard(
                 Spacer(modifier = Modifier.height(Spacing.small))
 
                 // Percentage slider (50% - 120%, 5% increments)
-                Slider(
+                ExpressiveSlider(
                     value = weightPercentOfPR.toFloat(),
                     onValueChange = { onWeightPercentOfPRChange(it.toInt()) },
                     valueRange = 50f..120f,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExercisesTab.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExercisesTab.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.unit.dp
 import com.devil.phoenixproject.domain.model.WeightUnit
 import com.devil.phoenixproject.domain.model.WorkoutSession
 import com.devil.phoenixproject.domain.model.displayLoadMultiplier
+import com.devil.phoenixproject.presentation.components.ConfirmEditTextField
 import com.devil.phoenixproject.ui.theme.Spacing
 import com.devil.phoenixproject.util.KmpUtils
 import com.devil.phoenixproject.util.OneRepMaxCalculator
@@ -99,7 +100,7 @@ fun ExercisesTab(
         // Search bar
         item {
             Spacer(Modifier.height(Spacing.medium))
-            OutlinedTextField(
+            ConfirmEditTextField(
                 value = searchQuery,
                 onValueChange = { searchQuery = it },
                 modifier = Modifier.fillMaxWidth(),

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/MoveToGroupDialog.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/MoveToGroupDialog.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.devil.phoenixproject.domain.model.RoutineGroup
+import com.devil.phoenixproject.presentation.components.ConfirmEditTextField
 
 /**
  * Dialog for moving routine(s) to a group.
@@ -172,7 +173,7 @@ fun GroupNameDialog(
         onDismissRequest = onDismiss,
         title = { Text(title) },
         text = {
-            OutlinedTextField(
+            ConfirmEditTextField(
                 value = name,
                 onValueChange = { name = it },
                 label = { Text("Group name") },

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RestTimerCard.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RestTimerCard.kt
@@ -34,7 +34,6 @@ import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -59,6 +58,7 @@ import androidx.compose.ui.unit.sp
 import com.devil.phoenixproject.domain.model.EchoLevel
 import com.devil.phoenixproject.domain.model.ProgramMode
 import com.devil.phoenixproject.domain.model.WeightUnit
+import com.devil.phoenixproject.presentation.components.ExpressiveSlider
 import com.devil.phoenixproject.presentation.components.SliderWithButtons
 import com.devil.phoenixproject.ui.theme.Spacing
 import com.devil.phoenixproject.util.Constants
@@ -730,7 +730,7 @@ private fun RestTimerEccentricLoadSlider(percent: Int, onPercentChange: (Int) ->
         Spacer(modifier = Modifier.height(Spacing.small))
 
         // Fine-grained slider (5% increments) - callback snaps to nearest valid EccentricLoad enum
-        Slider(
+        ExpressiveSlider(
             value = percent.toFloat(),
             onValueChange = { onPercentChange(it.toInt()) },
             valueRange = 0f..150f,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RoutineOverviewScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RoutineOverviewScreen.kt
@@ -38,7 +38,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -74,6 +73,7 @@ import com.devil.phoenixproject.domain.model.WeightUnit
 import com.devil.phoenixproject.domain.usecase.RoutineTimeEstimate
 import com.devil.phoenixproject.domain.usecase.RoutineTimeEstimator
 import com.devil.phoenixproject.presentation.components.BackHandler
+import com.devil.phoenixproject.presentation.components.ExpressiveSlider
 import com.devil.phoenixproject.presentation.components.SliderWithButtons
 import com.devil.phoenixproject.presentation.components.VideoPlayer
 import com.devil.phoenixproject.presentation.navigation.NavigationRoutes
@@ -861,7 +861,7 @@ private fun OverviewEccentricLoadSlider(percent: Int, onPercentChange: (Int) -> 
 
         Spacer(modifier = Modifier.height(Spacing.small))
 
-        Slider(
+        ExpressiveSlider(
             value = percent.toFloat(),
             onValueChange = { onPercentChange(it.toInt()) },
             valueRange = 0f..150f,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SetReadyScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SetReadyScreen.kt
@@ -34,7 +34,6 @@ import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -64,6 +63,7 @@ import com.devil.phoenixproject.domain.model.WeightUnit
 import com.devil.phoenixproject.domain.model.WorkoutState
 import com.devil.phoenixproject.domain.usecase.BodyweightVolumeCalculator
 import com.devil.phoenixproject.presentation.components.BackHandler
+import com.devil.phoenixproject.presentation.components.ExpressiveSlider
 import com.devil.phoenixproject.presentation.components.SliderWithButtons
 import com.devil.phoenixproject.presentation.components.VideoPlayer
 import com.devil.phoenixproject.presentation.navigation.NavigationRoutes
@@ -659,7 +659,7 @@ private fun SetReadyEccentricLoadSlider(percent: Int, onPercentChange: (Int) -> 
 
         Spacer(modifier = Modifier.height(Spacing.small))
 
-        Slider(
+        ExpressiveSlider(
             value = percent.toFloat(),
             onValueChange = { onPercentChange(it.toInt()) },
             valueRange = 0f..150f,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SettingsTab.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SettingsTab.kt
@@ -73,7 +73,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
-import androidx.compose.material3.Slider
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -103,7 +102,9 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import com.devil.phoenixproject.data.sync.SyncTriggerManager
 import com.devil.phoenixproject.domain.model.WeightUnit
+import com.devil.phoenixproject.presentation.components.ConfirmEditTextField
 import com.devil.phoenixproject.presentation.components.CountdownDropdown
+import com.devil.phoenixproject.presentation.components.ExpressiveSlider
 import com.devil.phoenixproject.ui.theme.*
 import com.devil.phoenixproject.util.BackupDestination
 import com.devil.phoenixproject.util.BackupProgress
@@ -793,7 +794,7 @@ fun SettingsTab(
                                     style = MaterialTheme.typography.bodyMedium,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 )
-                                OutlinedTextField(
+                                ConfirmEditTextField(
                                     value = bodyWeightInput,
                                     onValueChange = { input ->
                                         // Allow only valid numeric input
@@ -1426,7 +1427,7 @@ fun SettingsTab(
                 if (voiceStopEnabled) {
                     Spacer(modifier = Modifier.height(Spacing.medium))
 
-                    OutlinedTextField(
+                    ConfirmEditTextField(
                         value = localSafeWord,
                         onValueChange = { newValue ->
                             localSafeWord = newValue.uppercase().trim()
@@ -1768,7 +1769,7 @@ fun SettingsTab(
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
-                        Slider(
+                        ExpressiveSlider(
                             value = velocityLossThresholdPercent.toFloat(),
                             onValueChange = { onVelocityLossThresholdChange(it.roundToInt()) },
                             valueRange = 10f..50f,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/WorkoutSetupDialog.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/WorkoutSetupDialog.kt
@@ -20,6 +20,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.devil.phoenixproject.data.repository.ExerciseRepository
 import com.devil.phoenixproject.domain.model.*
+import com.devil.phoenixproject.presentation.components.ConfirmEditTextField
+import com.devil.phoenixproject.presentation.components.ExpressiveSlider
 import com.devil.phoenixproject.ui.theme.Spacing
 import org.jetbrains.compose.resources.stringResource
 import vitruvianprojectphoenix.shared.generated.resources.*
@@ -235,7 +237,7 @@ fun WorkoutSetupDialog(
                                 color = MaterialTheme.colorScheme.primary,
                             )
 
-                            Slider(
+                            ExpressiveSlider(
                                 value = kgToDisplay(workoutParameters.weightPerCableKg, weightUnit),
                                 onValueChange = { displayValue ->
                                     val kg = displayToKg(displayValue, weightUnit)
@@ -269,7 +271,7 @@ fun WorkoutSetupDialog(
                                 fontWeight = FontWeight.Bold,
                                 modifier = Modifier.padding(bottom = 8.dp),
                             )
-                            Slider(
+                            ExpressiveSlider(
                                 value = workoutParameters.reps.toFloat(),
                                 onValueChange = { reps ->
                                     onUpdateParameters(workoutParameters.copy(reps = reps.toInt()))
@@ -339,13 +341,14 @@ fun WorkoutSetupDialog(
                                 },
                             )
 
-                            Slider(
+                            ExpressiveSlider(
                                 value = currentProgression,
                                 onValueChange = { displayValue ->
                                     val kg = displayToKg(displayValue, weightUnit)
                                     onUpdateParameters(workoutParameters.copy(progressionRegressionKg = kg))
                                 },
                                 valueRange = -maxProgression..maxProgression,
+                                remoteStep = 0.1f,
                                 modifier = Modifier.fillMaxWidth(),
                             )
 
@@ -508,7 +511,7 @@ fun ExercisePickerDialog(exerciseRepository: ExerciseRepository, onDismiss: () -
                         .heightIn(max = maxSheetHeight),
                 ) {
                     // Search field
-                    OutlinedTextField(
+                    ConfirmEditTextField(
                         value = searchQuery,
                         onValueChange = { searchQuery = it },
                         label = { Text(stringResource(Res.string.search_exercises_short)) },

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/WorkoutSetupDialog.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/WorkoutSetupDialog.kt
@@ -27,6 +27,8 @@ import org.jetbrains.compose.resources.stringResource
 import vitruvianprojectphoenix.shared.generated.resources.*
 import vitruvianprojectphoenix.shared.generated.resources.Res
 
+internal const val WorkoutSetupTargetRepsRemoteStep = 1f
+
 /**
  * Workout Setup Dialog - Full configuration dialog for workout parameters
  */
@@ -278,6 +280,7 @@ fun WorkoutSetupDialog(
                                 },
                                 valueRange = 1f..50f,
                                 steps = 49,
+                                remoteStep = WorkoutSetupTargetRepsRemoteStep,
                                 modifier = Modifier.fillMaxWidth(),
                             )
                         } else {

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/util/DpadSliderSemantics.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/util/DpadSliderSemantics.kt
@@ -78,8 +78,14 @@ fun Modifier.tvSliderKeys(
     } else {
         val focusManager = LocalFocusManager.current
         onPreviewKeyEvent { event ->
-            if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
             val command = event.key.toDpadSliderCommand() ?: return@onPreviewKeyEvent false
+
+            if (shouldFinishDpadSliderValueChange(command = command, eventType = event.type, enabled = enabled)) {
+                onValueChangeFinished?.invoke()
+                return@onPreviewKeyEvent true
+            }
+
+            if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
             val result = calculateDpadSliderKeyResult(
                 command = command,
                 value = value,
@@ -102,7 +108,6 @@ fun Modifier.tvSliderKeys(
             result.newValue?.let { newValue ->
                 if (newValue != value) {
                     onValueChange(newValue)
-                    onValueChangeFinished?.invoke()
                 }
             }
 
@@ -110,6 +115,14 @@ fun Modifier.tvSliderKeys(
         }
     }
 }
+
+internal fun shouldFinishDpadSliderValueChange(
+    command: DpadSliderCommand,
+    eventType: KeyEventType,
+    enabled: Boolean,
+): Boolean = enabled &&
+    eventType == KeyEventType.KeyUp &&
+    (command == DpadSliderCommand.Left || command == DpadSliderCommand.Right)
 
 private fun resolveSliderStep(
     valueRange: ClosedFloatingPointRange<Float>,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/util/DpadSliderSemantics.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/util/DpadSliderSemantics.kt
@@ -1,0 +1,139 @@
+package com.devil.phoenixproject.presentation.util
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.LocalFocusManager
+
+internal enum class DpadSliderCommand {
+    Left,
+    Right,
+    Up,
+    Down,
+}
+
+internal enum class DpadSliderFocusMove {
+    Up,
+    Down,
+}
+
+internal data class DpadSliderKeyResult(
+    val consumed: Boolean,
+    val newValue: Float? = null,
+    val focusMove: DpadSliderFocusMove? = null,
+)
+
+internal fun calculateDpadSliderKeyResult(
+    command: DpadSliderCommand,
+    value: Float,
+    valueRange: ClosedFloatingPointRange<Float>,
+    steps: Int,
+    explicitStep: Float?,
+    enabled: Boolean,
+): DpadSliderKeyResult {
+    if (!enabled) return DpadSliderKeyResult(consumed = false)
+
+    return when (command) {
+        DpadSliderCommand.Up -> DpadSliderKeyResult(
+            consumed = true,
+            focusMove = DpadSliderFocusMove.Up,
+        )
+
+        DpadSliderCommand.Down -> DpadSliderKeyResult(
+            consumed = true,
+            focusMove = DpadSliderFocusMove.Down,
+        )
+
+        DpadSliderCommand.Left,
+        DpadSliderCommand.Right,
+        -> {
+            val step = resolveSliderStep(valueRange = valueRange, steps = steps, explicitStep = explicitStep)
+                ?: return DpadSliderKeyResult(consumed = false)
+            val delta = if (command == DpadSliderCommand.Left) -step else step
+            DpadSliderKeyResult(
+                consumed = true,
+                newValue = (value + delta).coerceIn(valueRange),
+            )
+        }
+    }
+}
+
+fun Modifier.tvSliderKeys(
+    value: Float,
+    onValueChange: (Float) -> Unit,
+    valueRange: ClosedFloatingPointRange<Float>,
+    steps: Int,
+    explicitStep: Float?,
+    enabled: Boolean,
+    isTvRemoteInputMode: Boolean,
+    onValueChangeFinished: (() -> Unit)? = null,
+): Modifier = composed {
+    if (!isTvRemoteInputMode) {
+        this
+    } else {
+        val focusManager = LocalFocusManager.current
+        onPreviewKeyEvent { event ->
+            if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
+            val command = event.key.toDpadSliderCommand() ?: return@onPreviewKeyEvent false
+            val result = calculateDpadSliderKeyResult(
+                command = command,
+                value = value,
+                valueRange = valueRange,
+                steps = steps,
+                explicitStep = explicitStep,
+                enabled = enabled,
+            )
+
+            result.focusMove?.let { focusMove ->
+                val moved = focusManager.moveFocus(
+                    when (focusMove) {
+                        DpadSliderFocusMove.Up -> FocusDirection.Up
+                        DpadSliderFocusMove.Down -> FocusDirection.Down
+                    },
+                )
+                return@onPreviewKeyEvent result.consumed || moved
+            }
+
+            result.newValue?.let { newValue ->
+                if (newValue != value) {
+                    onValueChange(newValue)
+                    onValueChangeFinished?.invoke()
+                }
+            }
+
+            result.consumed
+        }
+    }
+}
+
+private fun resolveSliderStep(
+    valueRange: ClosedFloatingPointRange<Float>,
+    steps: Int,
+    explicitStep: Float?,
+): Float? {
+    explicitStep?.takeIf { it > 0f }?.let { return it }
+
+    val range = valueRange.endInclusive - valueRange.start
+    if (range <= 0f) return null
+
+    return if (steps > 0) {
+        range / (steps + 1)
+    } else {
+        range / CONTINUOUS_SLIDER_REMOTE_INTERVALS
+    }.takeIf { it > 0f }
+}
+
+private fun Key.toDpadSliderCommand(): DpadSliderCommand? = when (this) {
+    Key.DirectionLeft -> DpadSliderCommand.Left
+    Key.DirectionRight -> DpadSliderCommand.Right
+    Key.DirectionUp -> DpadSliderCommand.Up
+    Key.DirectionDown -> DpadSliderCommand.Down
+    else -> null
+}
+
+private const val CONTINUOUS_SLIDER_REMOTE_INTERVALS = 100f

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/util/PlatformInputMode.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/util/PlatformInputMode.kt
@@ -1,0 +1,6 @@
+package com.devil.phoenixproject.presentation.util
+
+import androidx.compose.runtime.Composable
+
+@Composable
+expect fun rememberIsTvRemoteInputMode(): Boolean

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/components/ConfirmEditTextFieldStateTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/components/ConfirmEditTextFieldStateTest.kt
@@ -1,0 +1,50 @@
+package com.devil.phoenixproject.presentation.components
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ConfirmEditTextFieldStateTest {
+
+    @Test
+    fun focusAloneDoesNotEnterEditModeInTvMode() {
+        val state = ConfirmEditTextFieldState(isTvRemoteInputMode = true)
+
+        state.onFocusChanged(isFocused = true)
+
+        assertFalse(state.isEditing)
+        assertTrue(state.effectiveReadOnly(originalReadOnly = false))
+    }
+
+    @Test
+    fun confirmKeyEntersEditModeInTvMode() {
+        val state = ConfirmEditTextFieldState(isTvRemoteInputMode = true)
+
+        val consumed = state.onConfirmKey()
+
+        assertTrue(consumed)
+        assertTrue(state.isEditing)
+        assertFalse(state.effectiveReadOnly(originalReadOnly = false))
+    }
+
+    @Test
+    fun dismissEditingExitsEditModeInTvMode() {
+        val state = ConfirmEditTextFieldState(isTvRemoteInputMode = true)
+        state.onConfirmKey()
+
+        val consumed = state.onDismissEditing()
+
+        assertTrue(consumed)
+        assertFalse(state.isEditing)
+        assertTrue(state.effectiveReadOnly(originalReadOnly = false))
+    }
+
+    @Test
+    fun nonTvModeKeepsNormalTextFieldReadOnlyBehavior() {
+        val state = ConfirmEditTextFieldState(isTvRemoteInputMode = false)
+
+        assertFalse(state.onConfirmKey())
+        assertFalse(state.effectiveReadOnly(originalReadOnly = false))
+        assertTrue(state.effectiveReadOnly(originalReadOnly = true))
+    }
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/screen/WorkoutSetupDialogRemoteInputTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/screen/WorkoutSetupDialogRemoteInputTest.kt
@@ -1,0 +1,23 @@
+package com.devil.phoenixproject.presentation.screen
+
+import com.devil.phoenixproject.presentation.util.DpadSliderCommand
+import com.devil.phoenixproject.presentation.util.calculateDpadSliderKeyResult
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class WorkoutSetupDialogRemoteInputTest {
+
+    @Test
+    fun targetRepsRemoteStepAdvancesToNextIntegerRep() {
+        val result = calculateDpadSliderKeyResult(
+            command = DpadSliderCommand.Right,
+            value = 10f,
+            valueRange = 1f..50f,
+            steps = 49,
+            explicitStep = WorkoutSetupTargetRepsRemoteStep,
+            enabled = true,
+        )
+
+        assertEquals(11, result.newValue?.toInt())
+    }
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/util/DpadSliderSemanticsTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/util/DpadSliderSemanticsTest.kt
@@ -1,0 +1,122 @@
+package com.devil.phoenixproject.presentation.util
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+
+class DpadSliderSemanticsTest {
+
+    @Test
+    fun leftDecrementsByExplicitStep() {
+        val result = calculateDpadSliderKeyResult(
+            command = DpadSliderCommand.Left,
+            value = 50f,
+            valueRange = 0f..100f,
+            steps = 0,
+            explicitStep = 5f,
+            enabled = true,
+        )
+
+        assertEquals(true, result.consumed)
+        assertEquals(45f, result.newValue)
+        assertNull(result.focusMove)
+    }
+
+    @Test
+    fun rightIncrementsByExplicitStep() {
+        val result = calculateDpadSliderKeyResult(
+            command = DpadSliderCommand.Right,
+            value = 50f,
+            valueRange = 0f..100f,
+            steps = 0,
+            explicitStep = 5f,
+            enabled = true,
+        )
+
+        assertEquals(true, result.consumed)
+        assertEquals(55f, result.newValue)
+        assertNull(result.focusMove)
+    }
+
+    @Test
+    fun materialStepsDeriveIntervalWhenExplicitStepMissing() {
+        val result = calculateDpadSliderKeyResult(
+            command = DpadSliderCommand.Right,
+            value = 50f,
+            valueRange = 0f..100f,
+            steps = 3,
+            explicitStep = null,
+            enabled = true,
+        )
+
+        assertEquals(true, result.consumed)
+        assertEquals(75f, result.newValue)
+    }
+
+    @Test
+    fun clampsAtMinimumAndMaximum() {
+        val minResult = calculateDpadSliderKeyResult(
+            command = DpadSliderCommand.Left,
+            value = 0f,
+            valueRange = 0f..100f,
+            steps = 0,
+            explicitStep = 5f,
+            enabled = true,
+        )
+        val maxResult = calculateDpadSliderKeyResult(
+            command = DpadSliderCommand.Right,
+            value = 100f,
+            valueRange = 0f..100f,
+            steps = 0,
+            explicitStep = 5f,
+            enabled = true,
+        )
+
+        assertEquals(0f, minResult.newValue)
+        assertEquals(100f, maxResult.newValue)
+    }
+
+    @Test
+    fun disabledSliderDoesNotHandleDirectionalInput() {
+        val result = calculateDpadSliderKeyResult(
+            command = DpadSliderCommand.Right,
+            value = 50f,
+            valueRange = 0f..100f,
+            steps = 0,
+            explicitStep = 5f,
+            enabled = false,
+        )
+
+        assertFalse(result.consumed)
+        assertNull(result.newValue)
+        assertNull(result.focusMove)
+    }
+
+    @Test
+    fun upAndDownMoveFocusWithoutChangingValue() {
+        val upResult = calculateDpadSliderKeyResult(
+            command = DpadSliderCommand.Up,
+            value = 50f,
+            valueRange = 0f..100f,
+            steps = 0,
+            explicitStep = 5f,
+            enabled = true,
+        )
+        val downResult = calculateDpadSliderKeyResult(
+            command = DpadSliderCommand.Down,
+            value = 50f,
+            valueRange = 0f..100f,
+            steps = 0,
+            explicitStep = 5f,
+            enabled = true,
+        )
+
+        assertEquals(true, upResult.consumed)
+        assertNull(upResult.newValue)
+        assertEquals(DpadSliderFocusMove.Up, upResult.focusMove)
+        assertEquals(true, downResult.consumed)
+        assertNull(downResult.newValue)
+        assertEquals(DpadSliderFocusMove.Down, downResult.focusMove)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/util/DpadSliderSemanticsTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/util/DpadSliderSemanticsTest.kt
@@ -1,9 +1,11 @@
 package com.devil.phoenixproject.presentation.util
 
+import androidx.compose.ui.input.key.KeyEventType
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class DpadSliderSemanticsTest {
 
@@ -118,5 +120,48 @@ class DpadSliderSemanticsTest {
         assertEquals(true, downResult.consumed)
         assertNull(downResult.newValue)
         assertEquals(DpadSliderFocusMove.Down, downResult.focusMove)
+    }
+
+    @Test
+    fun leftAndRightFinishOnlyOnKeyUp() {
+        assertFalse(
+            shouldFinishDpadSliderValueChange(
+                command = DpadSliderCommand.Right,
+                eventType = KeyEventType.KeyDown,
+                enabled = true,
+            ),
+        )
+        assertTrue(
+            shouldFinishDpadSliderValueChange(
+                command = DpadSliderCommand.Right,
+                eventType = KeyEventType.KeyUp,
+                enabled = true,
+            ),
+        )
+        assertTrue(
+            shouldFinishDpadSliderValueChange(
+                command = DpadSliderCommand.Left,
+                eventType = KeyEventType.KeyUp,
+                enabled = true,
+            ),
+        )
+    }
+
+    @Test
+    fun focusMovesAndDisabledSliderDoNotFinishValueChange() {
+        assertFalse(
+            shouldFinishDpadSliderValueChange(
+                command = DpadSliderCommand.Up,
+                eventType = KeyEventType.KeyUp,
+                enabled = true,
+            ),
+        )
+        assertFalse(
+            shouldFinishDpadSliderValueChange(
+                command = DpadSliderCommand.Right,
+                eventType = KeyEventType.KeyUp,
+                enabled = false,
+            ),
+        )
     }
 }

--- a/shared/src/iosMain/kotlin/com/devil/phoenixproject/presentation/util/PlatformInputMode.ios.kt
+++ b/shared/src/iosMain/kotlin/com/devil/phoenixproject/presentation/util/PlatformInputMode.ios.kt
@@ -1,0 +1,6 @@
+package com.devil.phoenixproject.presentation.util
+
+import androidx.compose.runtime.Composable
+
+@Composable
+actual fun rememberIsTvRemoteInputMode(): Boolean = false


### PR DESCRIPTION
## Summary
- Add centralized TV remote input detection and shared D-pad slider handling.
- Route presentation sliders through `ExpressiveSlider` so left/right adjusts value and up/down moves focus.
- Introduce `ConfirmEditTextField` and apply it to the scoped high-impact editable fields.
- Add common, Android host, and state regression tests for slider behavior and confirm-to-edit flows.

## Testing
- `:shared:testAndroidHostTest` with the new slider, input-mode, and confirm-edit regressions
- `:shared:compileKotlinMetadata`
- `:shared:testAndroidHostTest`
- `:androidApp:assembleDebug`