### PR TITLE
Fix crash when deleting all workouts from a cycle

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/CycleEditorViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/CycleEditorViewModel.kt
@@ -179,6 +179,7 @@ class CycleEditorViewModel(
 
     fun deleteItem(index: Int) {
         _uiState.update { state ->
+            if (index !in state.items.indices) return@update state
             val item = state.items[index]
             val newList = state.items.toMutableList().apply { removeAt(index) }
             val renumbered = renumberItems(newList)
@@ -205,6 +206,7 @@ class CycleEditorViewModel(
 
     fun duplicateItem(index: Int) {
         _uiState.update { state ->
+            if (index !in state.items.indices) return@update state
             val item = state.items[index]
             val duplicate = when (item) {
                 is CycleItem.Workout -> item.copy(id = generateUUID(), dayNumber = index + 2)
@@ -218,6 +220,7 @@ class CycleEditorViewModel(
 
     fun reorderItems(from: Int, to: Int) {
         _uiState.update { state ->
+            if (from !in state.items.indices || to !in state.items.indices) return@update state
             val list = state.items.toMutableList()
             val moved = list.removeAt(from)
             list.add(to, moved)
@@ -228,6 +231,7 @@ class CycleEditorViewModel(
 
     fun convertToWorkout(index: Int, routine: Routine) {
         _uiState.update { state ->
+            if (index !in state.items.indices) return@update state
             val item = state.items[index]
             if (item is CycleItem.Rest) {
                 val workout = CycleItem.Workout(
@@ -248,6 +252,7 @@ class CycleEditorViewModel(
 
     fun convertToRest(index: Int) {
         _uiState.update { state ->
+            if (index !in state.items.indices) return@update state
             val item = state.items[index]
             if (item is CycleItem.Workout) {
                 val rest = CycleItem.Rest(
@@ -265,6 +270,7 @@ class CycleEditorViewModel(
 
     fun changeRoutine(index: Int, routine: Routine) {
         _uiState.update { state ->
+            if (index !in state.items.indices) return@update state
             val item = state.items[index]
             if (item is CycleItem.Workout) {
                 val updated = item.copy(

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/CycleEditorViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/CycleEditorViewModel.kt
@@ -220,7 +220,7 @@ class CycleEditorViewModel(
 
     fun reorderItems(from: Int, to: Int) {
         _uiState.update { state ->
-            if (from !in state.items.indices || to !in state.items.indices) return@update state
+            if (from == to || from !in state.items.indices || to !in state.items.indices) return@update state
             val list = state.items.toMutableList()
             val moved = list.removeAt(from)
             list.add(to, moved)


### PR DESCRIPTION
## Summary

- **Crash fix**: `CycleEditorViewModel.deleteItem()` threw `IndexOutOfBoundsException` when swipe-deleting cycle items rapidly (reported via TestFlight, iPhone 14 Pro Max / iOS 26.5)
- **Root cause**: `SwipeToDismissBox.confirmValueChange` fires with the Compose-captured `index`, but `MutableStateFlow.update` retries its lambda with the latest state — which may have fewer items after a concurrent delete
- **Fix**: Added bounds checks (`index !in state.items.indices`) to all six index-based mutation methods: `deleteItem`, `duplicateItem`, `reorderItems`, `convertToWorkout`, `convertToRest`, `changeRoutine`

## Test plan

- [ ] Open cycle editor with multiple workout/rest days
- [ ] Swipe-delete all items one by one rapidly — app should not crash
- [ ] Delete last remaining item — should show empty state, no crash
- [ ] Swipe-duplicate an item — verify it still works
- [ ] Reorder items via drag — verify it still works
- [ ] Undo a delete via snackbar — verify item is restored

https://claude.ai/code/session_011C2KidTSW3skiLyPgRTNqx

---
_Generated by [Claude Code](https://claude.ai/code/session_011C2KidTSW3skiLyPgRTNqx)_