### PR TITLE
Implement system theme mode selection end to end

### DIFF
--- a/androidApp/src/main/kotlin/com/devil/phoenixproject/ui/theme/AndroidTheme.kt
+++ b/androidApp/src/main/kotlin/com/devil/phoenixproject/ui/theme/AndroidTheme.kt
@@ -14,6 +14,9 @@ import com.devil.phoenixproject.ui.theme.VitruvianTheme as SharedVitruvianTheme
  * Delegates to shared theme and configures status bar appearance.
  * Note: enableEdgeToEdge() in MainActivity handles status bar coloring.
  */
+@Deprecated(
+    message = "Use the shared VitruvianTheme(themeMode = ..., dynamicColorEnabled = ...) overload so ThemeMode.SYSTEM is preserved.",
+)
 @Composable
 fun VitruvianTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),

--- a/iosApp/VitruvianPhoenix/VitruvianPhoenix/ContentView.swift
+++ b/iosApp/VitruvianPhoenix/VitruvianPhoenix/ContentView.swift
@@ -3,11 +3,8 @@ import shared
 
 /// Main ContentView that hosts the Compose Multiplatform UI
 struct ContentView: View {
-    @Environment(\.colorScheme) private var colorScheme
-
     var body: some View {
         ComposeView()
-            .id(colorScheme)
             .ignoresSafeArea(.all)
     }
 }

--- a/iosApp/VitruvianPhoenix/VitruvianPhoenix/ContentView.swift
+++ b/iosApp/VitruvianPhoenix/VitruvianPhoenix/ContentView.swift
@@ -3,8 +3,11 @@ import shared
 
 /// Main ContentView that hosts the Compose Multiplatform UI
 struct ContentView: View {
+    @Environment(\.colorScheme) private var colorScheme
+
     var body: some View {
         ComposeView()
+            .id(colorScheme)
             .ignoresSafeArea(.all)
     }
 }

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/theme/ThemeModeUiContractGuardTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/theme/ThemeModeUiContractGuardTest.kt
@@ -1,0 +1,87 @@
+package com.devil.phoenixproject.presentation.theme
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ThemeModeUiContractGuardTest {
+
+    private val projectRoot: File by lazy {
+        var dir = File(System.getProperty("user.dir") ?: ".")
+        while (!File(dir, "shared/src/commonMain").exists()) {
+            dir = dir.parentFile ?: break
+        }
+        dir
+    }
+
+    private fun read(relativePath: String): String = File(projectRoot, relativePath).readText()
+
+    @Test
+    fun settingsTab_editsThemeModeInsteadOfBooleanDarkMode() {
+        val source = read("shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SettingsTab.kt")
+
+        assertTrue(
+            source.contains("themeMode: ThemeMode"),
+            "SettingsTab must receive ThemeMode so System/Light/Dark can be represented.",
+        )
+        assertTrue(
+            source.contains("onThemeModeChange: (ThemeMode) -> Unit"),
+            "SettingsTab must emit ThemeMode changes directly.",
+        )
+        assertFalse(
+            source.contains("darkModeEnabled: Boolean"),
+            "SettingsTab must not collapse theme state to a dark-mode boolean.",
+        )
+        assertFalse(
+            source.contains("onDarkModeChange: (Boolean) -> Unit"),
+            "SettingsTab must not emit boolean dark-mode changes.",
+        )
+    }
+
+    @Test
+    fun navGraph_passesThemeModeThroughSettingsWithoutBooleanCoercion() {
+        val source = read("shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/navigation/NavGraph.kt")
+
+        assertFalse(
+            source.contains("darkModeEnabled = themeMode == ThemeMode.DARK"),
+            "Settings wiring must not treat System as Light by comparing only against DARK.",
+        )
+        assertFalse(
+            source.contains("onDarkModeChange ="),
+            "Settings wiring must pass onThemeModeChange directly.",
+        )
+        assertTrue(
+            source.contains("themeMode = themeMode"),
+            "Settings wiring should pass ThemeMode directly.",
+        )
+        assertTrue(
+            source.contains("onThemeModeChange = onThemeModeChange"),
+            "Settings wiring should pass the ThemeMode callback directly.",
+        )
+    }
+
+    @Test
+    fun commonTheme_mapsSystemToSystemDarkTheme() {
+        val source = read("shared/src/commonMain/kotlin/com/devil/phoenixproject/ui/theme/Theme.kt")
+
+        assertTrue(
+            source.contains("ThemeMode.SYSTEM -> isSystemInDarkTheme()"),
+            "System theme mode must continue to follow the platform system dark-theme signal.",
+        )
+    }
+
+    @Test
+    fun iosContentView_recreatesComposeHostWhenSwiftUIColorSchemeChanges() {
+        val source = read("iosApp/VitruvianPhoenix/VitruvianPhoenix/ContentView.swift")
+
+        assertTrue(
+            source.contains("@Environment(\\.colorScheme)"),
+            "ContentView should observe SwiftUI colorScheme changes.",
+        )
+        assertTrue(
+            source.contains(".id(colorScheme)"),
+            "Compose host should be recreated when the system color scheme changes on iOS.",
+        )
+    }
+}

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/theme/ThemeModeUiContractGuardTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/theme/ThemeModeUiContractGuardTest.kt
@@ -71,17 +71,4 @@ class ThemeModeUiContractGuardTest {
         )
     }
 
-    @Test
-    fun iosContentView_recreatesComposeHostWhenSwiftUIColorSchemeChanges() {
-        val source = read("iosApp/VitruvianPhoenix/VitruvianPhoenix/ContentView.swift")
-
-        assertTrue(
-            source.contains("@Environment(\\.colorScheme)"),
-            "ContentView should observe SwiftUI colorScheme changes.",
-        )
-        assertTrue(
-            source.contains(".id(colorScheme)"),
-            "Compose host should be recreated when the system color scheme changes on iOS.",
-        )
-    }
 }

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/ThemeViewModelTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/ThemeViewModelTest.kt
@@ -15,6 +15,13 @@ class ThemeViewModelTest {
     val testCoroutineRule = TestCoroutineRule()
 
     @Test
+    fun `theme mode enum names are stable persisted values`() {
+        assertEquals("SYSTEM", ThemeMode.SYSTEM.name)
+        assertEquals("LIGHT", ThemeMode.LIGHT.name)
+        assertEquals("DARK", ThemeMode.DARK.name)
+    }
+
+    @Test
     fun `defaults to system theme when no preference saved`() = runTest {
         val viewModel = ThemeViewModel(MapSettings())
 
@@ -23,15 +30,39 @@ class ThemeViewModelTest {
     }
 
     @Test
-    fun `setThemeMode updates state and persists`() = runTest {
+    fun `invalid saved theme defaults to system theme`() = runTest {
+        val settings = MapSettings()
+        settings.putString("theme_mode", "not-a-theme")
+
+        val viewModel = ThemeViewModel(settings)
+
+        assertEquals(ThemeMode.SYSTEM, viewModel.themeMode.value)
+    }
+
+    @Test
+    fun `stored theme mode values restore from settings`() = runTest {
+        ThemeMode.entries.forEach { mode ->
+            val settings = MapSettings()
+            settings.putString("theme_mode", mode.name)
+
+            val viewModel = ThemeViewModel(settings)
+
+            assertEquals(mode, viewModel.themeMode.value)
+        }
+    }
+
+    @Test
+    fun `setThemeMode updates state and persists every mode`() = runTest {
         val settings = MapSettings()
         val viewModel = ThemeViewModel(settings)
 
-        viewModel.setThemeMode(ThemeMode.DARK)
-        advanceUntilIdle()
+        ThemeMode.entries.forEach { mode ->
+            viewModel.setThemeMode(mode)
+            advanceUntilIdle()
 
-        assertEquals(ThemeMode.DARK, viewModel.themeMode.value)
-        assertEquals(ThemeMode.DARK.name, settings.getStringOrNull("theme_mode"))
+            assertEquals(mode, viewModel.themeMode.value)
+            assertEquals(mode.name, settings.getStringOrNull("theme_mode"))
+        }
     }
 
     @Test

--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -108,8 +108,11 @@
     <string name="settings_cloud_sync">Cloud-Sync</string>
     <string name="settings_weight_unit">Gewichtseinheit</string>
     <string name="settings_appearance">Erscheinungsbild</string>
-    <string name="settings_dark_mode">Dunkler Modus</string>
-    <string name="settings_dark_mode_description">Dunkles Thema für die App verwenden</string>
+    <string name="settings_theme_mode">Theme</string>
+    <string name="settings_theme_mode_description">Follow the system theme or keep the app in light or dark mode</string>
+    <string name="settings_theme_system">System</string>
+    <string name="settings_theme_light">Light</string>
+    <string name="settings_theme_dark">Dark</string>
     <string name="settings_dynamic_color">Material You-Farben</string>
     <string name="settings_dynamic_color_description">Farben aus deinem Android-Hintergrundbild verwenden, wenn verfügbar</string>
     <string name="settings_link_portal">Portal-Konto verknüpfen</string>
@@ -581,7 +584,7 @@
     <string name="cd_above_pr">Above PR</string>
     <string name="cd_below_pr">Below PR</string>
     <string name="cd_delete_workout">Delete workout</string>
-    <string name="cd_toggle_theme">Toggle theme (current: %1$s)</string>
+    <string name="cd_toggle_theme_cycle">Toggle theme (current: %1$s, next: %2$s)</string>
     <string name="cd_workouts">Workouts</string>
     <string name="cd_disconnect">Trennen</string>
 

--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -108,11 +108,11 @@
     <string name="settings_cloud_sync">Cloud-Sync</string>
     <string name="settings_weight_unit">Gewichtseinheit</string>
     <string name="settings_appearance">Erscheinungsbild</string>
-    <string name="settings_theme_mode">Theme</string>
-    <string name="settings_theme_mode_description">Follow the system theme or keep the app in light or dark mode</string>
+    <string name="settings_theme_mode">Design</string>
+    <string name="settings_theme_mode_description">Dem Systemdesign folgen oder die App im hellen oder dunklen Modus halten</string>
     <string name="settings_theme_system">System</string>
-    <string name="settings_theme_light">Light</string>
-    <string name="settings_theme_dark">Dark</string>
+    <string name="settings_theme_light">Hell</string>
+    <string name="settings_theme_dark">Dunkel</string>
     <string name="settings_dynamic_color">Material You-Farben</string>
     <string name="settings_dynamic_color_description">Farben aus deinem Android-Hintergrundbild verwenden, wenn verfügbar</string>
     <string name="settings_link_portal">Portal-Konto verknüpfen</string>
@@ -584,7 +584,7 @@
     <string name="cd_above_pr">Above PR</string>
     <string name="cd_below_pr">Below PR</string>
     <string name="cd_delete_workout">Delete workout</string>
-    <string name="cd_toggle_theme_cycle">Toggle theme (current: %1$s, next: %2$s)</string>
+    <string name="cd_toggle_theme_cycle">Design wechseln (aktuell: %1$s, nächstes: %2$s)</string>
     <string name="cd_workouts">Workouts</string>
     <string name="cd_disconnect">Trennen</string>
 

--- a/shared/src/commonMain/composeResources/values-es/strings.xml
+++ b/shared/src/commonMain/composeResources/values-es/strings.xml
@@ -108,11 +108,11 @@
     <string name="settings_cloud_sync">Sincronización en la nube</string>
     <string name="settings_weight_unit">Unidad de peso</string>
     <string name="settings_appearance">Apariencia</string>
-    <string name="settings_theme_mode">Theme</string>
-    <string name="settings_theme_mode_description">Follow the system theme or keep the app in light or dark mode</string>
-    <string name="settings_theme_system">System</string>
-    <string name="settings_theme_light">Light</string>
-    <string name="settings_theme_dark">Dark</string>
+    <string name="settings_theme_mode">Tema</string>
+    <string name="settings_theme_mode_description">Seguir el tema del sistema o mantener la aplicación en modo claro u oscuro</string>
+    <string name="settings_theme_system">Sistema</string>
+    <string name="settings_theme_light">Claro</string>
+    <string name="settings_theme_dark">Oscuro</string>
     <string name="settings_dynamic_color">Colores de Material You</string>
     <string name="settings_dynamic_color_description">Usar los colores de tu fondo de pantalla de Android cuando estén disponibles</string>
     <string name="settings_link_portal">Vincular cuenta del Portal</string>
@@ -584,7 +584,7 @@
     <string name="cd_above_pr">Above PR</string>
     <string name="cd_below_pr">Below PR</string>
     <string name="cd_delete_workout">Delete workout</string>
-    <string name="cd_toggle_theme_cycle">Toggle theme (current: %1$s, next: %2$s)</string>
+    <string name="cd_toggle_theme_cycle">Cambiar tema (actual: %1$s, siguiente: %2$s)</string>
     <string name="cd_workouts">Workouts</string>
     <string name="cd_disconnect">Desconectar</string>
 

--- a/shared/src/commonMain/composeResources/values-es/strings.xml
+++ b/shared/src/commonMain/composeResources/values-es/strings.xml
@@ -108,8 +108,11 @@
     <string name="settings_cloud_sync">Sincronización en la nube</string>
     <string name="settings_weight_unit">Unidad de peso</string>
     <string name="settings_appearance">Apariencia</string>
-    <string name="settings_dark_mode">Modo oscuro</string>
-    <string name="settings_dark_mode_description">Usar tema oscuro para la interfaz de la app</string>
+    <string name="settings_theme_mode">Theme</string>
+    <string name="settings_theme_mode_description">Follow the system theme or keep the app in light or dark mode</string>
+    <string name="settings_theme_system">System</string>
+    <string name="settings_theme_light">Light</string>
+    <string name="settings_theme_dark">Dark</string>
     <string name="settings_dynamic_color">Colores de Material You</string>
     <string name="settings_dynamic_color_description">Usar los colores de tu fondo de pantalla de Android cuando estén disponibles</string>
     <string name="settings_link_portal">Vincular cuenta del Portal</string>
@@ -581,7 +584,7 @@
     <string name="cd_above_pr">Above PR</string>
     <string name="cd_below_pr">Below PR</string>
     <string name="cd_delete_workout">Delete workout</string>
-    <string name="cd_toggle_theme">Toggle theme (current: %1$s)</string>
+    <string name="cd_toggle_theme_cycle">Toggle theme (current: %1$s, next: %2$s)</string>
     <string name="cd_workouts">Workouts</string>
     <string name="cd_disconnect">Desconectar</string>
 

--- a/shared/src/commonMain/composeResources/values-fr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fr/strings.xml
@@ -108,11 +108,11 @@
     <string name="settings_cloud_sync">Synchronisation cloud</string>
     <string name="settings_weight_unit">Unité de poids</string>
     <string name="settings_appearance">Apparence</string>
-    <string name="settings_theme_mode">Theme</string>
-    <string name="settings_theme_mode_description">Follow the system theme or keep the app in light or dark mode</string>
-    <string name="settings_theme_system">System</string>
-    <string name="settings_theme_light">Light</string>
-    <string name="settings_theme_dark">Dark</string>
+    <string name="settings_theme_mode">Thème</string>
+    <string name="settings_theme_mode_description">Suivre le thème du système ou garder l\'application en mode clair ou sombre</string>
+    <string name="settings_theme_system">Système</string>
+    <string name="settings_theme_light">Clair</string>
+    <string name="settings_theme_dark">Sombre</string>
     <string name="settings_dynamic_color">Couleurs Material You</string>
     <string name="settings_dynamic_color_description">Utiliser les couleurs de votre fond d\'écran Android lorsqu\'elles sont disponibles</string>
     <string name="settings_link_portal">Lier le compte Portal</string>
@@ -584,7 +584,7 @@
     <string name="cd_above_pr">Above PR</string>
     <string name="cd_below_pr">Below PR</string>
     <string name="cd_delete_workout">Delete workout</string>
-    <string name="cd_toggle_theme_cycle">Toggle theme (current: %1$s, next: %2$s)</string>
+    <string name="cd_toggle_theme_cycle">Changer de thème (actuel : %1$s, suivant : %2$s)</string>
     <string name="cd_workouts">Workouts</string>
     <string name="cd_disconnect">D\u00e9connecter</string>
 

--- a/shared/src/commonMain/composeResources/values-fr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fr/strings.xml
@@ -108,8 +108,11 @@
     <string name="settings_cloud_sync">Synchronisation cloud</string>
     <string name="settings_weight_unit">Unité de poids</string>
     <string name="settings_appearance">Apparence</string>
-    <string name="settings_dark_mode">Mode sombre</string>
-    <string name="settings_dark_mode_description">Utiliser le thème sombre pour l\'interface de l\'application</string>
+    <string name="settings_theme_mode">Theme</string>
+    <string name="settings_theme_mode_description">Follow the system theme or keep the app in light or dark mode</string>
+    <string name="settings_theme_system">System</string>
+    <string name="settings_theme_light">Light</string>
+    <string name="settings_theme_dark">Dark</string>
     <string name="settings_dynamic_color">Couleurs Material You</string>
     <string name="settings_dynamic_color_description">Utiliser les couleurs de votre fond d\'écran Android lorsqu\'elles sont disponibles</string>
     <string name="settings_link_portal">Lier le compte Portal</string>
@@ -581,7 +584,7 @@
     <string name="cd_above_pr">Above PR</string>
     <string name="cd_below_pr">Below PR</string>
     <string name="cd_delete_workout">Delete workout</string>
-    <string name="cd_toggle_theme">Toggle theme (current: %1$s)</string>
+    <string name="cd_toggle_theme_cycle">Toggle theme (current: %1$s, next: %2$s)</string>
     <string name="cd_workouts">Workouts</string>
     <string name="cd_disconnect">D\u00e9connecter</string>
 

--- a/shared/src/commonMain/composeResources/values-nl/strings.xml
+++ b/shared/src/commonMain/composeResources/values-nl/strings.xml
@@ -108,8 +108,11 @@
     <string name="settings_cloud_sync">Cloud Sync</string>
     <string name="settings_weight_unit">Gewichtseenheid</string>
     <string name="settings_appearance">Uiterlijk</string>
-    <string name="settings_dark_mode">Donkere modus</string>
-    <string name="settings_dark_mode_description">Gebruik donker thema voor de app</string>
+    <string name="settings_theme_mode">Theme</string>
+    <string name="settings_theme_mode_description">Follow the system theme or keep the app in light or dark mode</string>
+    <string name="settings_theme_system">System</string>
+    <string name="settings_theme_light">Light</string>
+    <string name="settings_theme_dark">Dark</string>
     <string name="settings_dynamic_color">Material You-kleuren</string>
     <string name="settings_dynamic_color_description">Gebruik kleuren van je Android-achtergrond wanneer beschikbaar</string>
     <string name="settings_link_portal">Koppel Portal-account</string>
@@ -560,7 +563,7 @@
     <string name="cd_above_pr">Boven PR</string>
     <string name="cd_below_pr">Onder PR</string>
     <string name="cd_delete_workout">Training verwijderen</string>
-    <string name="cd_toggle_theme">Thema wisselen (huidig: %1$s)</string>
+    <string name="cd_toggle_theme_cycle">Toggle theme (current: %1$s, next: %2$s)</string>
     <string name="cd_workouts">Trainingen</string>
     <string name="cd_disconnect">Verbinding verbreken</string>
 

--- a/shared/src/commonMain/composeResources/values-nl/strings.xml
+++ b/shared/src/commonMain/composeResources/values-nl/strings.xml
@@ -108,11 +108,11 @@
     <string name="settings_cloud_sync">Cloud Sync</string>
     <string name="settings_weight_unit">Gewichtseenheid</string>
     <string name="settings_appearance">Uiterlijk</string>
-    <string name="settings_theme_mode">Theme</string>
-    <string name="settings_theme_mode_description">Follow the system theme or keep the app in light or dark mode</string>
-    <string name="settings_theme_system">System</string>
-    <string name="settings_theme_light">Light</string>
-    <string name="settings_theme_dark">Dark</string>
+    <string name="settings_theme_mode">Thema</string>
+    <string name="settings_theme_mode_description">Volg het systeemthema of houd de app in de lichte of donkere modus</string>
+    <string name="settings_theme_system">Systeem</string>
+    <string name="settings_theme_light">Licht</string>
+    <string name="settings_theme_dark">Donker</string>
     <string name="settings_dynamic_color">Material You-kleuren</string>
     <string name="settings_dynamic_color_description">Gebruik kleuren van je Android-achtergrond wanneer beschikbaar</string>
     <string name="settings_link_portal">Koppel Portal-account</string>
@@ -563,7 +563,7 @@
     <string name="cd_above_pr">Boven PR</string>
     <string name="cd_below_pr">Onder PR</string>
     <string name="cd_delete_workout">Training verwijderen</string>
-    <string name="cd_toggle_theme_cycle">Toggle theme (current: %1$s, next: %2$s)</string>
+    <string name="cd_toggle_theme_cycle">Thema wisselen (huidig: %1$s, volgend: %2$s)</string>
     <string name="cd_workouts">Trainingen</string>
     <string name="cd_disconnect">Verbinding verbreken</string>
 

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -112,8 +112,11 @@
     <string name="settings_cloud_sync">Cloud Sync</string>
     <string name="settings_weight_unit">Weight Unit</string>
     <string name="settings_appearance">Appearance</string>
-    <string name="settings_dark_mode">Dark Mode</string>
-    <string name="settings_dark_mode_description">Use dark theme for the app interface</string>
+    <string name="settings_theme_mode">Theme</string>
+    <string name="settings_theme_mode_description">Follow the system theme or keep the app in light or dark mode</string>
+    <string name="settings_theme_system">System</string>
+    <string name="settings_theme_light">Light</string>
+    <string name="settings_theme_dark">Dark</string>
     <string name="settings_dynamic_color">Material You colors</string>
     <string name="settings_dynamic_color_description">Use colors from your Android wallpaper when available</string>
     <string name="settings_link_portal">Link Portal Account</string>
@@ -633,7 +636,7 @@
     <string name="cd_above_pr">Above PR</string>
     <string name="cd_below_pr">Below PR</string>
     <string name="cd_delete_workout">Delete workout</string>
-    <string name="cd_toggle_theme">Toggle theme (current: %1$s)</string>
+    <string name="cd_toggle_theme_cycle">Toggle theme (current: %1$s, next: %2$s)</string>
     <string name="cd_workouts">Workouts</string>
     <string name="cd_disconnect">Disconnect</string>
     <string name="single_exercise_unavailable">Exercise is no longer available</string>

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/ThemeToggle.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/ThemeToggle.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.DarkMode
 import androidx.compose.material.icons.filled.LightMode
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -17,18 +18,13 @@ import vitruvianprojectphoenix.shared.generated.resources.Res
 
 /**
  * Compact icon-only theme toggle.
- * Toggles between Light and Dark modes only.
+ * Cycles through System, Light, and Dark modes.
  */
 @Composable
 fun ThemeToggle(mode: ThemeMode, onModeChange: (ThemeMode) -> Unit, modifier: Modifier = Modifier) {
+    val nextMode = nextThemeModeAfterToggle(mode)
     IconButton(
         onClick = {
-            // Toggle between Light and Dark only
-            val nextMode = when (mode) {
-                ThemeMode.LIGHT -> ThemeMode.DARK
-                ThemeMode.DARK -> ThemeMode.LIGHT
-                ThemeMode.SYSTEM -> ThemeMode.LIGHT // If somehow in SYSTEM, go to LIGHT
-            }
             onModeChange(nextMode)
         },
         modifier = modifier,
@@ -37,11 +33,21 @@ fun ThemeToggle(mode: ThemeMode, onModeChange: (ThemeMode) -> Unit, modifier: Mo
             imageVector = when (mode) {
                 ThemeMode.LIGHT -> Icons.Default.LightMode
                 ThemeMode.DARK -> Icons.Default.DarkMode
-                ThemeMode.SYSTEM -> Icons.Default.LightMode // Fallback
+                ThemeMode.SYSTEM -> Icons.Default.Settings
             },
-            contentDescription = stringResource(Res.string.cd_toggle_theme, mode.name.lowercase()),
+            contentDescription = stringResource(
+                Res.string.cd_toggle_theme_cycle,
+                mode.name.lowercase(),
+                nextMode.name.lowercase(),
+            ),
             modifier = Modifier.size(24.dp),
             tint = MaterialTheme.colorScheme.onSurface,
         )
     }
+}
+
+internal fun nextThemeModeAfterToggle(mode: ThemeMode): ThemeMode = when (mode) {
+    ThemeMode.SYSTEM -> ThemeMode.LIGHT
+    ThemeMode.LIGHT -> ThemeMode.DARK
+    ThemeMode.DARK -> ThemeMode.SYSTEM
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/navigation/NavGraph.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/navigation/NavGraph.kt
@@ -318,7 +318,7 @@ fun NavGraph(
                 SettingsTab(
                     weightUnit = weightUnit,
                     enableVideoPlayback = userPreferences.enableVideoPlayback,
-                    darkModeEnabled = themeMode == ThemeMode.DARK,
+                    themeMode = themeMode,
                     dynamicColorAvailable = dynamicColorAvailable,
                     dynamicColorEnabled = dynamicColorEnabled,
                     audioRepCountEnabled = userPreferences.audioRepCountEnabled,
@@ -335,7 +335,7 @@ fun NavGraph(
                     selectedColorSchemeIndex = userPreferences.colorScheme,
                     onWeightUnitChange = { viewModel.setWeightUnit(it) },
                     onEnableVideoPlaybackChange = { viewModel.setEnableVideoPlayback(it) },
-                    onDarkModeChange = { enabled -> onThemeModeChange(if (enabled) ThemeMode.DARK else ThemeMode.LIGHT) },
+                    onThemeModeChange = onThemeModeChange,
                     onDynamicColorEnabledChange = onDynamicColorEnabledChange,
                     onAudioRepCountChange = { viewModel.setAudioRepCountEnabled(it) },
                     onSummaryCountdownChange = { viewModel.setSummaryCountdownSeconds(it) },

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SettingsTab.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SettingsTab.kt
@@ -73,6 +73,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -176,8 +179,6 @@ import vitruvianprojectphoenix.shared.generated.resources.settings_calibration_p
 import vitruvianprojectphoenix.shared.generated.resources.settings_calibration_prompt
 import vitruvianprojectphoenix.shared.generated.resources.settings_calibration_title
 import vitruvianprojectphoenix.shared.generated.resources.settings_cloud_sync
-import vitruvianprojectphoenix.shared.generated.resources.settings_dark_mode
-import vitruvianprojectphoenix.shared.generated.resources.settings_dark_mode_description
 import vitruvianprojectphoenix.shared.generated.resources.settings_dynamic_color
 import vitruvianprojectphoenix.shared.generated.resources.settings_dynamic_color_description
 import vitruvianprojectphoenix.shared.generated.resources.settings_language
@@ -185,17 +186,66 @@ import vitruvianprojectphoenix.shared.generated.resources.settings_language_help
 import vitruvianprojectphoenix.shared.generated.resources.settings_machine_diagnostics_description
 import vitruvianprojectphoenix.shared.generated.resources.settings_safe_word_hint
 import vitruvianprojectphoenix.shared.generated.resources.settings_safe_word_label
+import vitruvianprojectphoenix.shared.generated.resources.settings_theme_dark
+import vitruvianprojectphoenix.shared.generated.resources.settings_theme_light
+import vitruvianprojectphoenix.shared.generated.resources.settings_theme_mode
+import vitruvianprojectphoenix.shared.generated.resources.settings_theme_mode_description
+import vitruvianprojectphoenix.shared.generated.resources.settings_theme_system
 import vitruvianprojectphoenix.shared.generated.resources.settings_title
 import vitruvianprojectphoenix.shared.generated.resources.settings_version
 import vitruvianprojectphoenix.shared.generated.resources.settings_voice_stop_description
 import vitruvianprojectphoenix.shared.generated.resources.settings_voice_stop_title
 import vitruvianprojectphoenix.shared.generated.resources.settings_weight_unit
 
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ThemeModeSelector(
+    themeMode: ThemeMode,
+    onThemeModeChange: (ThemeMode) -> Unit,
+) {
+    val options = listOf(
+        ThemeMode.SYSTEM to stringResource(Res.string.settings_theme_system),
+        ThemeMode.LIGHT to stringResource(Res.string.settings_theme_light),
+        ThemeMode.DARK to stringResource(Res.string.settings_theme_dark),
+    )
+
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Text(
+            stringResource(Res.string.settings_theme_mode),
+            style = MaterialTheme.typography.bodyLarge,
+            fontWeight = FontWeight.Medium,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            stringResource(Res.string.settings_theme_mode_description),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(modifier = Modifier.height(Spacing.small))
+        SingleChoiceSegmentedButtonRow(
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            options.forEachIndexed { index, (mode, label) ->
+                SegmentedButton(
+                    selected = themeMode == mode,
+                    onClick = { onThemeModeChange(mode) },
+                    shape = SegmentedButtonDefaults.itemShape(index = index, count = options.size),
+                ) {
+                    Text(label, maxLines = 1)
+                }
+            }
+        }
+    }
+}
+
 @Composable
 fun SettingsTab(
     weightUnit: WeightUnit,
     enableVideoPlayback: Boolean,
-    darkModeEnabled: Boolean,
+    themeMode: ThemeMode,
     dynamicColorAvailable: Boolean = false,
     dynamicColorEnabled: Boolean = false,
     audioRepCountEnabled: Boolean = false,
@@ -215,7 +265,7 @@ fun SettingsTab(
     selectedColorSchemeIndex: Int = 0,
     onWeightUnitChange: (WeightUnit) -> Unit,
     onEnableVideoPlaybackChange: (Boolean) -> Unit,
-    onDarkModeChange: (Boolean) -> Unit,
+    onThemeModeChange: (ThemeMode) -> Unit,
     onDynamicColorEnabledChange: (Boolean) -> Unit = {},
     onAudioRepCountChange: (Boolean) -> Unit,
     onSummaryCountdownChange: (Int) -> Unit = {},
@@ -889,33 +939,10 @@ fun SettingsTab(
                 }
                 Spacer(modifier = Modifier.height(Spacing.small))
 
-                // Dark Mode toggle
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Column(
-                        modifier = Modifier.weight(1f),
-                    ) {
-                        Text(
-                            stringResource(Res.string.settings_dark_mode),
-                            style = MaterialTheme.typography.bodyLarge,
-                            fontWeight = FontWeight.Medium,
-                            color = MaterialTheme.colorScheme.onSurface,
-                        )
-                        Spacer(modifier = Modifier.height(4.dp))
-                        Text(
-                            stringResource(Res.string.settings_dark_mode_description),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
-                    Switch(
-                        checked = darkModeEnabled,
-                        onCheckedChange = onDarkModeChange,
-                    )
-                }
+                ThemeModeSelector(
+                    themeMode = themeMode,
+                    onThemeModeChange = onThemeModeChange,
+                )
 
                 if (dynamicColorAvailable) {
                     HorizontalDivider(

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/components/ThemeToggleTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/components/ThemeToggleTest.kt
@@ -1,0 +1,23 @@
+package com.devil.phoenixproject.presentation.components
+
+import com.devil.phoenixproject.ui.theme.ThemeMode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ThemeToggleTest {
+
+    @Test
+    fun `theme toggle cycles system to light`() {
+        assertEquals(ThemeMode.LIGHT, nextThemeModeAfterToggle(ThemeMode.SYSTEM))
+    }
+
+    @Test
+    fun `theme toggle cycles light to dark`() {
+        assertEquals(ThemeMode.DARK, nextThemeModeAfterToggle(ThemeMode.LIGHT))
+    }
+
+    @Test
+    fun `theme toggle cycles dark to system`() {
+        assertEquals(ThemeMode.SYSTEM, nextThemeModeAfterToggle(ThemeMode.DARK))
+    }
+}

--- a/shared/src/iosMain/kotlin/com/devil/phoenixproject/ui/theme/Theme.ios.kt
+++ b/shared/src/iosMain/kotlin/com/devil/phoenixproject/ui/theme/Theme.ios.kt
@@ -14,6 +14,9 @@ import com.devil.phoenixproject.ui.theme.VitruvianTheme as SharedVitruvianTheme
  * and status bar styling is typically handled at the SwiftUI level.
  * This wrapper exists for parity with Android and future iOS-specific theming needs.
  */
+@Deprecated(
+    message = "Use the common VitruvianTheme(themeMode = ...) overload so ThemeMode.SYSTEM is preserved.",
+)
 @Composable
 fun VitruvianTheme(darkTheme: Boolean = isSystemInDarkTheme(), content: @Composable () -> Unit) {
     val themeMode = if (darkTheme) SharedThemeMode.DARK else SharedThemeMode.LIGHT


### PR DESCRIPTION
## Summary
- Replace the Settings dark-mode boolean with a three-state `ThemeMode` selector for System, Light, and Dark.
- Keep `ThemeMode.SYSTEM` as a first-class persisted value across settings, navigation, Android, and iOS theme routing.
- Add iOS host refresh on `colorScheme` changes and deprecate the boolean theme wrappers to prevent regressions.
- Update theme strings and add regression coverage for persistence, toggle cycling, and UI contract guards.

## Testing
- `spotlessCheck` passed.
- `:shared:testAndroidHostTest --tests *Theme*` passed.
- `:shared:compileKotlinMetadata` passed.
- `:androidApp:assembleDebug` passed.
- `:shared:assembleXCFramework` passed.