### PR TITLE
Implement routine deload modifiers (Active Recovery & Heavy Deload)

### DIFF
--- a/shared/src/androidMain/kotlin/com/devil/phoenixproject/di/PlatformModule.android.kt
+++ b/shared/src/androidMain/kotlin/com/devil/phoenixproject/di/PlatformModule.android.kt
@@ -84,6 +84,7 @@ actual val platformModule: Module = module {
             repMetricRepository = get(),
             biomechanicsRepository = get(),
             resolveWeightsUseCase = get(),
+            applyRoutineModifierUseCase = get(),
             dataBackupManager = get(),
             userProfileRepository = get(),
             healthIntegration = get(),

--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -617,4 +617,12 @@
     <string name="tag_exercise_hint">Ordne diesen Lift zu, um ihn zu verfolgen</string>
     <string name="tag_exercise_action">Übung zuordnen</string>
     <string name="exercise_tagged">Übung zugeordnet</string>
+    <!-- Routine launch modifiers (Issue #495) -->
+    <string name="routine_modifier_active_recovery">Aktive Erholung starten…</string>
+    <string name="routine_modifier_heavy_deload">Schweren Deload starten…</string>
+    <string name="routine_modifier_percent_label">Modifikator</string>
+    <string name="routine_modifier_start">Starten</string>
+    <string name="routine_modifier_cancel">Abbrechen</string>
+    <string name="routine_modifier_active_recovery_description">Gewichte werden auf den gewählten 1RM-Prozentsatz reduziert; Arbeitswiederholungen bleiben gleich; Aufwärmen wird vereinfacht.</string>
+    <string name="routine_modifier_heavy_deload_description">Wiederholungen werden auf den gewählten Volumen-Prozentsatz reduziert; Gewichte bleiben gleich.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-es/strings.xml
+++ b/shared/src/commonMain/composeResources/values-es/strings.xml
@@ -617,4 +617,12 @@
     <string name="tag_exercise_hint">Etiqueta este levantamiento para registrarlo</string>
     <string name="tag_exercise_action">Etiquetar ejercicio</string>
     <string name="exercise_tagged">Ejercicio etiquetado</string>
+    <!-- Routine launch modifiers (Issue #495) -->
+    <string name="routine_modifier_active_recovery">Iniciar recuperación activa…</string>
+    <string name="routine_modifier_heavy_deload">Iniciar descarga pesada…</string>
+    <string name="routine_modifier_percent_label">Modificador</string>
+    <string name="routine_modifier_start">Iniciar</string>
+    <string name="routine_modifier_cancel">Cancelar</string>
+    <string name="routine_modifier_active_recovery_description">Los pesos se reducen al porcentaje de 1RM seleccionado; las repeticiones de trabajo no cambian; los calentamientos se simplifican.</string>
+    <string name="routine_modifier_heavy_deload_description">Las repeticiones se reducen al porcentaje de volumen seleccionado; los pesos no cambian.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-fr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fr/strings.xml
@@ -617,4 +617,12 @@
     <string name="tag_exercise_hint">Associez ce mouvement pour le suivre</string>
     <string name="tag_exercise_action">Associer l\'exercice</string>
     <string name="exercise_tagged">Exercice associé</string>
+    <!-- Routine launch modifiers (Issue #495) -->
+    <string name="routine_modifier_active_recovery">Démarrer récupération active…</string>
+    <string name="routine_modifier_heavy_deload">Démarrer deload lourd…</string>
+    <string name="routine_modifier_percent_label">Modificateur</string>
+    <string name="routine_modifier_start">Démarrer</string>
+    <string name="routine_modifier_cancel">Annuler</string>
+    <string name="routine_modifier_active_recovery_description">Les charges sont réduites au pourcentage de 1RM sélectionné ; les répétitions de travail restent identiques ; les échauffements sont simplifiés.</string>
+    <string name="routine_modifier_heavy_deload_description">Les répétitions sont réduites au pourcentage de volume sélectionné ; les charges restent identiques.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-nl/strings.xml
+++ b/shared/src/commonMain/composeResources/values-nl/strings.xml
@@ -596,4 +596,12 @@
     <string name="tag_exercise_hint">Label deze lift om hem bij te houden</string>
     <string name="tag_exercise_action">Oefening labelen</string>
     <string name="exercise_tagged">Oefening gelabeld</string>
+    <!-- Routine launch modifiers (Issue #495) -->
+    <string name="routine_modifier_active_recovery">Actief herstel starten…</string>
+    <string name="routine_modifier_heavy_deload">Zware deload starten…</string>
+    <string name="routine_modifier_percent_label">Modifier</string>
+    <string name="routine_modifier_start">Starten</string>
+    <string name="routine_modifier_cancel">Annuleren</string>
+    <string name="routine_modifier_active_recovery_description">Gewichten worden verlaagd naar het gekozen 1RM-percentage; werkherhalingen blijven gelijk; warming-ups worden vereenvoudigd.</string>
+    <string name="routine_modifier_heavy_deload_description">Herhalingen worden verlaagd naar het gekozen volumepercentage; gewichten blijven gelijk.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -670,4 +670,12 @@
     <string name="tag_exercise_hint">Label this lift to track it</string>
     <string name="tag_exercise_action">Tag exercise</string>
     <string name="exercise_tagged">Exercise tagged</string>
+    <!-- Routine launch modifiers (Issue #495) -->
+    <string name="routine_modifier_active_recovery">Start Active Recovery…</string>
+    <string name="routine_modifier_heavy_deload">Start Heavy Deload…</string>
+    <string name="routine_modifier_percent_label">Modifier</string>
+    <string name="routine_modifier_start">Start</string>
+    <string name="routine_modifier_cancel">Cancel</string>
+    <string name="routine_modifier_active_recovery_description">Weights reduced to selected 1RM percentage; working reps stay the same; warmups simplified.</string>
+    <string name="routine_modifier_heavy_deload_description">Reps reduced to selected volume percentage; weights stay the same.</string>
 </resources>

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/di/DomainModule.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/di/DomainModule.kt
@@ -6,6 +6,7 @@ import com.devil.phoenixproject.data.preferences.SettingsPreferencesManager
 import com.devil.phoenixproject.data.repository.GamificationRepository
 import com.devil.phoenixproject.data.repository.UserProfileRepository
 import com.devil.phoenixproject.domain.assessment.AssessmentEngine
+import com.devil.phoenixproject.domain.usecase.ApplyRoutineModifierUseCase
 import com.devil.phoenixproject.domain.usecase.ProgressionUseCase
 import com.devil.phoenixproject.domain.usecase.RepCounterFromMachine
 import com.devil.phoenixproject.domain.usecase.ResolveRoutineWeightsUseCase
@@ -24,6 +25,7 @@ val domainModule = module {
     single { RepCounterFromMachine() }
     single { ProgressionUseCase(get(), get()) }
     factory { ResolveRoutineWeightsUseCase(get(), get()) }
+    factory { ApplyRoutineModifierUseCase(get(), get()) }
     factory { RoutineTimeEstimator(get()) }
     single { TemplateConverter(get()) }
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/RoutineModifier.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/RoutineModifier.kt
@@ -1,0 +1,27 @@
+package com.devil.phoenixproject.domain.model
+
+/** One-shot launch-time routine modifier options. */
+enum class RoutineModifierType {
+    ACTIVE_RECOVERY,
+    HEAVY_DELOAD,
+}
+
+/**
+ * Modifier selected immediately before starting a routine.
+ *
+ * This model is intentionally not persisted on [Routine]; it describes a temporary
+ * transform applied to the resolved routine loaded into the current workout flow.
+ */
+data class AppliedRoutineModifier(
+    val type: RoutineModifierType,
+    val percent: Int,
+) {
+    init {
+        require(percent in VALID_PERCENT_RANGE) { "Routine modifier percent must be between 1 and 100" }
+    }
+
+    companion object {
+        val selectablePercents = listOf(50, 55, 60)
+        private val VALID_PERCENT_RANGE = 1..100
+    }
+}

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/ApplyRoutineModifierUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/ApplyRoutineModifierUseCase.kt
@@ -1,0 +1,92 @@
+package com.devil.phoenixproject.domain.usecase
+
+import com.devil.phoenixproject.data.repository.ExerciseRepository
+import com.devil.phoenixproject.data.repository.PersonalRecordRepository
+import com.devil.phoenixproject.data.repository.getBestWeightPRForWorkoutMode
+import com.devil.phoenixproject.domain.model.AppliedRoutineModifier
+import com.devil.phoenixproject.domain.model.Routine
+import com.devil.phoenixproject.domain.model.RoutineExercise
+import com.devil.phoenixproject.domain.model.RoutineModifierType
+import com.devil.phoenixproject.domain.model.WarmupSet
+import kotlin.math.roundToInt
+
+/**
+ * Applies one-shot Active Recovery or Heavy Deload transforms to a routine at launch time.
+ *
+ * The input routine is never mutated. Callers should resolve percent-of-PR routine weights
+ * before invoking this use case so fallback weights are absolute kg values.
+ */
+class ApplyRoutineModifierUseCase(
+    private val prRepository: PersonalRecordRepository,
+    private val exerciseRepository: ExerciseRepository,
+) {
+    suspend operator fun invoke(
+        routine: Routine,
+        modifier: AppliedRoutineModifier,
+        profileId: String = "default",
+    ): Routine = when (modifier.type) {
+        RoutineModifierType.ACTIVE_RECOVERY -> applyActiveRecovery(routine, modifier.percent, profileId)
+        RoutineModifierType.HEAVY_DELOAD -> applyHeavyDeload(routine, modifier.percent)
+    }
+
+    private suspend fun applyActiveRecovery(routine: Routine, percent: Int, profileId: String): Routine = routine.copy(
+        exercises = routine.exercises.map { exercise ->
+            if (exercise.exercise.isBodyweight) {
+                exercise.copy(warmupSets = scaleFirstWarmupOnly(exercise.warmupSets, percent))
+            } else {
+                val baseline = resolveBaselineOneRepMax(exercise, profileId)
+                val adjustedWeight = roundToHalfKg(baseline * percent / 100f).coerceAtLeast(MIN_WEIGHT_KG)
+                val adjustedSetWeights = if (exercise.setWeightsPerCableKg.isNotEmpty()) {
+                    List(exercise.sets) { adjustedWeight }
+                } else {
+                    emptyList()
+                }
+
+                exercise.copy(
+                    weightPerCableKg = adjustedWeight,
+                    setWeightsPerCableKg = adjustedSetWeights,
+                    warmupSets = scaleFirstWarmupOnly(exercise.warmupSets, percent),
+                )
+            }
+        },
+    )
+
+    private fun applyHeavyDeload(routine: Routine, percent: Int): Routine = routine.copy(
+        exercises = routine.exercises.map { exercise ->
+            exercise.copy(
+                setReps = exercise.setReps.map { reps -> reps?.let { scaleReps(it, percent) } },
+                warmupSets = exercise.warmupSets.map { it.copy(reps = scaleReps(it.reps, percent)) },
+            )
+        },
+    )
+
+    private suspend fun resolveBaselineOneRepMax(exercise: RoutineExercise, profileId: String): Float {
+        val exerciseId = exercise.exercise.id
+        val storedOneRepMax = exerciseId
+            ?.let { exerciseRepository.getExerciseById(it)?.oneRepMaxKg }
+            ?.takeIf { it > 0 }
+            ?: exercise.exercise.oneRepMaxKg?.takeIf { it > 0 }
+
+        if (storedOneRepMax != null) return storedOneRepMax
+
+        val weightPrOneRepMax = exerciseId
+            ?.let { prRepository.getBestWeightPRForWorkoutMode(it, exercise.programMode.displayName, profileId) }
+            ?.oneRepMax
+            ?.takeIf { it > 0 }
+
+        return weightPrOneRepMax ?: exercise.weightPerCableKg.takeIf { it > 0 } ?: MIN_WEIGHT_KG
+    }
+
+    private fun scaleFirstWarmupOnly(warmupSets: List<WarmupSet>, percent: Int): List<WarmupSet> = warmupSets
+        .firstOrNull()
+        ?.let { listOf(it.copy(reps = scaleReps(it.reps, percent))) }
+        ?: emptyList()
+
+    private fun scaleReps(reps: Int, percent: Int): Int = (reps * percent / 100f).roundToInt().coerceAtLeast(1)
+
+    private fun roundToHalfKg(value: Float): Float = (value * 2f).roundToInt() / 2f
+
+    private companion object {
+        const val MIN_WEIGHT_KG = 0.5f
+    }
+}

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/ApplyRoutineModifierUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/ApplyRoutineModifierUseCase.kt
@@ -37,7 +37,7 @@ class ApplyRoutineModifierUseCase(
                 val baseline = resolveBaselineOneRepMax(exercise, profileId)
                 val adjustedWeight = roundToHalfKg(baseline * percent / 100f).coerceAtLeast(MIN_WEIGHT_KG)
                 val adjustedSetWeights = if (exercise.setWeightsPerCableKg.isNotEmpty()) {
-                    List(exercise.sets) { adjustedWeight }
+                    List(exercise.setWeightsPerCableKg.size) { adjustedWeight }
                 } else {
                     emptyList()
                 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/RoutineModifierDialog.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/RoutineModifierDialog.kt
@@ -1,0 +1,77 @@
+package com.devil.phoenixproject.presentation.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.devil.phoenixproject.domain.model.AppliedRoutineModifier
+import com.devil.phoenixproject.domain.model.RoutineModifierType
+import org.jetbrains.compose.resources.stringResource
+import vitruvianprojectphoenix.shared.generated.resources.Res
+import vitruvianprojectphoenix.shared.generated.resources.routine_modifier_active_recovery
+import vitruvianprojectphoenix.shared.generated.resources.routine_modifier_active_recovery_description
+import vitruvianprojectphoenix.shared.generated.resources.routine_modifier_cancel
+import vitruvianprojectphoenix.shared.generated.resources.routine_modifier_heavy_deload
+import vitruvianprojectphoenix.shared.generated.resources.routine_modifier_heavy_deload_description
+import vitruvianprojectphoenix.shared.generated.resources.routine_modifier_percent_label
+import vitruvianprojectphoenix.shared.generated.resources.routine_modifier_start
+
+@Composable
+fun RoutineModifierDialog(
+    type: RoutineModifierType,
+    onDismiss: () -> Unit,
+    onConfirm: (AppliedRoutineModifier) -> Unit,
+) {
+    var selectedPercent by remember(type) { mutableIntStateOf(AppliedRoutineModifier.selectablePercents.first()) }
+    val title = when (type) {
+        RoutineModifierType.ACTIVE_RECOVERY -> stringResource(Res.string.routine_modifier_active_recovery)
+        RoutineModifierType.HEAVY_DELOAD -> stringResource(Res.string.routine_modifier_heavy_deload)
+    }
+    val description = when (type) {
+        RoutineModifierType.ACTIVE_RECOVERY -> stringResource(Res.string.routine_modifier_active_recovery_description)
+        RoutineModifierType.HEAVY_DELOAD -> stringResource(Res.string.routine_modifier_heavy_deload_description)
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(title) },
+        text = {
+            androidx.compose.foundation.layout.Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text(description)
+                Text(stringResource(Res.string.routine_modifier_percent_label))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    AppliedRoutineModifier.selectablePercents.forEach { percent ->
+                        FilterChip(
+                            selected = selectedPercent == percent,
+                            onClick = { selectedPercent = percent },
+                            label = { Text("$percent%") },
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onConfirm(AppliedRoutineModifier(type, selectedPercent)) }) {
+                Text(stringResource(Res.string.routine_modifier_start))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(Res.string.routine_modifier_cancel))
+            }
+        },
+    )
+}

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/DefaultWorkoutSessionManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/DefaultWorkoutSessionManager.kt
@@ -14,6 +14,7 @@ import com.devil.phoenixproject.data.repository.TrainingCycleRepository
 import com.devil.phoenixproject.data.repository.UserProfileRepository
 import com.devil.phoenixproject.data.repository.WorkoutRepository
 import com.devil.phoenixproject.data.sync.SyncTriggerManager
+import com.devil.phoenixproject.domain.model.AppliedRoutineModifier
 import com.devil.phoenixproject.domain.model.BodyweightVariantOption
 import com.devil.phoenixproject.domain.model.EccentricLoad
 import com.devil.phoenixproject.domain.model.EchoLevel
@@ -29,6 +30,7 @@ import com.devil.phoenixproject.domain.model.WorkoutParameters
 import com.devil.phoenixproject.domain.model.WorkoutState
 import com.devil.phoenixproject.domain.model.currentTimeMillis
 import com.devil.phoenixproject.domain.model.elapsedRealtimeMillis
+import com.devil.phoenixproject.domain.usecase.ApplyRoutineModifierUseCase
 import com.devil.phoenixproject.domain.usecase.RepCounterFromMachine
 import com.devil.phoenixproject.domain.usecase.ResolveRoutineWeightsUseCase
 import com.devil.phoenixproject.getPlatform
@@ -145,6 +147,7 @@ class DefaultWorkoutSessionManager(
     private val repMetricRepository: RepMetricRepository,
     private val biomechanicsRepository: BiomechanicsRepository,
     private val resolveWeightsUseCase: ResolveRoutineWeightsUseCase,
+    private val applyRoutineModifierUseCase: ApplyRoutineModifierUseCase,
     private val settingsManager: SettingsManager,
     private val dataBackupManager: DataBackupManager? = null,
     private val userProfileRepository: UserProfileRepository,
@@ -185,6 +188,7 @@ class DefaultWorkoutSessionManager(
         workoutRepository = workoutRepository,
         exerciseRepository = exerciseRepository,
         resolveWeightsUseCase = resolveWeightsUseCase,
+        applyRoutineModifierUseCase = applyRoutineModifierUseCase,
         completedSetRepository = completedSetRepository,
         settingsManager = settingsManager,
         userProfileRepository = userProfileRepository,
@@ -556,6 +560,7 @@ class DefaultWorkoutSessionManager(
     suspend fun loadRoutineAsync(routine: Routine) = routineFlowManager.loadRoutineAsync(routine)
     fun loadRoutineById(routineId: String) = routineFlowManager.loadRoutineById(routineId)
     fun enterRoutineOverview(routine: Routine) = routineFlowManager.enterRoutineOverview(routine)
+    fun enterRoutineOverview(routine: Routine, modifier: AppliedRoutineModifier) = routineFlowManager.enterRoutineOverview(routine, modifier)
 
     // ===== SetReady Navigation — delegated to RoutineFlowManager =====
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/RoutineFlowManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/RoutineFlowManager.kt
@@ -7,6 +7,7 @@ import com.devil.phoenixproject.data.repository.ExerciseRepository
 import com.devil.phoenixproject.data.repository.SqlDelightWorkoutRepository
 import com.devil.phoenixproject.data.repository.UserProfileRepository
 import com.devil.phoenixproject.data.repository.WorkoutRepository
+import com.devil.phoenixproject.domain.model.AppliedRoutineModifier
 import com.devil.phoenixproject.domain.model.EccentricLoad
 import com.devil.phoenixproject.domain.model.EchoLevel
 import com.devil.phoenixproject.domain.model.ProgramMode
@@ -23,6 +24,7 @@ import com.devil.phoenixproject.domain.model.WorkoutState
 import com.devil.phoenixproject.domain.model.currentTimeMillis
 import com.devil.phoenixproject.domain.model.generateSupersetId
 import com.devil.phoenixproject.domain.model.generateUUID
+import com.devil.phoenixproject.domain.usecase.ApplyRoutineModifierUseCase
 import com.devil.phoenixproject.domain.usecase.ResolveRoutineWeightsUseCase
 import com.devil.phoenixproject.util.Constants
 import kotlinx.coroutines.CancellationException
@@ -49,6 +51,7 @@ class RoutineFlowManager(
     private val workoutRepository: WorkoutRepository,
     private val exerciseRepository: ExerciseRepository,
     private val resolveWeightsUseCase: ResolveRoutineWeightsUseCase,
+    private val applyRoutineModifierUseCase: ApplyRoutineModifierUseCase,
     private val completedSetRepository: CompletedSetRepository,
     private val settingsManager: SettingsManager,
     private val userProfileRepository: UserProfileRepository,
@@ -825,31 +828,45 @@ class RoutineFlowManager(
      */
     fun enterRoutineOverview(routine: Routine) {
         scope.launch {
-            val resolvedRoutine = resolveRoutineWeights(routine)
-            val normalized = normalizeExerciseOrder(resolvedRoutine)
-            coordinator._loadedRoutine.value = normalized
-            coordinator._currentExerciseIndex.value = 0
-            coordinator._currentSetIndex.value = 0
-            coordinator._skippedExercises.value = emptySet()
-            coordinator._completedExercises.value = emptySet()
-            coordinator._completedRoutineSetKeys.value = emptySet()
-            coordinator._workoutState.value = WorkoutState.Idle
-            coordinator._routineFlowState.value = RoutineFlowState.Overview(
-                routine = normalized,
-                selectedExerciseIndex = 0,
-            )
+            enterRoutineOverviewInternal(resolveRoutineWeights(routine))
+        }
+    }
 
-            // Issue #356: Initialize warm-up state for the first exercise
-            val firstExercise = normalized.exercises.firstOrNull()
-            val isFirstBodyweight = firstExercise?.exercise?.isBodyweight ?: false
-            if (firstExercise != null && firstExercise.warmupSets.isNotEmpty() && !isFirstBodyweight) {
-                coordinator._currentWarmupSetIndex.value = 0
-                coordinator._totalWarmupSets.value = firstExercise.warmupSets.size
-                Logger.d("RoutineFlowManager") { "Issue #356: Overview init warm-up for ${firstExercise.exercise.name}: ${firstExercise.warmupSets.size} sets" }
-            } else {
-                coordinator._currentWarmupSetIndex.value = -1
-                coordinator._totalWarmupSets.value = 0
-            }
+    /**
+     * Enter routine overview with a one-shot launch modifier applied after PR% weights resolve.
+     */
+    fun enterRoutineOverview(routine: Routine, modifier: AppliedRoutineModifier) {
+        scope.launch {
+            val resolvedRoutine = resolveRoutineWeights(routine)
+            val adjustedRoutine = applyRoutineModifierUseCase(resolvedRoutine, modifier)
+            enterRoutineOverviewInternal(adjustedRoutine)
+        }
+    }
+
+    private fun enterRoutineOverviewInternal(routine: Routine) {
+        val normalized = normalizeExerciseOrder(routine)
+        coordinator._loadedRoutine.value = normalized
+        coordinator._currentExerciseIndex.value = 0
+        coordinator._currentSetIndex.value = 0
+        coordinator._skippedExercises.value = emptySet()
+        coordinator._completedExercises.value = emptySet()
+        coordinator._completedRoutineSetKeys.value = emptySet()
+        coordinator._workoutState.value = WorkoutState.Idle
+        coordinator._routineFlowState.value = RoutineFlowState.Overview(
+            routine = normalized,
+            selectedExerciseIndex = 0,
+        )
+
+        // Issue #356: Initialize warm-up state for the first exercise
+        val firstExercise = normalized.exercises.firstOrNull()
+        val isFirstBodyweight = firstExercise?.exercise?.isBodyweight ?: false
+        if (firstExercise != null && firstExercise.warmupSets.isNotEmpty() && !isFirstBodyweight) {
+            coordinator._currentWarmupSetIndex.value = 0
+            coordinator._totalWarmupSets.value = firstExercise.warmupSets.size
+            Logger.d("RoutineFlowManager") { "Issue #356: Overview init warm-up for ${firstExercise.exercise.name}: ${firstExercise.warmupSets.size} sets" }
+        } else {
+            coordinator._currentWarmupSetIndex.value = -1
+            coordinator._totalWarmupSets.value = 0
         }
     }
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/DailyRoutinesScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/DailyRoutinesScreen.kt
@@ -86,6 +86,10 @@ fun DailyRoutinesScreen(
                     navController.navigate(NavigationRoutes.RoutineOverview.route)
                 }
             },
+            onStartWorkoutWithModifier = { routine, modifier ->
+                viewModel.enterRoutineOverview(routine, modifier)
+                navController.navigate(NavigationRoutes.RoutineOverview.route)
+            },
             onDeleteRoutine = { routineId -> viewModel.deleteRoutine(routineId) },
             onDeleteRoutines = { routineIds -> viewModel.deleteRoutines(routineIds) },
             onSaveRoutine = { routine -> viewModel.saveRoutine(routine) },

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RoutinesTab.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RoutinesTab.kt
@@ -80,7 +80,9 @@ import co.touchlab.kermit.Logger
 import com.devil.phoenixproject.data.repository.ExerciseRepository
 import com.devil.phoenixproject.data.repository.PersonalRecordRepository
 import com.devil.phoenixproject.data.repository.UserProfile
+import com.devil.phoenixproject.domain.model.AppliedRoutineModifier
 import com.devil.phoenixproject.domain.model.Routine
+import com.devil.phoenixproject.domain.model.RoutineModifierType
 import com.devil.phoenixproject.domain.model.RoutineGroup
 import com.devil.phoenixproject.domain.model.WeightUnit
 import com.devil.phoenixproject.domain.model.generateSupersetId
@@ -88,6 +90,7 @@ import com.devil.phoenixproject.domain.model.generateUUID
 import com.devil.phoenixproject.domain.usecase.RoutineTimeEstimator
 import com.devil.phoenixproject.presentation.components.EmptyState
 import com.devil.phoenixproject.presentation.components.ProfileColors
+import com.devil.phoenixproject.presentation.components.RoutineModifierDialog
 import com.devil.phoenixproject.presentation.util.isCompactAccessibilityLayout
 import com.devil.phoenixproject.ui.theme.Spacing
 import com.devil.phoenixproject.ui.theme.ThemeMode
@@ -120,6 +123,8 @@ import vitruvianprojectphoenix.shared.generated.resources.empty_no_routines_titl
 import vitruvianprojectphoenix.shared.generated.resources.move_routines_confirm
 import vitruvianprojectphoenix.shared.generated.resources.move_to_profile
 import vitruvianprojectphoenix.shared.generated.resources.no_other_profiles
+import vitruvianprojectphoenix.shared.generated.resources.routine_modifier_active_recovery
+import vitruvianprojectphoenix.shared.generated.resources.routine_modifier_heavy_deload
 import vitruvianprojectphoenix.shared.generated.resources.select_target_profile
 import vitruvianprojectphoenix.shared.generated.resources.start_workout
 
@@ -138,6 +143,7 @@ fun RoutinesTab(
     kgToDisplay: (Float, WeightUnit) -> Float,
     displayToKg: (Float, WeightUnit) -> Float,
     onStartWorkout: (Routine) -> Unit,
+    onStartWorkoutWithModifier: (Routine, AppliedRoutineModifier) -> Unit = { _, _ -> },
     onDeleteRoutine: (String) -> Unit,
     onDeleteRoutines: (Set<String>) -> Unit, // Batch delete for multi-select
     onSaveRoutine: (Routine) -> Unit,
@@ -160,6 +166,9 @@ fun RoutinesTab(
     // showRoutineBuilder and routineToEdit states removed
 
     Logger.d { "RoutinesTab: ${routines.size} routines loaded" }
+
+    var modifierDialogRoutine by remember { mutableStateOf<Routine?>(null) }
+    var modifierDialogType by remember { mutableStateOf<RoutineModifierType?>(null) }
 
     // Historical time estimates (Issue #225)
     val timeEstimator: RoutineTimeEstimator = koinInject()
@@ -288,6 +297,14 @@ fun RoutinesTab(
                             onSelectionModeActivate = { selectionMode = true },
                             onSelectionModeDeactivate = { selectionMode = false },
                             onStartWorkout = onStartWorkout,
+                            onStartActiveRecovery = { routine ->
+                                modifierDialogRoutine = routine
+                                modifierDialogType = RoutineModifierType.ACTIVE_RECOVERY
+                            },
+                            onStartHeavyDeload = { routine ->
+                                modifierDialogRoutine = routine
+                                modifierDialogType = RoutineModifierType.HEAVY_DELOAD
+                            },
                             onEditRoutine = onEditRoutine,
                             onDeleteRoutine = onDeleteRoutine,
                             onSaveRoutine = onSaveRoutine,
@@ -331,6 +348,14 @@ fun RoutinesTab(
                                     onSelectionModeActivate = { selectionMode = true },
                                     onSelectionModeDeactivate = { selectionMode = false },
                                     onStartWorkout = onStartWorkout,
+                                    onStartActiveRecovery = { selectedRoutine ->
+                                        modifierDialogRoutine = selectedRoutine
+                                        modifierDialogType = RoutineModifierType.ACTIVE_RECOVERY
+                                    },
+                                    onStartHeavyDeload = { selectedRoutine ->
+                                        modifierDialogRoutine = selectedRoutine
+                                        modifierDialogType = RoutineModifierType.HEAVY_DELOAD
+                                    },
                                     onEditRoutine = onEditRoutine,
                                     onDeleteRoutine = onDeleteRoutine,
                                     onSaveRoutine = onSaveRoutine,
@@ -763,6 +788,24 @@ fun RoutinesTab(
             },
         )
     }
+
+
+    val pendingModifierType = modifierDialogType
+    val pendingModifierRoutine = modifierDialogRoutine
+    if (pendingModifierType != null && pendingModifierRoutine != null) {
+        RoutineModifierDialog(
+            type = pendingModifierType,
+            onDismiss = {
+                modifierDialogType = null
+                modifierDialogRoutine = null
+            },
+            onConfirm = { modifier ->
+                modifierDialogType = null
+                modifierDialogRoutine = null
+                onStartWorkoutWithModifier(pendingModifierRoutine, modifier)
+            },
+        )
+    }
 }
 
 /**
@@ -779,6 +822,8 @@ private fun RoutineCardWithActions(
     onSelectionModeActivate: () -> Unit,
     onSelectionModeDeactivate: () -> Unit,
     onStartWorkout: (Routine) -> Unit,
+    onStartActiveRecovery: (Routine) -> Unit,
+    onStartHeavyDeload: (Routine) -> Unit,
     onEditRoutine: (String) -> Unit,
     onDeleteRoutine: (String) -> Unit,
     onSaveRoutine: (Routine) -> Unit,
@@ -805,6 +850,8 @@ private fun RoutineCardWithActions(
             }
         },
         onStartWorkout = { onStartWorkout(routine) },
+        onStartActiveRecovery = { onStartActiveRecovery(routine) },
+        onStartHeavyDeload = { onStartHeavyDeload(routine) },
         onEdit = { onEditRoutine(routine.id) },
         onDelete = { onDeleteRoutine(routine.id) },
         onMoveToProfile = {
@@ -1005,6 +1052,8 @@ fun RoutineCard(
     onLongPress: () -> Unit,
     onSelectionToggle: () -> Unit,
     onStartWorkout: () -> Unit,
+    onStartActiveRecovery: () -> Unit = {},
+    onStartHeavyDeload: () -> Unit = {},
     onEdit: () -> Unit,
     onDelete: () -> Unit,
     onDuplicate: () -> Unit,
@@ -1258,11 +1307,10 @@ fun RoutineCard(
                             )
                         }
 
-                        // Overflow menu for Move/Copy to Profile and Move to Group
-                        if (hasOtherProfiles || hasGroups) {
-                            var showOverflow by remember { mutableStateOf(false) }
-                            Spacer(Modifier.width(2.dp))
-                            Box {
+                        // Overflow menu for routine launch modifiers, Move/Copy to Profile, and Move to Group
+                        var showOverflow by remember { mutableStateOf(false) }
+                        Spacer(Modifier.width(2.dp))
+                        Box {
                                 IconButton(
                                     onClick = { showOverflow = true },
                                     modifier = Modifier.size(36.dp),
@@ -1278,21 +1326,42 @@ fun RoutineCard(
                                     expanded = showOverflow,
                                     onDismissRequest = { showOverflow = false },
                                 ) {
-                                    // Move to Group option
                                     DropdownMenuItem(
-                                        text = { Text("Move to Group") },
+                                        text = { Text(stringResource(Res.string.routine_modifier_active_recovery)) },
                                         onClick = {
                                             showOverflow = false
-                                            onMoveToGroup()
+                                            onStartActiveRecovery()
                                         },
                                         leadingIcon = {
-                                            Icon(
-                                                Icons.Default.FolderOpen,
-                                                contentDescription = null,
-                                                modifier = Modifier.size(20.dp),
-                                            )
+                                            Icon(Icons.Default.PlayArrow, contentDescription = null, modifier = Modifier.size(20.dp))
                                         },
                                     )
+                                    DropdownMenuItem(
+                                        text = { Text(stringResource(Res.string.routine_modifier_heavy_deload)) },
+                                        onClick = {
+                                            showOverflow = false
+                                            onStartHeavyDeload()
+                                        },
+                                        leadingIcon = {
+                                            Icon(Icons.Default.PlayArrow, contentDescription = null, modifier = Modifier.size(20.dp))
+                                        },
+                                    )
+                                    if (hasGroups) {
+                                        DropdownMenuItem(
+                                            text = { Text("Move to Group") },
+                                            onClick = {
+                                                showOverflow = false
+                                                onMoveToGroup()
+                                            },
+                                            leadingIcon = {
+                                                Icon(
+                                                    Icons.Default.FolderOpen,
+                                                    contentDescription = null,
+                                                    modifier = Modifier.size(20.dp),
+                                                )
+                                            },
+                                        )
+                                    }
                                     if (hasOtherProfiles) {
                                         DropdownMenuItem(
                                             text = { Text(stringResource(Res.string.move_to_profile)) },
@@ -1325,7 +1394,6 @@ fun RoutineCard(
                                     }
                                 }
                             }
-                        }
                     }
                 }
             }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
@@ -20,6 +20,7 @@ import com.devil.phoenixproject.data.repository.TrainingCycleRepository
 import com.devil.phoenixproject.data.repository.UserProfileRepository
 import com.devil.phoenixproject.data.repository.WorkoutRepository
 import com.devil.phoenixproject.data.sync.SyncTriggerManager
+import com.devil.phoenixproject.domain.model.AppliedRoutineModifier
 import com.devil.phoenixproject.domain.model.Badge
 import com.devil.phoenixproject.domain.model.BodyweightVariantOption
 import com.devil.phoenixproject.domain.model.ConnectionState
@@ -41,6 +42,7 @@ import com.devil.phoenixproject.domain.model.WorkoutMetric
 import com.devil.phoenixproject.domain.model.WorkoutParameters
 import com.devil.phoenixproject.domain.model.WorkoutSession
 import com.devil.phoenixproject.domain.model.WorkoutState
+import com.devil.phoenixproject.domain.usecase.ApplyRoutineModifierUseCase
 import com.devil.phoenixproject.domain.usecase.RepCounterFromMachine
 import com.devil.phoenixproject.domain.usecase.ResolveRoutineWeightsUseCase
 import com.devil.phoenixproject.presentation.manager.BleConnectionManager
@@ -84,6 +86,7 @@ class MainViewModel constructor(
     private val repMetricRepository: RepMetricRepository,
     private val biomechanicsRepository: BiomechanicsRepository,
     private val resolveWeightsUseCase: ResolveRoutineWeightsUseCase,
+    private val applyRoutineModifierUseCase: ApplyRoutineModifierUseCase = ApplyRoutineModifierUseCase(personalRecordRepository, exerciseRepository),
     private val dataBackupManager: DataBackupManager,
     private val userProfileRepository: UserProfileRepository,
     private val healthIntegration: HealthIntegration? = null,
@@ -128,6 +131,7 @@ class MainViewModel constructor(
         repMetricRepository = repMetricRepository,
         biomechanicsRepository = biomechanicsRepository,
         resolveWeightsUseCase = resolveWeightsUseCase,
+        applyRoutineModifierUseCase = applyRoutineModifierUseCase,
         settingsManager = settingsManager,
         dataBackupManager = dataBackupManager,
         userProfileRepository = userProfileRepository,
@@ -352,6 +356,7 @@ class MainViewModel constructor(
     suspend fun loadRoutineAsync(routine: Routine) = workoutSessionManager.loadRoutineAsync(routine)
     fun loadRoutineById(routineId: String) = workoutSessionManager.loadRoutineById(routineId)
     fun enterRoutineOverview(routine: Routine) = workoutSessionManager.enterRoutineOverview(routine)
+    fun enterRoutineOverview(routine: Routine, modifier: AppliedRoutineModifier) = workoutSessionManager.enterRoutineOverview(routine, modifier)
     fun selectExerciseInOverview(index: Int) = workoutSessionManager.selectExerciseInOverview(index)
     fun enterSetReady(exerciseIndex: Int, setIndex: Int) = workoutSessionManager.enterSetReady(exerciseIndex, setIndex)
     fun enterSetReadyWithAdjustments(exerciseIndex: Int, setIndex: Int, adjustedWeight: Float, adjustedReps: Int) = workoutSessionManager.enterSetReadyWithAdjustments(exerciseIndex, setIndex, adjustedWeight, adjustedReps)

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/ApplyRoutineModifierUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/ApplyRoutineModifierUseCaseTest.kt
@@ -1,0 +1,176 @@
+package com.devil.phoenixproject.domain.usecase
+
+import com.devil.phoenixproject.domain.model.AppliedRoutineModifier
+import com.devil.phoenixproject.domain.model.Exercise
+import com.devil.phoenixproject.domain.model.PRType
+import com.devil.phoenixproject.domain.model.PersonalRecord
+import com.devil.phoenixproject.domain.model.ProgramMode
+import com.devil.phoenixproject.domain.model.Routine
+import com.devil.phoenixproject.domain.model.RoutineExercise
+import com.devil.phoenixproject.domain.model.RoutineModifierType
+import com.devil.phoenixproject.domain.model.Superset
+import com.devil.phoenixproject.domain.model.WarmupSet
+import com.devil.phoenixproject.domain.model.WorkoutPhase
+import com.devil.phoenixproject.testutil.FakeExerciseRepository
+import com.devil.phoenixproject.testutil.FakePersonalRecordRepository
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotSame
+import kotlinx.coroutines.test.runTest
+
+class ApplyRoutineModifierUseCaseTest {
+    private lateinit var prRepository: FakePersonalRecordRepository
+    private lateinit var exerciseRepository: FakeExerciseRepository
+    private lateinit var useCase: ApplyRoutineModifierUseCase
+
+    private val cableExercise = Exercise(
+        id = "bench",
+        name = "Bench Press",
+        muscleGroup = "Chest",
+        equipment = "BAR",
+    )
+    private val bodyweightExercise = Exercise(
+        id = "pushup",
+        name = "Push-Up",
+        muscleGroup = "Chest",
+        equipment = "",
+    )
+
+    @BeforeTest
+    fun setup() {
+        prRepository = FakePersonalRecordRepository()
+        exerciseRepository = FakeExerciseRepository()
+        useCase = ApplyRoutineModifierUseCase(prRepository, exerciseRepository)
+    }
+
+    @Test
+    fun `active recovery scales weights from stored baseline and keeps working reps`() = runTest {
+        exerciseRepository.addExercise(cableExercise.copy(oneRepMaxKg = 100f))
+        val routine = routineWith(
+            routineExercise(
+                weight = 70f,
+                setWeights = listOf(70f, 72.5f, 75f),
+                reps = listOf(10, 8, 6),
+            ),
+        )
+
+        val adjusted = useCase(routine, AppliedRoutineModifier(RoutineModifierType.ACTIVE_RECOVERY, 55))
+        val exercise = adjusted.exercises.single()
+
+        assertEquals(55f, exercise.weightPerCableKg)
+        assertEquals(listOf(55f, 55f, 55f), exercise.setWeightsPerCableKg)
+        assertEquals(listOf(10, 8, 6), exercise.setReps)
+    }
+
+    @Test
+    fun `active recovery drops later warmups and scales first warmup reps`() = runTest {
+        val routine = routineWith(
+            routineExercise(
+                warmups = listOf(WarmupSet(12, 50), WarmupSet(8, 70), WarmupSet(4, 85)),
+            ),
+        )
+
+        val adjusted = useCase(routine, AppliedRoutineModifier(RoutineModifierType.ACTIVE_RECOVERY, 50))
+
+        assertEquals(listOf(WarmupSet(6, 50)), adjusted.exercises.single().warmupSets)
+    }
+
+    @Test
+    fun `heavy deload keeps weights and scales working and warmup reps`() = runTest {
+        val routine = routineWith(
+            routineExercise(
+                weight = 42.5f,
+                setWeights = listOf(40f, 42.5f, 45f),
+                reps = listOf(10, 8, null),
+                warmups = listOf(WarmupSet(12, 50), WarmupSet(8, 70)),
+            ),
+        )
+
+        val adjusted = useCase(routine, AppliedRoutineModifier(RoutineModifierType.HEAVY_DELOAD, 50))
+        val exercise = adjusted.exercises.single()
+
+        assertEquals(42.5f, exercise.weightPerCableKg)
+        assertEquals(listOf(40f, 42.5f, 45f), exercise.setWeightsPerCableKg)
+        assertEquals(listOf(5, 4, null), exercise.setReps)
+        assertEquals(listOf(WarmupSet(6, 50), WarmupSet(4, 70)), exercise.warmupSets)
+    }
+
+    @Test
+    fun `bodyweight exercise weight is not modified by active recovery`() = runTest {
+        val routine = routineWith(
+            routineExercise(exercise = bodyweightExercise, weight = 0f, reps = listOf(15, 12)),
+        )
+
+        val adjusted = useCase(routine, AppliedRoutineModifier(RoutineModifierType.ACTIVE_RECOVERY, 60))
+
+        assertEquals(0f, adjusted.exercises.single().weightPerCableKg)
+        assertEquals(listOf(15, 12), adjusted.exercises.single().setReps)
+    }
+
+    @Test
+    fun `superset metadata and input routine are preserved`() = runTest {
+        val superset = Superset(id = "superset-1", routineId = "routine-1", name = "A", orderIndex = 0)
+        val originalExercise = routineExercise(supersetId = superset.id, orderInSuperset = 2, warmups = listOf(WarmupSet(12, 50)))
+        val routine = Routine(id = "routine-1", name = "Routine", exercises = listOf(originalExercise), supersets = listOf(superset))
+
+        val adjusted = useCase(routine, AppliedRoutineModifier(RoutineModifierType.HEAVY_DELOAD, 50))
+        val adjustedExercise = adjusted.exercises.single()
+
+        assertNotSame(routine, adjusted)
+        assertEquals(listOf(WarmupSet(12, 50)), routine.exercises.single().warmupSets)
+        assertEquals(superset.id, adjustedExercise.supersetId)
+        assertEquals(2, adjustedExercise.orderInSuperset)
+        assertEquals(routine.supersets, adjusted.supersets)
+    }
+
+    @Test
+    fun `active recovery falls back to max weight PR one rep max and rounds to half kg`() = runTest {
+        prRepository.addRecord(
+            PersonalRecord(
+                exerciseId = "bench",
+                exerciseName = "Bench Press",
+                weightPerCableKg = 81f,
+                reps = 3,
+                oneRepMax = 81f,
+                timestamp = 1L,
+                workoutMode = "Old School",
+                prType = PRType.MAX_WEIGHT,
+                volume = 243f,
+                phase = WorkoutPhase.CONCENTRIC,
+            ),
+        )
+        val routine = routineWith(routineExercise(weight = 40f))
+
+        val adjusted = useCase(routine, AppliedRoutineModifier(RoutineModifierType.ACTIVE_RECOVERY, 55))
+
+        assertEquals(44.5f, adjusted.exercises.single().weightPerCableKg)
+    }
+
+    private fun routineWith(vararg exercises: RoutineExercise): Routine = Routine(
+        id = "routine-1",
+        name = "Routine",
+        exercises = exercises.toList(),
+    )
+
+    private fun routineExercise(
+        exercise: Exercise = cableExercise,
+        weight: Float = 50f,
+        setWeights: List<Float> = emptyList(),
+        reps: List<Int?> = listOf(10, 10, 10),
+        warmups: List<WarmupSet> = emptyList(),
+        supersetId: String? = null,
+        orderInSuperset: Int = 0,
+    ): RoutineExercise = RoutineExercise(
+        id = "routine-ex-${exercise.id}",
+        exercise = exercise,
+        orderIndex = 0,
+        setReps = reps,
+        weightPerCableKg = weight,
+        setWeightsPerCableKg = setWeights,
+        programMode = ProgramMode.OldSchool,
+        warmupSets = warmups,
+        supersetId = supersetId,
+        orderInSuperset = orderInSuperset,
+    )
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/DWSMTestHarness.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/DWSMTestHarness.kt
@@ -2,6 +2,7 @@ package com.devil.phoenixproject.testutil
 
 import com.devil.phoenixproject.domain.model.HapticEvent
 import com.devil.phoenixproject.domain.usecase.RepCounterFromMachine
+import com.devil.phoenixproject.domain.usecase.ApplyRoutineModifierUseCase
 import com.devil.phoenixproject.domain.usecase.ResolveRoutineWeightsUseCase
 import com.devil.phoenixproject.presentation.manager.BleConnectionManager
 import com.devil.phoenixproject.presentation.manager.DefaultWorkoutSessionManager
@@ -60,6 +61,7 @@ class DWSMTestHarness(val testScope: TestScope) {
 
     val repCounter = RepCounterFromMachine()
     val resolveWeightsUseCase = ResolveRoutineWeightsUseCase(fakePRRepo, fakeExerciseRepo)
+    val applyRoutineModifierUseCase = ApplyRoutineModifierUseCase(fakePRRepo, fakeExerciseRepo)
 
     // Child scope of testScope: shares TestCoroutineScheduler so advanceUntilIdle() works,
     // but can be cancelled independently via cleanup() to prevent UncompletedCoroutinesError.
@@ -90,6 +92,7 @@ class DWSMTestHarness(val testScope: TestScope) {
         repMetricRepository = fakeRepMetricRepo,
         biomechanicsRepository = fakeBiomechanicsRepo,
         resolveWeightsUseCase = resolveWeightsUseCase,
+        applyRoutineModifierUseCase = applyRoutineModifierUseCase,
         settingsManager = settingsManager,
         userProfileRepository = FakeUserProfileRepository(),
         workoutServiceController = fakeWorkoutServiceController,

--- a/shared/src/iosMain/kotlin/com/devil/phoenixproject/di/PlatformModule.ios.kt
+++ b/shared/src/iosMain/kotlin/com/devil/phoenixproject/di/PlatformModule.ios.kt
@@ -108,6 +108,7 @@ actual val platformModule: Module = module {
             repMetricRepository = get(),
             biomechanicsRepository = get(),
             resolveWeightsUseCase = get(),
+            applyRoutineModifierUseCase = get(),
             dataBackupManager = get(),
             userProfileRepository = get(),
             healthIntegration = get(),


### PR DESCRIPTION
### Motivation
- Provide an ephemeral, launch-time way to start an existing routine in either Active Recovery (reduced working weights) or Heavy Deload (reduced reps) without mutating the saved routine.
- Ensure modifiers are applied after percent-of-PR weights are resolved to avoid ordering bugs for %PR-based programming.

### Description
- Add domain model and selection types: `RoutineModifierType` and `AppliedRoutineModifier` in `domain/model/RoutineModifier.kt` with selectable percents (50/55/60).
- Implement `ApplyRoutineModifierUseCase` in `domain/usecase/ApplyRoutineModifierUseCase.kt` that transforms routines purely (no mutation), including baseline 1RM lookup (exercise stored 1RM, PR fallback, then resolved weight fallback), half-kg rounding, warmup simplification for Active Recovery, and rep scaling for Heavy Deload.
- Wire modifier flow into runtime: accept and provide `ApplyRoutineModifierUseCase` in DI, thread it into `RoutineFlowManager`/`DefaultWorkoutSessionManager`/`MainViewModel`, and add an overloaded `enterRoutineOverview(routine, modifier)` path that resolves PR weights then applies the modifier before loading overview.
- UI and UX: add `RoutineModifierDialog` composable, kebab-menu actions on `RoutineCard` for “Start Active Recovery…” and “Start Heavy Deload…”, dialog state in `RoutinesTab`, and `DailyRoutinesScreen` wiring to launch the overview with the selected modifier.
- Localization: add strings for all supported locales describing dialogs and button text.
- Tests: add `ApplyRoutineModifierUseCaseTest` covering Active Recovery/Heavy Deload behavior, warmup handling, bodyweight safety, superset preservation, non-mutation, and rounding/fallback logic.

### Testing
- Compiled shared metadata and multiplatform targets: `./gradlew :shared:compileKotlinMetadata -Pskip.supabase.check=true` succeeded.  
- iOS compile checks: `./gradlew :shared:compileKotlinIosArm64 -Pskip.supabase.check=true` and `./gradlew :shared:compileTestKotlinIosArm64 -Pskip.supabase.check=true` succeeded.
- Added unit test `ApplyRoutineModifierUseCaseTest` and compiled test sources (`:shared:compileTestKotlinIosArm64`) successfully, but running the full `:shared:allTests` / Android-host tests was blocked by the environment (missing Android SDK and/or Supabase credentials), so automated test execution for Android-host targets could not be completed in this CI-like environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24edfd9288832285c8e2cf95b0fee1)