### PR TITLE
fix: return to app after Android OAuth callback

### DIFF
--- a/androidApp/src/main/kotlin/com/devil/phoenixproject/auth/OAuthRedirectActivity.kt
+++ b/androidApp/src/main/kotlin/com/devil/phoenixproject/auth/OAuthRedirectActivity.kt
@@ -67,10 +67,10 @@ class OAuthRedirectActivity : ComponentActivity() {
      *    task. Without this flag, the system would try to launch
      *    [MainActivity] into that same empty-affinity task, which is not
      *    what we want — we want the original app task.
-     *  - `FLAG_ACTIVITY_CLEAR_TOP`: if the app task is still around (the
-     *    common case), clear any activities that may have been pushed on
-     *    top of [MainActivity] (rare, but defensive) so we land on a
-     *    predictable state.
+     *  - `FLAG_ACTIVITY_REORDER_TO_FRONT`: if the existing [MainActivity]
+     *    instance is still in the app task, bring it forward without clearing
+     *    other app state. This preserves the user's link-account context while
+     *    still replacing the browser/redirect surface.
      *  - `FLAG_ACTIVITY_SINGLE_TOP`: if [MainActivity] is already at the
      *    top of its task, reuse that instance instead of creating a new
      *    one. This avoids a duplicate stack and any side effects of a
@@ -84,6 +84,8 @@ class OAuthRedirectActivity : ComponentActivity() {
         val launchIntent = buildReturnToAppIntent()
         try {
             startActivity(launchIntent)
+            @Suppress("DEPRECATION")
+            overridePendingTransition(0, 0)
         } catch (e: Exception) {
             // Defensive: if for some reason the explicit intent can't be
             // resolved (e.g. MainActivity was renamed / removed in a future
@@ -109,7 +111,7 @@ class OAuthRedirectActivity : ComponentActivity() {
             // See kdoc on [routeBackToApp] for why each flag is set.
             addFlags(
                 Intent.FLAG_ACTIVITY_NEW_TASK or
-                    Intent.FLAG_ACTIVITY_CLEAR_TOP or
+                    Intent.FLAG_ACTIVITY_REORDER_TO_FRONT or
                     Intent.FLAG_ACTIVITY_SINGLE_TOP,
             )
         }

--- a/androidApp/src/main/kotlin/com/devil/phoenixproject/auth/OAuthRedirectActivity.kt
+++ b/androidApp/src/main/kotlin/com/devil/phoenixproject/auth/OAuthRedirectActivity.kt
@@ -1,9 +1,11 @@
 package com.devil.phoenixproject.auth
 
+import android.content.ComponentName
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import co.touchlab.kermit.Logger
+import com.devil.phoenixproject.MainActivity
 import com.devil.phoenixproject.data.auth.AndroidOAuthBridge
 
 /**
@@ -15,17 +17,28 @@ import com.devil.phoenixproject.data.auth.AndroidOAuthBridge
  * This intentionally lives in the app module (not the shared module) because
  * it has to be declared in the host app's AndroidManifest to receive the
  * deep-link intent; the shared module has no manifest of its own.
+ *
+ * After delivering (or cancelling) the callback, this activity explicitly
+ * routes the user back to [MainActivity]. Without this handoff, the user can
+ * be left looking at the (now-finished) Custom Tab surface because the OAuth
+ * launcher uses `FLAG_ACTIVITY_NEW_TASK` on the Custom Tabs intent, and this
+ * redirect activity runs with `taskAffinity=""` / `singleTask` — meaning the
+ * system delivers the deep link into a transient task, not the app's own
+ * task. Foregrounding [MainActivity] by hand restores the expected "return
+ * to the app" UX (fixes Project Phoenix issue #508).
  */
 class OAuthRedirectActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         handleIntent(intent)
+        routeBackToApp()
         finish()
     }
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         handleIntent(intent)
+        routeBackToApp()
         finish()
     }
 
@@ -42,4 +55,62 @@ class OAuthRedirectActivity : ComponentActivity() {
         }
         AndroidOAuthBridge.deliverCallback(data.toString())
     }
+
+    /**
+     * Bring the app's existing task (and its [MainActivity]) to the front so
+     * the user isn't stranded on the (just-finished) browser/Custom Tab
+     * surface after the OAuth callback completes.
+     *
+     * Flag choice rationale:
+     *  - `FLAG_ACTIVITY_NEW_TASK`: required because this redirect activity
+     *    has `taskAffinity=""` and therefore lives in its own transient
+     *    task. Without this flag, the system would try to launch
+     *    [MainActivity] into that same empty-affinity task, which is not
+     *    what we want — we want the original app task.
+     *  - `FLAG_ACTIVITY_CLEAR_TOP`: if the app task is still around (the
+     *    common case), clear any activities that may have been pushed on
+     *    top of [MainActivity] (rare, but defensive) so we land on a
+     *    predictable state.
+     *  - `FLAG_ACTIVITY_SINGLE_TOP`: if [MainActivity] is already at the
+     *    top of its task, reuse that instance instead of creating a new
+     *    one. This avoids a duplicate stack and any side effects of a
+     *    second `onCreate`.
+     *
+     * `ACTION_MAIN` + `CATEGORY_LAUNCHER` mirror the launcher intent the
+     * system uses to start the app cold, which makes the routing behave
+     * consistently regardless of how the user originally launched the app.
+     */
+    private fun routeBackToApp() {
+        val launchIntent = buildReturnToAppIntent()
+        try {
+            startActivity(launchIntent)
+        } catch (e: Exception) {
+            // Defensive: if for some reason the explicit intent can't be
+            // resolved (e.g. MainActivity was renamed / removed in a future
+            // build), don't crash the redirect handler — the callback has
+            // already been delivered, so the user is technically signed in
+            // even if they have to relaunch the app manually.
+            Logger.w(tag = "OAuthRedirectActivity") {
+                "Failed to route back to MainActivity after OAuth callback: ${e.message}"
+            }
+        }
+    }
+
+    /**
+     * Build the [Intent] used by [routeBackToApp] to foreground the app's
+     * existing task. Exposed at internal visibility so focused unit tests
+     * can assert on the flag combination without needing to spin up an
+     * actual [android.app.Activity].
+     */
+    internal fun buildReturnToAppIntent(): Intent =
+        Intent(Intent.ACTION_MAIN).apply {
+            component = ComponentName(this@OAuthRedirectActivity, MainActivity::class.java)
+            addCategory(Intent.CATEGORY_LAUNCHER)
+            // See kdoc on [routeBackToApp] for why each flag is set.
+            addFlags(
+                Intent.FLAG_ACTIVITY_NEW_TASK or
+                    Intent.FLAG_ACTIVITY_CLEAR_TOP or
+                    Intent.FLAG_ACTIVITY_SINGLE_TOP,
+            )
+        }
 }


### PR DESCRIPTION
## Summary
- Explicitly routes Android OAuth redirects back to `MainActivity` after callback delivery/cancellation.
- Preserves the existing `AndroidOAuthBridge` handoff and OAuth token/provider logic.
- Documents the task/flag rationale for the Custom Tab + empty-affinity redirect activity case.

## RCA summary
Android OAuth linking succeeds in the data path, but `OAuthRedirectActivity` only delivered the callback and finished. Because the Custom Tab flow is launched with `FLAG_ACTIVITY_NEW_TASK` and the redirect activity uses its own transient task, Android could leave users on the browser/loading surface even though the account was linked.

## Tests / verification
- `git diff --check` ✅
- Spec-compliance review subagent: PASS, no blocking findings
- Code-quality review subagent: PASS, no blocking findings
- Attempted `./gradlew :androidApp:compileDebugKotlin -Pskip.supabase.check=true --no-daemon` but the cron host has no Java runtime installed (`Unable to locate a Java Runtime`), so Gradle compilation could not run in this environment.

## Manual QA recommended
- On Android, go to Settings → Link Portal Account.
- Complete Google/Apple OAuth.
- Verify the app is foregrounded on the linked-account/success state without manually closing the browser/Custom Tab.

Fixes #508

User retains final merge approval; this automation will not merge.
