### PR TITLE
Implement one-way body-weight sync from mobile health platforms

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -44,6 +44,7 @@
     <!-- Health Connect permissions (Android 14+ requires manifest declarations) -->
     <uses-permission android:name="android.permission.health.WRITE_EXERCISE" />
     <uses-permission android:name="android.permission.health.WRITE_TOTAL_CALORIES_BURNED" />
+    <uses-permission android:name="android.permission.health.READ_WEIGHT" />
 
     <!-- Camera feature (not required - app works without camera) -->
     <uses-feature

--- a/shared/src/androidMain/kotlin/com/devil/phoenixproject/data/integration/HealthIntegration.android.kt
+++ b/shared/src/androidMain/kotlin/com/devil/phoenixproject/data/integration/HealthIntegration.android.kt
@@ -4,15 +4,19 @@ import android.annotation.SuppressLint
 import android.content.Context
 import androidx.health.connect.client.HealthConnectClient
 import androidx.health.connect.client.permission.HealthPermission
+import androidx.health.connect.client.request.ReadRecordsRequest
 import androidx.health.connect.client.records.ExerciseSessionRecord
 import androidx.health.connect.client.records.TotalCaloriesBurnedRecord
+import androidx.health.connect.client.records.WeightRecord
 import androidx.health.connect.client.records.metadata.Device
 import androidx.health.connect.client.records.metadata.Metadata
+import androidx.health.connect.client.time.TimeRangeFilter
 import androidx.health.connect.client.units.Energy
 import co.touchlab.kermit.Logger
 import com.devil.phoenixproject.domain.model.WorkoutSession
 import java.time.Instant
 import java.time.ZoneId
+import java.time.temporal.ChronoUnit
 
 private val log = Logger.withTag("HealthIntegration.Android")
 
@@ -24,6 +28,7 @@ private val VITRUVIAN_DEVICE = Device(
 
 internal val requiredHealthPermissions = setOf(
     HealthPermission.getWritePermission(ExerciseSessionRecord::class),
+    HealthPermission.getReadPermission(WeightRecord::class),
 )
 
 internal val optionalHealthPermissions = setOf(
@@ -31,6 +36,20 @@ internal val optionalHealthPermissions = setOf(
 )
 
 internal val requestedHealthPermissions = requiredHealthPermissions + optionalHealthPermissions
+
+internal val workoutWriteHealthPermissions = setOf(
+    HealthPermission.getWritePermission(ExerciseSessionRecord::class),
+)
+
+internal val bodyWeightReadHealthPermissions = setOf(
+    HealthPermission.getReadPermission(WeightRecord::class),
+)
+
+internal val workoutExportRequestedHealthPermissions = workoutWriteHealthPermissions + optionalHealthPermissions
+
+private const val BODY_WEIGHT_LOOKBACK_DAYS = 3650L
+private const val BODY_WEIGHT_READ_PAGE_SIZE = 100
+private const val BODY_WEIGHT_READ_MAX_PAGES = 10
 
 /**
  * Android implementation of HealthIntegration using Google Health Connect.
@@ -68,7 +87,9 @@ actual class HealthIntegration(private val context: Context) {
      */
     actual suspend fun requestPermissions(): Boolean = hasPermissions()
 
-    actual suspend fun hasPermissions(): Boolean = hasGrantedPermissions(requiredHealthPermissions)
+    actual suspend fun hasPermissions(): Boolean = hasGrantedPermissions(workoutWriteHealthPermissions)
+
+    actual suspend fun hasBodyWeightReadPermission(): Boolean = hasGrantedPermissions(bodyWeightReadHealthPermissions)
 
     private suspend fun hasCalorieWritePermission(): Boolean = hasGrantedPermissions(optionalHealthPermissions)
 
@@ -80,6 +101,48 @@ actual class HealthIntegration(private val context: Context) {
         } catch (e: Exception) {
             log.w(e) { "Error checking Health Connect permissions" }
             false
+        }
+    }
+
+    actual suspend fun readLatestScaleBodyWeight(): Result<HealthBodyWeightSample?> {
+        val c = client ?: return Result.failure(
+            IllegalStateException("Health Connect is not available on this device"),
+        )
+
+        if (!hasBodyWeightReadPermission()) {
+            return Result.failure(SecurityException("Health Connect body weight read permission not granted"))
+        }
+
+        return try {
+            val end = Instant.now()
+            val start = end.minus(BODY_WEIGHT_LOOKBACK_DAYS, ChronoUnit.DAYS)
+            var pageToken: String? = null
+            var pagesRead = 0
+
+            do {
+                val response = c.readRecords(
+                    ReadRecordsRequest(
+                        recordType = WeightRecord::class,
+                        timeRangeFilter = TimeRangeFilter.between(start, end),
+                        ascendingOrder = false,
+                        pageSize = BODY_WEIGHT_READ_PAGE_SIZE,
+                        pageToken = pageToken,
+                    ),
+                )
+                response.records.firstNotNullOfOrNull { record ->
+                    record.toEligibleBodyWeightSampleOrNull()
+                }?.let { sample ->
+                    return Result.success(sample)
+                }
+
+                pageToken = response.pageToken
+                pagesRead++
+            } while (pageToken != null && pagesRead < BODY_WEIGHT_READ_MAX_PAGES)
+
+            Result.success(null)
+        } catch (e: Exception) {
+            log.e(e) { "Failed to read latest Health Connect scale body weight" }
+            Result.failure(e)
         }
     }
 
@@ -249,6 +312,85 @@ actual class HealthIntegration(private val context: Context) {
             "$exerciseName — ${totalWeightKg.toInt()}kg"
         } else {
             exerciseName
+        }
+    }
+
+    private fun WeightRecord.toEligibleBodyWeightSampleOrNull(): HealthBodyWeightSample? {
+        val recordMetadata = this.metadata
+        val device = recordMetadata.device
+        val evidence = HealthBodyWeightSourceEvidence(
+            platform = HealthBodyWeightSourcePlatform.ANDROID,
+            wasUserEntered = recordMetadata.recordingMethod == Metadata.RECORDING_METHOD_MANUAL_ENTRY,
+            deviceType = when (device?.type) {
+                Device.TYPE_SCALE -> HealthBodyWeightDeviceType.SCALE
+                Device.TYPE_UNKNOWN, null -> HealthBodyWeightDeviceType.UNKNOWN
+                else -> HealthBodyWeightDeviceType.OTHER
+            },
+            sourceName = recordMetadata.dataOrigin.packageName,
+            sourceBundleIdentifier = recordMetadata.dataOrigin.packageName,
+            deviceManufacturer = device?.manufacturer,
+            deviceModel = device?.model,
+        )
+
+        if (!HealthBodyWeightSourceClassifier.isEligibleScaleSource(evidence)) {
+            return null
+        }
+
+        return HealthBodyWeightSample(
+            weightKg = weight.inKilograms.toFloat(),
+            measuredAtMs = time.toEpochMilli(),
+            externalId = recordMetadata.clientRecordId?.takeIf { it.isNotBlank() }
+                ?: recordMetadata.id.takeIf { it.isNotBlank() }
+                ?: "healthconnect-weight-${time.toEpochMilli()}-${weight.inKilograms}",
+            sourceName = recordMetadata.dataOrigin.packageName.takeIf { it.isNotBlank() },
+            deviceMetadata = buildAndroidWeightDeviceMetadata(recordMetadata),
+            rawMetadataJson = buildAndroidWeightRawMetadataJson(this),
+        )
+    }
+
+    private fun buildAndroidWeightDeviceMetadata(metadata: Metadata): Map<String, String> = buildMap {
+        put("recordingMethod", metadata.recordingMethod.toString())
+        metadata.dataOrigin.packageName.takeIf { it.isNotBlank() }?.let { put("dataOriginPackage", it) }
+        metadata.device?.let { device ->
+            put("deviceType", device.type.toString())
+            device.manufacturer?.takeIf { it.isNotBlank() }?.let { put("deviceManufacturer", it) }
+            device.model?.takeIf { it.isNotBlank() }?.let { put("deviceModel", it) }
+        }
+    }
+
+    private fun buildAndroidWeightRawMetadataJson(record: WeightRecord): String {
+        val metadata = record.metadata
+        val device = metadata.device
+        return buildString {
+            append("{")
+            append("\"platform\":\"android\",")
+            append("\"recordId\":\"${metadata.id.escapeJson()}\",")
+            append("\"clientRecordId\":")
+            append(metadata.clientRecordId?.let { "\"${it.escapeJson()}\"" } ?: "null")
+            append(",\"dataOriginPackage\":\"${metadata.dataOrigin.packageName.escapeJson()}\",")
+            append("\"recordingMethod\":${metadata.recordingMethod},")
+            append("\"lastModifiedTimeMs\":${metadata.lastModifiedTime.toEpochMilli()},")
+            append("\"device\":{")
+            append("\"type\":${device?.type ?: Device.TYPE_UNKNOWN},")
+            append("\"manufacturer\":")
+            append(device?.manufacturer?.let { "\"${it.escapeJson()}\"" } ?: "null")
+            append(",\"model\":")
+            append(device?.model?.let { "\"${it.escapeJson()}\"" } ?: "null")
+            append("}")
+            append("}")
+        }
+    }
+
+    private fun String.escapeJson(): String = buildString {
+        this@escapeJson.forEach { char ->
+            when (char) {
+                '\\' -> append("\\\\")
+                '"' -> append("\\\"")
+                '\n' -> append("\\n")
+                '\r' -> append("\\r")
+                '\t' -> append("\\t")
+                else -> append(char)
+            }
         }
     }
 }

--- a/shared/src/androidMain/kotlin/com/devil/phoenixproject/presentation/components/OptionalPermissionsHandler.android.kt
+++ b/shared/src/androidMain/kotlin/com/devil/phoenixproject/presentation/components/OptionalPermissionsHandler.android.kt
@@ -39,8 +39,8 @@ import androidx.health.connect.client.HealthConnectClient
 import androidx.health.connect.client.PermissionController
 import co.touchlab.kermit.Logger
 import com.devil.phoenixproject.data.integration.optionalHealthPermissions
-import com.devil.phoenixproject.data.integration.requestedHealthPermissions
-import com.devil.phoenixproject.data.integration.requiredHealthPermissions
+import com.devil.phoenixproject.data.integration.workoutExportRequestedHealthPermissions
+import com.devil.phoenixproject.data.integration.workoutWriteHealthPermissions
 import com.devil.phoenixproject.data.preferences.SettingsPreferencesManager
 import org.koin.compose.koinInject
 
@@ -108,7 +108,7 @@ fun RequireOptionalPermissions(content: @Composable () -> Unit) {
     val healthPermissionLauncher = rememberLauncherForActivityResult(
         contract = PermissionController.createRequestPermissionResultContract(),
     ) { grantedPermissions ->
-        val granted = grantedPermissions.containsAll(requiredHealthPermissions)
+        val granted = grantedPermissions.containsAll(workoutWriteHealthPermissions)
         val optionalCaloriesGranted = grantedPermissions.containsAll(optionalHealthPermissions)
         log.d {
             "Health Connect permission result: required=$granted, optionalCalories=$optionalCaloriesGranted " +
@@ -127,7 +127,7 @@ fun RequireOptionalPermissions(content: @Composable () -> Unit) {
         // Mic done, now launch health if available
         if (healthAvailable) {
             phase = "HEALTH_REQUESTED"
-            healthPermissionLauncher.launch(requestedHealthPermissions)
+            healthPermissionLauncher.launch(workoutExportRequestedHealthPermissions)
         } else {
             // No health to request, we're done
             prefsManager.setPermissionsOnboardingShown(true)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/integration/HealthBodyWeightSourceClassifier.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/integration/HealthBodyWeightSourceClassifier.kt
@@ -1,0 +1,84 @@
+package com.devil.phoenixproject.data.integration
+
+enum class HealthBodyWeightSourcePlatform {
+    ANDROID,
+    IOS,
+}
+
+enum class HealthBodyWeightDeviceType {
+    SCALE,
+    UNKNOWN,
+    OTHER,
+}
+
+enum class HealthBodyWeightSourceClassification {
+    ELIGIBLE_SCALE,
+    MANUAL_ENTRY,
+    UNKNOWN_SOURCE,
+}
+
+data class HealthBodyWeightSourceEvidence(
+    val platform: HealthBodyWeightSourcePlatform,
+    val wasUserEntered: Boolean? = null,
+    val deviceType: HealthBodyWeightDeviceType = HealthBodyWeightDeviceType.UNKNOWN,
+    val sourceName: String? = null,
+    val sourceBundleIdentifier: String? = null,
+    val deviceManufacturer: String? = null,
+    val deviceModel: String? = null,
+    val deviceName: String? = null,
+)
+
+object HealthBodyWeightSourceClassifier {
+    private val scaleLikeTokens = listOf(
+        "scale",
+        "withings",
+        "renpho",
+        "eufy",
+        "fitbit aria",
+        "aria",
+        "garmin index",
+        "qardio",
+        "wyze",
+        "omron",
+        "tanita",
+    )
+
+    fun classify(evidence: HealthBodyWeightSourceEvidence): HealthBodyWeightSourceClassification {
+        if (evidence.wasUserEntered == true) {
+            return HealthBodyWeightSourceClassification.MANUAL_ENTRY
+        }
+
+        return when (evidence.platform) {
+            HealthBodyWeightSourcePlatform.ANDROID -> {
+                if (evidence.deviceType == HealthBodyWeightDeviceType.SCALE) {
+                    HealthBodyWeightSourceClassification.ELIGIBLE_SCALE
+                } else {
+                    HealthBodyWeightSourceClassification.UNKNOWN_SOURCE
+                }
+            }
+
+            HealthBodyWeightSourcePlatform.IOS -> {
+                if (hasScaleLikeMetadata(evidence)) {
+                    HealthBodyWeightSourceClassification.ELIGIBLE_SCALE
+                } else {
+                    HealthBodyWeightSourceClassification.UNKNOWN_SOURCE
+                }
+            }
+        }
+    }
+
+    fun isEligibleScaleSource(evidence: HealthBodyWeightSourceEvidence): Boolean =
+        classify(evidence) == HealthBodyWeightSourceClassification.ELIGIBLE_SCALE
+
+    private fun hasScaleLikeMetadata(evidence: HealthBodyWeightSourceEvidence): Boolean {
+        val searchable = listOfNotNull(
+            evidence.deviceName,
+            evidence.deviceManufacturer,
+            evidence.deviceModel,
+            evidence.sourceName,
+            evidence.sourceBundleIdentifier,
+        ).joinToString(separator = " ").lowercase()
+
+        return scaleLikeTokens.any { token -> searchable.contains(token) }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/integration/HealthBodyWeightSyncManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/integration/HealthBodyWeightSyncManager.kt
@@ -1,0 +1,174 @@
+package com.devil.phoenixproject.data.integration
+
+import co.touchlab.kermit.Logger
+import com.devil.phoenixproject.data.preferences.PreferencesManager
+import com.devil.phoenixproject.data.repository.UserProfileRepository
+import com.devil.phoenixproject.domain.model.ConnectionStatus
+import com.devil.phoenixproject.domain.model.ExternalBodyMeasurement
+import com.devil.phoenixproject.domain.model.IntegrationProvider
+import com.devil.phoenixproject.domain.model.currentTimeMillis
+import com.devil.phoenixproject.isIosPlatform
+import kotlinx.coroutines.flow.first
+
+private val bodyWeightSyncLog = Logger.withTag("HealthBodyWeightSync")
+
+sealed class HealthBodyWeightSyncResult {
+    object NotConnected : HealthBodyWeightSyncResult()
+    object Unavailable : HealthBodyWeightSyncResult()
+    object PermissionMissing : HealthBodyWeightSyncResult()
+    object NoEligibleSample : HealthBodyWeightSyncResult()
+    data class RejectedOutOfRange(val sample: HealthBodyWeightSample) : HealthBodyWeightSyncResult()
+    data class Synced(
+        val sample: HealthBodyWeightSample,
+        val measurement: ExternalBodyMeasurement,
+    ) : HealthBodyWeightSyncResult()
+    data class Failed(val error: Throwable) : HealthBodyWeightSyncResult()
+}
+
+class HealthBodyWeightSyncManager(
+    private val bodyWeightReader: HealthBodyWeightReader,
+    private val externalActivityRepository: ExternalActivityRepository,
+    private val externalMeasurementRepository: ExternalMeasurementRepository,
+    private val preferencesManager: PreferencesManager,
+    private val userProfileRepository: UserProfileRepository,
+    private val providerResolver: () -> IntegrationProvider = {
+        if (isIosPlatform) IntegrationProvider.APPLE_HEALTH else IntegrationProvider.GOOGLE_HEALTH
+    },
+    private val nowProvider: () -> Long = { currentTimeMillis() },
+) {
+    companion object {
+        const val MEASUREMENT_TYPE_WEIGHT = "weight"
+        const val UNIT_KG = "kg"
+        const val MIN_BODY_WEIGHT_KG = 20f
+        const val MAX_BODY_WEIGHT_KG = 300f
+    }
+
+    suspend fun syncLatestFromConnectedPlatform(): HealthBodyWeightSyncResult {
+        val provider = providerResolver()
+        val profileId = userProfileRepository.activeProfile.value?.id ?: "default"
+        val status = externalActivityRepository.getIntegrationStatus(provider, profileId).first()
+
+        if (status?.status != ConnectionStatus.CONNECTED) {
+            bodyWeightSyncLog.d { "Skipping body-weight sync: ${provider.key} is not connected for profile=$profileId" }
+            return HealthBodyWeightSyncResult.NotConnected
+        }
+
+        if (!bodyWeightReader.isAvailable()) {
+            updateConnectedStatus(
+                provider = provider,
+                profileId = profileId,
+                errorMessage = "Health body weight sync unavailable on this device",
+            )
+            return HealthBodyWeightSyncResult.Unavailable
+        }
+
+        if (!bodyWeightReader.hasBodyWeightReadPermission()) {
+            updateConnectedStatus(
+                provider = provider,
+                profileId = profileId,
+                errorMessage = "Body weight read permission is missing",
+            )
+            return HealthBodyWeightSyncResult.PermissionMissing
+        }
+
+        val readResult = bodyWeightReader.readLatestScaleBodyWeight()
+        val sample = readResult.getOrElse { error ->
+            bodyWeightSyncLog.w(error) { "Health body-weight read failed for ${provider.key}" }
+            updateConnectedStatus(
+                provider = provider,
+                profileId = profileId,
+                errorMessage = "Body weight sync failed: ${error.message ?: "unknown error"}",
+            )
+            return HealthBodyWeightSyncResult.Failed(error)
+        }
+
+        val now = nowProvider()
+        if (sample == null) {
+            updateConnectedStatus(
+                provider = provider,
+                profileId = profileId,
+                lastSyncAt = now,
+                errorMessage = "No eligible scale body weight found",
+            )
+            return HealthBodyWeightSyncResult.NoEligibleSample
+        }
+
+        if (sample.weightKg !in MIN_BODY_WEIGHT_KG..MAX_BODY_WEIGHT_KG) {
+            updateConnectedStatus(
+                provider = provider,
+                profileId = profileId,
+                lastSyncAt = now,
+                errorMessage = "Latest Health body weight is outside Phoenix's 20-300 kg range",
+            )
+            return HealthBodyWeightSyncResult.RejectedOutOfRange(sample)
+        }
+
+        val measurement = ExternalBodyMeasurement(
+            externalId = sample.externalId,
+            provider = provider,
+            measurementType = MEASUREMENT_TYPE_WEIGHT,
+            value = sample.weightKg.toDouble(),
+            unit = UNIT_KG,
+            measuredAt = sample.measuredAtMs,
+            rawData = sample.rawMetadataJson ?: sample.toRawDataJson(provider),
+            profileId = profileId,
+            syncedAt = now,
+        )
+        externalMeasurementRepository.upsertMeasurements(listOf(measurement))
+        preferencesManager.setBodyWeightKg(sample.weightKg)
+        updateConnectedStatus(
+            provider = provider,
+            profileId = profileId,
+            lastSyncAt = now,
+            errorMessage = null,
+        )
+        return HealthBodyWeightSyncResult.Synced(sample = sample, measurement = measurement)
+    }
+
+    private suspend fun updateConnectedStatus(
+        provider: IntegrationProvider,
+        profileId: String,
+        lastSyncAt: Long? = null,
+        errorMessage: String? = null,
+    ) {
+        externalActivityRepository.updateIntegrationStatus(
+            provider = provider,
+            status = ConnectionStatus.CONNECTED,
+            profileId = profileId,
+            lastSyncAt = lastSyncAt,
+            errorMessage = errorMessage,
+        )
+    }
+
+    private fun HealthBodyWeightSample.toRawDataJson(provider: IntegrationProvider): String {
+        val metadata = deviceMetadata.entries.joinToString(separator = ",") { (key, value) ->
+            "\"${key.escapeJson()}\":\"${value.escapeJson()}\""
+        }
+        return buildString {
+            append("{")
+            append("\"provider\":\"${provider.key.escapeJson()}\",")
+            append("\"externalId\":\"${externalId.escapeJson()}\",")
+            append("\"weightKg\":$weightKg,")
+            append("\"measuredAtMs\":$measuredAtMs,")
+            append("\"sourceName\":")
+            append(sourceName?.let { "\"${it.escapeJson()}\"" } ?: "null")
+            append(",\"deviceMetadata\":{")
+            append(metadata)
+            append("}")
+            append("}")
+        }
+    }
+
+    private fun String.escapeJson(): String = buildString {
+        this@escapeJson.forEach { char ->
+            when (char) {
+                '\\' -> append("\\\\")
+                '"' -> append("\\\"")
+                '\n' -> append("\\n")
+                '\r' -> append("\\r")
+                '\t' -> append("\\t")
+                else -> append(char)
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/integration/HealthIntegration.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/integration/HealthIntegration.kt
@@ -3,6 +3,20 @@ package com.devil.phoenixproject.data.integration
 import com.devil.phoenixproject.domain.model.WorkoutSession
 
 /**
+ * Latest eligible body-weight sample imported from a platform health store.
+ *
+ * Phoenix stores body weight in kg and keeps this one-way: platform health store -> Phoenix.
+ */
+data class HealthBodyWeightSample(
+    val weightKg: Float,
+    val measuredAtMs: Long,
+    val externalId: String,
+    val sourceName: String? = null,
+    val deviceMetadata: Map<String, String> = emptyMap(),
+    val rawMetadataJson: String? = null,
+)
+
+/**
  * Aggregated data for a completed routine, used to write a single
  * workout entry to the platform health store instead of one per set.
  */
@@ -23,13 +37,16 @@ data class RoutineHealthData(
  * Android: Google Health Connect
  * iOS: Apple HealthKit
  *
- * Write-only: pushes Phoenix workout data to the platform health store
- * after each completed workout.
+ * Workout export pushes Phoenix workout data to the platform health store
+ * after each completed workout. Body-weight read support is one-way from
+ * the platform health store into Phoenix.
  */
 expect class HealthIntegration {
     suspend fun isAvailable(): Boolean
     suspend fun requestPermissions(): Boolean
     suspend fun hasPermissions(): Boolean
+    suspend fun hasBodyWeightReadPermission(): Boolean
+    suspend fun readLatestScaleBodyWeight(): Result<HealthBodyWeightSample?>
 
     /** Write a single set/exercise session (used for Just Lift / non-routine workouts). */
     suspend fun writeWorkout(session: WorkoutSession): Result<Unit>
@@ -40,4 +57,20 @@ expect class HealthIntegration {
      * show one workout entry per routine instead of one per set.
      */
     suspend fun writeRoutineWorkout(data: RoutineHealthData): Result<Unit>
+}
+
+interface HealthBodyWeightReader {
+    suspend fun isAvailable(): Boolean
+    suspend fun hasBodyWeightReadPermission(): Boolean
+    suspend fun readLatestScaleBodyWeight(): Result<HealthBodyWeightSample?>
+}
+
+class HealthIntegrationBodyWeightReader(
+    private val healthIntegration: HealthIntegration,
+) : HealthBodyWeightReader {
+    override suspend fun isAvailable(): Boolean = healthIntegration.isAvailable()
+
+    override suspend fun hasBodyWeightReadPermission(): Boolean = healthIntegration.hasBodyWeightReadPermission()
+
+    override suspend fun readLatestScaleBodyWeight(): Result<HealthBodyWeightSample?> = healthIntegration.readLatestScaleBodyWeight()
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/SyncTriggerManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/SyncTriggerManager.kt
@@ -1,6 +1,7 @@
 package com.devil.phoenixproject.data.sync
 
 import co.touchlab.kermit.Logger
+import com.devil.phoenixproject.data.integration.HealthBodyWeightSyncManager
 import com.devil.phoenixproject.util.ConnectivityChecker
 import com.devil.phoenixproject.util.withPlatformLock
 import kotlin.time.Clock
@@ -43,7 +44,11 @@ data class RetryState(
  * - Max 3 consecutive retries before requiring manual intervention
  * - Backoff resets on successful sync
  */
-class SyncTriggerManager(private val syncManager: SyncManager, private val connectivityChecker: ConnectivityChecker) {
+class SyncTriggerManager(
+    private val syncManager: SyncManager,
+    private val connectivityChecker: ConnectivityChecker,
+    private val healthBodyWeightSyncManager: HealthBodyWeightSyncManager? = null,
+) {
     companion object {
         private const val DEFAULT_THROTTLE_MILLIS = 5 * 60 * 1000L // 5 minutes
         private const val MAX_CONSECUTIVE_FAILURES = 3
@@ -85,10 +90,19 @@ class SyncTriggerManager(private val syncManager: SyncManager, private val conne
      */
     suspend fun onAppForeground() {
         Logger.d { "SyncTrigger: App foreground, checking if sync needed" }
+        syncHealthBodyWeightFromConnectedPlatform()
         if (syncManager.isAuthenticated.value) {
             syncManager.refreshPremiumStatusFromServer()
         }
         attemptSync(bypassThrottle = false)
+    }
+
+    private suspend fun syncHealthBodyWeightFromConnectedPlatform() {
+        try {
+            healthBodyWeightSyncManager?.syncLatestFromConnectedPlatform()
+        } catch (e: Exception) {
+            Logger.w(e) { "SyncTrigger: Health body-weight sync failed without blocking portal sync" }
+        }
     }
 
     /**

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/di/PresentationModule.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/di/PresentationModule.kt
@@ -21,7 +21,7 @@ val presentationModule = module {
     factory { DiagnosticsViewModel(get()) }
     factory { CycleEditorViewModel(get(), get()) }
     factory { GamificationViewModel(get(), get()) }
-    factory { IntegrationsViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
+    factory { IntegrationsViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
     factory { ExternalActivitiesViewModel(get(), get()) }
     factory { ExternalRoutinesViewModel(get(), get()) }
     factory { ExternalProgramsViewModel(get(), get(), get()) }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/di/SyncModule.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/di/SyncModule.kt
@@ -1,5 +1,8 @@
 package com.devil.phoenixproject.di
 
+import com.devil.phoenixproject.data.integration.HealthBodyWeightReader
+import com.devil.phoenixproject.data.integration.HealthBodyWeightSyncManager
+import com.devil.phoenixproject.data.integration.HealthIntegrationBodyWeightReader
 import com.devil.phoenixproject.data.integration.IntegrationManager
 import com.devil.phoenixproject.data.repository.*
 import com.devil.phoenixproject.data.sync.PortalApiClient
@@ -30,7 +33,9 @@ val syncModule = module {
             externalActivityRepository = get(),
         )
     }
-    single { SyncTriggerManager(get(), get()) }
+    single<HealthBodyWeightReader> { HealthIntegrationBodyWeightReader(get()) }
+    single { HealthBodyWeightSyncManager(get(), get(), get(), get(), get()) }
+    single { SyncTriggerManager(get(), get(), get()) }
     single { IntegrationManager(get(), get(), get(), get(), get(), get(), get()) }
 
     // Auth (using Supabase GoTrue)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/IntegrationsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/IntegrationsScreen.kt
@@ -27,6 +27,7 @@ import com.devil.phoenixproject.presentation.viewmodel.IntegrationUiEvent
 import com.devil.phoenixproject.presentation.viewmodel.IntegrationsViewModel
 import com.devil.phoenixproject.ui.theme.Spacing
 import com.devil.phoenixproject.util.KmpUtils
+import com.devil.phoenixproject.util.UnitConverter
 import com.devil.phoenixproject.util.readUriContent
 import com.devil.phoenixproject.util.rememberFilePicker
 import com.devil.phoenixproject.util.rememberHealthPermissionRequester
@@ -255,11 +256,29 @@ fun IntegrationsScreen(
             val healthProvider = if (isIosPlatform) IntegrationProvider.APPLE_HEALTH else IntegrationProvider.GOOGLE_HEALTH
             val healthStatus = uiState.integrationStatuses[healthProvider]
             val healthConnected = healthStatus?.status == ConnectionStatus.CONNECTED
+            val latestHealthBodyWeight = uiState.latestHealthBodyWeight
+            val latestHealthBodyWeightLabel = latestHealthBodyWeight?.let { measurement ->
+                if (weightUnit == WeightUnit.KG) {
+                    "${UnitConverter.formatDecimal(measurement.value.toFloat())} kg"
+                } else {
+                    "${UnitConverter.formatDecimal(UnitConverter.kgToLb(measurement.value.toFloat()))} lb"
+                }
+            }
+            val healthSubtitle = when {
+                healthStatus?.errorMessage != null -> healthStatus.errorMessage
+                healthConnected && latestHealthBodyWeightLabel != null -> "Connected • latest scale weight $latestHealthBodyWeightLabel"
+                healthConnected -> "Connected"
+                else -> "Not connected"
+            }
 
             IntegrationCard(
                 title = if (isIosPlatform) "Apple Health" else "Google Health Connect",
-                subtitle = if (healthConnected) "Connected" else "Not connected",
+                subtitle = healthSubtitle,
                 statusConnected = healthConnected,
+                badges = buildList {
+                    latestHealthBodyWeightLabel?.let { add("Body weight: $it") }
+                    healthStatus?.lastSyncAt?.let { add("Last sync: ${KmpUtils.formatTimestamp(it)}") }
+                },
                 trailingContent = {
                     Switch(
                         checked = healthConnected,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SettingsTab.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SettingsTab.kt
@@ -101,7 +101,11 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
+import com.devil.phoenixproject.data.integration.ExternalMeasurementRepository
+import com.devil.phoenixproject.data.integration.HealthBodyWeightSyncManager
+import com.devil.phoenixproject.data.repository.UserProfileRepository
 import com.devil.phoenixproject.data.sync.SyncTriggerManager
+import com.devil.phoenixproject.domain.model.IntegrationProvider
 import com.devil.phoenixproject.domain.model.WeightUnit
 import com.devil.phoenixproject.presentation.components.CountdownDropdown
 import com.devil.phoenixproject.ui.theme.*
@@ -116,6 +120,7 @@ import com.devil.phoenixproject.util.KmpUtils
 import com.devil.phoenixproject.util.UnitConverter
 import com.devil.phoenixproject.util.rememberBackupLocationPicker
 import com.devil.phoenixproject.util.rememberFilePicker
+import kotlin.math.abs
 import kotlin.math.roundToInt
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
@@ -277,6 +282,23 @@ fun SettingsTab(
     modifier: Modifier = Modifier,
 ) {
     val focusManager = LocalFocusManager.current
+    val userProfileRepository = koinInject<UserProfileRepository>()
+    val externalMeasurementRepository = koinInject<ExternalMeasurementRepository>()
+    val activeProfile by userProfileRepository.activeProfile.collectAsState()
+    val activeProfileId = activeProfile?.id ?: "default"
+    val healthBodyWeightMeasurements by remember(activeProfileId) {
+        externalMeasurementRepository.observeMeasurementsByType(
+            profileId = activeProfileId,
+            measurementType = HealthBodyWeightSyncManager.MEASUREMENT_TYPE_WEIGHT,
+        )
+    }.collectAsState(initial = emptyList())
+    val latestMatchingHealthBodyWeight = healthBodyWeightMeasurements
+        .filter { measurement ->
+            measurement.unit == HealthBodyWeightSyncManager.UNIT_KG &&
+                measurement.provider in setOf(IntegrationProvider.APPLE_HEALTH, IntegrationProvider.GOOGLE_HEALTH) &&
+                abs(measurement.value.toFloat() - bodyWeightKg) < 0.05f
+        }
+        .maxByOrNull { it.measuredAt }
     var showDeleteAllDialog by remember { mutableStateOf(false) }
     // Backup/Restore state
     var showBackupDialog by remember { mutableStateOf(false) }
@@ -751,6 +773,9 @@ fun SettingsTab(
                 } else {
                     "Not set"
                 }
+                val bodyWeightDescription = latestMatchingHealthBodyWeight?.let { measurement ->
+                    "$displayBodyWeight - synced from ${measurement.provider.displayName}"
+                } ?: "$displayBodyWeight — for bodyweight exercise volume"
 
                 Row(
                     modifier = Modifier
@@ -767,7 +792,7 @@ fun SettingsTab(
                             color = MaterialTheme.colorScheme.onSurface,
                         )
                         Text(
-                            text = "$displayBodyWeight — for bodyweight exercise volume",
+                            text = bodyWeightDescription,
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/IntegrationsViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/IntegrationsViewModel.kt
@@ -10,6 +10,8 @@ import com.devil.phoenixproject.data.integration.ExternalExerciseTemplateReposit
 import com.devil.phoenixproject.data.integration.ExternalMeasurementRepository
 import com.devil.phoenixproject.data.integration.ExternalProgramRepository
 import com.devil.phoenixproject.data.integration.ExternalRoutineRepository
+import com.devil.phoenixproject.data.integration.HealthBodyWeightSyncManager
+import com.devil.phoenixproject.data.integration.HealthBodyWeightSyncResult
 import com.devil.phoenixproject.data.integration.HealthIntegration
 import com.devil.phoenixproject.data.integration.IntegrationManager
 import com.devil.phoenixproject.data.repository.SubscriptionStatus
@@ -56,6 +58,7 @@ data class IntegrationsUiState(
     val externalRoutineFolders: List<ExternalRoutineFolder> = emptyList(),
     val externalPrograms: List<ExternalProgram> = emptyList(),
     val externalMeasurements: List<ExternalBodyMeasurement> = emptyList(),
+    val latestHealthBodyWeight: ExternalBodyMeasurement? = null,
     val externalProgramStatsByProgramId: Map<String, ExternalProgramStats> = emptyMap(),
     val externalExerciseTemplateCountByProvider: Map<IntegrationProvider, Int> = emptyMap(),
     val activeProgram: ExternalProgram? = null,
@@ -80,6 +83,7 @@ class IntegrationsViewModel(
     private val integrationManager: IntegrationManager,
     private val workoutRepository: WorkoutRepository,
     private val healthIntegration: HealthIntegration,
+    private val healthBodyWeightSyncManager: HealthBodyWeightSyncManager,
     private val userProfileRepository: UserProfileRepository,
     private val portalTokenStorage: PortalTokenStorage,
 ) : ViewModel() {
@@ -176,7 +180,15 @@ class IntegrationsViewModel(
             activeProfileId.flatMapLatest { profileId ->
                 externalMeasurementRepo.observeMeasurements(profileId = profileId)
             }.collect { measurements ->
-                _uiState.value = _uiState.value.copy(externalMeasurements = measurements)
+                _uiState.value = _uiState.value.copy(
+                    externalMeasurements = measurements,
+                    latestHealthBodyWeight = measurements
+                        .filter { measurement ->
+                            measurement.measurementType == HealthBodyWeightSyncManager.MEASUREMENT_TYPE_WEIGHT &&
+                                measurement.provider in setOf(IntegrationProvider.APPLE_HEALTH, IntegrationProvider.GOOGLE_HEALTH)
+                        }
+                        .maxByOrNull { it.measuredAt },
+                )
             }
         }
 
@@ -400,7 +412,7 @@ class IntegrationsViewModel(
                     return@launch
                 }
 
-                if (healthIntegration.hasPermissions()) {
+                if (healthIntegration.hasPermissions() && healthIntegration.hasBodyWeightReadPermission()) {
                     markHealthIntegrationConnected(provider, profileId)
                     return@launch
                 }
@@ -477,21 +489,34 @@ class IntegrationsViewModel(
         profileId: String,
         granted: Boolean,
     ) {
-        val hasPerms = healthIntegration.hasPermissions()
-        log.d { "Health permission result: granted=$granted, hasPermissions=$hasPerms for ${provider.key}" }
-        if (granted && hasPerms) {
+        val hasWorkoutWritePermission = healthIntegration.hasPermissions()
+        val hasBodyWeightReadPermission = healthIntegration.hasBodyWeightReadPermission()
+        log.d {
+            "Health permission result: granted=$granted, " +
+                "hasWorkoutWritePermission=$hasWorkoutWritePermission, " +
+                "hasBodyWeightReadPermission=$hasBodyWeightReadPermission for ${provider.key}"
+        }
+        if (granted && hasWorkoutWritePermission && hasBodyWeightReadPermission) {
             markHealthIntegrationConnected(provider, profileId)
         } else {
+            val missingMessage = when {
+                !hasWorkoutWritePermission -> "Workout write permission was not granted"
+                !hasBodyWeightReadPermission -> "Body weight read permission was not granted"
+                else -> "Permission not granted"
+            }
             externalActivityRepo.updateIntegrationStatus(
                 provider = provider,
                 status = com.devil.phoenixproject.domain.model.ConnectionStatus.ERROR,
                 profileId = profileId,
-                errorMessage = "Permission not granted",
+                errorMessage = missingMessage,
             )
             _uiState.value = _uiState.value.copy(
-                errorMessage = "Health permissions were not granted. Please enable Health Connect permissions in your device's Health Connect settings.",
+                errorMessage = "Health permissions were not granted. $missingMessage.",
             )
-            log.w { "Health permissions not granted for ${provider.key} (granted=$granted, hasPerms=$hasPerms)" }
+            log.w {
+                "Health permissions not granted for ${provider.key} " +
+                    "(granted=$granted, workout=$hasWorkoutWritePermission, bodyWeight=$hasBodyWeightReadPermission)"
+            }
         }
     }
 
@@ -504,10 +529,43 @@ class IntegrationsViewModel(
             status = com.devil.phoenixproject.domain.model.ConnectionStatus.CONNECTED,
             profileId = profileId,
         )
+        val bodyWeightSyncMessage = syncHealthBodyWeightAfterConnect()
         _uiState.value = _uiState.value.copy(
-            successMessage = "Health integration enabled",
+            successMessage = bodyWeightSyncMessage,
         )
         log.i { "Health integration enabled for ${provider.key}" }
+    }
+
+    private suspend fun syncHealthBodyWeightAfterConnect(): String {
+        return when (val result = healthBodyWeightSyncManager.syncLatestFromConnectedPlatform()) {
+            is HealthBodyWeightSyncResult.Synced -> {
+                "Health integration enabled; body weight updated to ${result.sample.weightKg} kg"
+            }
+
+            HealthBodyWeightSyncResult.NoEligibleSample -> {
+                "Health integration enabled; no eligible scale body weight found"
+            }
+
+            HealthBodyWeightSyncResult.PermissionMissing -> {
+                "Health integration enabled; body weight read permission is missing"
+            }
+
+            is HealthBodyWeightSyncResult.RejectedOutOfRange -> {
+                "Health integration enabled; latest body weight is outside Phoenix's 20-300 kg range"
+            }
+
+            HealthBodyWeightSyncResult.Unavailable -> {
+                "Health integration enabled; body weight sync is unavailable on this device"
+            }
+
+            is HealthBodyWeightSyncResult.Failed -> {
+                "Health integration enabled; body weight sync failed"
+            }
+
+            HealthBodyWeightSyncResult.NotConnected -> {
+                "Health integration enabled"
+            }
+        }
     }
 
     /**

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/integration/HealthBodyWeightSourceClassifierTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/integration/HealthBodyWeightSourceClassifierTest.kt
@@ -1,0 +1,90 @@
+package com.devil.phoenixproject.data.integration
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class HealthBodyWeightSourceClassifierTest {
+
+    @Test
+    fun androidScaleDeviceIsEligible() {
+        val result = HealthBodyWeightSourceClassifier.classify(
+            HealthBodyWeightSourceEvidence(
+                platform = HealthBodyWeightSourcePlatform.ANDROID,
+                wasUserEntered = false,
+                deviceType = HealthBodyWeightDeviceType.SCALE,
+                deviceManufacturer = "Withings",
+                deviceModel = "Body+",
+            ),
+        )
+
+        assertEquals(HealthBodyWeightSourceClassification.ELIGIBLE_SCALE, result)
+    }
+
+    @Test
+    fun androidManualEntryIsRejectedEvenWithScaleDevice() {
+        val result = HealthBodyWeightSourceClassifier.classify(
+            HealthBodyWeightSourceEvidence(
+                platform = HealthBodyWeightSourcePlatform.ANDROID,
+                wasUserEntered = true,
+                deviceType = HealthBodyWeightDeviceType.SCALE,
+            ),
+        )
+
+        assertEquals(HealthBodyWeightSourceClassification.MANUAL_ENTRY, result)
+    }
+
+    @Test
+    fun androidUnknownDeviceIsRejected() {
+        val result = HealthBodyWeightSourceClassifier.classify(
+            HealthBodyWeightSourceEvidence(
+                platform = HealthBodyWeightSourcePlatform.ANDROID,
+                wasUserEntered = false,
+                deviceType = HealthBodyWeightDeviceType.UNKNOWN,
+                sourceName = "Health Connect",
+            ),
+        )
+
+        assertEquals(HealthBodyWeightSourceClassification.UNKNOWN_SOURCE, result)
+    }
+
+    @Test
+    fun iosScaleLikeSourceIsEligibleWhenNotUserEntered() {
+        val result = HealthBodyWeightSourceClassifier.classify(
+            HealthBodyWeightSourceEvidence(
+                platform = HealthBodyWeightSourcePlatform.IOS,
+                wasUserEntered = false,
+                sourceName = "Withings",
+                deviceModel = "Body Smart Scale",
+            ),
+        )
+
+        assertEquals(HealthBodyWeightSourceClassification.ELIGIBLE_SCALE, result)
+    }
+
+    @Test
+    fun iosUserEnteredSampleIsRejected() {
+        val result = HealthBodyWeightSourceClassifier.classify(
+            HealthBodyWeightSourceEvidence(
+                platform = HealthBodyWeightSourcePlatform.IOS,
+                wasUserEntered = true,
+                sourceName = "Withings",
+                deviceModel = "Body Smart Scale",
+            ),
+        )
+
+        assertEquals(HealthBodyWeightSourceClassification.MANUAL_ENTRY, result)
+    }
+
+    @Test
+    fun iosGenericHealthSourceWithoutScaleProvenanceIsRejected() {
+        val result = HealthBodyWeightSourceClassifier.classify(
+            HealthBodyWeightSourceEvidence(
+                platform = HealthBodyWeightSourcePlatform.IOS,
+                wasUserEntered = false,
+                sourceName = "Health",
+            ),
+        )
+
+        assertEquals(HealthBodyWeightSourceClassification.UNKNOWN_SOURCE, result)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/integration/HealthBodyWeightSyncManagerTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/integration/HealthBodyWeightSyncManagerTest.kt
@@ -1,0 +1,169 @@
+package com.devil.phoenixproject.data.integration
+
+import com.devil.phoenixproject.domain.model.ConnectionStatus
+import com.devil.phoenixproject.domain.model.IntegrationProvider
+import com.devil.phoenixproject.testutil.FakeExternalActivityRepository
+import com.devil.phoenixproject.testutil.FakeExternalMeasurementRepository
+import com.devil.phoenixproject.testutil.FakePreferencesManager
+import com.devil.phoenixproject.testutil.FakeUserProfileRepository
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+
+class HealthBodyWeightSyncManagerTest {
+
+    private class FakeHealthBodyWeightReader : HealthBodyWeightReader {
+        var available = true
+        var bodyWeightReadPermission = true
+        var readResult: Result<HealthBodyWeightSample?> = Result.success(null)
+        var readCallCount = 0
+
+        override suspend fun isAvailable(): Boolean = available
+
+        override suspend fun hasBodyWeightReadPermission(): Boolean = bodyWeightReadPermission
+
+        override suspend fun readLatestScaleBodyWeight(): Result<HealthBodyWeightSample?> {
+            readCallCount++
+            return readResult
+        }
+    }
+
+    @Test
+    fun disconnectedProviderDoesNotReadOrMutateManualPreference() = runTest {
+        val harness = Harness()
+        harness.preferences.setBodyWeightKg(72f)
+        harness.reader.readResult = Result.success(sample(weightKg = 81.5f))
+
+        val result = harness.manager.syncLatestFromConnectedPlatform()
+
+        assertTrue(result is HealthBodyWeightSyncResult.NotConnected)
+        assertEquals(0, harness.reader.readCallCount)
+        assertEquals(72f, harness.preferences.preferencesFlow.value.bodyWeightKg)
+        assertEquals(emptyList(), harness.measurements.measurements)
+    }
+
+    @Test
+    fun missingReadPermissionDoesNotReadAndReportsPermissionStatus() = runTest {
+        val harness = Harness()
+        harness.connectHealth()
+        harness.preferences.setBodyWeightKg(72f)
+        harness.reader.bodyWeightReadPermission = false
+
+        val result = harness.manager.syncLatestFromConnectedPlatform()
+
+        assertTrue(result is HealthBodyWeightSyncResult.PermissionMissing)
+        assertEquals(0, harness.reader.readCallCount)
+        assertEquals(72f, harness.preferences.preferencesFlow.value.bodyWeightKg)
+        assertEquals(emptyList(), harness.measurements.measurements)
+        assertTrue(harness.activities.statusUpdates.last().errorMessage?.contains("permission", ignoreCase = true) == true)
+    }
+
+    @Test
+    fun noEligibleSampleLeavesManualPreferenceAndUpdatesLastSyncAttempt() = runTest {
+        val harness = Harness()
+        harness.connectHealth()
+        harness.preferences.setBodyWeightKg(72f)
+        harness.reader.readResult = Result.success(null)
+
+        val result = harness.manager.syncLatestFromConnectedPlatform()
+
+        assertTrue(result is HealthBodyWeightSyncResult.NoEligibleSample)
+        assertEquals(1, harness.reader.readCallCount)
+        assertEquals(72f, harness.preferences.preferencesFlow.value.bodyWeightKg)
+        assertEquals(emptyList(), harness.measurements.measurements)
+        assertNotNull(harness.activities.statusUpdates.last().lastSyncAt)
+    }
+
+    @Test
+    fun validSampleUpsertsMeasurementAndOverridesManualBodyWeight() = runTest {
+        val harness = Harness()
+        harness.connectHealth()
+        harness.preferences.setBodyWeightKg(72f)
+        harness.reader.readResult = Result.success(sample(weightKg = 81.5f, externalId = "scale-1"))
+
+        val result = harness.manager.syncLatestFromConnectedPlatform()
+
+        assertTrue(result is HealthBodyWeightSyncResult.Synced)
+        assertEquals(81.5f, harness.preferences.preferencesFlow.value.bodyWeightKg)
+        val measurement = harness.measurements.measurements.single()
+        assertEquals("scale-1", measurement.externalId)
+        assertEquals(IntegrationProvider.GOOGLE_HEALTH, measurement.provider)
+        assertEquals("weight", measurement.measurementType)
+        assertEquals(81.5, measurement.value)
+        assertEquals("kg", measurement.unit)
+        assertEquals("profile-1", measurement.profileId)
+        assertNotNull(harness.activities.statusUpdates.last().lastSyncAt)
+    }
+
+    @Test
+    fun outOfRangeSampleDoesNotOverrideManualPreferenceOrInsertMeasurement() = runTest {
+        val harness = Harness()
+        harness.connectHealth()
+        harness.preferences.setBodyWeightKg(72f)
+        harness.reader.readResult = Result.success(sample(weightKg = 450f))
+
+        val result = harness.manager.syncLatestFromConnectedPlatform()
+
+        assertTrue(result is HealthBodyWeightSyncResult.RejectedOutOfRange)
+        assertEquals(72f, harness.preferences.preferencesFlow.value.bodyWeightKg)
+        assertEquals(emptyList(), harness.measurements.measurements)
+        assertTrue(harness.activities.statusUpdates.last().errorMessage?.contains("range", ignoreCase = true) == true)
+    }
+
+    @Test
+    fun duplicateExternalIdIsIdempotent() = runTest {
+        val harness = Harness()
+        harness.connectHealth()
+        harness.reader.readResult = Result.success(sample(weightKg = 81.5f, externalId = "scale-1"))
+
+        harness.manager.syncLatestFromConnectedPlatform()
+        harness.reader.readResult = Result.success(sample(weightKg = 82f, externalId = "scale-1"))
+        val result = harness.manager.syncLatestFromConnectedPlatform()
+
+        assertTrue(result is HealthBodyWeightSyncResult.Synced)
+        assertEquals(82f, harness.preferences.preferencesFlow.value.bodyWeightKg)
+        assertEquals(1, harness.measurements.measurements.size)
+        assertEquals(82.0, harness.measurements.measurements.single().value)
+    }
+
+    private class Harness {
+        val reader = FakeHealthBodyWeightReader()
+        val activities = FakeExternalActivityRepository()
+        val measurements = FakeExternalMeasurementRepository()
+        val preferences = FakePreferencesManager()
+        val profiles = FakeUserProfileRepository().apply {
+            setActiveProfileForTest(id = "profile-1")
+        }
+        val manager = HealthBodyWeightSyncManager(
+            bodyWeightReader = reader,
+            externalActivityRepository = activities,
+            externalMeasurementRepository = measurements,
+            preferencesManager = preferences,
+            userProfileRepository = profiles,
+            providerResolver = { IntegrationProvider.GOOGLE_HEALTH },
+            nowProvider = { 123_456L },
+        )
+
+        suspend fun connectHealth() {
+            activities.updateIntegrationStatus(
+                provider = IntegrationProvider.GOOGLE_HEALTH,
+                status = ConnectionStatus.CONNECTED,
+                profileId = "profile-1",
+            )
+        }
+    }
+
+    private fun sample(
+        weightKg: Float,
+        externalId: String = "scale-1",
+    ) = HealthBodyWeightSample(
+        weightKg = weightKg,
+        measuredAtMs = 100_000L,
+        externalId = externalId,
+        sourceName = "Withings",
+        deviceMetadata = mapOf("model" to "Body Smart Scale"),
+        rawMetadataJson = """{"source":"Withings"}""",
+    )
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeExternalActivityRepository.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeExternalActivityRepository.kt
@@ -8,6 +8,7 @@ import com.devil.phoenixproject.domain.model.IntegrationProvider
 import com.devil.phoenixproject.domain.model.IntegrationStatus
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
 
 class FakeExternalActivityRepository : ExternalActivityRepository {
 
@@ -25,6 +26,7 @@ class FakeExternalActivityRepository : ExternalActivityRepository {
         val errorMessage: String?,
     )
     val statusUpdates = mutableListOf<StatusUpdate>()
+    private val statusesFlow = MutableStateFlow<List<IntegrationStatus>>(emptyList())
 
     override fun getAll(profileId: String, provider: IntegrationProvider?): Flow<List<ExternalActivity>> = MutableStateFlow(
         activities.filter {
@@ -91,9 +93,13 @@ class FakeExternalActivityRepository : ExternalActivityRepository {
         activities.removeAll { it.provider == provider && it.profileId == profileId }
     }
 
-    override fun getIntegrationStatus(provider: IntegrationProvider, profileId: String): Flow<IntegrationStatus?> = MutableStateFlow(null)
+    override fun getIntegrationStatus(provider: IntegrationProvider, profileId: String): Flow<IntegrationStatus?> = statusesFlow.map { statuses ->
+        statuses.firstOrNull { it.provider == provider && it.profileId == profileId }
+    }
 
-    override fun getAllIntegrationStatuses(profileId: String): Flow<List<IntegrationStatus>> = MutableStateFlow(emptyList())
+    override fun getAllIntegrationStatuses(profileId: String): Flow<List<IntegrationStatus>> = statusesFlow.map { statuses ->
+        statuses.filter { it.profileId == profileId }
+    }
 
     override suspend fun updateIntegrationStatus(
         provider: IntegrationProvider,
@@ -103,5 +109,14 @@ class FakeExternalActivityRepository : ExternalActivityRepository {
         errorMessage: String?,
     ) {
         statusUpdates += StatusUpdate(provider, status, profileId, lastSyncAt, errorMessage)
+        statusesFlow.value = statusesFlow.value
+            .filterNot { it.provider == provider && it.profileId == profileId } +
+            IntegrationStatus(
+                provider = provider,
+                status = status,
+                lastSyncAt = lastSyncAt,
+                errorMessage = errorMessage,
+                profileId = profileId,
+            )
     }
 }

--- a/shared/src/iosMain/kotlin/com/devil/phoenixproject/data/integration/HealthIntegration.ios.kt
+++ b/shared/src/iosMain/kotlin/com/devil/phoenixproject/data/integration/HealthIntegration.ios.kt
@@ -6,17 +6,27 @@ import kotlin.coroutines.resume
 import kotlinx.coroutines.suspendCancellableCoroutine
 import platform.Foundation.NSDate
 import platform.Foundation.NSError
+import platform.Foundation.NSNumber
+import platform.Foundation.NSSortDescriptor
 import platform.HealthKit.HKAuthorizationStatusSharingAuthorized
+import platform.HealthKit.HKDevice
 import platform.HealthKit.HKHealthStore
+import platform.HealthKit.HKMetadataKeyWasUserEntered
 import platform.HealthKit.HKObjectType
 import platform.HealthKit.HKQuantity
+import platform.HealthKit.HKQuantitySample
 import platform.HealthKit.HKQuantityType
 import platform.HealthKit.HKQuantityTypeIdentifierActiveEnergyBurned
+import platform.HealthKit.HKQuantityTypeIdentifierBodyMass
+import platform.HealthKit.HKSampleQuery
+import platform.HealthKit.HKSampleSortIdentifierEndDate
 import platform.HealthKit.HKUnit
 import platform.HealthKit.HKWorkout
 import platform.HealthKit.HKWorkoutActivityTypeTraditionalStrengthTraining
 
 private val log = Logger.withTag("HealthIntegration.iOS")
+
+private const val BODY_MASS_QUERY_LIMIT = 50UL
 
 /**
  * iOS implementation of HealthIntegration using Apple HealthKit.
@@ -43,6 +53,10 @@ actual class HealthIntegration {
         HKQuantityType.quantityTypeForIdentifier(HKQuantityTypeIdentifierActiveEnergyBurned)
     }
 
+    private val bodyMassType: HKQuantityType? by lazy {
+        HKQuantityTypeIdentifierBodyMass?.let { HKQuantityType.quantityTypeForIdentifier(it) }
+    }
+
     /** Required HealthKit write types. Calories are optional so disabling them does not block workout sync. */
     private val requiredWriteTypes: Set<HKObjectType> by lazy { setOf(workoutType) }
 
@@ -53,6 +67,11 @@ actual class HealthIntegration {
 
     /** The full set requested from HealthKit when presenting authorization UI. */
     private val writeTypes: Set<HKObjectType> by lazy { requiredWriteTypes + optionalWriteTypes }
+
+    /** Read types requested for one-way body-weight import. */
+    private val readTypes: Set<HKObjectType> by lazy {
+        buildSet { bodyMassType?.let { add(it) } }
+    }
 
     /**
      * Checks whether HealthKit is available on this device.
@@ -98,6 +117,62 @@ actual class HealthIntegration {
     }
 
     /**
+     * HealthKit does not expose per-type read authorization status. If HealthKit and the body mass
+     * type are available, the query path is the only reliable read-permission check.
+     */
+    actual suspend fun hasBodyWeightReadPermission(): Boolean = isAvailable() && bodyMassType != null
+
+    actual suspend fun readLatestScaleBodyWeight(): Result<HealthBodyWeightSample?> {
+        if (!isAvailable()) {
+            return Result.failure(IllegalStateException("HealthKit is not available on this device"))
+        }
+
+        val sampleType = bodyMassType ?: return Result.success(null)
+
+        return try {
+            suspendCancellableCoroutine { continuation ->
+                val sortDescriptors = listOf(
+                    NSSortDescriptor.sortDescriptorWithKey(
+                        key = HKSampleSortIdentifierEndDate,
+                        ascending = false,
+                    ),
+                )
+                val query = HKSampleQuery(
+                    sampleType = sampleType,
+                    predicate = null,
+                    limit = BODY_MASS_QUERY_LIMIT,
+                    sortDescriptors = sortDescriptors,
+                ) { _, samples, error ->
+                    if (error != null) {
+                        log.e { "HealthKit body mass query error: ${error.localizedDescription}" }
+                        continuation.resume(
+                            Result.failure(
+                                RuntimeException("HealthKit body mass query failed: ${error.localizedDescription}"),
+                            ),
+                        )
+                        return@HKSampleQuery
+                    }
+
+                    val latest = samples.orEmpty()
+                        .filterIsInstance<HKQuantitySample>()
+                        .firstNotNullOfOrNull { sample ->
+                            sample.toEligibleBodyWeightSampleOrNull()
+                        }
+                    continuation.resume(Result.success(latest))
+                }
+
+                continuation.invokeOnCancellation {
+                    healthStore.stopQuery(query)
+                }
+                healthStore.executeQuery(query)
+            }
+        } catch (e: Exception) {
+            log.e(e) { "Failed to read latest HealthKit scale body weight" }
+            Result.failure(e)
+        }
+    }
+
+    /**
      * Requests HealthKit write authorization for workout and active energy types.
      *
      * The completion handler's `success` boolean only indicates whether the
@@ -115,7 +190,7 @@ actual class HealthIntegration {
             val dialogShown = suspendCancellableCoroutine { continuation ->
                 healthStore.requestAuthorizationToShareTypes(
                     typesToShare = writeTypes,
-                    readTypes = null,
+                    readTypes = readTypes,
                     completion = { success: Boolean, error: NSError? ->
                         if (error != null) {
                             log.e {
@@ -361,6 +436,100 @@ actual class HealthIntegration {
             "$exerciseName — ${totalWeightKg.toInt()}kg"
         } else {
             exerciseName
+        }
+    }
+
+    private fun HKQuantitySample.toEligibleBodyWeightSampleOrNull(): HealthBodyWeightSample? {
+        val metadata = metadata
+        val source = sourceRevision.source
+        val wasUserEntered = metadata?.get(HKMetadataKeyWasUserEntered).asBoolean()
+        val device = device
+        val evidence = HealthBodyWeightSourceEvidence(
+            platform = HealthBodyWeightSourcePlatform.IOS,
+            wasUserEntered = wasUserEntered,
+            sourceName = source.name,
+            sourceBundleIdentifier = source.bundleIdentifier,
+            deviceManufacturer = device?.manufacturer,
+            deviceModel = device?.model,
+            deviceName = device?.name,
+        )
+
+        if (!HealthBodyWeightSourceClassifier.isEligibleScaleSource(evidence)) {
+            return null
+        }
+
+        val weightKg = quantity.doubleValueForUnit(HKUnit.unitFromString("kg")).toFloat()
+        return HealthBodyWeightSample(
+            weightKg = weightKg,
+            measuredAtMs = endDate.toEpochMillis(),
+            externalId = UUID.UUIDString,
+            sourceName = source.name,
+            deviceMetadata = buildIosBodyWeightDeviceMetadata(source.name, source.bundleIdentifier, device),
+            rawMetadataJson = buildIosBodyWeightRawMetadataJson(this),
+        )
+    }
+
+    private fun buildIosBodyWeightDeviceMetadata(
+        sourceName: String,
+        sourceBundleIdentifier: String,
+        device: HKDevice?,
+    ): Map<String, String> = buildMap {
+        put("sourceName", sourceName)
+        put("sourceBundleIdentifier", sourceBundleIdentifier)
+        device?.name?.takeIf { it.isNotBlank() }?.let { put("deviceName", it) }
+        device?.manufacturer?.takeIf { it.isNotBlank() }?.let { put("deviceManufacturer", it) }
+        device?.model?.takeIf { it.isNotBlank() }?.let { put("deviceModel", it) }
+        device?.hardwareVersion?.takeIf { it.isNotBlank() }?.let { put("deviceHardwareVersion", it) }
+        device?.softwareVersion?.takeIf { it.isNotBlank() }?.let { put("deviceSoftwareVersion", it) }
+        device?.localIdentifier?.takeIf { it.isNotBlank() }?.let { put("deviceLocalIdentifier", it) }
+    }
+
+    private fun buildIosBodyWeightRawMetadataJson(sample: HKQuantitySample): String {
+        val source = sample.sourceRevision.source
+        val device = sample.device
+        val wasUserEntered = sample.metadata?.get(HKMetadataKeyWasUserEntered).asBoolean()
+        return buildString {
+            append("{")
+            append("\"platform\":\"ios\",")
+            append("\"uuid\":\"${sample.UUID.UUIDString.escapeJson()}\",")
+            append("\"sourceName\":\"${source.name.escapeJson()}\",")
+            append("\"sourceBundleIdentifier\":\"${source.bundleIdentifier.escapeJson()}\",")
+            append("\"wasUserEntered\":${wasUserEntered ?: false},")
+            append("\"device\":{")
+            append("\"name\":")
+            append(device?.name?.let { "\"${it.escapeJson()}\"" } ?: "null")
+            append(",\"manufacturer\":")
+            append(device?.manufacturer?.let { "\"${it.escapeJson()}\"" } ?: "null")
+            append(",\"model\":")
+            append(device?.model?.let { "\"${it.escapeJson()}\"" } ?: "null")
+            append(",\"hardwareVersion\":")
+            append(device?.hardwareVersion?.let { "\"${it.escapeJson()}\"" } ?: "null")
+            append(",\"softwareVersion\":")
+            append(device?.softwareVersion?.let { "\"${it.escapeJson()}\"" } ?: "null")
+            append("}")
+            append("}")
+        }
+    }
+
+    private fun NSDate.toEpochMillis(): Long =
+        ((timeIntervalSinceReferenceDate + UNIX_TO_APPLE_EPOCH_OFFSET) * 1000.0).toLong()
+
+    private fun Any?.asBoolean(): Boolean? = when (this) {
+        is Boolean -> this
+        is NSNumber -> boolValue
+        else -> null
+    }
+
+    private fun String.escapeJson(): String = buildString {
+        this@escapeJson.forEach { char ->
+            when (char) {
+                '\\' -> append("\\\\")
+                '"' -> append("\\\"")
+                '\n' -> append("\\n")
+                '\r' -> append("\\r")
+                '\t' -> append("\\t")
+                else -> append(char)
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add opt-in, one-way body-weight import from Google Health Connect and Apple Health into Phoenix.
- Sync the latest eligible scale-sourced body-mass sample on connect and app foreground, then update `bodyWeightKg` when the value is within Phoenix's supported range.
- Keep workout export behavior intact while exposing sync status in Integrations and Settings.

## Testing
- Added unit coverage for body-weight source classification and sync-manager behavior, including no-op, permission-missing, out-of-range, and idempotency cases.
- Verified the shared Android host tests and iOS Kotlin compilation locally.
- Confirmed schema manifest validation and diff cleanliness during verification.