### PR TITLE
Add structural Health Connect export for Phoenix workouts

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,7 +29,7 @@ androidx-savedstate = "1.4.0"
 androidx-security-crypto = "1.1.0"
 androidx-browser = "1.10.0"
 androidx-documentfile = "1.1.0"
-androidx-health-connect = "1.1.0"
+androidx-health-connect = "1.2.0-alpha04"
 
 # Dependency Injection - Koin (Multiplatform alternative to Hilt)
 koin = "4.2.1"

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/di/KoinModuleVerifyTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/di/KoinModuleVerifyTest.kt
@@ -1,6 +1,7 @@
 package com.devil.phoenixproject.di
 
 import com.devil.phoenixproject.data.integration.HealthIntegration
+import com.devil.phoenixproject.data.integration.HealthWorkoutWriter
 import com.devil.phoenixproject.data.local.DriverFactory
 import com.devil.phoenixproject.data.repository.BleRepository
 import com.devil.phoenixproject.data.sync.SupabaseConfig
@@ -35,6 +36,7 @@ class KoinModuleVerifyTest {
                 SafeWordListenerFactory::class,
                 // Platform-provided health integration (Android: HealthIntegration(context), iOS: HealthIntegration())
                 HealthIntegration::class,
+                HealthWorkoutWriter::class,
                 WorkoutServiceController::class,
                 // Lambda types used in constructor injection (e.g. PortalApiClient tokenProvider)
                 Function0::class,

--- a/shared/src/androidMain/kotlin/com/devil/phoenixproject/data/integration/HealthIntegration.android.kt
+++ b/shared/src/androidMain/kotlin/com/devil/phoenixproject/data/integration/HealthIntegration.android.kt
@@ -4,11 +4,13 @@ import android.annotation.SuppressLint
 import android.content.Context
 import androidx.health.connect.client.HealthConnectClient
 import androidx.health.connect.client.permission.HealthPermission
+import androidx.health.connect.client.records.ExerciseSegment
 import androidx.health.connect.client.records.ExerciseSessionRecord
 import androidx.health.connect.client.records.TotalCaloriesBurnedRecord
 import androidx.health.connect.client.records.metadata.Device
 import androidx.health.connect.client.records.metadata.Metadata
 import androidx.health.connect.client.units.Energy
+import androidx.health.connect.client.units.Mass
 import co.touchlab.kermit.Logger
 import com.devil.phoenixproject.domain.model.WorkoutSession
 import java.time.Instant
@@ -83,86 +85,14 @@ actual class HealthIntegration(private val context: Context) {
         }
     }
 
-    @SuppressLint("RestrictedApi") // ExerciseSessionRecord constructor restricted in alpha; fixed in stable 1.1.0
     actual suspend fun writeWorkout(session: WorkoutSession): Result<Unit> {
-        val c = client ?: return Result.failure(
-            IllegalStateException("Health Connect is not available on this device"),
-        )
-
-        if (!hasPermissions()) {
-            return Result.failure(
-                SecurityException("Health Connect write permissions not granted"),
-            )
-        }
-
-        return try {
-            val startInstant = Instant.ofEpochMilli(session.timestamp)
-            // session.duration is stored in MILLISECONDS (from currentTimeMillis() - startTime)
-            // Issue #362: Convert to seconds for Health Connect; minimum 1 second
-            val durationMs = session.duration.coerceAtLeast(1000L)
-            val durationSeconds = durationMs / 1000L
-            val endInstant = startInstant.plusSeconds(durationSeconds)
-            val zoneOffset = ZoneId.systemDefault().rules.getOffset(startInstant)
-            val title = buildExerciseTitle(session)
-            val canWriteCalories = hasCalorieWritePermission()
-
-            log.i {
-                "HEALTH_DEBUG_ANDROID_WRITE: sessionId=${session.id}, " +
-                    "exercise=${session.exerciseName ?: "NULL"}, " +
-                    "weightPerCableKg=${session.weightPerCableKg}, cableCount=${session.cableCount ?: -1}, " +
-                    "displayMultiplier=${session.displayMultiplier ?: -1}, " +
-                    "builtTitle=$title, estimatedCalories=${session.estimatedCalories ?: -1f}, " +
-                    "canWriteCalories=$canWriteCalories, " +
-                    "durationMs=${session.duration}, durationSeconds=$durationSeconds"
-            }
-
-            val records = buildList {
-                add(
-                    ExerciseSessionRecord(
-                        startTime = startInstant,
-                        startZoneOffset = zoneOffset,
-                        endTime = endInstant,
-                        endZoneOffset = zoneOffset,
-                        exerciseType = ExerciseSessionRecord.EXERCISE_TYPE_WEIGHTLIFTING,
-                        title = title,
-                        metadata = Metadata.activelyRecorded(VITRUVIAN_DEVICE),
-                    ),
-                )
-
-                val calories = session.estimatedCalories
-                if (calories != null && calories > 0f) {
-                    if (canWriteCalories) {
-                        add(
-                            TotalCaloriesBurnedRecord(
-                                startTime = startInstant,
-                                startZoneOffset = zoneOffset,
-                                endTime = endInstant,
-                                endZoneOffset = zoneOffset,
-                                energy = Energy.kilocalories(calories.toDouble()),
-                                metadata = Metadata.activelyRecorded(VITRUVIAN_DEVICE),
-                            ),
-                        )
-                    } else {
-                        log.i { "Skipping Health Connect calorie record for session ${session.id}: optional calorie write permission not granted" }
-                    }
-                }
-            }
-
-            c.insertRecords(records)
-            log.d { "Wrote ${records.size} Health Connect record(s) for session ${session.id}" }
-            Result.success(Unit)
-        } catch (e: Exception) {
-            log.e(e) { "Failed to write workout to Health Connect for session ${session.id}" }
-            Result.failure(e)
-        }
+        val data = HealthWorkoutExportBuilder.buildStandaloneWorkout(session, completedSets = emptyList())
+            ?: return Result.failure(IllegalArgumentException("Workout session has no completed reps to write"))
+        return writeHealthWorkout(data)
     }
 
-    /**
-     * Issue #395: Write a single aggregate Health Connect workout for an entire routine.
-     * Called once at routine completion instead of per-set.
-     */
     @SuppressLint("RestrictedApi")
-    actual suspend fun writeRoutineWorkout(data: RoutineHealthData): Result<Unit> {
+    actual suspend fun writeHealthWorkout(data: HealthWorkoutData): Result<Unit> {
         val c = client ?: return Result.failure(
             IllegalStateException("Health Connect is not available on this device"),
         )
@@ -175,17 +105,21 @@ actual class HealthIntegration(private val context: Context) {
 
         return try {
             val startInstant = Instant.ofEpochMilli(data.startTimeMs)
-            val durationMs = data.durationMs.coerceAtLeast(1000L)
-            val durationSeconds = durationMs / 1000L
-            val endInstant = startInstant.plusSeconds(durationSeconds)
+            val endInstant = Instant.ofEpochMilli(data.endTimeMs.coerceAtLeast(data.startTimeMs + 1000L))
             val zoneOffset = ZoneId.systemDefault().rules.getOffset(startInstant)
             val canWriteCalories = hasCalorieWritePermission()
+            val exerciseSegments = data.segments.map { segment -> segment.toHealthConnectSegment() }
+            val sessionRpe = data.segments
+                .mapNotNull { it.rpe }
+                .takeIf { it.isNotEmpty() }
+                ?.average()
+                ?.toFloat()
 
             log.i {
-                "HEALTH_DEBUG_ANDROID_ROUTINE: externalId=${data.externalId}, " +
-                    "routineName=${data.routineName}, durationMs=${data.durationMs}, " +
-                    "durationSeconds=$durationSeconds, totalCalories=${data.totalCalories ?: -1f}, " +
-                    "canWriteCalories=$canWriteCalories"
+                "HEALTH_DEBUG_ANDROID_WRITE: externalId=${data.externalId}, title=${data.title}, " +
+                    "segments=${data.segments.size}, totalCalories=${data.totalCalories ?: -1f}, " +
+                    "canWriteCalories=$canWriteCalories, " +
+                    "durationMs=${data.endTimeMs - data.startTimeMs}"
             }
 
             val records = buildList {
@@ -195,9 +129,15 @@ actual class HealthIntegration(private val context: Context) {
                         startZoneOffset = zoneOffset,
                         endTime = endInstant,
                         endZoneOffset = zoneOffset,
-                        exerciseType = ExerciseSessionRecord.EXERCISE_TYPE_WEIGHTLIFTING,
-                        title = data.routineName,
-                        metadata = Metadata.activelyRecorded(VITRUVIAN_DEVICE),
+                        metadata = Metadata.activelyRecorded(VITRUVIAN_DEVICE, data.externalId, 0L),
+                        exerciseType = ExerciseSessionRecord.EXERCISE_TYPE_STRENGTH_TRAINING,
+                        title = data.title,
+                        notes = null,
+                        segments = exerciseSegments,
+                        laps = emptyList(),
+                        exerciseRoute = null,
+                        plannedExerciseSessionId = null,
+                        rateOfPerceivedExertion = sessionRpe,
                     ),
                 )
 
@@ -211,44 +151,63 @@ actual class HealthIntegration(private val context: Context) {
                                 endTime = endInstant,
                                 endZoneOffset = zoneOffset,
                                 energy = Energy.kilocalories(calories.toDouble()),
-                                metadata = Metadata.activelyRecorded(VITRUVIAN_DEVICE),
+                                metadata = Metadata.activelyRecorded(
+                                    VITRUVIAN_DEVICE,
+                                    HealthWorkoutExportBuilder.calorieClientRecordId(data.externalId),
+                                    0L,
+                                ),
                             ),
                         )
                     } else {
-                        log.i { "Skipping Health Connect calorie record for routine ${data.externalId}: optional calorie write permission not granted" }
+                        log.i { "Skipping Health Connect calorie record for ${data.externalId}: optional calorie write permission not granted" }
                     }
                 }
             }
 
             c.insertRecords(records)
-            log.d { "Wrote ${records.size} Health Connect record(s) for routine: ${data.routineName}" }
+            log.d { "Wrote ${records.size} Health Connect record(s) for ${data.externalId}" }
             Result.success(Unit)
         } catch (e: Exception) {
-            log.e(e) { "Failed to write routine workout to Health Connect: ${data.externalId}" }
+            log.e(e) { "Failed to write workout to Health Connect for ${data.externalId}" }
             Result.failure(e)
         }
     }
 
-    /**
-     * Builds a human-readable title for the exercise session.
-     *
-     * Weight display logic:
-     * - Prefer persisted displayMultiplier when present (established display semantics)
-     * - Fall back to raw physical cableCount only for legacy sessions without displayMultiplier
-     * - If both are null, default to 1 (per-cable weight shown as-is)
-     *
-     * This keeps Health titles aligned with persisted WorkoutSession display semantics.
-     */
-    private fun buildExerciseTitle(session: WorkoutSession): String {
-        val exerciseName = session.exerciseName?.takeIf { it.isNotBlank() } ?: "Phoenix Workout"
-        // Prefer displayMultiplier; raw physical cableCount is only the legacy fallback.
-        // This prevents incorrect bilateral handle inflation (Issue #358: 80kg showing as 160kg).
-        val totalWeightKg = session.weightPerCableKg *
-            (session.displayMultiplier ?: session.cableCount ?: 1).toFloat()
-        return if (totalWeightKg > 0f) {
-            "$exerciseName — ${totalWeightKg.toInt()}kg"
-        } else {
-            exerciseName
+    private fun HealthWorkoutSegment.toHealthConnectSegment(): ExerciseSegment {
+        val sessionType = ExerciseSessionRecord.EXERCISE_TYPE_STRENGTH_TRAINING
+        val preferredType = segmentTypeForExercise(exerciseName)
+        val fallbackType = ExerciseSegment.EXERCISE_SEGMENT_TYPE_WEIGHTLIFTING
+        val segmentType = when {
+            ExerciseSegment.isSegmentTypeCompatibleWithSessionType(preferredType, sessionType) -> preferredType
+            ExerciseSegment.isSegmentTypeCompatibleWithSessionType(fallbackType, sessionType) -> fallbackType
+            else -> ExerciseSegment.EXERCISE_SEGMENT_TYPE_UNKNOWN
+        }
+
+        return ExerciseSegment(
+            startTime = Instant.ofEpochMilli(startTimeMs),
+            endTime = Instant.ofEpochMilli(endTimeMs.coerceAtLeast(startTimeMs + 1000L)),
+            segmentType = segmentType,
+            repetitions = reps.coerceAtLeast(0),
+            weight = Mass.kilograms(weightKg.toDouble().coerceAtLeast(0.0)),
+            setIndex = setIndex.coerceAtLeast(0),
+            rateOfPerceivedExertion = rpe?.toFloat(),
+        )
+    }
+
+    private fun segmentTypeForExercise(name: String): Int {
+        val normalized = name.lowercase()
+        return when {
+            "bench" in normalized && "press" in normalized -> ExerciseSegment.EXERCISE_SEGMENT_TYPE_BENCH_PRESS
+            "deadlift" in normalized -> ExerciseSegment.EXERCISE_SEGMENT_TYPE_DEADLIFT
+            "squat" in normalized -> ExerciseSegment.EXERCISE_SEGMENT_TYPE_SQUAT
+            "curl" in normalized -> ExerciseSegment.EXERCISE_SEGMENT_TYPE_ARM_CURL
+            "row" in normalized -> ExerciseSegment.EXERCISE_SEGMENT_TYPE_WEIGHTLIFTING
+            "pulldown" in normalized || "pull down" in normalized || "lat pull" in normalized -> ExerciseSegment.EXERCISE_SEGMENT_TYPE_WEIGHTLIFTING
+            "pull-up" in normalized || "pull up" in normalized -> ExerciseSegment.EXERCISE_SEGMENT_TYPE_PULL_UP
+            "lunge" in normalized -> ExerciseSegment.EXERCISE_SEGMENT_TYPE_LUNGE
+            "shoulder press" in normalized || "overhead press" in normalized -> ExerciseSegment.EXERCISE_SEGMENT_TYPE_SHOULDER_PRESS
+            "tricep" in normalized || "triceps" in normalized -> ExerciseSegment.EXERCISE_SEGMENT_TYPE_DOUBLE_ARM_TRICEPS_EXTENSION
+            else -> ExerciseSegment.EXERCISE_SEGMENT_TYPE_WEIGHTLIFTING
         }
     }
 }

--- a/shared/src/androidMain/kotlin/com/devil/phoenixproject/data/integration/HealthIntegration.android.kt
+++ b/shared/src/androidMain/kotlin/com/devil/phoenixproject/data/integration/HealthIntegration.android.kt
@@ -42,7 +42,7 @@ internal val requestedHealthPermissions = requiredHealthPermissions + optionalHe
  * the Compose/Activity layer via [HealthConnectClient.getOrCreate] and the
  * Health Connect permission contract.
  */
-actual class HealthIntegration(private val context: Context) {
+actual class HealthIntegration(private val context: Context) : HealthWorkoutWriter {
 
     private val client: HealthConnectClient? by lazy {
         try {
@@ -57,7 +57,7 @@ actual class HealthIntegration(private val context: Context) {
         }
     }
 
-    actual suspend fun isAvailable(): Boolean = try {
+    actual override suspend fun isAvailable(): Boolean = try {
         HealthConnectClient.getSdkStatus(context) == HealthConnectClient.SDK_AVAILABLE
     } catch (e: Exception) {
         log.w(e) { "Error checking Health Connect availability" }
@@ -70,7 +70,7 @@ actual class HealthIntegration(private val context: Context) {
      */
     actual suspend fun requestPermissions(): Boolean = hasPermissions()
 
-    actual suspend fun hasPermissions(): Boolean = hasGrantedPermissions(requiredHealthPermissions)
+    actual override suspend fun hasPermissions(): Boolean = hasGrantedPermissions(requiredHealthPermissions)
 
     private suspend fun hasCalorieWritePermission(): Boolean = hasGrantedPermissions(optionalHealthPermissions)
 
@@ -92,7 +92,7 @@ actual class HealthIntegration(private val context: Context) {
     }
 
     @SuppressLint("RestrictedApi")
-    actual suspend fun writeHealthWorkout(data: HealthWorkoutData): Result<Unit> {
+    actual override suspend fun writeHealthWorkout(data: HealthWorkoutData): Result<Unit> {
         val c = client ?: return Result.failure(
             IllegalStateException("Health Connect is not available on this device"),
         )

--- a/shared/src/androidMain/kotlin/com/devil/phoenixproject/di/PlatformModule.android.kt
+++ b/shared/src/androidMain/kotlin/com/devil/phoenixproject/di/PlatformModule.android.kt
@@ -7,6 +7,7 @@ import androidx.security.crypto.MasterKeys
 import co.touchlab.kermit.Logger
 import com.devil.phoenixproject.data.auth.OAuthLauncher
 import com.devil.phoenixproject.data.integration.HealthIntegration
+import com.devil.phoenixproject.data.integration.HealthWorkoutWriter
 import com.devil.phoenixproject.data.local.DriverFactory
 import com.devil.phoenixproject.data.repository.BleRepository
 import com.devil.phoenixproject.data.repository.KableBleRepository
@@ -68,6 +69,7 @@ actual val platformModule: Module = module {
     single { ConnectivityChecker(androidContext()) }
     single<SafeWordListenerFactory> { AndroidSafeWordListenerFactory(androidContext()) }
     single { HealthIntegration(androidContext()) }
+    single<HealthWorkoutWriter> { get<HealthIntegration>() }
     single<WorkoutServiceController> { AndroidWorkoutServiceController(androidContext()) }
     viewModel {
         MainViewModel(
@@ -89,6 +91,7 @@ actual val platformModule: Module = module {
             healthIntegration = get(),
             externalActivityRepository = get(),
             workoutServiceController = get(),
+            healthExportCursorRepository = get(),
         )
     }
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/integration/HealthBackfillManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/integration/HealthBackfillManager.kt
@@ -4,6 +4,7 @@ import co.touchlab.kermit.Logger
 import com.devil.phoenixproject.data.repository.CompletedSetRepository
 import com.devil.phoenixproject.data.repository.WorkoutRepository
 import com.devil.phoenixproject.domain.model.CompletedSet
+import com.devil.phoenixproject.domain.model.IntegrationProvider
 import com.devil.phoenixproject.domain.model.WorkoutSession
 
 private val healthBackfillLog = Logger.withTag("HealthBackfillManager")
@@ -17,14 +18,18 @@ data class HealthBackfillResult(
 class HealthBackfillManager(
     private val workoutRepository: WorkoutRepository,
     private val completedSetRepository: CompletedSetRepository,
-    private val healthIntegration: HealthIntegration,
+    private val cursorRepository: IntegrationSyncCursorRepository,
+    private val healthWriter: HealthWorkoutWriter,
 ) {
-    suspend fun syncPreviousWorkouts(profileId: String): Result<HealthBackfillResult> {
-        if (!healthIntegration.isAvailable()) {
+    suspend fun syncPreviousWorkouts(
+        provider: IntegrationProvider,
+        profileId: String,
+    ): Result<HealthBackfillResult> {
+        if (!healthWriter.isAvailable()) {
             return Result.failure(IllegalStateException("Health app is not available on this device"))
         }
 
-        if (!healthIntegration.hasPermissions()) {
+        if (!healthWriter.hasPermissions()) {
             return Result.failure(IllegalStateException("Health write permissions are not granted"))
         }
 
@@ -40,17 +45,31 @@ class HealthBackfillManager(
         }
 
         val completedSetsBySessionId = completedSetRepository
-            .getCompletedSetsForSessions(sessions.map { it.id })
+            .getCompletedSetsForSessionsChunked(sessions.map { it.id })
             .groupBy { it.sessionId }
 
         val workouts = buildWorkouts(sessions, completedSetsBySessionId)
+            .filterNot { workout ->
+                HealthExportMarkers.isExported(
+                    cursorRepository = cursorRepository,
+                    provider = provider,
+                    profileId = profileId,
+                    externalId = workout.externalId,
+                )
+            }
         var written = 0
         var firstFailure: Throwable? = null
 
         workouts.forEach { workout ->
-            healthIntegration.writeHealthWorkout(workout)
+            healthWriter.writeHealthWorkout(workout)
                 .onSuccess {
                     written += 1
+                    HealthExportMarkers.markExported(
+                        cursorRepository = cursorRepository,
+                        provider = provider,
+                        profileId = profileId,
+                        externalId = workout.externalId,
+                    )
                     healthBackfillLog.d { "Backfilled health workout ${workout.externalId}" }
                 }
                 .onFailure { error ->
@@ -65,8 +84,18 @@ class HealthBackfillManager(
             skippedWorkouts = (workouts.size - written).coerceAtLeast(0),
         )
 
-        return firstFailure?.let { Result.failure(it) } ?: Result.success(result)
+        return if (written == 0 && workouts.isNotEmpty()) {
+            Result.failure(firstFailure ?: IllegalStateException("All backfill writes failed"))
+        } else {
+            Result.success(result)
+        }
     }
+
+    private suspend fun CompletedSetRepository.getCompletedSetsForSessionsChunked(
+        sessionIds: List<String>,
+    ): List<CompletedSet> = sessionIds
+        .chunked(500)
+        .flatMap { chunk -> getCompletedSetsForSessions(chunk) }
 
     private fun buildWorkouts(
         sessions: List<WorkoutSession>,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/integration/HealthBackfillManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/integration/HealthBackfillManager.kt
@@ -1,0 +1,97 @@
+package com.devil.phoenixproject.data.integration
+
+import co.touchlab.kermit.Logger
+import com.devil.phoenixproject.data.repository.CompletedSetRepository
+import com.devil.phoenixproject.data.repository.WorkoutRepository
+import com.devil.phoenixproject.domain.model.CompletedSet
+import com.devil.phoenixproject.domain.model.WorkoutSession
+
+private val healthBackfillLog = Logger.withTag("HealthBackfillManager")
+
+data class HealthBackfillResult(
+    val eligibleWorkouts: Int,
+    val writtenWorkouts: Int,
+    val skippedWorkouts: Int,
+)
+
+class HealthBackfillManager(
+    private val workoutRepository: WorkoutRepository,
+    private val completedSetRepository: CompletedSetRepository,
+    private val healthIntegration: HealthIntegration,
+) {
+    suspend fun syncPreviousWorkouts(profileId: String): Result<HealthBackfillResult> {
+        if (!healthIntegration.isAvailable()) {
+            return Result.failure(IllegalStateException("Health app is not available on this device"))
+        }
+
+        if (!healthIntegration.hasPermissions()) {
+            return Result.failure(IllegalStateException("Health write permissions are not granted"))
+        }
+
+        val sessions = workoutRepository.getCompletedHealthExportCandidates(profileId)
+        if (sessions.isEmpty()) {
+            return Result.success(
+                HealthBackfillResult(
+                    eligibleWorkouts = 0,
+                    writtenWorkouts = 0,
+                    skippedWorkouts = 0,
+                ),
+            )
+        }
+
+        val completedSetsBySessionId = completedSetRepository
+            .getCompletedSetsForSessions(sessions.map { it.id })
+            .groupBy { it.sessionId }
+
+        val workouts = buildWorkouts(sessions, completedSetsBySessionId)
+        var written = 0
+        var firstFailure: Throwable? = null
+
+        workouts.forEach { workout ->
+            healthIntegration.writeHealthWorkout(workout)
+                .onSuccess {
+                    written += 1
+                    healthBackfillLog.d { "Backfilled health workout ${workout.externalId}" }
+                }
+                .onFailure { error ->
+                    firstFailure = firstFailure ?: error
+                    healthBackfillLog.w(error) { "Failed health backfill for ${workout.externalId}" }
+                }
+        }
+
+        val result = HealthBackfillResult(
+            eligibleWorkouts = workouts.size,
+            writtenWorkouts = written,
+            skippedWorkouts = (workouts.size - written).coerceAtLeast(0),
+        )
+
+        return firstFailure?.let { Result.failure(it) } ?: Result.success(result)
+    }
+
+    private fun buildWorkouts(
+        sessions: List<WorkoutSession>,
+        completedSetsBySessionId: Map<String, List<CompletedSet>>,
+    ): List<HealthWorkoutData> {
+        val routineWorkouts = sessions
+            .filter { it.routineSessionId != null }
+            .groupBy { it.routineSessionId.orEmpty() }
+            .mapNotNull { (routineSessionId, routineSessions) ->
+                HealthWorkoutExportBuilder.buildRoutineWorkout(
+                    routineSessionId = routineSessionId,
+                    sessions = routineSessions,
+                    completedSetsBySessionId = completedSetsBySessionId,
+                )
+            }
+
+        val standaloneWorkouts = sessions
+            .filter { it.routineSessionId == null }
+            .mapNotNull { session ->
+                HealthWorkoutExportBuilder.buildStandaloneWorkout(
+                    session = session,
+                    completedSets = completedSetsBySessionId[session.id].orEmpty(),
+                )
+            }
+
+        return (routineWorkouts + standaloneWorkouts).sortedBy { it.startTimeMs }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/integration/HealthIntegration.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/integration/HealthIntegration.kt
@@ -1,8 +1,10 @@
 package com.devil.phoenixproject.data.integration
 
 import com.devil.phoenixproject.domain.model.CompletedSet
+import com.devil.phoenixproject.domain.model.IntegrationProvider
 import com.devil.phoenixproject.domain.model.SetType
 import com.devil.phoenixproject.domain.model.WorkoutSession
+import com.devil.phoenixproject.domain.model.currentTimeMillis
 import com.devil.phoenixproject.domain.model.displayLoadMultiplier
 
 /**
@@ -96,21 +98,34 @@ object HealthWorkoutExportBuilder {
     private fun buildSegments(
         sessions: List<WorkoutSession>,
         completedSetsBySessionId: Map<String, List<CompletedSet>>,
-    ): List<HealthWorkoutSegment> = sessions
-        .sortedBy { it.timestamp }
-        .flatMap { session ->
-            val completedSets = completedSetsBySessionId[session.id]
-                .orEmpty()
-                .sortedWith(compareBy<CompletedSet> { it.setNumber }.thenBy { it.completedAt })
+    ): List<HealthWorkoutSegment> {
+        val rawSegments = sessions
+            .sortedBy { it.timestamp }
+            .flatMap { session ->
+                val completedSets = completedSetsBySessionId[session.id]
+                    .orEmpty()
+                    .sortedWith(compareBy<CompletedSet> { it.setNumber }.thenBy { it.completedAt })
 
-            if (completedSets.isNotEmpty()) {
-                completedSets.mapNotNull { completedSet ->
-                    buildSegment(session, completedSet)
+                if (completedSets.isNotEmpty()) {
+                    completedSets.mapNotNull { completedSet ->
+                        buildSegment(session, completedSet)
+                    }
+                } else {
+                    buildSegment(session, completedSet = null)?.let(::listOf).orEmpty()
                 }
-            } else {
-                buildSegment(session, completedSet = null)?.let(::listOf).orEmpty()
             }
+
+        var lastEndTimeMs = 0L
+        return rawSegments.map { segment ->
+            val adjustedStartMs = segment.startTimeMs.coerceAtLeast(lastEndTimeMs)
+            val adjustedEndMs = segment.endTimeMs.coerceAtLeast(adjustedStartMs + 1000L)
+            lastEndTimeMs = adjustedEndMs
+            segment.copy(
+                startTimeMs = adjustedStartMs,
+                endTimeMs = adjustedEndMs,
+            )
         }
+    }
 
     private fun buildSegment(
         session: WorkoutSession,
@@ -162,6 +177,45 @@ object HealthWorkoutExportBuilder {
     }
 }
 
+interface HealthWorkoutWriter {
+    suspend fun isAvailable(): Boolean
+    suspend fun hasPermissions(): Boolean
+    suspend fun writeHealthWorkout(data: HealthWorkoutData): Result<Unit>
+}
+
+object HealthExportMarkers {
+    fun cursorType(externalId: String): String = "health_export:$externalId"
+
+    suspend fun isExported(
+        cursorRepository: IntegrationSyncCursorRepository,
+        provider: IntegrationProvider,
+        profileId: String,
+        externalId: String,
+    ): Boolean = cursorRepository.getCursor(
+        provider = provider,
+        profileId = profileId,
+        cursorType = cursorType(externalId),
+    ) != null
+
+    suspend fun markExported(
+        cursorRepository: IntegrationSyncCursorRepository,
+        provider: IntegrationProvider,
+        profileId: String,
+        externalId: String,
+    ) {
+        val now = currentTimeMillis()
+        cursorRepository.upsertCursor(
+            IntegrationSyncCursor(
+                provider = provider,
+                profileId = profileId,
+                cursorType = cursorType(externalId),
+                cursorValue = now.toString(),
+                updatedAt = now,
+            ),
+        )
+    }
+}
+
 /**
  * Platform-specific health integration.
  * Android: Google Health Connect
@@ -170,10 +224,10 @@ object HealthWorkoutExportBuilder {
  * Write-only: pushes Phoenix workout data to the platform health store
  * after each completed workout.
  */
-expect class HealthIntegration {
-    suspend fun isAvailable(): Boolean
+expect class HealthIntegration : HealthWorkoutWriter {
+    override suspend fun isAvailable(): Boolean
     suspend fun requestPermissions(): Boolean
-    suspend fun hasPermissions(): Boolean
+    override suspend fun hasPermissions(): Boolean
 
     /** Write a single set/exercise session (used for Just Lift / non-routine workouts). */
     suspend fun writeWorkout(session: WorkoutSession): Result<Unit>
@@ -182,5 +236,5 @@ expect class HealthIntegration {
      * Write a health workout derived from Phoenix sessions and completed sets.
      * Android stores set-level [HealthWorkoutData.segments]; iOS stores the aggregate workout only.
      */
-    suspend fun writeHealthWorkout(data: HealthWorkoutData): Result<Unit>
+    override suspend fun writeHealthWorkout(data: HealthWorkoutData): Result<Unit>
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/integration/HealthIntegration.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/integration/HealthIntegration.kt
@@ -1,22 +1,166 @@
 package com.devil.phoenixproject.data.integration
 
+import com.devil.phoenixproject.domain.model.CompletedSet
+import com.devil.phoenixproject.domain.model.SetType
 import com.devil.phoenixproject.domain.model.WorkoutSession
+import com.devil.phoenixproject.domain.model.displayLoadMultiplier
 
 /**
- * Aggregated data for a completed routine, used to write a single
- * workout entry to the platform health store instead of one per set.
+ * Rich workout data for platform health stores.
+ *
+ * Android Health Connect can persist [segments] as exercise sets. Apple HealthKit's
+ * public workout write API cannot store comparable per-set strength segments, so
+ * iOS writes the aggregate workout fields and ignores [segments].
  */
-data class RoutineHealthData(
-    val routineName: String,
-    /** Routine start time as Unix epoch milliseconds. */
-    val startTimeMs: Long,
-    /** Total routine duration in milliseconds. */
-    val durationMs: Long,
-    /** Sum of estimated calories across all sets, or null if no set had calorie data. */
-    val totalCalories: Float?,
-    /** Deduplication key (routineSessionId). */
+data class HealthWorkoutData(
+    val title: String,
+    /** Deduplication key with a Phoenix namespace. */
     val externalId: String,
+    /** Workout start time as Unix epoch milliseconds. */
+    val startTimeMs: Long,
+    /** Workout end time as Unix epoch milliseconds. */
+    val endTimeMs: Long,
+    /** Sum of estimated calories across included sessions, or null when unavailable. */
+    val totalCalories: Float?,
+    val segments: List<HealthWorkoutSegment>,
 )
+
+data class HealthWorkoutSegment(
+    val sessionId: String,
+    val exerciseId: String?,
+    val exerciseName: String,
+    val setIndex: Int,
+    val setType: SetType,
+    val startTimeMs: Long,
+    val endTimeMs: Long,
+    val reps: Int,
+    val weightKg: Float,
+    val rpe: Int?,
+)
+
+object HealthWorkoutExportBuilder {
+    fun buildRoutineWorkout(
+        routineSessionId: String,
+        sessions: List<WorkoutSession>,
+        completedSetsBySessionId: Map<String, List<CompletedSet>>,
+    ): HealthWorkoutData? {
+        val routineSessions = sessions
+            .filter { it.routineSessionId == routineSessionId }
+            .sortedBy { it.timestamp }
+
+        if (routineSessions.isEmpty()) return null
+
+        val segments = buildSegments(routineSessions, completedSetsBySessionId)
+        if (segments.isEmpty()) return null
+
+        val title = routineSessions.firstNotNullOfOrNull { session ->
+            session.routineName?.takeIf { it.isNotBlank() }
+        } ?: "Phoenix Routine"
+
+        return HealthWorkoutData(
+            title = title,
+            externalId = routineClientRecordId(routineSessionId),
+            startTimeMs = segments.minOf { it.startTimeMs },
+            endTimeMs = segments.maxOf { it.endTimeMs },
+            totalCalories = routineSessions.sumPositiveCalories(),
+            segments = segments,
+        )
+    }
+
+    fun buildStandaloneWorkout(
+        session: WorkoutSession,
+        completedSets: List<CompletedSet>,
+    ): HealthWorkoutData? {
+        val segments = buildSegments(
+            sessions = listOf(session),
+            completedSetsBySessionId = mapOf(session.id to completedSets),
+        )
+        if (segments.isEmpty()) return null
+
+        return HealthWorkoutData(
+            title = session.exerciseName?.takeIf { it.isNotBlank() } ?: "Phoenix Workout",
+            externalId = sessionClientRecordId(session.id),
+            startTimeMs = segments.minOf { it.startTimeMs },
+            endTimeMs = segments.maxOf { it.endTimeMs },
+            totalCalories = listOf(session).sumPositiveCalories(),
+            segments = segments,
+        )
+    }
+
+    fun routineClientRecordId(routineSessionId: String): String = "phoenix:routine:$routineSessionId"
+
+    fun sessionClientRecordId(sessionId: String): String = "phoenix:session:$sessionId"
+
+    fun calorieClientRecordId(externalId: String): String = "$externalId:calories"
+
+    private fun buildSegments(
+        sessions: List<WorkoutSession>,
+        completedSetsBySessionId: Map<String, List<CompletedSet>>,
+    ): List<HealthWorkoutSegment> = sessions
+        .sortedBy { it.timestamp }
+        .flatMap { session ->
+            val completedSets = completedSetsBySessionId[session.id]
+                .orEmpty()
+                .sortedWith(compareBy<CompletedSet> { it.setNumber }.thenBy { it.completedAt })
+
+            if (completedSets.isNotEmpty()) {
+                completedSets.mapNotNull { completedSet ->
+                    buildSegment(session, completedSet)
+                }
+            } else {
+                buildSegment(session, completedSet = null)?.let(::listOf).orEmpty()
+            }
+        }
+
+    private fun buildSegment(
+        session: WorkoutSession,
+        completedSet: CompletedSet?,
+    ): HealthWorkoutSegment? {
+        val reps = completedSet?.actualReps
+            ?: session.workingReps.takeIf { it > 0 }
+            ?: session.totalReps.takeIf { it > 0 }
+            ?: return null
+        if (reps <= 0) return null
+
+        val (startTimeMs, endTimeMs) = segmentTimes(session, completedSet)
+        val weightKg = session.weightPerCableKg * session.displayLoadMultiplier().toFloat()
+        val exerciseName = session.exerciseName?.takeIf { it.isNotBlank() } ?: "Phoenix Workout"
+
+        return HealthWorkoutSegment(
+            sessionId = session.id,
+            exerciseId = session.exerciseId,
+            exerciseName = exerciseName,
+            setIndex = completedSet?.setNumber?.coerceAtLeast(0) ?: 0,
+            setType = completedSet?.setType ?: SetType.STANDARD,
+            startTimeMs = startTimeMs,
+            endTimeMs = endTimeMs,
+            reps = reps,
+            weightKg = weightKg.coerceAtLeast(0f),
+            rpe = (completedSet?.loggedRpe ?: session.rpe)?.coerceIn(0, 10),
+        )
+    }
+
+    private fun segmentTimes(
+        session: WorkoutSession,
+        completedSet: CompletedSet?,
+    ): Pair<Long, Long> {
+        val fallbackDurationMs = session.duration.coerceAtLeast(1000L)
+        val fallbackStartMs = session.timestamp
+        val fallbackEndMs = (fallbackStartMs + fallbackDurationMs).coerceAtLeast(fallbackStartMs + 1000L)
+        val completedAtMs = completedSet?.completedAt ?: return fallbackStartMs to fallbackEndMs
+        if (completedAtMs <= fallbackStartMs) return fallbackStartMs to fallbackEndMs
+
+        val startMs = (completedAtMs - fallbackDurationMs).coerceAtLeast(fallbackStartMs)
+        val endMs = completedAtMs.coerceAtLeast(startMs + 1000L)
+        return startMs to endMs
+    }
+
+    private fun List<WorkoutSession>.sumPositiveCalories(): Float? {
+        val total = mapNotNull { it.estimatedCalories?.takeIf { calories -> calories > 0f } }
+            .sum()
+        return total.takeIf { it > 0f }
+    }
+}
 
 /**
  * Platform-specific health integration.
@@ -35,9 +179,8 @@ expect class HealthIntegration {
     suspend fun writeWorkout(session: WorkoutSession): Result<Unit>
 
     /**
-     * Write a single aggregate workout for an entire routine.
-     * Issue #395: Replaces per-set writes so Apple Health / Google Health
-     * show one workout entry per routine instead of one per set.
+     * Write a health workout derived from Phoenix sessions and completed sets.
+     * Android stores set-level [HealthWorkoutData.segments]; iOS stores the aggregate workout only.
      */
-    suspend fun writeRoutineWorkout(data: RoutineHealthData): Result<Unit>
+    suspend fun writeHealthWorkout(data: HealthWorkoutData): Result<Unit>
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/CompletedSetRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/CompletedSetRepository.kt
@@ -51,6 +51,11 @@ interface CompletedSetRepository {
     suspend fun getCompletedSets(sessionId: String): List<CompletedSet>
 
     /**
+     * Get completed sets for multiple workout sessions, ordered by session and set number.
+     */
+    suspend fun getCompletedSetsForSessions(sessionIds: List<String>): List<CompletedSet>
+
+    /**
      * Get completed sets as a Flow for reactive updates.
      */
     fun getCompletedSetsFlow(sessionId: String): Flow<List<CompletedSet>>

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightCompletedSetRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightCompletedSetRepository.kt
@@ -140,6 +140,14 @@ class SqlDelightCompletedSetRepository(db: VitruvianDatabase) : CompletedSetRepo
         queries.selectCompletedSetsBySession(sessionId, ::mapToCompletedSet).executeAsList()
     }
 
+    override suspend fun getCompletedSetsForSessions(sessionIds: List<String>): List<CompletedSet> = withContext(Dispatchers.IO) {
+        if (sessionIds.isEmpty()) {
+            emptyList()
+        } else {
+            queries.selectCompletedSetsBySessionIds(sessionIds, ::mapToCompletedSet).executeAsList()
+        }
+    }
+
     override fun getCompletedSetsFlow(sessionId: String): Flow<List<CompletedSet>> = queries.selectCompletedSetsBySession(sessionId, ::mapToCompletedSet)
         .asFlow().mapToList(Dispatchers.IO)
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepository.kt
@@ -971,6 +971,24 @@ class SqlDelightWorkoutRepository(private val db: VitruvianDatabase, private val
         queries.selectSessionById(sessionId, ::mapToSession).executeAsOneOrNull()
     }
 
+    override suspend fun getSessionsForRoutineSession(
+        profileId: String,
+        routineSessionId: String,
+    ): List<WorkoutSession> = withContext(Dispatchers.IO) {
+        queries.selectSessionsByRoutineSessionId(
+            profileId = profileId,
+            routineSessionId = routineSessionId,
+            mapper = ::mapToSession,
+        ).executeAsList()
+    }
+
+    override suspend fun getCompletedHealthExportCandidates(profileId: String): List<WorkoutSession> = withContext(Dispatchers.IO) {
+        queries.selectCompletedHealthExportCandidates(
+            profileId = profileId,
+            mapper = ::mapToSession,
+        ).executeAsList()
+    }
+
     override suspend fun markRoutineUsed(routineId: String) {
         withContext(Dispatchers.IO) {
             if (routineId.isBlank()) return@withContext

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/WorkoutRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/WorkoutRepository.kt
@@ -40,6 +40,16 @@ interface WorkoutRepository {
      */
     suspend fun getSession(sessionId: String): WorkoutSession?
 
+    /**
+     * Get completed workout sessions belonging to a routine session.
+     */
+    suspend fun getSessionsForRoutineSession(profileId: String, routineSessionId: String): List<WorkoutSession>
+
+    /**
+     * Get completed local sessions that can be exported to platform health stores.
+     */
+    suspend fun getCompletedHealthExportCandidates(profileId: String): List<WorkoutSession>
+
     // Routines
     fun getAllRoutines(profileId: String): Flow<List<Routine>>
     suspend fun saveRoutine(routine: Routine)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/di/DataModule.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/di/DataModule.kt
@@ -5,6 +5,7 @@ import com.devil.phoenixproject.data.integration.ExternalExerciseTemplateReposit
 import com.devil.phoenixproject.data.integration.ExternalMeasurementRepository
 import com.devil.phoenixproject.data.integration.ExternalProgramRepository
 import com.devil.phoenixproject.data.integration.ExternalRoutineRepository
+import com.devil.phoenixproject.data.integration.HealthBackfillManager
 import com.devil.phoenixproject.data.integration.IntegrationSyncCursorRepository
 import com.devil.phoenixproject.data.integration.SqlDelightExternalActivityRepository
 import com.devil.phoenixproject.data.integration.SqlDelightExternalExerciseTemplateRepository
@@ -58,4 +59,5 @@ val dataModule = module {
     single<ExternalMeasurementRepository> { SqlDelightExternalMeasurementRepository(get()) }
     single<ExternalExerciseTemplateRepository> { SqlDelightExternalExerciseTemplateRepository(get()) }
     single<IntegrationSyncCursorRepository> { SqlDelightIntegrationSyncCursorRepository(get()) }
+    single { HealthBackfillManager(get(), get(), get()) }
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/di/DataModule.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/di/DataModule.kt
@@ -59,5 +59,5 @@ val dataModule = module {
     single<ExternalMeasurementRepository> { SqlDelightExternalMeasurementRepository(get()) }
     single<ExternalExerciseTemplateRepository> { SqlDelightExternalExerciseTemplateRepository(get()) }
     single<IntegrationSyncCursorRepository> { SqlDelightIntegrationSyncCursorRepository(get()) }
-    single { HealthBackfillManager(get(), get(), get()) }
+    single { HealthBackfillManager(get(), get(), get(), get()) }
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/di/PresentationModule.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/di/PresentationModule.kt
@@ -21,7 +21,7 @@ val presentationModule = module {
     factory { DiagnosticsViewModel(get()) }
     factory { CycleEditorViewModel(get(), get()) }
     factory { GamificationViewModel(get(), get()) }
-    factory { IntegrationsViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
+    factory { IntegrationsViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
     factory { ExternalActivitiesViewModel(get(), get()) }
     factory { ExternalRoutinesViewModel(get(), get()) }
     factory { ExternalProgramsViewModel(get(), get(), get()) }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -3,7 +3,7 @@ package com.devil.phoenixproject.presentation.manager
 import co.touchlab.kermit.Logger
 import com.devil.phoenixproject.data.integration.ExternalActivityRepository
 import com.devil.phoenixproject.data.integration.HealthIntegration
-import com.devil.phoenixproject.data.integration.RoutineHealthData
+import com.devil.phoenixproject.data.integration.HealthWorkoutExportBuilder
 import com.devil.phoenixproject.data.preferences.PreferencesManager
 import com.devil.phoenixproject.data.repository.AutoStopUiState
 import com.devil.phoenixproject.data.repository.BiomechanicsRepository
@@ -2714,8 +2714,6 @@ class ActiveSessionEngine(
                 coordinator._completedRoutineSetKeys.update {
                     it + (coordinator._currentExerciseIndex.value to coordinator._currentSetIndex.value)
                 }
-            } else if (!isRoutineSet) {
-                enqueueWorkoutHealthPush(session)
             }
             val persistedSummary = summary.copy(
                 sessionId = session.id,
@@ -2762,6 +2760,10 @@ class ActiveSessionEngine(
             if (hasPR && completedSetId != null) {
                 completedSetRepository.markAsPr(completedSetId)
                 Logger.d("Marked CompletedSet $completedSetId as PR (manual stop)")
+            }
+
+            if (!isRoutineSet) {
+                enqueueWorkoutHealthPush(session)
             }
 
             scope.launch {
@@ -3000,7 +3002,19 @@ class ActiveSessionEngine(
                     return@launch
                 }
 
-                healthIntegration.writeWorkout(session)
+                val completedSets = completedSetRepository.getCompletedSets(session.id)
+                val data = HealthWorkoutExportBuilder.buildStandaloneWorkout(
+                    session = session,
+                    completedSets = completedSets,
+                )
+                if (data == null) {
+                    Logger.i("ActiveSessionEngine") {
+                        "Health auto-push skipped: no exportable segments for sessionId=${session.id}"
+                    }
+                    return@launch
+                }
+
+                healthIntegration.writeHealthWorkout(data)
                     .onSuccess {
                         Logger.i("ActiveSessionEngine") { "Auto-pushed workout to ${provider.displayName}: sessionId=${session.id}" }
                     }
@@ -3062,17 +3076,29 @@ class ActiveSessionEngine(
                     return@launch
                 }
 
-                val data = RoutineHealthData(
-                    routineName = routineName,
-                    startTimeMs = startTime,
-                    durationMs = durationMs,
-                    totalCalories = totalCalories,
-                    externalId = routineSessionId,
+                val sessions = workoutRepository.getSessionsForRoutineSession(
+                    profileId = profileId,
+                    routineSessionId = routineSessionId,
                 )
-                healthIntegration.writeRoutineWorkout(data)
+                val completedSetsBySessionId = completedSetRepository
+                    .getCompletedSetsForSessions(sessions.map { it.id })
+                    .groupBy { it.sessionId }
+                val data = HealthWorkoutExportBuilder.buildRoutineWorkout(
+                    routineSessionId = routineSessionId,
+                    sessions = sessions,
+                    completedSetsBySessionId = completedSetsBySessionId,
+                )
+                if (data == null) {
+                    Logger.i("ActiveSessionEngine") {
+                        "Routine health push skipped: no persisted exportable segments for routineSessionId=$routineSessionId"
+                    }
+                    return@launch
+                }
+
+                healthIntegration.writeHealthWorkout(data)
                     .onSuccess {
                         Logger.i("ActiveSessionEngine") {
-                            "Auto-pushed routine workout to ${provider.displayName}: $routineName (${durationMs / 1000}s)"
+                            "Auto-pushed routine workout to ${provider.displayName}: $routineName (${durationMs / 1000}s, segments=${data.segments.size})"
                         }
                     }
                     .onFailure { e ->
@@ -3223,13 +3249,6 @@ class ActiveSessionEngine(
             }
         }
 
-        // Fire-and-forget health push: auto-push to Health Connect (Android) or HealthKit (iOS)
-        // after the session is persisted. Failure is non-fatal and never blocks workout completion.
-        // Issue #395: Skip per-set writes for routine sets — aggregate written at routine completion.
-        if (!isRoutineSet) {
-            enqueueWorkoutHealthPush(session)
-        }
-
         if (metricsSnapshot.isNotEmpty()) {
             workoutRepository.saveMetrics(sessionId, metricsSnapshot)
         }
@@ -3274,6 +3293,12 @@ class ActiveSessionEngine(
         if (hasPR && completedSetId != null) {
             completedSetRepository.markAsPr(completedSetId)
             Logger.d("Marked CompletedSet $completedSetId as PR")
+        }
+
+        // Fire-and-forget health push after session, metrics, CompletedSet, and PR persistence.
+        // Issue #395: Skip per-set writes for routine sets; aggregate is written at routine completion.
+        if (!isRoutineSet) {
+            enqueueWorkoutHealthPush(session)
         }
 
         // Sync trigger AFTER all persistence (session, metrics, CompletedSet, PR marking)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -2,8 +2,10 @@ package com.devil.phoenixproject.presentation.manager
 
 import co.touchlab.kermit.Logger
 import com.devil.phoenixproject.data.integration.ExternalActivityRepository
+import com.devil.phoenixproject.data.integration.HealthExportMarkers
 import com.devil.phoenixproject.data.integration.HealthIntegration
 import com.devil.phoenixproject.data.integration.HealthWorkoutExportBuilder
+import com.devil.phoenixproject.data.integration.IntegrationSyncCursorRepository
 import com.devil.phoenixproject.data.preferences.PreferencesManager
 import com.devil.phoenixproject.data.repository.AutoStopUiState
 import com.devil.phoenixproject.data.repository.BiomechanicsRepository
@@ -95,6 +97,7 @@ class ActiveSessionEngine(
     private val dataBackupManager: DataBackupManager? = null,
     private val healthIntegration: HealthIntegration? = null,
     private val externalActivityRepository: ExternalActivityRepository? = null,
+    private val healthExportCursorRepository: IntegrationSyncCursorRepository? = null,
     private val elapsedRealtimeProvider: () -> Long = ::elapsedRealtimeMillis,
 ) {
 
@@ -3013,9 +3016,19 @@ class ActiveSessionEngine(
                     }
                     return@launch
                 }
+                val cursorRepository = healthExportCursorRepository
+                if (cursorRepository != null && HealthExportMarkers.isExported(cursorRepository, provider, profileId, data.externalId)) {
+                    Logger.i("ActiveSessionEngine") {
+                        "Health auto-push skipped: ${data.externalId} is already marked exported"
+                    }
+                    return@launch
+                }
 
                 healthIntegration.writeHealthWorkout(data)
                     .onSuccess {
+                        if (cursorRepository != null) {
+                            HealthExportMarkers.markExported(cursorRepository, provider, profileId, data.externalId)
+                        }
                         Logger.i("ActiveSessionEngine") { "Auto-pushed workout to ${provider.displayName}: sessionId=${session.id}" }
                     }
                     .onFailure { e ->
@@ -3094,9 +3107,19 @@ class ActiveSessionEngine(
                     }
                     return@launch
                 }
+                val cursorRepository = healthExportCursorRepository
+                if (cursorRepository != null && HealthExportMarkers.isExported(cursorRepository, provider, profileId, data.externalId)) {
+                    Logger.i("ActiveSessionEngine") {
+                        "Routine health push skipped: ${data.externalId} is already marked exported"
+                    }
+                    return@launch
+                }
 
                 healthIntegration.writeHealthWorkout(data)
                     .onSuccess {
+                        if (cursorRepository != null) {
+                            HealthExportMarkers.markExported(cursorRepository, provider, profileId, data.externalId)
+                        }
                         Logger.i("ActiveSessionEngine") {
                             "Auto-pushed routine workout to ${provider.displayName}: $routineName (${durationMs / 1000}s, segments=${data.segments.size})"
                         }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/DefaultWorkoutSessionManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/DefaultWorkoutSessionManager.kt
@@ -3,6 +3,7 @@ package com.devil.phoenixproject.presentation.manager
 import co.touchlab.kermit.Logger
 import com.devil.phoenixproject.data.integration.ExternalActivityRepository
 import com.devil.phoenixproject.data.integration.HealthIntegration
+import com.devil.phoenixproject.data.integration.IntegrationSyncCursorRepository
 import com.devil.phoenixproject.data.preferences.PreferencesManager
 import com.devil.phoenixproject.data.repository.BiomechanicsRepository
 import com.devil.phoenixproject.data.repository.BleRepository
@@ -151,6 +152,7 @@ class DefaultWorkoutSessionManager(
     private val healthIntegration: HealthIntegration? = null,
     private val externalActivityRepository: ExternalActivityRepository? = null,
     private val workoutServiceController: WorkoutServiceController,
+    private val healthExportCursorRepository: IntegrationSyncCursorRepository? = null,
     private val scope: CoroutineScope,
     private val elapsedRealtimeProvider: () -> Long = ::elapsedRealtimeMillis,
     private val _hapticEvents: MutableSharedFlow<HapticEvent> = MutableSharedFlow(
@@ -230,6 +232,7 @@ class DefaultWorkoutSessionManager(
         dataBackupManager = dataBackupManager,
         healthIntegration = healthIntegration,
         externalActivityRepository = externalActivityRepository,
+        healthExportCursorRepository = healthExportCursorRepository,
         elapsedRealtimeProvider = elapsedRealtimeProvider,
     )
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/IntegrationsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/IntegrationsScreen.kt
@@ -255,18 +255,52 @@ fun IntegrationsScreen(
             val healthProvider = if (isIosPlatform) IntegrationProvider.APPLE_HEALTH else IntegrationProvider.GOOGLE_HEALTH
             val healthStatus = uiState.integrationStatuses[healthProvider]
             val healthConnected = healthStatus?.status == ConnectionStatus.CONNECTED
+            val healthError = healthStatus?.status == ConnectionStatus.ERROR
+            val healthBusy = uiState.operationLoading.any { it.startsWith("${healthProvider.key}:") }
 
             IntegrationCard(
                 title = if (isIosPlatform) "Apple Health" else "Google Health Connect",
-                subtitle = if (healthConnected) "Connected" else "Not connected",
+                subtitle = when {
+                    healthConnected -> "Connected"
+                    healthError -> healthStatus.errorMessage ?: "Permissions need attention"
+                    else -> "Not connected"
+                },
                 statusConnected = healthConnected,
                 trailingContent = {
-                    Switch(
-                        checked = healthConnected,
-                        onCheckedChange = { enabled ->
-                            viewModel.toggleHealthIntegration(enabled)
-                        },
-                    )
+                    Column(
+                        horizontalAlignment = Alignment.End,
+                        verticalArrangement = Arrangement.spacedBy(4.dp),
+                    ) {
+                        Switch(
+                            checked = healthConnected,
+                            onCheckedChange = { enabled ->
+                                viewModel.toggleHealthIntegration(enabled)
+                            },
+                        )
+                        if (healthError) {
+                            TextButton(
+                                onClick = { viewModel.retryHealthPermissions() },
+                                enabled = !healthBusy,
+                                modifier = Modifier.height(32.dp),
+                            ) {
+                                Text("Retry permissions", style = MaterialTheme.typography.labelMedium)
+                            }
+                        }
+                        if (healthConnected || healthError) {
+                            OutlinedButton(
+                                onClick = { viewModel.syncPreviousHealthWorkouts() },
+                                enabled = !healthBusy,
+                                shape = RoundedCornerShape(12.dp),
+                                modifier = Modifier.height(36.dp),
+                            ) {
+                                if (healthBusy) {
+                                    CircularProgressIndicator(Modifier.size(14.dp), strokeWidth = 2.dp)
+                                } else {
+                                    Text("Sync previous", style = MaterialTheme.typography.labelMedium)
+                                }
+                            }
+                        }
+                    }
                 },
             )
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/IntegrationsViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/IntegrationsViewModel.kt
@@ -440,7 +440,10 @@ class IntegrationsViewModel(
             val provider = platformHealthProvider()
             setOperationLoading(provider, "health_backfill", true)
             try {
-                healthBackfillManager.syncPreviousWorkouts(profileId)
+                healthBackfillManager.syncPreviousWorkouts(
+                    provider = provider,
+                    profileId = profileId,
+                )
                     .onSuccess { result ->
                         externalActivityRepo.updateIntegrationStatus(
                             provider = provider,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/IntegrationsViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/IntegrationsViewModel.kt
@@ -10,6 +10,7 @@ import com.devil.phoenixproject.data.integration.ExternalExerciseTemplateReposit
 import com.devil.phoenixproject.data.integration.ExternalMeasurementRepository
 import com.devil.phoenixproject.data.integration.ExternalProgramRepository
 import com.devil.phoenixproject.data.integration.ExternalRoutineRepository
+import com.devil.phoenixproject.data.integration.HealthBackfillManager
 import com.devil.phoenixproject.data.integration.HealthIntegration
 import com.devil.phoenixproject.data.integration.IntegrationManager
 import com.devil.phoenixproject.data.repository.SubscriptionStatus
@@ -28,6 +29,7 @@ import com.devil.phoenixproject.domain.model.IntegrationStatus
 import com.devil.phoenixproject.domain.model.IntegrationSyncProgress
 import com.devil.phoenixproject.domain.model.IntegrationSyncResult
 import com.devil.phoenixproject.domain.model.WeightUnit
+import com.devil.phoenixproject.domain.model.currentTimeMillis
 import com.devil.phoenixproject.isIosPlatform
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -80,6 +82,7 @@ class IntegrationsViewModel(
     private val integrationManager: IntegrationManager,
     private val workoutRepository: WorkoutRepository,
     private val healthIntegration: HealthIntegration,
+    private val healthBackfillManager: HealthBackfillManager,
     private val userProfileRepository: UserProfileRepository,
     private val portalTokenStorage: PortalTokenStorage,
 ) : ViewModel() {
@@ -424,6 +427,59 @@ class IntegrationsViewModel(
             val profileId = activeProfileId.value
             val provider = platformHealthProvider()
             applyHealthPermissionResult(provider, profileId, granted)
+        }
+    }
+
+    fun retryHealthPermissions() {
+        toggleHealthIntegration(enable = true)
+    }
+
+    fun syncPreviousHealthWorkouts() {
+        viewModelScope.launch {
+            val profileId = activeProfileId.value
+            val provider = platformHealthProvider()
+            setOperationLoading(provider, "health_backfill", true)
+            try {
+                healthBackfillManager.syncPreviousWorkouts(profileId)
+                    .onSuccess { result ->
+                        externalActivityRepo.updateIntegrationStatus(
+                            provider = provider,
+                            status = com.devil.phoenixproject.domain.model.ConnectionStatus.CONNECTED,
+                            profileId = profileId,
+                            lastSyncAt = currentTimeMillis(),
+                        )
+                        _uiState.value = _uiState.value.copy(
+                            successMessage = "Synced ${result.writtenWorkouts} previous health workout(s)",
+                        )
+                        log.i {
+                            "Health backfill complete for ${provider.key}: " +
+                                "eligible=${result.eligibleWorkouts}, written=${result.writtenWorkouts}, skipped=${result.skippedWorkouts}"
+                        }
+                    }
+                    .onFailure { error ->
+                        externalActivityRepo.updateIntegrationStatus(
+                            provider = provider,
+                            status = com.devil.phoenixproject.domain.model.ConnectionStatus.ERROR,
+                            profileId = profileId,
+                            errorMessage = error.message,
+                        )
+                        _uiState.value = _uiState.value.copy(
+                            errorMessage = "Health sync failed: ${error.message}",
+                        )
+                        log.w(error) { "Health backfill failed for ${provider.key}" }
+                    }
+            } catch (e: Exception) {
+                log.e(e) { "Unexpected error syncing previous health workouts" }
+                externalActivityRepo.updateIntegrationStatus(
+                    provider = provider,
+                    status = com.devil.phoenixproject.domain.model.ConnectionStatus.ERROR,
+                    profileId = profileId,
+                    errorMessage = e.message,
+                )
+                _uiState.value = _uiState.value.copy(errorMessage = "Health sync failed: ${e.message}")
+            } finally {
+                setOperationLoading(provider, "health_backfill", false)
+            }
         }
     }
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
 import com.devil.phoenixproject.data.integration.ExternalActivityRepository
 import com.devil.phoenixproject.data.integration.HealthIntegration
+import com.devil.phoenixproject.data.integration.IntegrationSyncCursorRepository
 import com.devil.phoenixproject.data.preferences.PreferencesManager
 import com.devil.phoenixproject.data.repository.AutoStopUiState
 import com.devil.phoenixproject.data.repository.BiomechanicsRepository
@@ -89,6 +90,7 @@ class MainViewModel constructor(
     private val healthIntegration: HealthIntegration? = null,
     private val externalActivityRepository: ExternalActivityRepository? = null,
     private val workoutServiceController: WorkoutServiceController,
+    private val healthExportCursorRepository: IntegrationSyncCursorRepository? = null,
 ) : ViewModel() {
 
     // Shared haptic events flow - created here, passed to both GamificationManager and WorkoutSessionManager
@@ -133,6 +135,7 @@ class MainViewModel constructor(
         userProfileRepository = userProfileRepository,
         healthIntegration = healthIntegration,
         externalActivityRepository = externalActivityRepository,
+        healthExportCursorRepository = healthExportCursorRepository,
         workoutServiceController = workoutServiceController,
         scope = viewModelScope,
         _hapticEvents = _hapticEvents,

--- a/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
+++ b/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
@@ -554,6 +554,21 @@ SELECT id FROM WorkoutSession;
 selectRecentSessions:
 SELECT * FROM WorkoutSession WHERE profile_id = :profileId ORDER BY timestamp DESC LIMIT :limit;
 
+selectSessionsByRoutineSessionId:
+SELECT * FROM WorkoutSession
+WHERE profile_id = :profileId
+AND routineSessionId = :routineSessionId
+AND deletedAt IS NULL
+AND (workingReps > 0 OR totalReps > 0)
+ORDER BY timestamp ASC;
+
+selectCompletedHealthExportCandidates:
+SELECT * FROM WorkoutSession
+WHERE profile_id = :profileId
+AND deletedAt IS NULL
+AND (workingReps > 0 OR totalReps > 0)
+ORDER BY timestamp ASC;
+
 selectSessionsForPhasePRBackfill:
 SELECT * FROM WorkoutSession
 WHERE profile_id = :profileId
@@ -1620,6 +1635,11 @@ DELETE FROM PlannedSet WHERE routine_exercise_id = ?;
 -- CompletedSet Queries
 selectCompletedSetsBySession:
 SELECT * FROM CompletedSet WHERE session_id = ? ORDER BY set_number ASC;
+
+selectCompletedSetsBySessionIds:
+SELECT * FROM CompletedSet
+WHERE session_id IN :sessionIds
+ORDER BY session_id ASC, set_number ASC, completed_at ASC;
 
 selectCompletedSetById:
 SELECT * FROM CompletedSet WHERE id = ?;

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/integration/HealthBackfillManagerTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/integration/HealthBackfillManagerTest.kt
@@ -1,0 +1,169 @@
+package com.devil.phoenixproject.data.integration
+
+import com.devil.phoenixproject.domain.model.CompletedSet
+import com.devil.phoenixproject.domain.model.IntegrationProvider
+import com.devil.phoenixproject.domain.model.SetType
+import com.devil.phoenixproject.domain.model.WorkoutSession
+import com.devil.phoenixproject.testutil.FakeCompletedSetRepository
+import com.devil.phoenixproject.testutil.FakeIntegrationSyncCursorRepository
+import com.devil.phoenixproject.testutil.FakeWorkoutRepository
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+
+class HealthBackfillManagerTest {
+
+    @Test
+    fun chunksCompletedSetLookupsAndDoesNotFailWhenOneWorkoutFails() = runTest {
+        val workoutRepository = FakeWorkoutRepository()
+        val completedSetRepository = CountingCompletedSetRepository()
+        val cursorRepository = FakeIntegrationSyncCursorRepository()
+        val writer = FakeHealthWorkoutWriter(failExternalIds = setOf("phoenix:session:session-2"))
+
+        repeat(1_001) { index ->
+            val session = workoutSession(id = "session-$index", timestamp = index * 10_000L)
+            workoutRepository.addSession(session)
+            completedSetRepository.saveCompletedSet(
+                completedSet(
+                    sessionId = session.id,
+                    completedAt = session.timestamp + session.duration,
+                ),
+            )
+        }
+
+        val result = HealthBackfillManager(
+            workoutRepository = workoutRepository,
+            completedSetRepository = completedSetRepository,
+            cursorRepository = cursorRepository,
+            healthWriter = writer,
+        ).syncPreviousWorkouts(
+            provider = IntegrationProvider.GOOGLE_HEALTH,
+            profileId = "default",
+        )
+
+        assertTrue(result.isSuccess)
+        assertEquals(1_001, result.getOrThrow().eligibleWorkouts)
+        assertEquals(1_000, result.getOrThrow().writtenWorkouts)
+        assertEquals(1, result.getOrThrow().skippedWorkouts)
+        assertEquals(listOf(500, 500, 1), completedSetRepository.requestedBatchSizes)
+    }
+
+    @Test
+    fun skipsWorkoutsAlreadyMarkedAsExported() = runTest {
+        val workoutRepository = FakeWorkoutRepository()
+        val completedSetRepository = CountingCompletedSetRepository()
+        val cursorRepository = FakeIntegrationSyncCursorRepository()
+        val writer = FakeHealthWorkoutWriter()
+        val session = workoutSession(id = "already-exported")
+        workoutRepository.addSession(session)
+        completedSetRepository.saveCompletedSet(
+            completedSet(
+                sessionId = session.id,
+                completedAt = session.timestamp + session.duration,
+            ),
+        )
+
+        HealthExportMarkers.markExported(
+            cursorRepository = cursorRepository,
+            provider = IntegrationProvider.APPLE_HEALTH,
+            profileId = "default",
+            externalId = "phoenix:session:${session.id}",
+        )
+
+        val result = HealthBackfillManager(
+            workoutRepository = workoutRepository,
+            completedSetRepository = completedSetRepository,
+            cursorRepository = cursorRepository,
+            healthWriter = writer,
+        ).syncPreviousWorkouts(
+            provider = IntegrationProvider.APPLE_HEALTH,
+            profileId = "default",
+        )
+
+        assertTrue(result.isSuccess)
+        assertEquals(0, result.getOrThrow().eligibleWorkouts)
+        assertEquals(0, writer.writes.size)
+    }
+
+    @Test
+    fun failsBackfillOnlyWhenAllWritesFail() = runTest {
+        val workoutRepository = FakeWorkoutRepository()
+        val completedSetRepository = CountingCompletedSetRepository()
+        val cursorRepository = FakeIntegrationSyncCursorRepository()
+        val writer = FakeHealthWorkoutWriter(failAll = true)
+        val session = workoutSession(id = "failed")
+        workoutRepository.addSession(session)
+        completedSetRepository.saveCompletedSet(
+            completedSet(
+                sessionId = session.id,
+                completedAt = session.timestamp + session.duration,
+            ),
+        )
+
+        val result = HealthBackfillManager(
+            workoutRepository = workoutRepository,
+            completedSetRepository = completedSetRepository,
+            cursorRepository = cursorRepository,
+            healthWriter = writer,
+        ).syncPreviousWorkouts(
+            provider = IntegrationProvider.GOOGLE_HEALTH,
+            profileId = "default",
+        )
+
+        assertFalse(result.isSuccess)
+    }
+
+    private class CountingCompletedSetRepository : FakeCompletedSetRepository() {
+        val requestedBatchSizes = mutableListOf<Int>()
+
+        override suspend fun getCompletedSetsForSessions(sessionIds: List<String>): List<CompletedSet> {
+            requestedBatchSizes += sessionIds.size
+            return super.getCompletedSetsForSessions(sessionIds)
+        }
+    }
+
+    private class FakeHealthWorkoutWriter(
+        private val failExternalIds: Set<String> = emptySet(),
+        private val failAll: Boolean = false,
+    ) : HealthWorkoutWriter {
+        val writes = mutableListOf<HealthWorkoutData>()
+
+        override suspend fun isAvailable(): Boolean = true
+
+        override suspend fun hasPermissions(): Boolean = true
+
+        override suspend fun writeHealthWorkout(data: HealthWorkoutData): Result<Unit> {
+            writes += data
+            return if (failAll || data.externalId in failExternalIds) {
+                Result.failure(IllegalStateException("write failed for ${data.externalId}"))
+            } else {
+                Result.success(Unit)
+            }
+        }
+    }
+
+    private fun workoutSession(id: String, timestamp: Long = 10_000L) = WorkoutSession(
+        id = id,
+        timestamp = timestamp,
+        duration = 5_000L,
+        exerciseId = "exercise",
+        exerciseName = "Cable Row",
+        workingReps = 8,
+        weightPerCableKg = 20f,
+    )
+
+    private fun completedSet(sessionId: String, completedAt: Long) = CompletedSet(
+        id = "set-$sessionId",
+        sessionId = sessionId,
+        plannedSetId = null,
+        setNumber = 0,
+        setType = SetType.STANDARD,
+        actualReps = 8,
+        actualWeightKg = 20f,
+        loggedRpe = null,
+        isPr = false,
+        completedAt = completedAt,
+    )
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/integration/HealthDataMappingTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/integration/HealthDataMappingTest.kt
@@ -121,12 +121,12 @@ class HealthDataMappingTest {
         assertEquals(true, shouldIncludeCalories(250f))
     }
 
-    // ---- Issue #395: RoutineHealthData construction ----
+    // ---- Issue #395 / #513: HealthWorkoutData construction ----
 
     @Test
-    fun routineHealthDataHasCorrectTitle() {
+    fun healthWorkoutDataHasCorrectTitle() {
         val data = buildRoutineHealthData(routineName = "Push Day", totalCalories = 150f)
-        assertEquals("Push Day", data.routineName)
+        assertEquals("Push Day", data.title)
     }
 
     @Test
@@ -159,7 +159,7 @@ class HealthDataMappingTest {
             durationMs = durationMs,
             totalCalories = 300f,
         )
-        assertEquals(3600000L, data.durationMs)
+        assertEquals(endMs, data.endTimeMs)
         assertEquals(startMs, data.startTimeMs)
     }
 
@@ -186,18 +186,19 @@ class HealthDataMappingTest {
 
     private fun shouldIncludeCalories(estimatedCalories: Float?): Boolean = estimatedCalories != null && estimatedCalories > 0f
 
-    /** Mirrors the routine health data construction in writeRoutineHealthData() */
+    /** Mirrors the aggregate health workout data construction in writeRoutineHealthData() */
     private fun buildRoutineHealthData(
         routineName: String,
         startTimeMs: Long = 1700000000000L,
         durationMs: Long = 60000L,
         totalCalories: Float?,
-    ): RoutineHealthData = RoutineHealthData(
-        routineName = routineName,
+    ): HealthWorkoutData = HealthWorkoutData(
+        title = routineName,
+        externalId = HealthWorkoutExportBuilder.routineClientRecordId("test-routine-session-id"),
         startTimeMs = startTimeMs,
-        durationMs = durationMs,
+        endTimeMs = startTimeMs + durationMs.coerceAtLeast(1000L),
         totalCalories = totalCalories?.takeIf { it > 0f },
-        externalId = "test-routine-session-id",
+        segments = emptyList(),
     )
 
     /** Mirrors calorie accumulation logic in saveWorkoutSession() */

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/integration/HealthWorkoutExportBuilderTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/integration/HealthWorkoutExportBuilderTest.kt
@@ -1,0 +1,212 @@
+package com.devil.phoenixproject.data.integration
+
+import com.devil.phoenixproject.domain.model.CompletedSet
+import com.devil.phoenixproject.domain.model.SetType
+import com.devil.phoenixproject.domain.model.WorkoutSession
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class HealthWorkoutExportBuilderTest {
+
+    @Test
+    fun routineWorkoutUsesOneRecordWithSegmentsFromCompletedSets() {
+        val routineId = "routine-session-1"
+        val sessions = listOf(
+            workoutSession(
+                id = "session-a",
+                timestamp = 1_000L,
+                duration = 30_000L,
+                exerciseId = "bench-press",
+                exerciseName = "Bench Press",
+                routineSessionId = routineId,
+                routineName = "Push Day",
+                workingReps = 8,
+                weightPerCableKg = 30f,
+                displayMultiplier = 2,
+                estimatedCalories = 40f,
+                rpe = 7,
+            ),
+            workoutSession(
+                id = "session-b",
+                timestamp = 40_000L,
+                duration = 45_000L,
+                exerciseId = "lat-pulldown",
+                exerciseName = "Lat Pulldown",
+                routineSessionId = routineId,
+                routineName = "Push Day",
+                workingReps = 10,
+                weightPerCableKg = 25f,
+                displayMultiplier = 1,
+                estimatedCalories = 35f,
+            ),
+        )
+        val completedSets = mapOf(
+            "session-a" to listOf(
+                completedSet(
+                    id = "set-a",
+                    sessionId = "session-a",
+                    setNumber = 0,
+                    actualReps = 9,
+                    actualWeightKg = 60f,
+                    loggedRpe = 8,
+                    completedAt = 31_000L,
+                ),
+            ),
+            "session-b" to listOf(
+                completedSet(
+                    id = "set-b",
+                    sessionId = "session-b",
+                    setNumber = 1,
+                    setType = SetType.WARMUP,
+                    actualReps = 12,
+                    actualWeightKg = 25f,
+                    loggedRpe = null,
+                    completedAt = 85_000L,
+                ),
+            ),
+        )
+
+        val export = HealthWorkoutExportBuilder.buildRoutineWorkout(
+            routineSessionId = routineId,
+            sessions = sessions,
+            completedSetsBySessionId = completedSets,
+        )
+
+        assertNotNull(export)
+        assertEquals("Push Day", export.title)
+        assertEquals("phoenix:routine:$routineId", export.externalId)
+        assertEquals(1_000L, export.startTimeMs)
+        assertEquals(85_000L, export.endTimeMs)
+        assertEquals(75f, export.totalCalories)
+        assertEquals(2, export.segments.size)
+
+        val first = export.segments[0]
+        assertEquals("session-a", first.sessionId)
+        assertEquals("bench-press", first.exerciseId)
+        assertEquals("Bench Press", first.exerciseName)
+        assertEquals(0, first.setIndex)
+        assertEquals(SetType.STANDARD, first.setType)
+        assertEquals(9, first.reps)
+        assertEquals(60f, first.weightKg)
+        assertEquals(8, first.rpe)
+        assertEquals(1_000L, first.startTimeMs)
+        assertEquals(31_000L, first.endTimeMs)
+
+        val second = export.segments[1]
+        assertEquals("session-b", second.sessionId)
+        assertEquals(1, second.setIndex)
+        assertEquals(SetType.WARMUP, second.setType)
+        assertEquals(12, second.reps)
+        assertEquals(25f, second.weightKg)
+        assertEquals(null, second.rpe)
+        assertEquals(40_000L, second.startTimeMs)
+        assertEquals(85_000L, second.endTimeMs)
+    }
+
+    @Test
+    fun standaloneWorkoutFallsBackToSessionWhenCompletedSetMissing() {
+        val session = workoutSession(
+            id = "standalone-1",
+            timestamp = 10_000L,
+            duration = 20_000L,
+            exerciseId = "cable-row",
+            exerciseName = "Cable Row",
+            workingReps = 11,
+            totalReps = 13,
+            weightPerCableKg = 22.5f,
+            displayMultiplier = 2,
+            estimatedCalories = 18f,
+            rpe = 6,
+        )
+
+        val export = HealthWorkoutExportBuilder.buildStandaloneWorkout(
+            session = session,
+            completedSets = emptyList(),
+        )
+
+        assertNotNull(export)
+        assertEquals("Cable Row", export.title)
+        assertEquals("phoenix:session:standalone-1", export.externalId)
+        assertEquals(10_000L, export.startTimeMs)
+        assertEquals(30_000L, export.endTimeMs)
+        assertEquals(18f, export.totalCalories)
+        assertEquals(1, export.segments.size)
+        assertEquals(11, export.segments.single().reps)
+        assertEquals(45f, export.segments.single().weightKg)
+        assertEquals(6, export.segments.single().rpe)
+    }
+
+    @Test
+    fun invalidRoutineReturnsNullWhenNoCompletedRepsExist() {
+        val routineId = "empty-routine"
+        val export = HealthWorkoutExportBuilder.buildRoutineWorkout(
+            routineSessionId = routineId,
+            sessions = listOf(
+                workoutSession(
+                    id = "session-empty",
+                    routineSessionId = routineId,
+                    routineName = "Empty Routine",
+                    workingReps = 0,
+                    totalReps = 0,
+                ),
+            ),
+            completedSetsBySessionId = emptyMap(),
+        )
+
+        assertNull(export)
+    }
+
+    private fun workoutSession(
+        id: String,
+        timestamp: Long = 1_000L,
+        duration: Long = 30_000L,
+        exerciseId: String? = "exercise",
+        exerciseName: String? = "Exercise",
+        routineSessionId: String? = null,
+        routineName: String? = null,
+        workingReps: Int = 8,
+        totalReps: Int = workingReps,
+        weightPerCableKg: Float = 20f,
+        displayMultiplier: Int? = 1,
+        estimatedCalories: Float? = null,
+        rpe: Int? = null,
+    ) = WorkoutSession(
+        id = id,
+        timestamp = timestamp,
+        duration = duration,
+        exerciseId = exerciseId,
+        exerciseName = exerciseName,
+        routineSessionId = routineSessionId,
+        routineName = routineName,
+        workingReps = workingReps,
+        totalReps = totalReps,
+        weightPerCableKg = weightPerCableKg,
+        displayMultiplier = displayMultiplier,
+        estimatedCalories = estimatedCalories,
+        rpe = rpe,
+    )
+
+    private fun completedSet(
+        id: String,
+        sessionId: String,
+        setNumber: Int,
+        setType: SetType = SetType.STANDARD,
+        actualReps: Int,
+        actualWeightKg: Float,
+        loggedRpe: Int?,
+        completedAt: Long,
+    ) = CompletedSet(
+        id = id,
+        sessionId = sessionId,
+        plannedSetId = null,
+        setNumber = setNumber,
+        setType = setType,
+        actualReps = actualReps,
+        actualWeightKg = actualWeightKg,
+        loggedRpe = loggedRpe,
+        isPr = false,
+        completedAt = completedAt,
+    )
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/integration/HealthWorkoutExportBuilderTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/integration/HealthWorkoutExportBuilderTest.kt
@@ -158,6 +158,47 @@ class HealthWorkoutExportBuilderTest {
         assertNull(export)
     }
 
+    @Test
+    fun multipleSetsInOneSessionAreAdjustedToNonOverlappingSegments() {
+        val session = workoutSession(
+            id = "session-overlap",
+            timestamp = 10_000L,
+            duration = 30_000L,
+            workingReps = 8,
+        )
+        val export = HealthWorkoutExportBuilder.buildStandaloneWorkout(
+            session = session,
+            completedSets = listOf(
+                completedSet(
+                    id = "set-1",
+                    sessionId = session.id,
+                    setNumber = 0,
+                    actualReps = 8,
+                    actualWeightKg = 20f,
+                    loggedRpe = null,
+                    completedAt = 40_000L,
+                ),
+                completedSet(
+                    id = "set-2",
+                    sessionId = session.id,
+                    setNumber = 1,
+                    actualReps = 8,
+                    actualWeightKg = 20f,
+                    loggedRpe = null,
+                    completedAt = 45_000L,
+                ),
+            ),
+        )
+
+        assertNotNull(export)
+        val first = export.segments[0]
+        val second = export.segments[1]
+        assertEquals(10_000L, first.startTimeMs)
+        assertEquals(40_000L, first.endTimeMs)
+        assertEquals(40_000L, second.startTimeMs)
+        assertEquals(45_000L, second.endTimeMs)
+    }
+
     private fun workoutSession(
         id: String,
         timestamp: Long = 1_000L,

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeCompletedSetRepository.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeCompletedSetRepository.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.flow.asStateFlow
  * Fake CompletedSetRepository for testing.
  * Stores planned and completed sets in memory with basic filtering support.
  */
-class FakeCompletedSetRepository : CompletedSetRepository {
+open class FakeCompletedSetRepository : CompletedSetRepository {
 
     private val plannedSets = mutableMapOf<String, PlannedSet>()
     private val completedSets = mutableMapOf<String, CompletedSet>()
@@ -77,7 +77,7 @@ class FakeCompletedSetRepository : CompletedSetRepository {
         ?.sortedBy { it.setNumber }
         ?: emptyList()
 
-    override suspend fun getCompletedSetsForSessions(sessionIds: List<String>): List<CompletedSet> = sessionIds
+    open override suspend fun getCompletedSetsForSessions(sessionIds: List<String>): List<CompletedSet> = sessionIds
         .flatMap { sessionId -> getCompletedSets(sessionId) }
 
     override fun getCompletedSetsFlow(sessionId: String): Flow<List<CompletedSet>> {

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeCompletedSetRepository.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeCompletedSetRepository.kt
@@ -77,6 +77,9 @@ class FakeCompletedSetRepository : CompletedSetRepository {
         ?.sortedBy { it.setNumber }
         ?: emptyList()
 
+    override suspend fun getCompletedSetsForSessions(sessionIds: List<String>): List<CompletedSet> = sessionIds
+        .flatMap { sessionId -> getCompletedSets(sessionId) }
+
     override fun getCompletedSetsFlow(sessionId: String): Flow<List<CompletedSet>> {
         val flow = completedSetsFlows.getOrPut(sessionId) {
             MutableStateFlow(emptyList())

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeWorkoutRepository.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeWorkoutRepository.kt
@@ -105,6 +105,21 @@ class FakeWorkoutRepository : WorkoutRepository {
 
     override suspend fun getSession(sessionId: String): WorkoutSession? = sessions[sessionId]
 
+    override suspend fun getSessionsForRoutineSession(
+        profileId: String,
+        routineSessionId: String,
+    ): List<WorkoutSession> = sessions.values
+        .filter {
+            it.profileId == profileId &&
+                it.routineSessionId == routineSessionId &&
+                (it.workingReps > 0 || it.totalReps > 0)
+        }
+        .sortedBy { it.timestamp }
+
+    override suspend fun getCompletedHealthExportCandidates(profileId: String): List<WorkoutSession> = sessions.values
+        .filter { it.profileId == profileId && (it.workingReps > 0 || it.totalReps > 0) }
+        .sortedBy { it.timestamp }
+
     override fun getAllRoutines(profileId: String): Flow<List<Routine>> = _routinesFlow
 
     override suspend fun saveRoutine(routine: Routine) {

--- a/shared/src/iosMain/kotlin/com/devil/phoenixproject/data/integration/HealthIntegration.ios.kt
+++ b/shared/src/iosMain/kotlin/com/devil/phoenixproject/data/integration/HealthIntegration.ios.kt
@@ -28,7 +28,7 @@ private val log = Logger.withTag("HealthIntegration.iOS")
  * Unlike Android Health Connect, no Activity Result contract is needed --
  * requestAuthorization can be called from any context.
  */
-actual class HealthIntegration {
+actual class HealthIntegration : HealthWorkoutWriter {
 
     companion object {
         /** Seconds between Unix epoch (1970-01-01) and Apple reference date (2001-01-01). */
@@ -58,7 +58,7 @@ actual class HealthIntegration {
      * Checks whether HealthKit is available on this device.
      * Returns false on iPad and devices without HealthKit support.
      */
-    actual suspend fun isAvailable(): Boolean = try {
+    actual override suspend fun isAvailable(): Boolean = try {
         HKHealthStore.isHealthDataAvailable()
     } catch (e: Exception) {
         log.w(e) { "Error checking HealthKit availability" }
@@ -72,7 +72,7 @@ actual class HealthIntegration {
      * Note: HealthKit's authorizationStatusForType only reflects *write* status.
      * A status of SharingAuthorized means the user explicitly granted write access.
      */
-    actual suspend fun hasPermissions(): Boolean {
+    actual override suspend fun hasPermissions(): Boolean {
         if (!isAvailable()) return false
 
         return try {
@@ -166,7 +166,7 @@ actual class HealthIntegration {
      * HealthKit does not expose a public per-set strength segment model comparable to
      * Android Health Connect ExerciseSegment, so [HealthWorkoutData.segments] are not persisted on iOS.
      */
-    actual suspend fun writeHealthWorkout(data: HealthWorkoutData): Result<Unit> {
+    actual override suspend fun writeHealthWorkout(data: HealthWorkoutData): Result<Unit> {
         if (!isAvailable()) {
             return Result.failure(
                 IllegalStateException("HealthKit is not available on this device"),

--- a/shared/src/iosMain/kotlin/com/devil/phoenixproject/data/integration/HealthIntegration.ios.kt
+++ b/shared/src/iosMain/kotlin/com/devil/phoenixproject/data/integration/HealthIntegration.ios.kt
@@ -155,6 +155,18 @@ actual class HealthIntegration {
      * fall back to raw physical cableCount only for legacy sessions, then default to 1.
      */
     actual suspend fun writeWorkout(session: WorkoutSession): Result<Unit> {
+        val data = HealthWorkoutExportBuilder.buildStandaloneWorkout(session, completedSets = emptyList())
+            ?: return Result.failure(IllegalArgumentException("Workout session has no completed reps to write"))
+        return writeHealthWorkout(data)
+    }
+
+    /**
+     * Writes a completed Phoenix workout to HealthKit as one aggregate strength workout.
+     *
+     * HealthKit does not expose a public per-set strength segment model comparable to
+     * Android Health Connect ExerciseSegment, so [HealthWorkoutData.segments] are not persisted on iOS.
+     */
+    actual suspend fun writeHealthWorkout(data: HealthWorkoutData): Result<Unit> {
         if (!isAvailable()) {
             return Result.failure(
                 IllegalStateException("HealthKit is not available on this device"),
@@ -171,15 +183,13 @@ actual class HealthIntegration {
             // Convert epoch millis to NSDate
             // NSDate uses "reference date" (2001-01-01), not Unix epoch (1970-01-01)
             // Offset: 978307200 seconds between the two reference points
-            val epochSeconds = session.timestamp / 1000.0
+            val epochSeconds = data.startTimeMs / 1000.0
             val startDate = NSDate(
                 timeIntervalSinceReferenceDate =
                     epochSeconds - UNIX_TO_APPLE_EPOCH_OFFSET,
             )
 
-            // session.duration is stored in MILLISECONDS (from currentTimeMillis() - startTime)
-            // Issue #362: Convert to seconds for HealthKit; minimum 1 second
-            val durationMs = session.duration.coerceAtLeast(1000L)
+            val durationMs = (data.endTimeMs - data.startTimeMs).coerceAtLeast(1000L)
             val durationSeconds = (durationMs / 1000L).toDouble()
             val endDate = NSDate(
                 timeIntervalSinceReferenceDate =
@@ -188,7 +198,7 @@ actual class HealthIntegration {
 
             // Build optional calorie quantity. Active energy permission is optional; do not block workout sync.
             val canWriteCalories = canWriteActiveEnergy()
-            val calorieQuantity: HKQuantity? = session.estimatedCalories?.let { cal ->
+            val calorieQuantity: HKQuantity? = data.totalCalories?.let { cal ->
                 if (cal > 0f && canWriteCalories) {
                     HKQuantity.quantityWithUnit(
                         unit = HKUnit.unitFromString("kcal"),
@@ -198,18 +208,15 @@ actual class HealthIntegration {
                     null
                 }
             }
-            if ((session.estimatedCalories ?: 0f) > 0f && !canWriteCalories) {
-                log.i { "Skipping HealthKit calorie value for session ${session.id}: optional active energy permission not granted" }
+            if ((data.totalCalories ?: 0f) > 0f && !canWriteCalories) {
+                log.i { "Skipping HealthKit calorie value for ${data.externalId}: optional active energy permission not granted" }
             }
-
-            // Build exercise title with Android-parity persisted display semantics
-            val title = buildExerciseTitle(session)
 
             // Build metadata for deduplication and display
             val metadata = mutableMapOf<Any?, Any?>(
-                "HKExternalUUID" to session.id,
+                "HKExternalUUID" to data.externalId,
             )
-            metadata["title"] = title
+            metadata["title"] = data.title
 
             // Create the HKWorkout object
             @Suppress("DEPRECATION")
@@ -243,124 +250,14 @@ actual class HealthIntegration {
                             ),
                         )
                     } else {
-                        log.d { "Wrote HealthKit workout for session ${session.id}" }
+                        log.d { "Wrote HealthKit workout for ${data.externalId}" }
                         continuation.resume(Result.success(Unit))
                     }
                 }
             }
         } catch (e: Exception) {
-            log.e(e) { "Failed to write workout to HealthKit for session ${session.id}" }
+            log.e(e) { "Failed to write workout to HealthKit for ${data.externalId}" }
             Result.failure(e)
-        }
-    }
-
-    /**
-     * Issue #395: Write a single aggregate HealthKit workout for an entire routine.
-     * Called once at routine completion instead of per-set.
-     */
-    actual suspend fun writeRoutineWorkout(data: RoutineHealthData): Result<Unit> {
-        if (!isAvailable()) {
-            return Result.failure(
-                IllegalStateException("HealthKit is not available on this device"),
-            )
-        }
-
-        if (!hasPermissions()) {
-            return Result.failure(
-                IllegalStateException("HealthKit write permissions not granted"),
-            )
-        }
-
-        return try {
-            val epochSeconds = data.startTimeMs / 1000.0
-            val startDate = NSDate(
-                timeIntervalSinceReferenceDate =
-                    epochSeconds - UNIX_TO_APPLE_EPOCH_OFFSET,
-            )
-
-            val durationMs = data.durationMs.coerceAtLeast(1000L)
-            val durationSeconds = (durationMs / 1000L).toDouble()
-            val endDate = NSDate(
-                timeIntervalSinceReferenceDate =
-                    (epochSeconds + durationSeconds) - UNIX_TO_APPLE_EPOCH_OFFSET,
-            )
-
-            val canWriteCalories = canWriteActiveEnergy()
-            val calorieQuantity: HKQuantity? = data.totalCalories?.let { cal ->
-                if (cal > 0f && canWriteCalories) {
-                    HKQuantity.quantityWithUnit(
-                        unit = HKUnit.unitFromString("kcal"),
-                        doubleValue = cal.toDouble(),
-                    )
-                } else {
-                    null
-                }
-            }
-            if ((data.totalCalories ?: 0f) > 0f && !canWriteCalories) {
-                log.i { "Skipping HealthKit calorie value for routine ${data.externalId}: optional active energy permission not granted" }
-            }
-
-            val metadata = mutableMapOf<Any?, Any?>(
-                "HKExternalUUID" to data.externalId,
-            )
-            metadata["title"] = data.routineName
-
-            @Suppress("DEPRECATION")
-            val workout = HKWorkout.workoutWithActivityType(
-                workoutActivityType = HKWorkoutActivityTypeTraditionalStrengthTraining,
-                startDate = startDate,
-                endDate = endDate,
-                duration = durationSeconds,
-                totalEnergyBurned = calorieQuantity,
-                totalDistance = null,
-                metadata = metadata,
-            )
-
-            suspendCancellableCoroutine { continuation ->
-                healthStore.saveObject(workout) { success: Boolean, error: NSError? ->
-                    if (error != null) {
-                        log.e { "HealthKit routine save error: ${error.localizedDescription}" }
-                        continuation.resume(
-                            Result.failure<Unit>(
-                                RuntimeException(
-                                    "HealthKit routine save failed: ${error.localizedDescription}",
-                                ),
-                            ),
-                        )
-                    } else if (!success) {
-                        log.e { "HealthKit routine save returned false without error" }
-                        continuation.resume(
-                            Result.failure<Unit>(
-                                RuntimeException("HealthKit routine save failed without error details"),
-                            ),
-                        )
-                    } else {
-                        log.d { "Wrote HealthKit routine workout: ${data.routineName} (${data.externalId})" }
-                        continuation.resume(Result.success(Unit))
-                    }
-                }
-            }
-        } catch (e: Exception) {
-            log.e(e) { "Failed to write routine workout to HealthKit: ${data.externalId}" }
-            Result.failure(e)
-        }
-    }
-
-    /**
-     * Builds a human-readable title for the exercise session.
-     * Total weight shown is per-cable x persisted displayMultiplier when available.
-     *
-     * Falls back to raw physical cableCount only for legacy sessions without displayMultiplier,
-     * then defaults to 1. This preserves Android/iOS Health title parity (Issue #358).
-     */
-    private fun buildExerciseTitle(session: WorkoutSession): String {
-        val exerciseName = session.exerciseName?.takeIf { it.isNotBlank() } ?: "Phoenix Workout"
-        val totalWeightKg = session.weightPerCableKg *
-            (session.displayMultiplier ?: session.cableCount ?: 1).toFloat()
-        return if (totalWeightKg > 0f) {
-            "$exerciseName — ${totalWeightKg.toInt()}kg"
-        } else {
-            exerciseName
         }
     }
 }

--- a/shared/src/iosMain/kotlin/com/devil/phoenixproject/di/PlatformModule.ios.kt
+++ b/shared/src/iosMain/kotlin/com/devil/phoenixproject/di/PlatformModule.ios.kt
@@ -3,6 +3,7 @@ package com.devil.phoenixproject.di
 import co.touchlab.kermit.Logger
 import com.devil.phoenixproject.data.auth.OAuthLauncher
 import com.devil.phoenixproject.data.integration.HealthIntegration
+import com.devil.phoenixproject.data.integration.HealthWorkoutWriter
 import com.devil.phoenixproject.data.local.DriverFactory
 import com.devil.phoenixproject.data.repository.BleRepository
 import com.devil.phoenixproject.data.repository.KableBleRepository
@@ -92,6 +93,7 @@ actual val platformModule: Module = module {
     single { ConnectivityChecker() }
     single<SafeWordListenerFactory> { IosSafeWordListenerFactory() }
     single { HealthIntegration() }
+    single<HealthWorkoutWriter> { get<HealthIntegration>() }
     single<WorkoutServiceController> { NoOpWorkoutServiceController }
     single {
         MainViewModel(
@@ -113,6 +115,7 @@ actual val platformModule: Module = module {
             healthIntegration = get(),
             externalActivityRepository = get(),
             workoutServiceController = get(),
+            healthExportCursorRepository = get(),
         )
     }
 }


### PR DESCRIPTION
## Summary
- Upgrade Android Health Connect to `1.2.0-alpha04` and export Phoenix workouts as one session with per-set `ExerciseSegment`s.
- Keep iOS on aggregate-only HealthKit writes, since the public write API does not support equivalent strength segments.
- Add persisted-session/export mappers, repository accessors, historical backfill, and Integrations UI actions for retry permissions and sync previous workouts.

## Testing
- Passed `:shared:testAndroidHostTest`
- Passed `:shared:compileKotlinIosArm64`
- Passed `:shared:verifyCommonMainVitruvianDatabaseMigration`
- Passed `:shared:checkKotlinAbi`
- Passed `:androidApp:assembleDebug`
- `spotlessCheck` still fails on a pre-existing unrelated formatting issue in `OAuthRedirectActivity.kt`