### PR TITLE
fix: harden sync profile payloads

### DIFF
--- a/androidApp/src/main/kotlin/com/devil/phoenixproject/auth/OAuthRedirectActivity.kt
+++ b/androidApp/src/main/kotlin/com/devil/phoenixproject/auth/OAuthRedirectActivity.kt
@@ -104,15 +104,14 @@ class OAuthRedirectActivity : ComponentActivity() {
      * can assert on the flag combination without needing to spin up an
      * actual [android.app.Activity].
      */
-    internal fun buildReturnToAppIntent(): Intent =
-        Intent(Intent.ACTION_MAIN).apply {
-            component = ComponentName(this@OAuthRedirectActivity, MainActivity::class.java)
-            addCategory(Intent.CATEGORY_LAUNCHER)
-            // See kdoc on [routeBackToApp] for why each flag is set.
-            addFlags(
-                Intent.FLAG_ACTIVITY_NEW_TASK or
-                    Intent.FLAG_ACTIVITY_REORDER_TO_FRONT or
-                    Intent.FLAG_ACTIVITY_SINGLE_TOP,
-            )
-        }
+    internal fun buildReturnToAppIntent(): Intent = Intent(Intent.ACTION_MAIN).apply {
+        component = ComponentName(this@OAuthRedirectActivity, MainActivity::class.java)
+        addCategory(Intent.CATEGORY_LAUNCHER)
+        // See kdoc on [routeBackToApp] for why each flag is set.
+        addFlags(
+            Intent.FLAG_ACTIVITY_NEW_TASK or
+                Intent.FLAG_ACTIVITY_REORDER_TO_FRONT or
+                Intent.FLAG_ACTIVITY_SINGLE_TOP,
+        )
+    }
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/SyncManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/SyncManager.kt
@@ -804,6 +804,13 @@ class SyncManager(
         val payloadProfileName = activeProfile?.name ?: "Default"
         val profileDtos = allProfiles
             .map { LocalProfileDto(it.id, it.name, it.colorIndex) }
+            .let { dtos ->
+                if (activeProfile != null && dtos.none { it.id == activeProfile.id }) {
+                    dtos + LocalProfileDto(activeProfile.id, activeProfile.name, activeProfile.colorIndex)
+                } else {
+                    dtos
+                }
+            }
             .ifEmpty {
                 listOf(
                     LocalProfileDto(

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/SyncManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/SyncManager.kt
@@ -534,7 +534,12 @@ class SyncManager(
         val deviceId = tokenStorage.getDeviceId()
         val lastSync = tokenStorage.getLastSyncTimestamp()
         val platform = getPlatformName()
-        val activeProfileId = userProfileRepository.activeProfile.value?.id ?: "default"
+        userProfileRepository.ensureDefaultProfile()
+        val allProfiles = userProfileRepository.allProfiles.value
+        val activeProfile = userProfileRepository.activeProfile.value
+            ?: allProfiles.firstOrNull { it.isActive }
+            ?: allProfiles.firstOrNull { it.id == "default" }
+        val activeProfileId = activeProfile?.id ?: "default"
 
         val phaseBackfillCheckpoint = tokenStorage.getPhasePRBackfillCheckpoint(activeProfileId)
         val phaseBackfillResult = syncRepository.backfillPhaseSpecificPRs(
@@ -711,9 +716,7 @@ class SyncManager(
         }
 
         // 5b. External activities (paid users only)
-        val localPaid =
-            userProfileRepository.activeProfile.value?.subscriptionStatus ==
-                SubscriptionStatus.ACTIVE
+        val localPaid = activeProfile?.subscriptionStatus == SubscriptionStatus.ACTIVE
         val portalPaid = tokenStorage.currentUser.value?.isPremium == true
         val isPremium = localPaid || portalPaid
         val externalActivityDtos = if (isPremium) {
@@ -793,13 +796,23 @@ class SyncManager(
         val telemetryBySetId = effectiveTelemetry.groupBy { it.setId }
 
         // 7b. Profile data for portal tagging and profile-scoped filtering
-        val activeProfile = userProfileRepository.activeProfile.value
-        val allProfiles = userProfileRepository.allProfiles.value
         val routineDtos = routines.map { PortalSyncAdapter.toPortalRoutine(it, userId) }
         val cycleDtos = cyclesWithContext.map {
             PortalSyncAdapter.toPortalTrainingCycle(it, userId)
         }
-        val profileDtos = allProfiles.map { LocalProfileDto(it.id, it.name, it.colorIndex) }
+        val payloadProfileId = activeProfile?.id ?: "default"
+        val payloadProfileName = activeProfile?.name ?: "Default"
+        val profileDtos = allProfiles
+            .map { LocalProfileDto(it.id, it.name, it.colorIndex) }
+            .ifEmpty {
+                listOf(
+                    LocalProfileDto(
+                        id = payloadProfileId,
+                        name = payloadProfileName,
+                        colorIndex = activeProfile?.colorIndex ?: 0,
+                    ),
+                )
+            }
 
         // 8. Chunked push -- batch sessions to stay under Edge Function body limit (~1 MB)
         //    AND under the server-side rep_telemetry array cap (MAX_TELEMETRY_PER_BATCH).
@@ -848,8 +861,8 @@ class SyncManager(
                 phaseStatistics = phaseStatsBySessionId.values.flatten(),
                 assessments = assessmentDtos,
                 customExercises = customExerciseDtos,
-                profileId = activeProfile?.id,
-                profileName = activeProfile?.name,
+                profileId = payloadProfileId,
+                profileName = payloadProfileName,
                 allProfiles = profileDtos,
                 externalActivities = externalActivityDtos,
                 personalRecords = personalRecordDtos,
@@ -899,8 +912,8 @@ class SyncManager(
                     phaseStatistics = batchPhaseStats,
                     assessments = if (isLastBatch) assessmentDtos else emptyList(),
                     customExercises = if (isLastBatch) customExerciseDtos else emptyList(),
-                    profileId = activeProfile?.id,
-                    profileName = activeProfile?.name,
+                    profileId = payloadProfileId,
+                    profileName = payloadProfileName,
                     allProfiles = if (isLastBatch) profileDtos else null,
                     externalActivities = if (isLastBatch) externalActivityDtos else emptyList(),
                     personalRecords = if (isLastBatch) personalRecordDtos else emptyList(),

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/SyncManagerTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/SyncManagerTest.kt
@@ -433,6 +433,43 @@ class SyncManagerTest {
     }
 
     @Test
+    fun syncEnsuresDefaultProfileBeforeSendingDefaultScopedPersonalRecords() = runTest {
+        setupAuthenticated()
+        fakeSyncRepo.fullPRsToReturn = listOf(
+            makePersonalRecord(
+                id = 42,
+                exerciseId = "squat",
+                exerciseName = "Squat",
+                weightPerCableKg = 100f,
+                reps = 1,
+                timestamp = 1_740_916_800_000L,
+                prType = PRType.MAX_WEIGHT,
+                phase = WorkoutPhase.COMBINED,
+            ),
+        )
+        fakeApi.pushResult = Result.success(
+            PortalSyncPushResponse(syncTime = "2026-03-02T12:00:00Z"),
+        )
+        val manager = createManager()
+
+        val result = manager.sync()
+
+        assertTrue(result.isSuccess)
+        val payload = assertNotNull(fakeApi.lastPushPayload, "Push payload should be captured")
+        assertEquals(
+            "default",
+            payload.profileId,
+            "Default-scoped PR rows must not be pushed without matching top-level profile context",
+        )
+        assertEquals(
+            listOf(LocalProfileDto(id = "default", name = "Default", colorIndex = 0)),
+            payload.allProfiles,
+            "The payload must include the local_profiles row required by the portal FK",
+        )
+        assertEquals("default", payload.personalRecords.single().localProfileId)
+    }
+
+    @Test
     fun syncResolvesSessionIdForDedicatedPROutsideDeltaSessionBatch() = runTest {
         setupAuthenticated()
         val exerciseId = "bicep-curl"


### PR DESCRIPTION
Ensure default profile context is loaded before building sync payloads so default-scoped personal records are sent with matching profile metadata. Add regression coverage for the legacy no-active-profile payload shape. Apply the Spotless formatting required on the main-based branch for OAuthRedirectActivity.