### PR TITLE
Fix mobile Cloud Sync stale error persistence

### DIFF
--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -106,6 +106,7 @@
     <!-- Settings -->
     <string name="settings_title">Einstellungen</string>
     <string name="settings_cloud_sync">Cloud-Sync</string>
+    <string name="settings_sync_error_tap_to_dismiss">Sync error — tap to dismiss</string>
     <string name="settings_weight_unit">Gewichtseinheit</string>
     <string name="settings_appearance">Erscheinungsbild</string>
     <string name="settings_theme_mode">Design</string>

--- a/shared/src/commonMain/composeResources/values-es/strings.xml
+++ b/shared/src/commonMain/composeResources/values-es/strings.xml
@@ -106,6 +106,7 @@
     <!-- Settings -->
     <string name="settings_title">Configuración</string>
     <string name="settings_cloud_sync">Sincronización en la nube</string>
+    <string name="settings_sync_error_tap_to_dismiss">Sync error — tap to dismiss</string>
     <string name="settings_weight_unit">Unidad de peso</string>
     <string name="settings_appearance">Apariencia</string>
     <string name="settings_theme_mode">Tema</string>

--- a/shared/src/commonMain/composeResources/values-fr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fr/strings.xml
@@ -106,6 +106,7 @@
     <!-- Settings -->
     <string name="settings_title">Paramètres</string>
     <string name="settings_cloud_sync">Synchronisation cloud</string>
+    <string name="settings_sync_error_tap_to_dismiss">Sync error — tap to dismiss</string>
     <string name="settings_weight_unit">Unité de poids</string>
     <string name="settings_appearance">Apparence</string>
     <string name="settings_theme_mode">Thème</string>

--- a/shared/src/commonMain/composeResources/values-nl/strings.xml
+++ b/shared/src/commonMain/composeResources/values-nl/strings.xml
@@ -106,6 +106,7 @@
     <!-- Settings -->
     <string name="settings_title">Instellingen</string>
     <string name="settings_cloud_sync">Cloud Sync</string>
+    <string name="settings_sync_error_tap_to_dismiss">Sync error — tap to dismiss</string>
     <string name="settings_weight_unit">Gewichtseenheid</string>
     <string name="settings_appearance">Uiterlijk</string>
     <string name="settings_theme_mode">Thema</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -114,6 +114,7 @@
     <!-- ==================== Settings screen ==================== -->
     <string name="settings_title">Settings</string>
     <string name="settings_cloud_sync">Cloud Sync</string>
+    <string name="settings_sync_error_tap_to_dismiss">Sync error — tap to dismiss</string>
     <string name="settings_weight_unit">Weight Unit</string>
     <string name="settings_appearance">Appearance</string>
     <string name="settings_theme_mode">Theme</string>

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt
@@ -162,6 +162,15 @@ class SqlDelightSyncRepository(
         }
     }
 
+    override suspend fun updatePersonalRecordTimestamp(prIds: List<Long>, timestamp: Long) {
+        if (prIds.isEmpty()) return
+        withContext(Dispatchers.IO) {
+            prIds.chunked(900).forEach { chunk ->
+                queries.updatePRTimestamp(timestamp, chunk)
+            }
+        }
+    }
+
     // === ID Mapping ===
 
     override suspend fun updateServerIds(mappings: IdMappings) {

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SyncRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SyncRepository.kt
@@ -176,6 +176,18 @@ interface SyncRepository {
      */
     suspend fun updateSessionTimestamp(sessionId: String, timestamp: Long)
 
+    /**
+     * Stamp pushed personal records with the same timestamp used for
+     * [updateSessionTimestamp] so they are not re-sent on every subsequent
+     * push. PRs with NULL `updatedAt` would otherwise match every
+     * `getFullPRsModifiedSince(lastSync, ...)` delta query indefinitely.
+     *
+     * Issue #528: without this, pre-fix PRs that already exist on the
+     * portal are re-shipped on every sync because the push path only
+     * stamped WorkoutSession rows.
+     */
+    suspend fun updatePersonalRecordTimestamp(prIds: List<Long>, timestamp: Long)
+
     // === ID Mapping (after push) ===
 
     /**

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/SyncManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/SyncManager.kt
@@ -1021,6 +1021,21 @@ class SyncManager(
             }
         }
 
+        // Stamp pushed PRs (Issue #528) so getFullPRsModifiedSince doesn't keep
+        // re-shipping the same rows on every push. Re-use the exact recentPRs
+        // collected for this payload, deduped by id, and stamp only after the
+        // server confirmed the push. This gives PersonalRecord rows the same
+        // post-confirmation resend protection that WorkoutSession rows get from
+        // the caller's post-push stamping block.
+        val pushedPrIds = recentPRs.map { it.id }.distinct()
+        if (pushedPrIds.isNotEmpty()) {
+            val prStampTime = currentTimeMillis()
+            syncRepository.updatePersonalRecordTimestamp(pushedPrIds, prStampTime)
+            Logger.d("SyncManager") {
+                "Stamped ${pushedPrIds.size} pushed personal records with updatedAt=$prStampTime"
+            }
+        }
+
         return Result.success(lastResponse!!)
         // No updateServerIds() -- portal uses client-provided UUIDs
     }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/SyncTriggerManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/SyncTriggerManager.kt
@@ -205,13 +205,13 @@ class SyncTriggerManager(
                 }
             }
 
-            // Check for retry storm (max 3 consecutive failures for same error type)
-            if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES && classified.category == SyncErrorCategory.TRANSIENT) {
-                _hasPersistentError.value = true
-                Logger.e {
-                    "SyncTrigger: Retry storm detected - $MAX_CONSECUTIVE_FAILURES consecutive failures"
-                }
-            }
+            // Note: a TRANSIENT retry storm (>= MAX_CONSECUTIVE_FAILURES consecutive
+            // 5xx) intentionally does NOT latch the persistent error flag anymore.
+            // Transient failures/backoff are non-actionable for the user — the
+            // backoff schedule alone suppresses further auto retries, and the
+            // next transient storm simply re-arms it. Only PERMANENT and AUTH
+            // errors set _hasPersistentError, which is what the Settings > Cloud
+            // Sync red row binds to. Issue #528.
         }
 
         updateRetryState()

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SettingsTab.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SettingsTab.kt
@@ -190,6 +190,7 @@ import vitruvianprojectphoenix.shared.generated.resources.settings_calibration_p
 import vitruvianprojectphoenix.shared.generated.resources.settings_calibration_prompt
 import vitruvianprojectphoenix.shared.generated.resources.settings_calibration_title
 import vitruvianprojectphoenix.shared.generated.resources.settings_cloud_sync
+import vitruvianprojectphoenix.shared.generated.resources.settings_sync_error_tap_to_dismiss
 import vitruvianprojectphoenix.shared.generated.resources.settings_dynamic_color
 import vitruvianprojectphoenix.shared.generated.resources.settings_dynamic_color_description
 import vitruvianprojectphoenix.shared.generated.resources.settings_language
@@ -564,7 +565,18 @@ fun SettingsTab(
                 if (hasSyncError) {
                     Spacer(modifier = Modifier.height(Spacing.small))
                     Row(
-                        modifier = Modifier.fillMaxWidth(),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable {
+                                // Issue #528: allow the user to dismiss a stale
+                                // persistent error (e.g. PERMANENT/AUTH or pre-fix
+                                // backoff latch). The trigger manager resets its
+                                // backoff and consecutive-failure state so the
+                                // next foreground / workout-completed trigger can
+                                // run clean. The user is still able to retry by
+                                // tapping the Link Portal Account button above.
+                                syncTriggerManager.clearError()
+                            },
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         Icon(
@@ -575,7 +587,7 @@ fun SettingsTab(
                         )
                         Spacer(modifier = Modifier.width(Spacing.small))
                         Text(
-                            "Sync error — tap above to retry",
+                            stringResource(Res.string.settings_sync_error_tap_to_dismiss),
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.error,
                         )

--- a/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
+++ b/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
@@ -1976,6 +1976,11 @@ AND profile_id = :profileId;
 updatePRServerId:
 UPDATE PersonalRecord SET serverId = ? WHERE id = ?;
 
+-- Stamp pushed PRs with current updatedAt so they aren't re-sent on next sync
+-- (Issue #528). Matches the WorkoutSession.updateSessionTimestamp pattern.
+updatePRTimestamp:
+UPDATE PersonalRecord SET updatedAt = ? WHERE id IN ?;
+
 -- Get routines modified since last sync
 selectRoutinesModifiedSince:
 SELECT * FROM Routine

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/SyncBackoffTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/SyncBackoffTest.kt
@@ -176,11 +176,8 @@ class SyncBackoffTest {
                     _hasPersistentError.value = true
                 }
             }
-            if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES &&
-                classified.category == SyncErrorCategory.TRANSIENT
-            ) {
-                _hasPersistentError.value = true
-            }
+            // Issue #528: TRANSIENT storms do NOT latch the persistent error flag
+            // anymore — only PERMANENT and AUTH do. Mirrors SyncTriggerManager.kt.
         }
 
         private fun onSyncSuccess() {

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/SyncFailureCapTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/SyncFailureCapTest.kt
@@ -10,14 +10,18 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.runTest
 
 /**
- * Tests for the 3-consecutive-failure retry-storm cap documented by SyncTriggerManager:
- *   - After 3 consecutive transient failures the trigger manager flips into a
- *     `hasPersistentError` state that blocks further automatic retries until a
- *     manual/bypass trigger (or clearError) clears it.
- *   - Manual retry (clearError / bypass) resets the failure count.
- *   - Mixed error categories: PERMANENT & TRANSIENT increment the counter, AUTH sets
- *     persistent error and emits a re-login signal, NETWORK keeps the trigger waiting
- *     for connectivity rather than counting toward the TRANSIENT retry-storm cap.
+ * Tests for SyncTriggerManager's failure classification and persistent-error
+ * contract. Issue #528 tightened this so TRANSIENT storms do NOT latch the
+ * user-visible persistent error anymore — only PERMANENT and AUTH do.
+ *
+ *   - A TRANSIENT storm still ratchets the exponential backoff, but the
+ *     `hasPersistentError` flag stays false (it backs the Settings > Cloud
+ *     Sync red row, which is meant for actionable errors, not backpressure).
+ *   - PERMANENT and AUTH errors still set the persistent error flag
+ *     immediately (they are the actionable categories the user can resolve).
+ *   - NETWORK errors do not increment the TRANSIENT counter; they switch the
+ *     trigger to waiting-for-connectivity.
+ *   - clearError() always resets the flag and the failure/backoff counters.
  */
 class SyncFailureCapTest {
 
@@ -140,11 +144,11 @@ class SyncFailureCapTest {
                     _hasPersistentError.value = true
                 }
             }
-            if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES &&
-                classified.category == SyncErrorCategory.TRANSIENT
-            ) {
-                _hasPersistentError.value = true
-            }
+            // Issue #528: TRANSIENT storms do NOT latch the persistent error flag
+            // anymore — only PERMANENT and AUTH do. Transient errors are non-
+            // actionable for the user; the backoff schedule alone suppresses
+            // further auto retries, and the Settings > Cloud Sync red row would
+            // be misleading if it stayed red through a normal 5xx recovery.
         }
 
         private fun onSyncSuccess() {
@@ -159,7 +163,11 @@ class SyncFailureCapTest {
     // ==================== Retry-Storm Cap ====================
 
     @Test
-    fun threeTransientFailuresTripsPersistentErrorFlag() = runTest {
+    fun threeTransientFailuresStaysInBackoffWithoutTrippingPersistentErrorFlag() = runTest {
+        // Issue #528: TRANSIENT storms no longer latch the persistent error flag.
+        // The backoff schedule alone suppresses further auto retries; the
+        // Settings > Cloud Sync red row is meant for actionable errors
+        // (PERMANENT / AUTH), not for transient backpressure.
         val sm = TestSyncManager()
         val cc = TestConnectivityChecker()
         val trigger = TestableSyncTriggerManager(sm, cc)
@@ -170,20 +178,29 @@ class SyncFailureCapTest {
         trigger.onWorkoutCompleted()
         assertFalse(trigger.hasPersistentError.value, "2 failures is below cap")
         trigger.onWorkoutCompleted()
-        assertTrue(trigger.hasPersistentError.value, "3 failures trips the manual-intervention flag")
+        assertFalse(
+            trigger.hasPersistentError.value,
+            "3 TRANSIENT failures stay in backoff (no persistent latch — Issue #528)",
+        )
         assertEquals(3, trigger.consecutiveFailures())
     }
 
     @Test
     fun clearErrorResetsFailureCountAndPersistentFlag() = runTest {
+        // Issue #528: TRANSIENT storms no longer latch the flag, so use a
+        // PERMANENT error to exercise the clearError() reset path against a
+        // genuinely latched persistent error.
         val sm = TestSyncManager()
         val cc = TestConnectivityChecker()
         val trigger = TestableSyncTriggerManager(sm, cc)
-        sm.syncResult = Result.failure(PortalApiException("boom", null, 500))
+        sm.syncResult = Result.failure(PortalApiException("bad request", null, 400))
 
-        repeat(3) { trigger.onWorkoutCompleted() }
-        assertTrue(trigger.hasPersistentError.value)
-        assertEquals(3, trigger.consecutiveFailures())
+        trigger.onWorkoutCompleted()
+        assertTrue(
+            trigger.hasPersistentError.value,
+            "PERMANENT error latches the persistent error flag (clearError target)",
+        )
+        assertEquals(1, trigger.consecutiveFailures())
 
         trigger.clearError()
 

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/SyncManagerTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/SyncManagerTest.kt
@@ -433,6 +433,114 @@ class SyncManagerTest {
     }
 
     @Test
+    fun syncStampsPushedPersonalRecordsToPreventResend() = runTest {
+        // Issue #528 regression: pushLocalChanges must stamp PersonalRecord.updatedAt
+        // the same way it stamps WorkoutSession.updatedAt, otherwise
+        // getFullPRsModifiedSince(lastSync, ...) keeps re-shipping the same PRs
+        // on every push.
+        setupAuthenticated()
+        val exerciseId = "squat"
+        val timestamp = 1_740_916_800_000L
+        val firstSession = makeWorkoutSession(
+            id = "session-pr-stamp",
+            timestamp = timestamp,
+            reps = 5,
+            totalReps = 5,
+            exerciseId = exerciseId,
+            exerciseName = "Squat",
+        )
+        val pushedPr = makePersonalRecord(
+            id = 7,
+            exerciseId = exerciseId,
+            exerciseName = "Squat",
+            weightPerCableKg = 100f,
+            reps = 5,
+            timestamp = timestamp,
+            prType = PRType.MAX_WEIGHT,
+            phase = WorkoutPhase.COMBINED,
+        )
+        fakeSyncRepo.workoutSessionsToReturn = listOf(firstSession)
+        fakeSyncRepo.fullPRsToReturn = listOf(pushedPr)
+        fakeApi.pushResult = Result.success(
+            PortalSyncPushResponse(syncTime = "2026-03-02T12:00:00Z"),
+        )
+        val manager = createManager()
+
+        val result = manager.sync()
+
+        assertTrue(result.isSuccess)
+        assertEquals(
+            1,
+            fakeSyncRepo.updatePersonalRecordTimestampCalls.size,
+            "Pushed PRs are stamped exactly once per sync (Issue #528)",
+        )
+        assertEquals(
+            listOf(pushedPr.id),
+            fakeSyncRepo.updatePersonalRecordTimestampCalls.single(),
+            "The stamp call must carry the same PR id that was just pushed",
+        )
+        assertNotNull(
+            fakeSyncRepo.lastUpdatePersonalRecordTimestamp,
+            "PR stamping must use the same stampTime as session stamping so " +
+                "next-sync parity (lastSync) lines up across both tables",
+        )
+    }
+
+    @Test
+    fun syncDeduplicatesPersonalRecordIdsBeforeStamping() = runTest {
+        // Issue #528 dedupe guard: even if getFullPRsModifiedSince returns the
+        // same PR id twice (e.g. one row from the recent delta and one from the
+        // historical session-id resolution), the stamp call should carry each
+        // id exactly once.
+        setupAuthenticated()
+        val exerciseId = "bench"
+        val timestamp = 1_740_916_800_000L
+        fakeSyncRepo.workoutSessionsToReturn = listOf(
+            makeWorkoutSession(
+                id = "session-pr-dup",
+                timestamp = timestamp,
+                reps = 5,
+                totalReps = 5,
+                exerciseId = exerciseId,
+                exerciseName = "Bench",
+            ),
+        )
+        val prA = makePersonalRecord(
+            id = 11,
+            exerciseId = exerciseId,
+            exerciseName = "Bench",
+            weightPerCableKg = 80f,
+            reps = 5,
+            timestamp = timestamp,
+            prType = PRType.MAX_WEIGHT,
+            phase = WorkoutPhase.COMBINED,
+        )
+        // Simulate a duplicate local PR id in the recent-PRs query result while
+        // keeping distinct portal payload keys so push validation succeeds and
+        // this test isolates the post-push stamping behavior.
+        fakeSyncRepo.fullPRsToReturn = listOf(
+            prA,
+            prA.copy(
+                prType = PRType.MAX_VOLUME,
+                volume = 640f,
+            ),
+        )
+        fakeApi.pushResult = Result.success(
+            PortalSyncPushResponse(syncTime = "2026-03-02T12:00:00Z"),
+        )
+        val manager = createManager()
+
+        val result = manager.sync()
+
+        assertTrue(result.isSuccess)
+        assertEquals(
+            listOf(prA.id),
+            fakeSyncRepo.updatePersonalRecordTimestampCalls.single(),
+            "Duplicate PR ids in the delta query result must be deduped before stamping",
+        )
+    }
+
+    @Test
     fun syncEnsuresDefaultProfileBeforeSendingDefaultScopedPersonalRecords() = runTest {
         setupAuthenticated()
         fakeSyncRepo.fullPRsToReturn = listOf(

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeSyncRepository.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeSyncRepository.kt
@@ -138,6 +138,18 @@ class FakeSyncRepository : SyncRepository {
         updatedSessionTimestamps[sessionId] = timestamp
     }
 
+    // Issue #528: capture PR stamp calls so SyncManagerTest can assert that
+    // pushed PRs are stamped the same way pushed sessions are.
+    var updatedPersonalRecordTimestamps: MutableMap<Long, Long> = mutableMapOf()
+    var updatePersonalRecordTimestampCalls: MutableList<List<Long>> = mutableListOf()
+    var lastUpdatePersonalRecordTimestamp: Long? = null
+
+    override suspend fun updatePersonalRecordTimestamp(prIds: List<Long>, timestamp: Long) {
+        updatePersonalRecordTimestampCalls += prIds
+        lastUpdatePersonalRecordTimestamp = timestamp
+        prIds.forEach { id -> updatedPersonalRecordTimestamps[id] = timestamp }
+    }
+
     // === Parity Sync: Entity ID lists (simulate local database content) ===
 
     var sessionIds: List<String> = emptyList()


### PR DESCRIPTION
## Summary

Fixes #528

This PR addresses the mobile-side Cloud Sync persistence identified in the RCA for issue #528:

- Stops treating a 3x TRANSIENT retry storm as a persistent user-visible Cloud Sync error. PERMANENT and AUTH failures still latch the persistent error state.
- Lets the Settings > Cloud Sync error row dismiss the existing persistent error via `SyncTriggerManager.clearError()` so stale errors can be cleared by the user.
- Stamps pushed `PersonalRecord.updatedAt` rows after the server confirms a push, matching the resend-prevention behavior already present for workout sessions.
- Adds SQLDelight/repository support for PR timestamp stamping and regression coverage for PR stamping/deduping plus the transient retry-storm contract.

## RCA basis

RCA comment: https://github.com/9thLevelSoftware/Project-Phoenix-MP/issues/528#issuecomment-4663039686

Root causes addressed:

1. `SyncTriggerManager._hasPersistentError` latched after three TRANSIENT 500s and had no UI clear path.
2. `SyncManager.pushLocalChanges()` stamped pushed sessions but not pushed personal records, causing pre-fix PR rows to be re-sent on every push.

## Verification

Ran locally on macOS with Homebrew OpenJDK 17 and Android SDK:

```bash
JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home \
ANDROID_HOME=/opt/homebrew/share/android-commandlinetools \
./gradlew -Pskip.supabase.check=true :shared:allTests --no-daemon
```

Result:

```text
BUILD SUCCESSFUL in 33s
23 actionable tasks: 7 executed, 16 up-to-date
```

Also ran:

```bash
git diff --check
```

No whitespace errors.

## Review notes

- Spec-compliance reviewer: CLEAN.
- Code-quality reviewer: CLEAN after applying the suggested SQLDelight bulk-list call cleanup and clarifying the PR-stamping comment.

User retains final merge approval; this automation will not merge.
