### PR TITLE
Fix ExerciseConfigModal eccentric percent label

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/EccentricLoadLabels.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/EccentricLoadLabels.kt
@@ -48,10 +48,20 @@ import vitruvianprojectphoenix.shared.generated.resources.echo_level_hardest
  *                 get the ASCII form.
  */
 internal fun formatEccentricLoad(load: EccentricLoad, language: String): String {
+    return formatEccentricLoad(load.percentage, language)
+}
+
+/**
+ * Non-Composable pure formatter for raw eccentric-load percentages surfaced by
+ * slider UIs. Unlike [EccentricLoad], sliders can land on intermediate values
+ * such as `105`, so callers must not coerce through the enum and accidentally
+ * relabel the selected percentage.
+ */
+internal fun formatEccentricLoad(percentage: Int, language: String): String {
     return if (language.equals("it", ignoreCase = true)) {
-        "${load.percentage}\u00A0%"
+        "$percentage\u00A0%"
     } else {
-        "${load.percentage}%"
+        "$percentage%"
     }
 }
 
@@ -62,12 +72,18 @@ internal fun formatEccentricLoad(load: EccentricLoad, language: String): String 
  * compiles cleanly for both the Android and iOS targets.
  *
  * Returns the locale-formatted percentage for the dropdown value cell in
- * [com.devil.phoenixproject.presentation.screen.JustLiftScreen] (line ~528)
- * and the matching dropdown item text (line ~544).
+ * [com.devil.phoenixproject.presentation.screen.JustLiftScreen] (line ~528),
+ * the matching dropdown item text (line ~544), and slider value labels that
+ * surface raw eccentric-load percentages.
  */
 @Composable
 fun eccentricLoadLabel(load: EccentricLoad): String {
     return formatEccentricLoad(load, currentLanguageCode())
+}
+
+@Composable
+fun eccentricLoadLabel(percentage: Int): String {
+    return formatEccentricLoad(percentage, currentLanguageCode())
 }
 
 /**

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/EccentricLoadLabels.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/EccentricLoadLabels.kt
@@ -58,7 +58,8 @@ internal fun formatEccentricLoad(load: EccentricLoad, language: String): String 
  * relabel the selected percentage.
  */
 internal fun formatEccentricLoad(percentage: Int, language: String): String {
-    return if (language.equals("it", ignoreCase = true)) {
+    val lang = language.substringBefore('-').substringBefore('_')
+    return if (lang.equals("it", ignoreCase = true)) {
         "$percentage\u00A0%"
     } else {
         "$percentage%"
@@ -66,7 +67,7 @@ internal fun formatEccentricLoad(percentage: Int, language: String): String {
 }
 
 /**
- * Composable wrapper that resolves the active language code via
+ * Convenience wrapper that resolves the active language code via
  * [currentLanguageCode] and delegates to [formatEccentricLoad]. No
  * Compose-Multiplatform-specific locale API is required, so this helper
  * compiles cleanly for both the Android and iOS targets.
@@ -76,12 +77,10 @@ internal fun formatEccentricLoad(percentage: Int, language: String): String {
  * the matching dropdown item text (line ~544), and slider value labels that
  * surface raw eccentric-load percentages.
  */
-@Composable
 fun eccentricLoadLabel(load: EccentricLoad): String {
     return formatEccentricLoad(load, currentLanguageCode())
 }
 
-@Composable
 fun eccentricLoadLabel(percentage: Int): String {
     return formatEccentricLoad(percentage, currentLanguageCode())
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/ExerciseConfigModal.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/ExerciseConfigModal.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.window.Dialog
 import com.devil.phoenixproject.domain.model.EchoLevel
 import com.devil.phoenixproject.domain.model.ExerciseConfig
 import com.devil.phoenixproject.domain.model.ProgramMode
+import com.devil.phoenixproject.domain.model.eccentricLoadLabel
 import com.devil.phoenixproject.ui.theme.Spacing
 import org.jetbrains.compose.resources.stringResource
 import vitruvianprojectphoenix.shared.generated.resources.*
@@ -415,7 +416,7 @@ private fun EccentricSlider(percent: Int, onPercentChange: (Int) -> Unit, label:
                 letterSpacing = 1.sp,
             )
             Text(
-                text = "$percent%",
+                text = eccentricLoadLabel(percent),
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.primary,

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/EccentricLoadDisplayNameTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/EccentricLoadDisplayNameTest.kt
@@ -107,6 +107,21 @@ class EccentricLoadDisplayNameTest {
     }
 
     @Test
+    fun formatEccentricLoadEnglishSupportsIntermediateSliderPercentages() {
+        val label = formatEccentricLoad(105, "en")
+        assertEquals("105%", label)
+        assertFalse(label.contains('\u00A0'), "en must not introduce NBSP")
+    }
+
+    @Test
+    fun formatEccentricLoadItalianSupportsIntermediateSliderPercentages() {
+        val label = formatEccentricLoad(105, "it")
+        assertEquals("105\u00A0%", label)
+        assertTrue(label.contains('\u00A0'), "it must contain NBSP (U+00A0)")
+        assertTrue(label.endsWith("%"), "percent glyph still required")
+    }
+
+    @Test
     fun currentLanguageCodeIosExtractsLanguageSubtag() {
         // The iOS actual for `currentLanguageCode()` must reduce a BCP-47
         // AppleLanguages entry like "it-IT" / "en-US" to the language subtag

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/EccentricLoadDisplayNameTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/EccentricLoadDisplayNameTest.kt
@@ -122,19 +122,21 @@ class EccentricLoadDisplayNameTest {
     }
 
     @Test
+    fun formatEccentricLoadItalianAcceptsRegionTags() {
+        assertEquals("110\u00A0%", formatEccentricLoad(EccentricLoad.LOAD_110, "it-IT"))
+        assertEquals("105\u00A0%", formatEccentricLoad(105, "it_IT"))
+    }
+
+    @Test
     fun currentLanguageCodeIosExtractsLanguageSubtag() {
-        // The iOS actual for `currentLanguageCode()` must reduce a BCP-47
-        // AppleLanguages entry like "it-IT" / "en-US" to the language subtag
-        // so the formatter's `equals("it", ignoreCase = true)` branch fires
-        // regardless of region. We can't directly test the iOS actual from
-        // androidHostTest (it's an iosMain source set), but we can pin the
-        // invariant by exercising the formatter with the already-extracted
-        // short code: passing the full tag would fail the equals check, so
-        // the iOS actual MUST strip the region before the call.
+        // The iOS actual for `currentLanguageCode()` should reduce a BCP-47
+        // AppleLanguages entry like "it-IT" / "en-US" to the language subtag.
+        // The formatter also defensively accepts full tags, but the platform
+        // helper should still keep its public contract of returning only the
+        // language subtag.
         val full = "it-IT"
         val extracted = full.substringBefore('-').lowercase()
         assertEquals("it", extracted)
-        // And the formatter must accept the extracted form.
         val label = formatEccentricLoad(EccentricLoad.LOAD_110, extracted)
         assertEquals("110\u00A0%", label)
     }


### PR DESCRIPTION
## Summary
- Route `ExerciseConfigModal`'s `EccentricSlider` value label through the locale-aware eccentric-load formatter used for issue #540.
- Add a raw-percent overload so slider-only intermediate values like `105` are formatted correctly instead of being coerced through `EccentricLoad` enum entries.
- Harden locale matching for `it-IT` / `it_IT`, remove unnecessary `@Composable` from pure label helpers, and cover English/Italian NBSP formatting for intermediate slider percentages.

Refs #540
Follow-up to #542.

## Tests
- PASS: `./gradlew :shared:testAndroidHostTest -Pskip.supabase.check=true --no-daemon --console=plain`
- PASS: `git diff --check`
- PASS: GitHub CI run 27488527632 (Security Hygiene, iOS Schema Sync Check, Lint Check, Unit Tests, Build Android, iOS Test Target Compile, Shared Module Test Results, Android App Unit Test Results)
- PASS: Kilo Code Review
- NOTE: local `./gradlew spotlessKotlinCheck -Pskip.supabase.check=true --no-daemon --console=plain` still fails on pre-existing unrelated files; none of the 3 changed files appeared in the Spotless violation log.
