### PR TITLE
Fix Rest Timer eccentric percent localization

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/EccentricLoadLabels.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/EccentricLoadLabels.kt
@@ -48,7 +48,7 @@ import vitruvianprojectphoenix.shared.generated.resources.echo_level_hardest
  *                 get the ASCII form.
  */
 internal fun formatEccentricLoad(load: EccentricLoad, language: String): String {
-    return formatEccentricLoad(load.percentage, language)
+    return formatEccentricLoadPercent(load.percentage, language)
 }
 
 /**
@@ -57,7 +57,7 @@ internal fun formatEccentricLoad(load: EccentricLoad, language: String): String 
  * such as `105`, so callers must not coerce through the enum and accidentally
  * relabel the selected percentage.
  */
-internal fun formatEccentricLoad(percentage: Int, language: String): String {
+internal fun formatEccentricLoadPercent(percentage: Int, language: String): String {
     val lang = language.substringBefore('-').substringBefore('_')
     return if (lang.equals("it", ignoreCase = true)) {
         "$percentage\u00A0%"
@@ -66,8 +66,8 @@ internal fun formatEccentricLoad(percentage: Int, language: String): String {
     }
 }
 
-internal fun formatEccentricLoad(load: EccentricLoad, language: String): String {
-    return formatEccentricLoadPercent(load.percentage, language)
+internal fun formatEccentricLoad(percentage: Int, language: String): String {
+    return formatEccentricLoadPercent(percentage, language)
 }
 
 /**
@@ -95,12 +95,8 @@ fun eccentricLoadLabel(percentage: Int): String {
  */
 @Composable
 fun eccentricLoadPercentLabel(percent: Int): String {
-@Composable
-fun eccentricLoadPercentLabel(percent: Int): String {
     val language = currentLanguageCode()
     return formatEccentricLoadPercent(percent, language)
-}
-    return androidx.compose.runtime.remember(percent, language) { formatEccentricLoadPercent(percent, language) }
 }
 
 /**

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/EccentricLoadLabels.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/EccentricLoadLabels.kt
@@ -47,12 +47,16 @@ import vitruvianprojectphoenix.shared.generated.resources.echo_level_hardest
  *                 `"en"`, `"it"`, `"de"`. Pass `""` or a non-`"it"` value to
  *                 get the ASCII form.
  */
-internal fun formatEccentricLoad(load: EccentricLoad, language: String): String {
+internal fun formatEccentricLoadPercent(percent: Int, language: String): String {
     return if (language.equals("it", ignoreCase = true)) {
-        "${load.percentage}\u00A0%"
+        "$percent\u00A0%"
     } else {
-        "${load.percentage}%"
+        "$percent%"
     }
+}
+
+internal fun formatEccentricLoad(load: EccentricLoad, language: String): String {
+    return formatEccentricLoadPercent(load.percentage, language)
 }
 
 /**
@@ -68,6 +72,15 @@ internal fun formatEccentricLoad(load: EccentricLoad, language: String): String 
 @Composable
 fun eccentricLoadLabel(load: EccentricLoad): String {
     return formatEccentricLoad(load, currentLanguageCode())
+}
+
+/**
+ * Composable wrapper for UI surfaces that store eccentric load as an integer
+ * percentage rather than as an [EccentricLoad] enum entry.
+ */
+@Composable
+fun eccentricLoadPercentLabel(percent: Int): String {
+    return formatEccentricLoadPercent(percent, currentLanguageCode())
 }
 
 /**

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/EccentricLoadLabels.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/EccentricLoadLabels.kt
@@ -80,7 +80,11 @@ fun eccentricLoadLabel(load: EccentricLoad): String {
  */
 @Composable
 fun eccentricLoadPercentLabel(percent: Int): String {
-    val language = androidx.compose.runtime.remember { currentLanguageCode() }
+@Composable
+fun eccentricLoadPercentLabel(percent: Int): String {
+    val language = currentLanguageCode()
+    return formatEccentricLoadPercent(percent, language)
+}
     return androidx.compose.runtime.remember(percent, language) { formatEccentricLoadPercent(percent, language) }
 }
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/EccentricLoadLabels.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/EccentricLoadLabels.kt
@@ -80,7 +80,8 @@ fun eccentricLoadLabel(load: EccentricLoad): String {
  */
 @Composable
 fun eccentricLoadPercentLabel(percent: Int): String {
-    return formatEccentricLoadPercent(percent, currentLanguageCode())
+    val language = androidx.compose.runtime.remember { currentLanguageCode() }
+    return androidx.compose.runtime.remember(percent, language) { formatEccentricLoadPercent(percent, language) }
 }
 
 /**

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RestTimerCard.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RestTimerCard.kt
@@ -58,6 +58,7 @@ import androidx.compose.ui.unit.sp
 import com.devil.phoenixproject.domain.model.EchoLevel
 import com.devil.phoenixproject.domain.model.ProgramMode
 import com.devil.phoenixproject.domain.model.WeightUnit
+import com.devil.phoenixproject.domain.model.eccentricLoadPercentLabel
 import com.devil.phoenixproject.presentation.components.ExpressiveSlider
 import com.devil.phoenixproject.presentation.components.SliderWithButtons
 import com.devil.phoenixproject.ui.theme.Spacing
@@ -720,7 +721,7 @@ private fun RestTimerEccentricLoadSlider(percent: Int, onPercentChange: (Int) ->
                 letterSpacing = 1.sp,
             )
             Text(
-                text = "$percent%",
+                text = eccentricLoadPercentLabel(percent),
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.primary,

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/EccentricLoadDisplayNameTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/EccentricLoadDisplayNameTest.kt
@@ -30,8 +30,9 @@ import kotlin.test.assertTrue
  * The bugfix:
  *   - Replaces the hard-coded English literals with `stringResource` lookups.
  *   - Routes the dropdown value through a new `formatEccentricLoad(load,
- *     language)` helper that emits `"110\u00A0%"` (with U+00A0 NBSP) for any
- *     `it-*` language and `"110%"` for every other locale.
+ *     language)` helper (and the Rest Timer integer-percent equivalent) that
+ *     emits `"110\u00A0%"` (with U+00A0 NBSP) for any `it-*` language and
+ *     `"110%"` for every other locale.
  *   - Adds `values-it/strings.xml` plus a `CFBundleLocalizations` entry in the
  *     iOS Info.plist so the system actually advertises Italian as a shipped
  *     locale.
@@ -85,6 +86,26 @@ class EccentricLoadDisplayNameTest {
     }
 
     // -------- Post-fix: locale-aware formatter (issue #540) --------
+
+    @Test
+    fun formatEccentricLoadPercentSupportsRestTimerFivePercentIncrements() {
+        // RestTimerEccentricLoadSlider stores the slider value as an Int rather
+        // than as an EccentricLoad enum entry, and can land on 5% increments
+        // such as 105. The integer helper must preserve the same locale policy.
+        assertEquals("105%", formatEccentricLoadPercent(105, "en"))
+        assertEquals("105\u00A0%", formatEccentricLoadPercent(105, "it"))
+    }
+
+    @Test
+    fun formatEccentricLoadDelegatesToIntegerPercentFormatter() {
+        EccentricLoad.entries.forEach { load ->
+            assertEquals(
+                formatEccentricLoadPercent(load.percentage, "it"),
+                formatEccentricLoad(load, "it"),
+                "enum helper should share the integer formatter for ${load.name}",
+            )
+        }
+    }
 
     @Test
     fun formatEccentricLoadEnglishKeepsAsciiPercentNoSeparator() {


### PR DESCRIPTION
## Summary
- route the Rest Timer eccentric-load value through the shared locale-aware percent label helper
- add an integer percent formatter for Rest Timer slider values that are not always `EccentricLoad` enum entries
- extend the eccentric-load regression coverage for Italian NBSP percent rendering on 5% slider increments

## Verification
- `git diff --check`
- `./gradlew :shared:testAndroidHostTest -Pskip.supabase.check=true --no-daemon --console=plain`
- `./gradlew :shared:compileKotlinIosArm64 :shared:compileTestKotlinIosArm64 -Pskip.supabase.check=true --no-daemon --console=plain`

Related to #540.
