### PR TITLE
Fix Routine Overview eccentric percentage localization

### DIFF
--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/screen/RoutineOverviewLocalizationGuardTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/screen/RoutineOverviewLocalizationGuardTest.kt
@@ -15,7 +15,16 @@ class RoutineOverviewLocalizationGuardTest {
         dir
     }
 
-    private fun read(relativePath: String): String = File(projectRoot, relativePath).readText()
+    private fun read(relativePath: String): String {
+        val file = File(projectRoot, relativePath)
+        if (!file.exists()) {
+            throw IllegalStateException(
+                "Source file not found at ${file.absolutePath}. " +
+                    "This localization guard test requires project source files to be present on disk.",
+            )
+        }
+        return file.readText()
+    }
 
     @Test
     fun overviewEchoLevelSelectorUsesResourceLabelAndLocalizedChipText() {

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/screen/RoutineOverviewLocalizationGuardTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/screen/RoutineOverviewLocalizationGuardTest.kt
@@ -1,0 +1,63 @@
+package com.devil.phoenixproject.presentation.screen
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class RoutineOverviewLocalizationGuardTest {
+
+    private val projectRoot: File by lazy {
+        var dir = File(System.getProperty("user.dir") ?: ".")
+        while (!File(dir, "shared/src/commonMain").exists()) {
+            dir = dir.parentFile ?: break
+        }
+        dir
+    }
+
+    private fun read(relativePath: String): String = File(projectRoot, relativePath).readText()
+
+    @Test
+    fun overviewEchoLevelSelectorUsesResourceLabelAndLocalizedChipText() {
+        val source = read("shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RoutineOverviewScreen.kt")
+
+        assertTrue(
+            source.contains("stringResource(Res.string.rest_echo_level)"),
+            "Overview Echo Level label must use the Compose resource system.",
+        )
+        assertTrue(
+            source.contains("echoLevelLabel(level)"),
+            "Overview Echo Level chips must use localized EchoLevel labels instead of enum displayName.",
+        )
+        assertFalse(
+            source.contains("text = \"ECHO LEVEL\""),
+            "Overview Echo Level label must not be hard-coded English.",
+        )
+        assertFalse(
+            source.contains("text = level.displayName"),
+            "Overview Echo Level chips must not surface hard-coded enum displayName values.",
+        )
+    }
+
+    @Test
+    fun overviewEccentricLoadSliderUsesResourceLabelAndLocalizedPercentText() {
+        val source = read("shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RoutineOverviewScreen.kt")
+
+        assertTrue(
+            source.contains("stringResource(Res.string.rest_eccentric_load)"),
+            "Overview Eccentric Load label must use the Compose resource system.",
+        )
+        assertTrue(
+            source.contains("eccentricPercentLabel(percent)"),
+            "Overview Eccentric Load value must use the locale-aware percent formatter.",
+        )
+        assertFalse(
+            source.contains("text = \"ECCENTRIC LOAD\""),
+            "Overview Eccentric Load label must not be hard-coded English.",
+        )
+        assertFalse(
+            source.contains("text = \"\$percent%\""),
+            "Overview Eccentric Load value must not use the raw <int>% rendering.",
+        )
+    }
+}

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/EccentricLoadLabels.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/EccentricLoadLabels.kt
@@ -18,7 +18,8 @@ import vitruvianprojectphoenix.shared.generated.resources.echo_level_hardest
  * Italian typography inserts a hard non-breaking space (U+00A0) between the
  * digits and the percent sign — `110 %` — and iOS SF Pro renders that form
  * without a glyph collision. This file emits that form for any `it-*`
- * language and the back-compat ASCII `110%` form for every other locale.
+ * language (including regional variants like `it-IT` / `it_IT`) and the
+ * back-compat ASCII `110%` form for every other locale.
  *
  * The pure formatter [formatEccentricPercent] is `internal` so the unit test
  * in `commonTest` can exercise the per-locale behaviour without needing a
@@ -33,7 +34,7 @@ import vitruvianprojectphoenix.shared.generated.resources.echo_level_hardest
  * Exposed as `internal` for unit testing.
  *
  * Behaviour:
- *  * For Italian (the language code `it`, case-insensitive) this returns the
+ *  * For Italian (the base language code `it`, case-insensitive) this returns the
  *    digits followed by U+00A0 NBSP and `%` — e.g. `"110\u00A0%"`. This is
  *    the canonical Italian typographic form and resolves the iOS SF Pro
  *    `%`-glyph collision.
@@ -42,15 +43,16 @@ import vitruvianprojectphoenix.shared.generated.resources.echo_level_hardest
  *    the existing English UI is unchanged).
  *
  * @param percent  the eccentric load percentage to format for display.
- * @param language the lowercased language code of the active locale, e.g.
- *                 `"en"`, `"it"`, `"de"`. Pass `""` or a non-`"it"` value to
- *                 get the ASCII form.
+ * @param language the language code or locale tag of the active locale, e.g.
+ *                 `"en"`, `"it"`, `"it-IT"`, `"it_IT"`, `"de"`. Pass `""`
+ *                 or a non-Italian value to get the ASCII form.
  */
-internal fun formatEccentricPercent(percent: Int, language: String): String = if (language.equals("it", ignoreCase = true)) {
-    "$percent\u00A0%"
-} else {
-    "$percent%"
-}
+internal fun formatEccentricPercent(percent: Int, language: String): String =
+    if (language.substringBefore('-').substringBefore('_').equals("it", ignoreCase = true)) {
+        "$percent\u00A0%"
+    } else {
+        "$percent%"
+    }
 
 /**
  * Formats an [EccentricLoad] enum entry while preserving the enum's raw

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/EccentricLoadLabels.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/EccentricLoadLabels.kt
@@ -20,17 +20,17 @@ import vitruvianprojectphoenix.shared.generated.resources.echo_level_hardest
  * without a glyph collision. This file emits that form for any `it-*`
  * language and the back-compat ASCII `110%` form for every other locale.
  *
- * The pure formatter [formatEccentricLoad] is `internal` so the unit test in
- * `commonTest` can exercise the per-locale behaviour without needing a
+ * The pure formatter [formatEccentricPercent] is `internal` so the unit test
+ * in `commonTest` can exercise the per-locale behaviour without needing a
  * Compose runtime or a platform-specific locale implementation. The
- * `@Composable` [eccentricLoadLabel] wrapper uses the expect/actual
- * [currentLanguageCode] helper to get the active app locale without pulling
- * in any Compose-Multiplatform-specific locale API.
+ * `@Composable` [eccentricLoadLabel] / [eccentricPercentLabel] wrappers use the
+ * expect/actual [currentLanguageCode] helper to get the active app locale
+ * without pulling in any Compose-Multiplatform-specific locale API.
  */
 
 /**
- * Non-Composable pure formatter used by the `@Composable` [eccentricLoadLabel]
- * wrapper. Exposed as `internal` for unit testing.
+ * Non-Composable pure formatter used by the `@Composable` label wrappers.
+ * Exposed as `internal` for unit testing.
  *
  * Behaviour:
  *  * For Italian (the language code `it`, case-insensitive) this returns the
@@ -41,19 +41,22 @@ import vitruvianprojectphoenix.shared.generated.resources.echo_level_hardest
  *    `"110%"` (byte-identical to the legacy `EccentricLoad.displayName` so
  *    the existing English UI is unchanged).
  *
- * @param load     the [EccentricLoad] enum entry whose
- *                 [EccentricLoad.percentage] is formatted.
+ * @param percent  the eccentric load percentage to format for display.
  * @param language the lowercased language code of the active locale, e.g.
  *                 `"en"`, `"it"`, `"de"`. Pass `""` or a non-`"it"` value to
  *                 get the ASCII form.
  */
-internal fun formatEccentricLoad(load: EccentricLoad, language: String): String {
-    return if (language.equals("it", ignoreCase = true)) {
-        "${load.percentage}\u00A0%"
-    } else {
-        "${load.percentage}%"
-    }
+internal fun formatEccentricPercent(percent: Int, language: String): String = if (language.equals("it", ignoreCase = true)) {
+    "$percent\u00A0%"
+} else {
+    "$percent%"
 }
+
+/**
+ * Formats an [EccentricLoad] enum entry while preserving the enum's raw
+ * [EccentricLoad.displayName] contract for non-Italian locales.
+ */
+internal fun formatEccentricLoad(load: EccentricLoad, language: String): String = formatEccentricPercent(load.percentage, language)
 
 /**
  * Composable wrapper that resolves the active language code via
@@ -66,9 +69,14 @@ internal fun formatEccentricLoad(load: EccentricLoad, language: String): String 
  * and the matching dropdown item text (line ~544).
  */
 @Composable
-fun eccentricLoadLabel(load: EccentricLoad): String {
-    return formatEccentricLoad(load, currentLanguageCode())
-}
+fun eccentricLoadLabel(load: EccentricLoad): String = formatEccentricLoad(load, currentLanguageCode())
+
+/**
+ * Composable wrapper for slider/readout surfaces that store eccentric load as
+ * a raw integer percentage instead of an [EccentricLoad] enum entry.
+ */
+@Composable
+fun eccentricPercentLabel(percent: Int): String = formatEccentricPercent(percent, currentLanguageCode())
 
 /**
  * Returns the [EchoLevel] label via the [stringResource] lookup so the

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RoutineOverviewScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RoutineOverviewScreen.kt
@@ -70,6 +70,8 @@ import com.devil.phoenixproject.domain.model.ProgramMode
 import com.devil.phoenixproject.domain.model.RoutineExercise
 import com.devil.phoenixproject.domain.model.RoutineFlowState
 import com.devil.phoenixproject.domain.model.WeightUnit
+import com.devil.phoenixproject.domain.model.eccentricPercentLabel
+import com.devil.phoenixproject.domain.model.echoLevelLabel
 import com.devil.phoenixproject.domain.usecase.RoutineTimeEstimate
 import com.devil.phoenixproject.domain.usecase.RoutineTimeEstimator
 import com.devil.phoenixproject.presentation.components.BackHandler
@@ -92,6 +94,8 @@ import vitruvianprojectphoenix.shared.generated.resources.action_exit
 import vitruvianprojectphoenix.shared.generated.resources.action_stop
 import vitruvianprojectphoenix.shared.generated.resources.exit_routine_message
 import vitruvianprojectphoenix.shared.generated.resources.exit_routine_title
+import vitruvianprojectphoenix.shared.generated.resources.rest_eccentric_load
+import vitruvianprojectphoenix.shared.generated.resources.rest_echo_level
 import vitruvianprojectphoenix.shared.generated.resources.start_exercise
 import vitruvianprojectphoenix.shared.generated.resources.target_reps
 
@@ -783,7 +787,7 @@ private fun ExerciseOverviewCard(
 private fun OverviewEchoLevelSelector(selectedLevel: EchoLevel, onLevelChange: (EchoLevel) -> Unit) {
     Column {
         Text(
-            text = "ECHO LEVEL",
+            text = stringResource(Res.string.rest_echo_level),
             style = MaterialTheme.typography.labelSmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             letterSpacing = 1.sp,
@@ -815,7 +819,7 @@ private fun OverviewEchoLevelSelector(selectedLevel: EchoLevel, onLevelChange: (
                     onClick = { onLevelChange(level) },
                 ) {
                     Text(
-                        text = level.displayName,
+                        text = echoLevelLabel(level),
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(vertical = Spacing.small),
@@ -846,13 +850,13 @@ private fun OverviewEccentricLoadSlider(percent: Int, onPercentChange: (Int) -> 
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
-                text = "ECCENTRIC LOAD",
+                text = stringResource(Res.string.rest_eccentric_load),
                 style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 letterSpacing = 1.sp,
             )
             Text(
-                text = "$percent%",
+                text = eccentricPercentLabel(percent),
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.primary,

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/EccentricLoadDisplayNameTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/EccentricLoadDisplayNameTest.kt
@@ -31,7 +31,7 @@ import kotlin.test.assertTrue
  *   - Replaces the hard-coded English literals with `stringResource` lookups.
  *   - Routes the dropdown value through a new `formatEccentricLoad(load,
  *     language)` helper that emits `"110\u00A0%"` (with U+00A0 NBSP) for any
- *     `it-*` language and `"110%"` for every other locale.
+ *     `it-*` / `it_*` language and `"110%"` for every other locale.
  *   - Adds `values-it/strings.xml` plus a `CFBundleLocalizations` entry in the
  *     iOS Info.plist so the system actually advertises Italian as a shipped
  *     locale.
@@ -40,8 +40,8 @@ import kotlin.test.assertTrue
  *   - The unchanged `EccentricLoad` / `EchoLevel` / `WorkoutMode.Echo` enum
  *     `displayName` values (BLE, tests, CSV consumers rely on the raw form).
  *   - The new locale-aware formatter's behaviour for `en` (ASCII) and `it`
- *     (NBSP), including a region-subtag variant (`it-IT`) so we know the
- *     substring check is robust to BCP-47 tags.
+ *     (NBSP), including region variants (`it-IT`, `it_IT`) so we know the
+ *     substring check is robust to BCP-47 and Java-style locale tags.
  *   - A per-entry cross-locale invariant (every `EccentricLoad` value
  *     formats correctly under both `en` and `it`).
  */
@@ -122,21 +122,10 @@ class EccentricLoadDisplayNameTest {
     }
 
     @Test
-    fun currentLanguageCodeIosExtractsLanguageSubtag() {
-        // The iOS actual for `currentLanguageCode()` must reduce a BCP-47
-        // AppleLanguages entry like "it-IT" / "en-US" to the language subtag
-        // so the formatter's `equals("it", ignoreCase = true)` branch fires
-        // regardless of region. We can't directly test the iOS actual from
-        // androidHostTest (it's an iosMain source set), but we can pin the
-        // invariant by exercising the formatter with the already-extracted
-        // short code: passing the full tag would fail the equals check, so
-        // the iOS actual MUST strip the region before the call.
-        val full = "it-IT"
-        val extracted = full.substringBefore('-').lowercase()
-        assertEquals("it", extracted)
-        // And the formatter must accept the extracted form.
-        val label = formatEccentricLoad(EccentricLoad.LOAD_110, extracted)
-        assertEquals("110\u00A0%", label)
+    fun formatEccentricLoadItalianRegionTagsInsertNbspBeforePercentGlyph() {
+        assertEquals("110\u00A0%", formatEccentricLoad(EccentricLoad.LOAD_110, "it-IT"))
+        assertEquals("110\u00A0%", formatEccentricLoad(EccentricLoad.LOAD_110, "it_IT"))
+        assertEquals("110\u00A0%", formatEccentricLoad(EccentricLoad.LOAD_110, "IT-ch"))
     }
 
     @Test
@@ -149,8 +138,8 @@ class EccentricLoadDisplayNameTest {
 
     @Test
     fun formatEccentricLoadItCaseInsensitive() {
-        // The helper uses equals("it", ignoreCase = true); verify the
-        // uppercase / mixed-case form still routes to the Italian branch.
+        // The helper compares the extracted base language case-insensitively;
+        // verify the uppercase / mixed-case form still routes to the Italian branch.
         val label = formatEccentricLoad(EccentricLoad.LOAD_100, "IT")
         assertEquals("100\u00A0%", label)
     }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/EccentricLoadDisplayNameTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/EccentricLoadDisplayNameTest.kt
@@ -107,6 +107,21 @@ class EccentricLoadDisplayNameTest {
     }
 
     @Test
+    fun formatEccentricPercentItalianInsertsNbspBeforePercentGlyph() {
+        val label = formatEccentricPercent(110, "it")
+        assertEquals("110\u00A0%", label)
+        assertTrue(label.contains('\u00A0'), "it must contain NBSP (U+00A0)")
+        assertTrue(label.endsWith("%"), "percent glyph still required")
+    }
+
+    @Test
+    fun formatEccentricPercentEnglishKeepsAsciiPercentNoSeparator() {
+        val label = formatEccentricPercent(110, "en")
+        assertEquals("110%", label)
+        assertFalse(label.contains('\u00A0'), "en must not introduce NBSP")
+    }
+
+    @Test
     fun currentLanguageCodeIosExtractsLanguageSubtag() {
         // The iOS actual for `currentLanguageCode()` must reduce a BCP-47
         // AppleLanguages entry like "it-IT" / "en-US" to the language subtag


### PR DESCRIPTION
## Summary
- Localize RoutineOverview Echo/Eccentric headings with existing Compose string resources.
- Route RoutineOverview EchoLevel chips through `echoLevelLabel(level)` instead of enum `displayName`.
- Add an Int-based eccentric percent label helper so slider readouts use the Italian NBSP percent form (`110 %`) while keeping other locales as `110%`.
- Add regression coverage for the formatter and RoutineOverview source call sites.

## Verification
- PASS: `./gradlew :shared:testAndroidHostTest -Pskip.supabase.check=true --no-daemon --console=plain`
- PASS: `./gradlew :shared:compileKotlinIosArm64 :shared:compileTestKotlinIosArm64 -Pskip.supabase.check=true --no-daemon --console=plain`
- PASS: `bash .github/scripts/forbid-tracked-secrets.sh`
- PASS: `bash .github/scripts/validate-ios-schema.sh`
- PASS: `git diff --check`

## Notes
- Refs #540.
- `./gradlew spotlessCheck` currently fails on unrelated pre-existing files from `origin/main` (for example `HealthConnectReenableGuardTest.kt` import ordering and other baseline formatting violations); this PR's touched files were formatted with `spotlessApply`, with unrelated formatter changes restored before commit.
