### PR TITLE
fix(issue-549): refresh Home cycle banner via checkAndAutoAdvance

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/HomeScreen.kt
@@ -98,7 +98,13 @@ fun HomeScreen(navController: NavController, viewModel: MainViewModel) {
     var showOneRepMaxComingSoonDialog by remember { mutableStateOf(false) }
 
     LaunchedEffect(activeCycle) {
-        cycleProgress = activeCycle?.let { cycle -> cycleRepository.getCycleProgress(cycle.id) }
+        // Issue #549: route the Home banner through `checkAndAutoAdvance` so the cycle banner
+        // refreshes to the current day on initial Home load. Previously this called
+        // `getCycleProgress` directly, which is a pure read and never reconciles
+        // `lastAdvancedAt` against the current calendar day. `TrainingCyclesScreen` is the only
+        // other production caller of `checkAndAutoAdvance` — that is exactly why the reporter's
+        // tap-Cycles-then-back workaround refreshed the banner.
+        cycleProgress = activeCycle?.let { cycle -> loadHomeCycleProgress(cycleRepository, cycle) }
     }
 
     LaunchedEffect(Unit) {
@@ -637,6 +643,26 @@ private data class CycleStartRequest(
     val cycleId: String,
     val dayNumber: Int,
 )
+
+/**
+ * Issue #549: load the active cycle's progress for the Home cycle banner.
+ *
+ * Calls [TrainingCycleRepository.checkAndAutoAdvance] first so the banner reflects the current
+ * calendar day on initial Home load (the previous `getCycleProgress`-only path left the banner
+ * showing the prior day's workout until the user visited the Cycles tab, which is the only
+ * other production caller of `checkAndAutoAdvance`). Falls back to `getCycleProgress` when
+ * `checkAndAutoAdvance` returns null (e.g. no progress row exists for the active cycle) so
+ * the Home path still renders the persisted value if one is present.
+ *
+ * Exposed as an `internal` suspend function so it can be unit-tested with a fake repository
+ * without spinning up a Compose UI host.
+ */
+internal suspend fun loadHomeCycleProgress(
+    repository: TrainingCycleRepository,
+    cycle: TrainingCycle,
+): CycleProgress? {
+    return repository.checkAndAutoAdvance(cycle.id) ?: repository.getCycleProgress(cycle.id)
+}
 
 internal fun buildHomeShortcutActions(
     onSingleExercise: () -> Unit,

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/screen/HomeScreenCycleBannerTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/screen/HomeScreenCycleBannerTest.kt
@@ -1,0 +1,122 @@
+package com.devil.phoenixproject.presentation.screen
+
+import com.devil.phoenixproject.domain.model.CycleDay
+import com.devil.phoenixproject.domain.model.TrainingCycle
+import com.devil.phoenixproject.testutil.FakeTrainingCycleRepository
+import com.devil.phoenixproject.util.KmpLocalDate
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atStartOfDayIn
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * Issue #549: Home cycle banner showed the prior day's workout on initial load because
+ * HomeScreen called `getCycleProgress` directly, skipping `checkAndAutoAdvance`. The fix routes
+ * the Home path through a new helper `loadHomeCycleProgress` that calls
+ * `checkAndAutoAdvance` first and falls back to `getCycleProgress` if the result is null.
+ *
+ * These tests assert:
+ *  1. `checkAndAutoAdvance` is called before `getCycleProgress`.
+ *  2. The returned `CycleProgress?` from `checkAndAutoAdvance` is used (auto-advance is honoured).
+ *  3. If `checkAndAutoAdvance` returns null (no progress row), the helper falls back to
+ *     `getCycleProgress` and returns whatever the persisted value is.
+ *  4. If both are null (no progress at all), the helper returns null (same as before).
+ *
+ * Uses `kotlinx.datetime` and the project's `KmpLocalDate` for system-tz midnight calculation so
+ * the test stays KMP-portable (the test source set is shared with iosTest, which has no
+ * `java.time.*` on the classpath).
+ */
+class HomeScreenCycleBannerTest {
+
+    @Test
+    fun `loadHomeCycleProgress calls checkAndAutoAdvance before getCycleProgress`() = runTest {
+        val repo = FakeTrainingCycleRepository()
+        val cycle = newTwoDayCycle(cycleId = "cycle-call-order")
+        repo.addCycle(cycle)
+        // Force a "yesterday" auto-advance by setting lastAdvancedAt to yesterday midnight.
+        val initial = repo.initializeProgress("cycle-call-order")
+        val yesterdayMidnight = yesterdayMidnightEpochMs()
+        repo.updateCycleProgress(initial.copy(lastAdvancedAt = yesterdayMidnight))
+        repo.resetCallLog()
+
+        loadHomeCycleProgress(repo, cycle)
+
+        val log = repo.callLog
+        // checkAndAutoAdvance is the only call the helper makes when it succeeds.
+        assertEquals("checkAndAutoAdvance", log.first())
+    }
+
+    @Test
+    fun `loadHomeCycleProgress uses the auto-advanced day from checkAndAutoAdvance`() = runTest {
+        val repo = FakeTrainingCycleRepository()
+        val cycle = newTwoDayCycle(cycleId = "cycle-auto-advance")
+        repo.addCycle(cycle)
+        val initial = repo.initializeProgress("cycle-auto-advance")
+        repo.updateCycleProgress(initial.copy(lastAdvancedAt = yesterdayMidnightEpochMs()))
+
+        val result = loadHomeCycleProgress(repo, cycle)
+
+        // Yesterday's progress (day 1) should auto-advance to day 2, not stay at day 1.
+        assertNotNull(result)
+        assertEquals(2, result.currentDayNumber)
+    }
+
+    @Test
+    fun `loadHomeCycleProgress falls back to getCycleProgress when checkAndAutoAdvance returns null`() = runTest {
+        val repo = FakeTrainingCycleRepository()
+        val cycle = newTwoDayCycle(cycleId = "cycle-fallback")
+        repo.addCycle(cycle)
+        // No progress row is initialized -> checkAndAutoAdvance will return null and the helper
+        // must fall back to getCycleProgress, which also returns null here (no persisted row).
+        repo.resetCallLog()
+
+        val result = loadHomeCycleProgress(repo, cycle)
+
+        // Both calls should have happened in this order, then the helper returned null.
+        assertNull(result)
+        assertEquals(listOf("checkAndAutoAdvance", "getCycleProgress"), repo.callLog)
+    }
+
+    @Test
+    fun `loadHomeCycleProgress returns the persisted value when no auto-advance is due`() = runTest {
+        val repo = FakeTrainingCycleRepository()
+        val cycle = newTwoDayCycle(cycleId = "cycle-no-advance")
+        repo.addCycle(cycle)
+        // Fresh progress initialized just now: pendingAutoAdvanceDays() == 0, so
+        // checkAndAutoAdvance returns the same row without advancing.
+        repo.initializeProgress("cycle-no-advance")
+
+        val result = loadHomeCycleProgress(repo, cycle)
+
+        // Still on day 1 because we just initialized; checkAndAutoAdvance was the only call.
+        assertNotNull(result)
+        assertEquals(1, result.currentDayNumber)
+        assertEquals(listOf("checkAndAutoAdvance"), repo.callLog)
+    }
+
+    private fun newTwoDayCycle(cycleId: String): TrainingCycle = TrainingCycle.create(
+        id = cycleId,
+        name = "Test cycle $cycleId",
+        days = listOf(
+            CycleDay.create(cycleId = cycleId, dayNumber = 1, name = "Day 1"),
+            CycleDay.create(cycleId = cycleId, dayNumber = 2, name = "Day 2"),
+        ),
+    )
+
+    /**
+     * Returns the epoch-ms for "yesterday at midnight in the system timezone" using the project's
+     * KMP-compatible date utilities. `pendingAutoAdvanceDays()` compares calendar dates in the
+     * system timezone, so anchoring to yesterday-midnight guarantees exactly 1 calendar day
+     * elapsed regardless of where in the day the test runs.
+     */
+    private fun yesterdayMidnightEpochMs(): Long {
+        val yesterday: KmpLocalDate = KmpLocalDate.today().minusDays(1)
+        return LocalDate(yesterday.year, yesterday.month, yesterday.dayOfMonth)
+            .atStartOfDayIn(TimeZone.currentSystemDefault())
+            .toEpochMilliseconds()
+    }
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeTrainingCycleRepository.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeTrainingCycleRepository.kt
@@ -24,6 +24,14 @@ class FakeTrainingCycleRepository : TrainingCycleRepository {
     private val cycleProgressions = mutableMapOf<String, CycleProgression>()
     private var activeCycleId: String? = null
 
+    // Issue #549: ordered log of mutating/read methods invoked on this fake. Tests can inspect
+    // it to assert call order (e.g. that the Home path calls `checkAndAutoAdvance` before
+    // `getCycleProgress`). Public read-only List, mutated only inside the fake's overrides.
+    private val _callLog = mutableListOf<String>()
+    val callLog: List<String> get() = _callLog.toList()
+
+    fun resetCallLog() { _callLog.clear() }
+
     private val _cyclesFlow = MutableStateFlow<List<TrainingCycle>>(emptyList())
     private val _activeCycleFlow = MutableStateFlow<TrainingCycle?>(null)
 
@@ -126,7 +134,10 @@ class FakeTrainingCycleRepository : TrainingCycleRepository {
         }
     }
 
-    override suspend fun getCycleProgress(cycleId: String): CycleProgress? = cycleProgress[cycleId]
+    override suspend fun getCycleProgress(cycleId: String): CycleProgress? {
+        _callLog.add("getCycleProgress")
+        return cycleProgress[cycleId]
+    }
 
     override suspend fun initializeProgress(cycleId: String): CycleProgress {
         val now = currentTimeMillis()
@@ -189,6 +200,7 @@ class FakeTrainingCycleRepository : TrainingCycleRepository {
     }
 
     override suspend fun checkAndAutoAdvance(cycleId: String): CycleProgress? {
+        _callLog.add("checkAndAutoAdvance")
         val progress = cycleProgress[cycleId] ?: return null
         val totalDays = cycleDays[cycleId]?.size ?: return progress
         if (totalDays == 0) return progress


### PR DESCRIPTION
## Summary

Home screen's cycle banner was reading the active cycle's `CycleProgress` via a pure `getCycleProgress` call, which never reconciles `lastAdvancedAt` against the current calendar day. `TrainingCyclesScreen` is the only other production caller of `checkAndAutoAdvance`, which is exactly why the reporter's tap-Cycles-then-back workaround refreshed the banner.

Route the Home path through a new `loadHomeCycleProgress` helper that calls `checkAndAutoAdvance` first and falls back to `getCycleProgress` if the result is null. The helper uses the returned `CycleProgress?` directly so the banner renders the post-advance `currentDayNumber` on the first composition after a calendar-day boundary.

Fixes #549

## RCA

The RCA is in #549 (comment: 4702176144):

- `HomeScreen.kt:100-102` reads `getCycleProgress` only; never `checkAndAutoAdvance`.
- `TrainingCyclesScreen.kt:200` is the only production `checkAndAutoAdvance` call site in `commonMain`. Its 60s polling loop (lines 226-231) re-runs it for as long as the user is on the Cycles tab.
- `SqlDelightTrainingCycleRepository.checkAndAutoAdvance` (lines 539-574) writes the new `current_day_number` and `last_advanced_at` back to the `cycle_progress` row; subsequent Home reads pick up the new value.
- `TrainingCycleModels.kt:198-268` and `TrainingCycleModelsTest.kt:67-94` are correct; the bug is purely a missing call site on the Home path.

## Changes

- `shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/HomeScreen.kt`
  - New `internal suspend fun loadHomeCycleProgress(repository, cycle)` helper.
  - `LaunchedEffect(activeCycle)` now calls the helper instead of `getCycleProgress` directly.
- `shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/screen/HomeScreenCycleBannerTest.kt` (new)
  - 4 unit tests covering call order, auto-advance honored, fallback to `getCycleProgress`, and no-advance path.
- `shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeTrainingCycleRepository.kt`
  - `callLog` / `resetCallLog` instrumentation on `getCycleProgress` and `checkAndAutoAdvance` to support call-order assertions. Test infrastructure only; no public repo surface change.

## Out of scope

- `UpNextWidget.kt:46-50` has the same pattern but is not currently rendered in the composable tree; leaving for a separate issue if it is reintroduced.
- Lifecycle resume observer for the Home banner (recommended in RCA "A more robust variant"); not required for the headline bug.

## Tests

`gradle :shared:compileAndroidMain :shared:compileKotlinIosArm64 :shared:compileTestKotlinIosArm64 :shared:testAndroidHostTest -Pskip.supabase.check=true`

- `compileAndroidMain`: clean
- `compileKotlinIosArm64`: clean
- `compileTestKotlinIosArm64`: clean
- `testAndroidHostTest`: **2052 tests, 0 failures, 0 errors, 0 skipped**

New tests:
- `loadHomeCycleProgress calls checkAndAutoAdvance before getCycleProgress`
- `loadHomeCycleProgress uses the auto-advanced day from checkAndAutoAdvance`
- `loadHomeCycleProgress falls back to getCycleProgress when checkAndAutoAdvance returns null`
- `loadHomeCycleProgress returns the persisted value when no auto-advance is due`

GPT-5.5/default retains final merge authority; MiniMax/phoenixworker will not merge.
