### PR TITLE
[codex] Align weight handling with official per-cable behavior

### DIFF
--- a/docs/superpowers/specs/2026-06-16-official-weight-handling-design.md
+++ b/docs/superpowers/specs/2026-06-16-official-weight-handling-design.md
@@ -1,0 +1,131 @@
+# Official Weight Handling Alignment Design
+
+## Goal
+
+Align Phoenix weight handling with the official Vitruvian app: the selected, stored, commanded, and primary displayed load is a per-cable value. Two-cable totals may be shown only as clearly labeled supplemental context and must not feed back into saved weights, personal records, recommendations, BLE commands, sync payloads, or routine configuration.
+
+## Current Evidence
+
+The official-app deobfuscation findings show a single scalar force value in kilograms flowing through set storage and BLE command encoding. Cable count is exercise metadata and does not branch load math. The only official-app doubling found is a display-only caption: "Total weight for 2 cables".
+
+Phoenix already mostly matches this at the machine contract:
+
+- `WorkoutParameters.weightPerCableKg` is the active workout load.
+- BLE packet tests assert selected weight is written as the selected per-cable value.
+- `WorkoutSession.weightPerCableKg` and `CompletedSet.actualWeightKg` store per-cable values.
+
+Phoenix diverges in presentation and summary behavior:
+
+- `WeightDisplayFormatter` multiplies by `cableCount`.
+- History, home, exercise detail, set summary, and dashboard-style displays use `displayMultiplier` or `cableCount` to show total load as the main load.
+- Tests such as `WeightDisplayFormatterTest`, `WeightDisplayRegressionTest`, and `WeightDisplayIntegrationTest` explicitly expect dual-cable display doubling.
+
+## Display Contract
+
+Phoenix will use these semantics:
+
+1. **Canonical load:** `weightPerCableKg` is always kilograms per cable.
+2. **Primary selected-load display:** setup screens, routine screens, workout HUD, set summary, history, PR displays, recent activity, and recommendations show per-cable load as the main value.
+3. **Supplemental total display:** a helper line may show total two-cable load only when the text explicitly says "Total weight for 2 cables" or equivalent.
+4. **Analytics volume/work:** true total volume and work calculations may still use physical cable count where the metric is explicitly total work, not selected load.
+5. **Cable metadata:** `preferredCableCount`, `cableCount`, and `displayMultiplier` remain metadata for exercise context, telemetry summaries, and compatibility with existing persisted rows. They must not drive ordinary selected-load display.
+
+## Architecture
+
+Introduce clearer display APIs instead of overloading one formatter:
+
+- Keep or refactor `WeightDisplayFormatter` so its default named operation formats per-cable load without cable multiplication.
+- Move any total-load helper into an explicitly named method such as `toTwoCableTotalDisplayWeight` or `formatTwoCableTotalWeight`.
+- Replace call sites that currently pass `cableCount` or `displayMultiplier` for ordinary load display with per-cable formatting.
+- Leave BLE, database, routine config, sync DTOs, backup models, and weight recommendation data contracts unchanged.
+
+This avoids a database migration and keeps the change local to presentation semantics plus tests.
+
+## Components To Review
+
+Primary display formatting:
+
+- `shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/util/WeightDisplayFormatter.kt`
+- `shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/util/WeightDisplayFormatterTest.kt`
+- `shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/util/WeightDisplayRegressionTest.kt`
+- `shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/util/WeightDisplayIntegrationTest.kt`
+
+Saved workout and summary display:
+
+- `shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/Models.kt`
+- `shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SetSummaryCard.kt`
+- `shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/HistoryTab.kt`
+- `shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/HomeScreen.kt`
+- `shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseDetailScreen.kt`
+- `shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/DashboardComponents.kt`
+- `shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/AnalyticsScreen.kt`
+
+Live workout and setup surfaces:
+
+- `shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/WorkoutHud.kt`
+- `shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/WorkoutTab.kt`
+- `shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/WeightAdjustmentControls.kt`
+- `shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/WeightStepper.kt`
+- `shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/WorkoutSetupDialog.kt`
+- `shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SetReadyScreen.kt`
+- `shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RoutineOverviewScreen.kt`
+
+Accessory/rack behavior:
+
+- `shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/ApplyEquipmentRackLoadUseCase.kt`
+- Active-session rack snapshot and BLE adjustment code in `ActiveSessionEngine.kt`
+
+## Data Flow
+
+Selected load flow after the change:
+
+1. User selects `N kg` in setup or adjustment UI.
+2. UI labels it as `N kg/cable` or "Weight per cable".
+3. Workout parameters store `weightPerCableKg = N`.
+4. Rack counterweight logic adjusts the machine-facing per-cable value only when the selected rack item behavior requires it.
+5. BLE receives the adjusted or selected per-cable value.
+6. Session, set, PR, recommendation, backup, and sync records keep per-cable values.
+7. History and summaries display the stored value as per-cable unless showing a separately labeled total helper.
+
+## Error Handling And Edge Cases
+
+- Invalid cable metadata must not cause main weights to double, zero out, or become negative. Primary display should ignore cable count.
+- Legacy sessions with null `cableCount` or `displayMultiplier` should display their stored per-cable weight.
+- Existing total-volume fields remain total metrics. If a row lacks `totalVolumeKg`, fallback volume may continue to use physical cable count because volume is a total work metric.
+- Unified attachments such as bar or belt should not silently change the main selected weight. If useful, they may show an explicit total helper.
+- Rack counterweights need careful review because current logic divides counterweight by display multiplier. The implementation plan must decide whether that multiplier is truly physical cable count or display-only metadata and rename/split it if needed.
+
+## Testing Strategy
+
+Update tests so failures first prove the current mismatch:
+
+- Formatter tests should assert that `50 kg` displays as `50 kg` for both one-cable and two-cable metadata.
+- A separate explicit-total helper test should assert that `50 kg/cable` can render `100 kg total for 2 cables`.
+- Source guard tests should continue proving BLE and sync layers do not import display formatters.
+- Set summary and history tests should verify primary load display uses per-cable values while total volume remains total.
+- Rack-load tests should cover two-cable counterweight behavior so machine-facing load is correct and not driven by display-only semantics.
+- BLE packet tests should remain unchanged and continue proving selected per-cable values are sent to the machine.
+
+Recommended verification commands:
+
+- `./gradlew.bat :shared:testAndroidHostTest --tests "com.devil.phoenixproject.presentation.util.WeightDisplaySourceGuardTest" --console=plain --rerun-tasks`
+- `./gradlew.bat :shared:testAndroidHostTest --tests "com.devil.phoenixproject.presentation.components.WeightFeatureGuardTest" --console=plain --rerun-tasks`
+- `./gradlew.bat :shared:testAndroidHostTest --console=plain --rerun-tasks`
+- `./gradlew.bat :shared:testDebugUnitTest --console=plain --rerun-tasks` if Android unit-test wiring is available for common tests in this checkout.
+
+## Non-Goals
+
+- No BLE protocol redesign.
+- No database migration unless implementation reveals a persisted field is incorrectly named or impossible to interpret safely.
+- No change to exercise catalog cable metadata except where a test fixture needs explicit metadata.
+- No automatic conversion of historical per-cable values.
+- No new production dependency.
+
+## Acceptance Criteria
+
+- Main user-visible load values match the official app's per-cable convention.
+- The app can still show an explicitly labeled two-cable total helper where useful.
+- Stored/session/PR/recommendation/sync/backup contracts remain per-cable.
+- BLE packet tests still prove machine commands are per-cable.
+- Regression tests prevent cable-count metadata from re-entering ordinary load display.
+- Total-volume/work metrics remain intentionally total and are documented as distinct from selected load.

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/util/WeightDisplaySourceGuardTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/util/WeightDisplaySourceGuardTest.kt
@@ -187,44 +187,68 @@ class WeightDisplaySourceGuardTest {
     }
 
     @Test
-    fun workoutHud_liveForceDisplayUsesOnlyUnifiedAccessoryGate() {
+    fun workoutHud_primaryDisplaysStayPerCable() {
         val path = "com/devil/phoenixproject/presentation/screen/WorkoutHud.kt"
         val source = readSourceFile(path)
         if (source != null) {
             assertFalse(
                 source.contains("WeightDisplayFormatter"),
                 "GUARD VIOLATION: WorkoutHud.kt must not use WeightDisplayFormatter. " +
-                    "Live HUD display is allowed to multiply only after the unified-accessory gate.",
+                    "HUD primary weight display should format already-selected per-cable values directly.",
             )
             assertFalse(
-                source.contains("preferredCableCount"),
-                "GUARD VIOLATION: WorkoutHud.kt must not gate live total display on physical cable count. " +
-                    "Use liveUnifiedAccessoryDisplayMultiplier() instead.",
-            )
-            assertFalse(
-                Regex("""\bcableCount\b""").containsMatchIn(source),
-                "GUARD VIOLATION: WorkoutHud.kt must not pass generic cableCount into live weight display. " +
-                    "Dual handles and other individual attachments must remain per-cable.",
-            )
-            assertTrue(
-                source.contains("liveUnifiedAccessoryDisplayMultiplier()"),
-                "WorkoutHud.kt should derive live display multiplier from the unified-accessory helper.",
-            )
-            assertTrue(
                 source.contains("workoutParameters.weightPerCableKg * liveDisplayMultiplier"),
-                "WorkoutHud.kt should multiply selected display weight only by the narrow live display multiplier.",
+                "GUARD VIOLATION: WorkoutHud.kt selected load display must stay per-cable.",
             )
-            assertTrue(
+            assertFalse(
                 source.contains("perCableKg * liveDisplayMultiplier"),
-                "WorkoutHud.kt should multiply measured live force only by the narrow live display multiplier.",
+                "GUARD VIOLATION: WorkoutHud.kt live force display must stay per-cable.",
+            )
+            assertFalse(
+                source.contains("""subLabel = if (liveDisplayMultiplier == 2) "TOTAL" else "PER CABLE""""),
+                "GUARD VIOLATION: WorkoutHud.kt primary force display should always be labeled per-cable.",
             )
             assertTrue(
-                source.contains("""subLabel = if (liveDisplayMultiplier == 2) "TOTAL" else "PER CABLE""""),
-                "WorkoutHud.kt should label total force only when the unified-accessory multiplier is active.",
+                source.contains("formatWeight(selectedDisplayKg, weightUnit)"),
+                "WorkoutHud.kt should format selectedDisplayKg directly for target weight display.",
+            )
+            assertTrue(
+                source.contains("formatWeight(displayKg, weightUnit)"),
+                "WorkoutHud.kt should format displayKg directly for live force display.",
             )
         } else {
             assertTrue(true, "WorkoutHud.kt not found; guard passes")
         }
+    }
+
+    @Test
+    fun savedSessionPrimaryDisplays_doNotMultiplyByDisplayLoadMultiplier() {
+        val primaryDisplayFiles = listOf(
+            "com/devil/phoenixproject/presentation/screen/ExerciseDetailScreen.kt",
+            "com/devil/phoenixproject/presentation/screen/ExercisesTab.kt",
+            "com/devil/phoenixproject/presentation/screen/HistoryTab.kt",
+            "com/devil/phoenixproject/presentation/screen/HomeScreen.kt",
+            "com/devil/phoenixproject/presentation/components/InsightCards.kt",
+        )
+        val forbiddenSnippets = listOf(
+            "weightPerCableKg * session.displayLoadMultiplier()",
+            "session.weightPerCableKg * session.displayLoadMultiplier()",
+            "effectiveHeaviestKgPerCable() * session.displayLoadMultiplier().toFloat()",
+            "WeightDisplayFormatter.formatDisplayWeight(session.weightPerCableKg, session.displayLoadMultiplier()",
+            "WeightDisplayFormatter.formatDisplayWeight(session.weightPerCableKg, session.displayMultiplier ?: session.cableCount",
+        )
+
+        val violations = primaryDisplayFiles.flatMap { relativePath ->
+            val source = readSourceFile(relativePath).orEmpty()
+            forbiddenSnippets
+                .filter { forbidden -> source.contains(forbidden) }
+                .map { forbidden -> "$relativePath contains '$forbidden'" }
+        }
+
+        assertTrue(
+            violations.isEmpty(),
+            "GUARD VIOLATION: Saved-session primary display must stay per-cable. Violations: $violations",
+        )
     }
 
     // ===== Guard: CSV export has its own multiplication =====

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/util/WeightDisplaySourceGuardTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/util/WeightDisplaySourceGuardTest.kt
@@ -251,6 +251,28 @@ class WeightDisplaySourceGuardTest {
         )
     }
 
+    @Test
+    fun setSummary_primaryWeightLabelsStayPerCable() {
+        val path = "com/devil/phoenixproject/presentation/screen/SetSummaryCard.kt"
+        val source = readSourceFile(path)
+        if (source != null) {
+            assertFalse(
+                source.contains("unit = \"(\$unitLabel total)\""),
+                "GUARD VIOLATION: Set Summary set weight is per-cable and must not be labeled total.",
+            )
+            assertFalse(
+                source.contains("\"\$unitLabel total\""),
+                "GUARD VIOLATION: Echo phase weights are per-cable and must not be labeled total.",
+            )
+            assertTrue(
+                source.contains("unit = \"(\$unitLabel/cable)\""),
+                "Set Summary set weight should be labeled per-cable.",
+            )
+        } else {
+            assertTrue(true, "SetSummaryCard.kt not found; guard passes")
+        }
+    }
+
     // ===== Guard: CSV export has its own multiplication =====
 
     @Test

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/Models.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/Models.kt
@@ -30,10 +30,9 @@ enum class WorkoutPhase {
 /**
  * Personal record for an exercise.
  *
- * [cableCount] enables cable-aware weight display for PRs. Populated from
- * exercise `preferredCableCount` when a PR is recorded. Legacy PRs have
- * `cableCount = null`, which causes WeightDisplayFormatter to default to 1
- * (showing per-cable weight — safe backward-compatible behavior).
+ * [weightPerCableKg] is the official-app display contract for PR load. [cableCount]
+ * is retained for legacy metadata and analytics context; ordinary PR display must
+ * not multiply by it.
  */
 data class PersonalRecord(
     val id: Long = 0,
@@ -478,8 +477,8 @@ sealed class HapticEvent {
  * @property timestamp Session start time as Unix epoch milliseconds
  * @property duration Session duration in MILLISECONDS (not seconds!)
  *                    Computed as `currentTimeMillis() - startTime`
- * @property weightPerCableKg Machine/storage weight per cable in kilograms. User-facing load
- *                            displays should prefer displayMultiplier over physical cableCount.
+ * @property weightPerCableKg Machine/storage weight per cable in kilograms. Ordinary
+ *                            selected-load displays should show this per-cable value.
  */
 data class WorkoutSession(
     val id: String = generateUUID(),
@@ -561,10 +560,10 @@ data class WorkoutSession(
 fun WorkoutSession.effectiveHeaviestKgPerCable(): Float = heaviestLiftKg ?: weightPerCableKg
 
 /**
- * Multiplier for user-facing saved-session load display.
+ * Legacy multiplier metadata for explicit total/compatibility paths.
  *
- * Prefer persisted display semantics when present; fall back to physical cable count only for
- * legacy rows that predate displayMultiplier.
+ * Ordinary saved-session load display matches the official app and stays per-cable.
+ * Do not use this helper to format primary selected/heaviest load values.
  */
 fun WorkoutSession.displayLoadMultiplier(): Int = displayMultiplier ?: cableCount ?: 1
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/ApplyEquipmentRackLoadUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/ApplyEquipmentRackLoadUseCase.kt
@@ -8,24 +8,24 @@ import com.devil.phoenixproject.util.Constants
 class ApplyEquipmentRackLoadUseCase {
     fun calculate(
         programmedWeightPerCableKg: Float,
-        displayMultiplier: Int,
+        physicalCableCount: Int,
         selectedItems: List<RackItem>,
         isEchoMode: Boolean,
         validatorMinimumPerCableKg: Float = Constants.MIN_WEIGHT_KG,
     ): RackLoadAdjustment {
-        val multiplier = displayMultiplier.coerceAtLeast(1)
+        val cableCount = physicalCableCount.coerceIn(1, 2)
         val uniqueItems = selectedItems.distinctBy { it.id }
         val externalAddedLoadKg = uniqueItems.loadFor(RackItemBehavior.ADDED_RESISTANCE)
         val counterweightKg = uniqueItems.loadFor(RackItemBehavior.COUNTERWEIGHT)
         val displayLoadKg = (
-            programmedWeightPerCableKg.coerceAtLeast(0f) * multiplier +
+            programmedWeightPerCableKg.coerceAtLeast(0f) * cableCount +
                 externalAddedLoadKg -
                 counterweightKg
             ).coerceAtLeast(0f)
         val adjustedMachineWeightPerCableKg = if (isEchoMode) {
             programmedWeightPerCableKg
         } else {
-            (programmedWeightPerCableKg - (counterweightKg / multiplier))
+            (programmedWeightPerCableKg - (counterweightKg / cableCount))
                 .coerceIn(
                     validatorMinimumPerCableKg.coerceAtLeast(Constants.MIN_WEIGHT_KG),
                     Constants.MAX_WEIGHT_PER_CABLE_KG,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/DashboardComponents.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/DashboardComponents.kt
@@ -381,7 +381,7 @@ private fun PRListItem(
             Text(
                 text = WeightDisplayFormatter.formatDisplayWeight(
                     pr.weightPerCableKg,
-                    cableCount = pr.cableCount,
+                    cableCount = null,
                     weightUnit,
                 ),
                 style = MaterialTheme.typography.titleMedium,
@@ -536,7 +536,7 @@ private fun TopExerciseItem(
             Text(
                 text = WeightDisplayFormatter.formatDisplayWeight(
                     pr.weightPerCableKg,
-                    cableCount = pr.cableCount,
+                    cableCount = null,
                     weightUnit,
                 ),
                 style = MaterialTheme.typography.titleLarge,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/InsightCards.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/InsightCards.kt
@@ -63,7 +63,6 @@ import com.devil.phoenixproject.data.repository.ExerciseRepository
 import com.devil.phoenixproject.domain.model.PersonalRecord
 import com.devil.phoenixproject.domain.model.WeightUnit
 import com.devil.phoenixproject.domain.model.WorkoutSession
-import com.devil.phoenixproject.domain.model.displayLoadMultiplier
 import com.devil.phoenixproject.domain.model.effectiveHeaviestKgPerCable
 import com.devil.phoenixproject.domain.model.effectiveTotalVolumeKg
 import com.devil.phoenixproject.presentation.components.charts.ComboChart
@@ -499,7 +498,7 @@ fun VolumeVsIntensityCard(workoutSessions: List<WorkoutSession>, weightUnit: Wei
 
             val lines = sortedSessions.mapIndexed { index, session ->
                 val label = "S${index + 1}"
-                val maxWeight = session.effectiveHeaviestKgPerCable() * session.displayLoadMultiplier().toFloat()
+                val maxWeight = session.effectiveHeaviestKgPerCable()
                 // Convert to lbs if needed
                 val adjustedWeight = if (weightUnit == WeightUnit.LB) maxWeight * 2.20462f else maxWeight
                 label to adjustedWeight

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/WeightAdjustmentControls.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/WeightAdjustmentControls.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.devil.phoenixproject.domain.model.WeightUnit
+import com.devil.phoenixproject.presentation.util.WeightDisplayFormatter
 import com.devil.phoenixproject.ui.theme.Spacing
 import com.devil.phoenixproject.util.Constants
 import com.devil.phoenixproject.util.UnitConverter
@@ -133,7 +134,9 @@ fun WeightAdjustmentControls(
                 )
                 Spacer(modifier = Modifier.width(Spacing.small))
                 Text(
-                    text = "Total weight for 2 cables: ${formatWeight(currentWeightKg * 2, weightUnit)}",
+                    text = "Total weight for 2 cables: ${
+                        WeightDisplayFormatter.formatTwoCableTotalWeight(currentWeightKg, weightUnit)
+                    } ${if (weightUnit == WeightUnit.LB) "lbs" else "kg"}",
                     style = MaterialTheme.typography.labelMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -380,7 +383,9 @@ private fun WeightPickerDialog(
                         )
                         Spacer(modifier = Modifier.width(Spacing.small))
                         Text(
-                            text = "Total weight for 2 cables: ${formatWeight(selectedWeightKg * 2, weightUnit)}",
+                            text = "Total weight for 2 cables: ${
+                                WeightDisplayFormatter.formatTwoCableTotalWeight(selectedWeightKg, weightUnit)
+                            } ${if (weightUnit == WeightUnit.LB) "lbs" else "kg"}",
                             style = MaterialTheme.typography.labelMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/WeightStepper.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/WeightStepper.kt
@@ -15,6 +15,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.devil.phoenixproject.domain.model.WeightUnit
+import com.devil.phoenixproject.presentation.util.WeightDisplayFormatter
 import com.devil.phoenixproject.ui.theme.Spacing
 import com.devil.phoenixproject.util.format
 import org.jetbrains.compose.resources.stringResource
@@ -162,12 +164,10 @@ fun WeightStepper(
                     tint = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
                 Spacer(modifier = Modifier.width(Spacing.small))
-                val totalWeight = weight * 2
-                val totalFormatted = if (totalWeight == totalWeight.toLong().toFloat()) {
-                    totalWeight.toLong().toString()
-                } else {
-                    totalWeight.format(1)
-                }
+                val totalFormatted = WeightDisplayFormatter.formatTwoCableTotalWeight(
+                    weightPerCableKg = weight,
+                    unit = WeightUnit.KG,
+                )
                 Text(
                     text = stringResource(Res.string.weight_total_two_cables, totalFormatted),
                     style = MaterialTheme.typography.labelMedium,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -451,12 +451,12 @@ class ActiveSessionEngine(
         val selectedItems = equipmentRackRepository.resolveActiveItems(
             ActiveRackSelection(coordinator._activeRackItemIds.value),
         )
-        val displayMultiplier = currentExercise?.exercise?.displayMultiplier
-            ?: resolveSelectedExercise(params)?.displayMultiplier
+        val physicalCableCount = currentExercise?.exercise?.preferredCableCount
+            ?: resolveSelectedExercise(params)?.preferredCableCount
             ?: 1
         val adjustment = applyEquipmentRackLoadUseCase.calculate(
             programmedWeightPerCableKg = params.weightPerCableKg,
-            displayMultiplier = displayMultiplier,
+            physicalCableCount = physicalCableCount,
             selectedItems = selectedItems,
             isEchoMode = params.isEchoMode,
             validatorMinimumPerCableKg = validatorSafeMinimum(params),
@@ -474,12 +474,12 @@ class ActiveSessionEngine(
 
     private fun applyRackToBleParams(
         params: WorkoutParameters,
-        displayMultiplier: Int,
+        physicalCableCount: Int,
         selectedItems: List<RackItem>,
     ): WorkoutParameters {
         val adjustment = applyEquipmentRackLoadUseCase.calculate(
             programmedWeightPerCableKg = params.weightPerCableKg,
-            displayMultiplier = displayMultiplier,
+            physicalCableCount = physicalCableCount,
             selectedItems = selectedItems,
             isEchoMode = params.isEchoMode,
             validatorMinimumPerCableKg = validatorSafeMinimum(params),
@@ -1905,10 +1905,10 @@ class ActiveSessionEngine(
             val resolvedItems = equipmentRackRepository.rackItems.value
                 .filter { it.enabled && it.id in distinctIds }
             val currentParams = coordinator._workoutParameters.value
-            val displayMultiplier = currentExercise?.exercise?.displayMultiplier ?: 1
+            val physicalCableCount = currentExercise?.exercise?.preferredCableCount ?: 1
             val adjustment = applyEquipmentRackLoadUseCase.calculate(
                 programmedWeightPerCableKg = currentParams.weightPerCableKg,
-                displayMultiplier = displayMultiplier,
+                physicalCableCount = physicalCableCount,
                 selectedItems = resolvedItems,
                 isEchoMode = currentParams.isEchoMode,
                 validatorMinimumPerCableKg = validatorSafeMinimum(currentParams),
@@ -2424,8 +2424,8 @@ class ActiveSessionEngine(
                     coordinator._workoutParameters.value = warmupOverrideParams
                 }
 
-                val rackDisplayMultiplier = currentExercise?.exercise?.displayMultiplier
-                    ?: resolveSelectedExercise(effectiveParams)?.displayMultiplier
+                val rackPhysicalCableCount = currentExercise?.exercise?.preferredCableCount
+                    ?: resolveSelectedExercise(effectiveParams)?.preferredCableCount
                     ?: 1
                 val rackSnapshotItems = coordinator._currentRackLoadAdjustment.value.selectedItems
                 val bleParams = run {
@@ -2455,7 +2455,7 @@ class ActiveSessionEngine(
                 }.let { paramsForBle ->
                     applyRackToBleParams(
                         params = paramsForBle,
-                        displayMultiplier = rackDisplayMultiplier,
+                        physicalCableCount = rackPhysicalCableCount,
                         selectedItems = rackSnapshotItems,
                     )
                 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/RoutineFlowManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/RoutineFlowManager.kt
@@ -839,10 +839,10 @@ class RoutineFlowManager(
         // Use the exercise's own weight — not the coordinator's currently-mirrored
         // workout parameters, which may still reflect the previous set / routine.
         val programmedWeightPerCableKg = exercise.weightPerCableKg
-        val displayMultiplier = exercise.exercise.displayMultiplier ?: 1
+        val physicalCableCount = exercise.exercise.preferredCableCount ?: 1
         val adjustment = applyEquipmentRackLoadUseCase.calculate(
             programmedWeightPerCableKg = programmedWeightPerCableKg,
-            displayMultiplier = displayMultiplier,
+            physicalCableCount = physicalCableCount,
             selectedItems = resolvedItems,
             isEchoMode = false,
             validatorMinimumPerCableKg = Constants.DEFAULT_WEIGHT_INCREMENT_KG,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutCoordinator.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutCoordinator.kt
@@ -191,6 +191,11 @@ class WorkoutCoordinator(
     internal val _activeRackItemIds = MutableStateFlow<List<String>>(emptyList())
     val activeRackItemIds: StateFlow<List<String>> = _activeRackItemIds.asStateFlow()
 
+    /**
+     * Rack-load adjustment for the current set. Machine-facing counterweight
+     * math uses physical cable count, while display code decides separately
+     * whether to show per-cable load or an explicit total helper.
+     */
     internal val _currentRackLoadAdjustment = MutableStateFlow(RackLoadAdjustment())
     val currentRackLoadAdjustment: StateFlow<RackLoadAdjustment> = _currentRackLoadAdjustment.asStateFlow()
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/AnalyticsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/AnalyticsScreen.kt
@@ -180,7 +180,7 @@ fun ProgressTab(
                                 Text(
                                     text = WeightDisplayFormatter.formatDisplayWeight(
                                         pr.weightPerCableKg,
-                                        cableCount = pr.cableCount,
+                                        cableCount = null,
                                         weightUnit,
                                     ),
                                     style = MaterialTheme.typography.headlineSmall,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseDetailScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseDetailScreen.kt
@@ -29,7 +29,6 @@ import com.devil.phoenixproject.data.repository.ExerciseRepository
 import com.devil.phoenixproject.domain.model.ConnectionState
 import com.devil.phoenixproject.domain.model.WeightUnit
 import com.devil.phoenixproject.domain.model.WorkoutSession
-import com.devil.phoenixproject.domain.model.displayLoadMultiplier
 import com.devil.phoenixproject.domain.model.effectiveTotalVolumeKg
 import com.devil.phoenixproject.presentation.components.charts.ProgressionLineChart
 import com.devil.phoenixproject.presentation.components.charts.VolumeTrendChart
@@ -75,12 +74,11 @@ fun ExerciseDetailScreen(exerciseId: String, navController: NavController, viewM
         viewModel.updateTopBarTitle("")
     }
 
-    // Calculate 1RM progression using saved-session display load semantics.
+    // Calculate 1RM progression using saved per-cable load.
     val oneRepMaxData = remember(exerciseSessions) {
         exerciseSessions.mapNotNull { session ->
             if (session.workingReps > 0) {
-                val displayWeight = session.weightPerCableKg * session.displayLoadMultiplier()
-                val oneRm = calculateOneRepMax(displayWeight, session.workingReps)
+                val oneRm = calculateOneRepMax(session.weightPerCableKg, session.workingReps)
                 session.timestamp to oneRm
             } else {
                 null
@@ -88,12 +86,11 @@ fun ExerciseDetailScreen(exerciseId: String, navController: NavController, viewM
         }.reversed() // Chronological order for chart
     }
 
-    // Weight-over-time trend data using saved-session display load semantics.
+    // Weight-over-time trend data using saved per-cable load.
     val weightTrendData = remember(exerciseSessions) {
         exerciseSessions.mapNotNull { session ->
             if (session.weightPerCableKg > 0) {
-                val displayWeight = session.weightPerCableKg * session.displayLoadMultiplier()
-                session.timestamp to displayWeight
+                session.timestamp to session.weightPerCableKg
             } else {
                 null
             }
@@ -602,7 +599,7 @@ private fun ExerciseHistoryTable(sessions: List<WorkoutSession>, weightUnit: Wei
                         TableCell(
                             WeightDisplayFormatter.formatDisplayWeight(
                                 session.weightPerCableKg,
-                                session.displayLoadMultiplier(),
+                                null,
                                 weightUnit,
                             ),
                             Modifier.weight(1f),
@@ -617,9 +614,8 @@ private fun ExerciseHistoryTable(sessions: List<WorkoutSession>, weightUnit: Wei
                         )
                         TableCell(
                             if (session.workingReps > 0) {
-                                val displayWeight = session.weightPerCableKg * session.displayLoadMultiplier()
                                 formatWeight(
-                                    calculateOneRepMax(displayWeight, session.workingReps),
+                                    calculateOneRepMax(session.weightPerCableKg, session.workingReps),
                                     weightUnit,
                                 )
                             } else {
@@ -693,7 +689,7 @@ private fun SessionHistoryRow(session: WorkoutSession, weightUnit: WeightUnit, f
                         color = MaterialTheme.colorScheme.onSurface,
                     )
                     Text(
-                        "${WeightDisplayFormatter.formatDisplayWeight(session.weightPerCableKg, session.displayLoadMultiplier(), weightUnit)} × ${session.workingReps} reps",
+                        "${WeightDisplayFormatter.formatDisplayWeight(session.weightPerCableKg, null, weightUnit)} × ${session.workingReps} reps",
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExercisesTab.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExercisesTab.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.devil.phoenixproject.domain.model.WeightUnit
 import com.devil.phoenixproject.domain.model.WorkoutSession
-import com.devil.phoenixproject.domain.model.displayLoadMultiplier
 import com.devil.phoenixproject.presentation.components.ConfirmEditTextField
 import com.devil.phoenixproject.ui.theme.Spacing
 import com.devil.phoenixproject.util.KmpUtils
@@ -65,7 +64,7 @@ fun ExercisesTab(
                     exerciseId = exerciseId,
                     exerciseName = exerciseNames[exerciseId] ?: "Unknown Exercise",
                     bestOneRepMax = calculateBestOneRepMax(sessions),
-                    bestWeight = sessions.maxOf { it.weightPerCableKg * it.displayLoadMultiplier() },
+                    bestWeight = sessions.maxOf { it.weightPerCableKg },
                     lastPerformed = sessions.maxOf { it.timestamp },
                     totalSessions = sessions.size,
                     totalSets = sessions.sumOf { estimateSets(it) },
@@ -346,8 +345,7 @@ private fun calculateOneRepMax(weight: Float, reps: Int): Float = OneRepMaxCalcu
  */
 private fun calculateBestOneRepMax(sessions: List<WorkoutSession>): Float? = sessions.mapNotNull { session ->
     if (session.workingReps > 0) {
-        val displayWeight = session.weightPerCableKg * session.displayLoadMultiplier()
-        calculateOneRepMax(displayWeight, session.workingReps)
+        calculateOneRepMax(session.weightPerCableKg, session.workingReps)
     } else {
         null
     }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/HistoryTab.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/HistoryTab.kt
@@ -355,8 +355,7 @@ fun WorkoutHistoryCard(
 
             Spacer(modifier = Modifier.height(Spacing.small))
 
-            // Measured Peak (Total) | Workout Mode
-            // Issue #5: Show total weight (per-cable * cableCount) via WeightDisplayFormatter
+            // Measured Peak | Workout Mode
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween,
@@ -372,7 +371,7 @@ fun WorkoutHistoryCard(
                     } else {
                         WeightDisplayFormatter.formatDisplayWeight(
                             session.effectiveHeaviestKgPerCable(),
-                            session.displayMultiplier ?: session.cableCount,
+                            null,
                             weightUnit,
                         ) + " ${if (weightUnit == WeightUnit.LB) "lbs" else "kg"}"
                     },
@@ -489,7 +488,7 @@ fun WorkoutHistoryCard(
                     // CompletedSet breakdown (set-level tracking)
                     CompletedSetsSection(
                         sessionId = session.id,
-                        cableCount = session.displayMultiplier ?: session.cableCount,
+                        cableCount = null,
                         weightUnit = weightUnit,
                         formatWeight = formatWeight,
                     )
@@ -607,7 +606,7 @@ fun WorkoutHistoryCard(
  *
  * Note: CompletedSet.actualWeightKg stores per-cable weight (populated from
  * WorkoutParameters.weightPerCableKg in ActiveSessionEngine). We use
- * WeightDisplayFormatter to apply cable multiplication for display.
+ * WeightDisplayFormatter for unit conversion only; ordinary display stays per-cable.
  */
 @Composable
 private fun CompletedSetsSection(
@@ -672,7 +671,7 @@ private fun CompletedSetsSection(
 
                 // Reps x Weight + RPE
                 Row(verticalAlignment = Alignment.CenterVertically) {
-                    // actualWeightKg is per-cable; use WeightDisplayFormatter for total display weight
+                    // actualWeightKg is per-cable; ordinary display stays per-cable.
                     val displayWeight = WeightDisplayFormatter.formatDisplayWeight(
                         set.actualWeightKg,
                         cableCount,
@@ -926,14 +925,7 @@ fun GroupedRoutineCard(
 
                 Spacer(modifier = Modifier.height(Spacing.small))
 
-                // Measured Peak (Total) | Workout Mode
-                // Issue #5: Show total weight via WeightDisplayFormatter
-                // Use max cableCount from sessions in this group for display
-                val groupCableCount = groupedItem.sessions
-                    .filter { it.exerciseId == exerciseGroup.exerciseId }
-                    .mapNotNull { it.displayMultiplier ?: it.cableCount }
-                    .maxOrNull()
-
+                // Measured Peak | Workout Mode
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceBetween,
@@ -949,7 +941,7 @@ fun GroupedRoutineCard(
                         } else {
                             WeightDisplayFormatter.formatDisplayWeight(
                                 exerciseGroup.highestWeightPerCableKg,
-                                groupCableCount,
+                                null,
                                 weightUnit,
                             ) + " ${if (weightUnit == WeightUnit.LB) "lbs" else "kg"}"
                         },
@@ -1083,7 +1075,7 @@ fun GroupedRoutineCard(
                         // CompletedSet breakdown per session
                         CompletedSetsSection(
                             sessionId = session.id,
-                            cableCount = session.displayMultiplier ?: session.cableCount,
+                            cableCount = null,
                             weightUnit = weightUnit,
                             formatWeight = formatWeight,
                         )
@@ -1241,7 +1233,7 @@ fun WorkoutSessionCard(
                     color = MaterialTheme.colorScheme.onSurface,
                 )
                 Text(
-                    "${WeightDisplayFormatter.formatDisplayWeight(session.weightPerCableKg, session.displayMultiplier ?: session.cableCount, weightUnit)} ${if (weightUnit == WeightUnit.LB) "lbs" else "kg"} • ${session.totalReps} reps • ${session.mode}",
+                    "${WeightDisplayFormatter.formatDisplayWeight(session.weightPerCableKg, null, weightUnit)} ${if (weightUnit == WeightUnit.LB) "lbs" else "kg"}/cable • ${session.totalReps} reps • ${session.mode}",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/HomeScreen.kt
@@ -607,7 +607,7 @@ private fun RecentActivityRowContent(session: WorkoutSession, weightUnit: Weight
         Column(modifier = Modifier.weight(1f)) {
             val displayWeight = WeightDisplayFormatter.formatDisplayWeight(
                 session.weightPerCableKg,
-                session.displayMultiplier ?: session.cableCount,
+                null,
                 weightUnit,
             )
             val unitLabel = if (weightUnit == WeightUnit.LB) "lbs" else "kg"

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SetSummaryCard.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SetSummaryCard.kt
@@ -198,7 +198,7 @@ fun SetSummaryCard(
                 SummaryStatCard(
                     label = "Set Weight",
                     value = "${setWeightDisplay.roundToInt()}",
-                    unit = "($unitLabel total)",
+                    unit = "($unitLabel/cable)",
                     icon = Icons.Default.FitnessCenter,
                     modifier = Modifier.weight(1f),
                 )
@@ -636,7 +636,7 @@ private fun EchoPhaseBreakdownCard(
                     color = MaterialTheme.colorScheme.primary,
                 )
                 Text(
-                    "Peak: ${peakWeight.roundToInt()} $unitLabel",
+                    "Peak: ${peakWeight.roundToInt()} $unitLabel/cable",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -706,7 +706,7 @@ private fun PhaseStatColumn(phaseName: String, reps: Int, avgWeight: Float, unit
             color = MaterialTheme.colorScheme.onSurface,
         )
         Text(
-            "$unitLabel total",
+            "$unitLabel/cable",
             style = MaterialTheme.typography.labelSmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SetSummaryCard.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SetSummaryCard.kt
@@ -98,30 +98,27 @@ fun SetSummaryCard(
         }
     }
 
-    // Calculate display values
-    // Issue #5: Use WeightDisplayFormatter for cable-aware weight display.
-    // heaviestLift and setWeight are per-cable values that must be multiplied by cableCount
-    // before unit conversion to show total weight to the user.
-    // totalVolume is already a total value (not per-cable), so it only needs unit conversion.
-    val cableCount = summary.displayMultiplier
+    // Calculate display values.
+    // Official app primary load display is per-cable. Total volume is already a total value,
+    // so it only needs unit conversion.
     val displayReps = summary.repCount
     val totalVolumeDisplay = kgToDisplay(summary.totalVolumeKg, weightUnit)
-    val heaviestLiftDisplay = WeightDisplayFormatter.toDisplayWeight(summary.heaviestLiftKgPerCable, cableCount, weightUnit)
-    val setWeightDisplay = WeightDisplayFormatter.toDisplayWeight(summary.configuredWeightKgPerCable, cableCount, weightUnit)
+    val heaviestLiftDisplay = WeightDisplayFormatter.toDisplayWeight(summary.heaviestLiftKgPerCable, null, weightUnit)
+    val setWeightDisplay = WeightDisplayFormatter.toDisplayWeight(summary.configuredWeightKgPerCable, null, weightUnit)
 
-    // Debug logging for Issue #5 investigation
+    // Debug logging for weight display investigation
     co.touchlab.kermit.Logger.i {
-        "WEIGHT_DEBUG[Summary]: configuredWeightKgPerCable=${summary.configuredWeightKgPerCable} kg x cableCount=$cableCount → $setWeightDisplay ($weightUnit)"
+        "WEIGHT_DEBUG[Summary]: configuredWeightKgPerCable=${summary.configuredWeightKgPerCable} kg -> $setWeightDisplay ($weightUnit)"
     }
     val durationSeconds = (summary.durationMs / 1000).toInt()
     val durationFormatted = "${durationSeconds / 60}:${(durationSeconds % 60).toString().padStart(2, '0')}"
 
     // Peak/Avg forces - take max of both cables for display
-    // Force values are per-cable measurements; multiply by cableCount for total display
-    val peakConcentric = WeightDisplayFormatter.toDisplayWeight(maxOf(summary.peakForceConcentricA, summary.peakForceConcentricB), cableCount, weightUnit)
-    val peakEccentric = WeightDisplayFormatter.toDisplayWeight(maxOf(summary.peakForceEccentricA, summary.peakForceEccentricB), cableCount, weightUnit)
-    val avgConcentric = WeightDisplayFormatter.toDisplayWeight(maxOf(summary.avgForceConcentricA, summary.avgForceConcentricB), cableCount, weightUnit)
-    val avgEccentric = WeightDisplayFormatter.toDisplayWeight(maxOf(summary.avgForceEccentricA, summary.avgForceEccentricB), cableCount, weightUnit)
+    // Force values are per-cable measurements; primary display stays per-cable.
+    val peakConcentric = WeightDisplayFormatter.toDisplayWeight(maxOf(summary.peakForceConcentricA, summary.peakForceConcentricB), null, weightUnit)
+    val peakEccentric = WeightDisplayFormatter.toDisplayWeight(maxOf(summary.peakForceEccentricA, summary.peakForceEccentricB), null, weightUnit)
+    val avgConcentric = WeightDisplayFormatter.toDisplayWeight(maxOf(summary.avgForceConcentricA, summary.avgForceConcentricB), null, weightUnit)
+    val avgEccentric = WeightDisplayFormatter.toDisplayWeight(maxOf(summary.avgForceEccentricA, summary.avgForceEccentricB), null, weightUnit)
 
     val unitLabel = if (weightUnit == WeightUnit.LB) "lbs" else "kg"
 
@@ -248,16 +245,16 @@ fun SetSummaryCard(
             }
 
             // Echo Mode Phase Breakdown
-            // Echo weights are per-cable; multiply by cableCount for total display
+            // Echo weights are per-cable; primary display stays per-cable.
             if (summary.isEchoMode && (summary.warmupAvgWeightKg > 0 || summary.workingAvgWeightKg > 0)) {
                 EchoPhaseBreakdownCard(
                     warmupReps = summary.warmupReps,
                     workingReps = summary.workingReps,
                     burnoutReps = summary.burnoutReps,
-                    warmupAvgWeight = WeightDisplayFormatter.toDisplayWeight(summary.warmupAvgWeightKg, cableCount, weightUnit),
-                    workingAvgWeight = WeightDisplayFormatter.toDisplayWeight(summary.workingAvgWeightKg, cableCount, weightUnit),
-                    burnoutAvgWeight = WeightDisplayFormatter.toDisplayWeight(summary.burnoutAvgWeightKg, cableCount, weightUnit),
-                    peakWeight = WeightDisplayFormatter.toDisplayWeight(summary.peakWeightKg, cableCount, weightUnit),
+                    warmupAvgWeight = WeightDisplayFormatter.toDisplayWeight(summary.warmupAvgWeightKg, null, weightUnit),
+                    workingAvgWeight = WeightDisplayFormatter.toDisplayWeight(summary.workingAvgWeightKg, null, weightUnit),
+                    burnoutAvgWeight = WeightDisplayFormatter.toDisplayWeight(summary.burnoutAvgWeightKg, null, weightUnit),
+                    peakWeight = WeightDisplayFormatter.toDisplayWeight(summary.peakWeightKg, null, weightUnit),
                     unitLabel = unitLabel,
                 )
             }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/WorkoutHud.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/WorkoutHud.kt
@@ -85,7 +85,6 @@ fun WorkoutHud(
     val pagerState = rememberPagerState(pageCount = { 2 })
     val topBarModeLabel = if (isCurrentExerciseBodyweight) "Bodyweight" else workoutParameters.programMode.displayName
     val currentRoutineExercise = loadedRoutine?.exercises?.getOrNull(currentExerciseIndex)
-    val liveDisplayMultiplier = currentRoutineExercise?.exercise.liveUnifiedAccessoryDisplayMultiplier()
 
     // Track consecutive high-asymmetry reps for alert (ASYM-05)
     var consecutiveHighAsymmetryCount by remember { mutableStateOf(0) }
@@ -129,7 +128,6 @@ fun WorkoutHud(
                 // should only be allowed when the machine is not engaged. Official app behavior.
                 showNextButton = false,
                 isCurrentExerciseBodyweight = isCurrentExerciseBodyweight,
-                liveDisplayMultiplier = liveDisplayMultiplier,
                 rackLoadAdjustment = rackLoadAdjustment,
             )
         },
@@ -166,7 +164,6 @@ fun WorkoutHud(
                             totalSets = totalSets,
                             timedExerciseRemainingSeconds = timedExerciseRemainingSeconds,
                             isCurrentExerciseBodyweight = isCurrentExerciseBodyweight,
-                            liveDisplayMultiplier = liveDisplayMultiplier,
                             isExerciseTimerPaused = isExerciseTimerPaused,
                             onPauseExerciseTimer = onPauseExerciseTimer,
                             onResumeExerciseTimer = onResumeExerciseTimer,
@@ -357,7 +354,6 @@ private fun HudBottomBar(
     onNextExercise: () -> Unit,
     showNextButton: Boolean,
     isCurrentExerciseBodyweight: Boolean,
-    liveDisplayMultiplier: Int,
     rackLoadAdjustment: RackLoadAdjustment,
 ) {
     Surface(
@@ -374,8 +370,7 @@ private fun HudBottomBar(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             // Weight Controls - Echo mode shows "Adaptive" since weight is dynamic
-            val isUnifiedAccessoryDisplay = liveDisplayMultiplier == 2
-            val selectedDisplayKg = workoutParameters.weightPerCableKg * liveDisplayMultiplier
+            val selectedDisplayKg = workoutParameters.weightPerCableKg
             val rackContext = rackLoadAdjustment.toHudText(formatWeight, weightUnit)
             Column {
                 if (isCurrentExerciseBodyweight) {
@@ -391,7 +386,7 @@ private fun HudBottomBar(
                     )
                 } else {
                     Text(
-                        if (isUnifiedAccessoryDisplay) "Total weight" else "Weight/cable",
+                        "Weight/cable",
                         style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
@@ -464,7 +459,6 @@ private fun ExecutionPage(
     totalSets: Int = 0, // Total number of sets for current exercise
     timedExerciseRemainingSeconds: Int? = null, // Issue #192: Countdown for timed exercises
     isCurrentExerciseBodyweight: Boolean = false,
-    liveDisplayMultiplier: Int,
     isExerciseTimerPaused: Boolean = false,
     onPauseExerciseTimer: () -> Unit = {},
     onResumeExerciseTimer: () -> Unit = {},
@@ -667,8 +661,8 @@ private fun ExecutionPage(
                 // Use max of both loads - works for single and double cable exercises
                 maxOf(metric.loadA, metric.loadB)
             }
-            val displayKg = perCableKg * liveDisplayMultiplier
-            val targetDisplayWeight = workoutParameters.weightPerCableKg * liveDisplayMultiplier
+            val displayKg = perCableKg
+            val targetDisplayWeight = workoutParameters.weightPerCableKg
             val gaugeMax = (targetDisplayWeight * 1.5f).coerceAtLeast(20f)
 
             // For Echo mode: show "—" when force data isn't available yet (Issue #52)
@@ -685,7 +679,7 @@ private fun ExecutionPage(
                 maxForce = gaugeMax,
                 velocity = (metric.velocityA + metric.velocityB) / 2.0,
                 label = forceLabel,
-                subLabel = if (liveDisplayMultiplier == 2) "TOTAL" else "PER CABLE",
+                subLabel = "PER CABLE",
                 modifier = Modifier.size(hudSize),
             )
         } else if (isCurrentExerciseBodyweight) {

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/WorkoutTab.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/WorkoutTab.kt
@@ -507,14 +507,11 @@ fun WorkoutTab(
                 is WorkoutState.Countdown -> {
                     if (!workoutParameters.isJustLift) {
                         val currentExercise = loadedRoutine?.exercises?.getOrNull(currentExerciseIndex)
-                        val displayMultiplier = currentExercise?.exercise?.displayMultiplier
-                            ?: currentExercise?.exercise?.preferredCableCount
-                            ?: 1
-                        val totalWeight = workoutParameters.weightPerCableKg * displayMultiplier
+                        val nextWeightPerCable = workoutParameters.weightPerCableKg
                         CountdownCard(
                             countdownSecondsRemaining = workoutState.secondsRemaining,
                             nextExerciseName = currentExercise?.exercise?.name ?: "Exercise",
-                            nextExerciseWeight = totalWeight,
+                            nextExerciseWeight = nextWeightPerCable,
                             nextExerciseReps = workoutParameters.reps,
                             nextExerciseMode = workoutParameters.programMode.displayName,
                             currentExerciseIndex = if (loadedRoutine != null) currentExerciseIndex else null,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/util/WeightDisplayFormatter.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/util/WeightDisplayFormatter.kt
@@ -4,55 +4,54 @@ import com.devil.phoenixproject.domain.model.WeightUnit
 import com.devil.phoenixproject.util.format
 
 /**
- * Centralized weight display formatter that applies cable multiplication BEFORE unit conversion.
+ * Centralized weight display formatter.
  *
- * Architecture Decision:
- * - Database stores `weightPerCableKg` (Float) — always per-cable, always kg.
- * - This formatter multiplies by cableCount to get total weight, then converts to display unit.
- * - Storage, sync DTOs, and BLE commands remain per-cable — this is display-only.
- * - HealthIntegration already multiplies by cableCount — do NOT use this formatter there.
- * - Portal already multiplies by WEIGHT_MULTIPLIER (transforms.ts) — sync must stay per-cable.
- *
- * Null cableCount defaults to 1, matching:
- * - HealthIntegration convention
- * - SessionSummary.cableMultiplier: `if (cableCount == 2) 2 else 1`
+ * Phoenix stores, syncs, recommends, and commands machine load as per-cable kg.
+ * That matches the official app: cable count metadata must not change ordinary
+ * selected-load display. Total two-cable text is available only through the
+ * explicitly named total helper methods below.
  */
 object WeightDisplayFormatter {
 
     private const val KG_TO_LB = 2.20462f
 
     /**
-     * Convert a per-cable kg weight to display weight (total, in user's preferred unit).
+     * Convert per-cable kg to the user's selected display unit.
      *
-     * @param weightPerCableKg Weight per cable in kilograms (from DB/model)
-     * @param cableCount Number of cables (null = legacy data, defaults to 1)
-     * @param unit User's preferred weight unit (KG or LB)
-     * @return Display weight as Float (total weight in chosen unit)
+     * [cableCount] is accepted for backward source compatibility with existing
+     * call sites but intentionally ignored. Ordinary load display is per-cable.
      */
-    fun toDisplayWeight(weightPerCableKg: Float, cableCount: Int?, unit: WeightUnit): Float {
-        val multiplier = cableCount ?: 1
-        val totalKg = weightPerCableKg * multiplier
-        return when (unit) {
-            WeightUnit.KG -> totalKg
-            WeightUnit.LB -> totalKg * KG_TO_LB
-        }
-    }
+    @Suppress("UNUSED_PARAMETER")
+    fun toDisplayWeight(weightPerCableKg: Float, cableCount: Int?, unit: WeightUnit): Float =
+        toPerCableDisplayWeight(weightPerCableKg, unit)
 
     /**
-     * Format a per-cable kg weight as a display string (total, in user's preferred unit).
-     * Integers display without decimals; fractional values show 1 decimal place.
+     * Format per-cable kg in the user's selected display unit.
      *
-     * @param weightPerCableKg Weight per cable in kilograms (from DB/model)
-     * @param cableCount Number of cables (null = legacy data, defaults to 1)
-     * @param unit User's preferred weight unit (KG or LB)
-     * @return Formatted display string (e.g., "100" or "110.2")
+     * [cableCount] is accepted for backward source compatibility with existing
+     * call sites but intentionally ignored. Ordinary load display is per-cable.
      */
-    fun formatDisplayWeight(weightPerCableKg: Float, cableCount: Int?, unit: WeightUnit): String {
-        val display = toDisplayWeight(weightPerCableKg, cableCount, unit)
-        return if (display % 1f == 0f) {
-            display.toInt().toString()
-        } else {
-            display.format(1)
-        }
+    @Suppress("UNUSED_PARAMETER")
+    fun formatDisplayWeight(weightPerCableKg: Float, cableCount: Int?, unit: WeightUnit): String =
+        formatNumeric(toPerCableDisplayWeight(weightPerCableKg, unit))
+
+    fun toPerCableDisplayWeight(weightPerCableKg: Float, unit: WeightUnit): Float = when (unit) {
+        WeightUnit.KG -> weightPerCableKg
+        WeightUnit.LB -> weightPerCableKg * KG_TO_LB
+    }
+
+    fun formatPerCableWeight(weightPerCableKg: Float, unit: WeightUnit): String =
+        formatNumeric(toPerCableDisplayWeight(weightPerCableKg, unit))
+
+    fun toTwoCableTotalDisplayWeight(weightPerCableKg: Float, unit: WeightUnit): Float =
+        toPerCableDisplayWeight(weightPerCableKg * 2f, unit)
+
+    fun formatTwoCableTotalWeight(weightPerCableKg: Float, unit: WeightUnit): String =
+        formatNumeric(toTwoCableTotalDisplayWeight(weightPerCableKg, unit))
+
+    private fun formatNumeric(display: Float): String = if (display % 1f == 0f) {
+        display.toInt().toString()
+    } else {
+        display.format(1)
     }
 }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/ApplyEquipmentRackLoadUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/ApplyEquipmentRackLoadUseCaseTest.kt
@@ -14,7 +14,7 @@ class ApplyEquipmentRackLoadUseCaseTest {
     fun `added resistance changes display load but not machine weight`() {
         val result = useCase.calculate(
             programmedWeightPerCableKg = 20f,
-            displayMultiplier = 1,
+            physicalCableCount = 1,
             selectedItems = listOf(rackItem("vest", 10f, RackItemBehavior.ADDED_RESISTANCE)),
             isEchoMode = false,
         )
@@ -29,7 +29,7 @@ class ApplyEquipmentRackLoadUseCaseTest {
     fun `display only does not affect display or machine load math`() {
         val result = useCase.calculate(
             programmedWeightPerCableKg = 20f,
-            displayMultiplier = 1,
+            physicalCableCount = 1,
             selectedItems = listOf(rackItem("plate carrier", 30f, RackItemBehavior.DISPLAY_ONLY)),
             isEchoMode = false,
         )
@@ -44,7 +44,7 @@ class ApplyEquipmentRackLoadUseCaseTest {
     fun `counterweight subtracts from display and non echo machine command`() {
         val result = useCase.calculate(
             programmedWeightPerCableKg = 40f,
-            displayMultiplier = 2,
+            physicalCableCount = 2,
             selectedItems = listOf(rackItem("assist", 12f, RackItemBehavior.COUNTERWEIGHT)),
             isEchoMode = false,
             validatorMinimumPerCableKg = 1f,
@@ -56,17 +56,32 @@ class ApplyEquipmentRackLoadUseCaseTest {
     }
 
     @Test
+    fun `two cable counterweight splits across physical cables`() {
+        val result = useCase.calculate(
+            programmedWeightPerCableKg = 40f,
+            physicalCableCount = 2,
+            selectedItems = listOf(rackItem("assist", 10f, RackItemBehavior.COUNTERWEIGHT)),
+            isEchoMode = false,
+            validatorMinimumPerCableKg = 1f,
+        )
+
+        assertEquals(10f, result.counterweightKg)
+        assertEquals(70f, result.displayLoadKg)
+        assertEquals(35f, result.adjustedMachineWeightPerCableKg)
+    }
+
+    @Test
     fun `counterweight machine command clamps to validator minimum and max`() {
         val minimum = useCase.calculate(
             programmedWeightPerCableKg = 3f,
-            displayMultiplier = 1,
+            physicalCableCount = 1,
             selectedItems = listOf(rackItem("assist", 20f, RackItemBehavior.COUNTERWEIGHT)),
             isEchoMode = false,
             validatorMinimumPerCableKg = 1f,
         )
         val maximum = useCase.calculate(
             programmedWeightPerCableKg = 120f,
-            displayMultiplier = 1,
+            physicalCableCount = 1,
             selectedItems = emptyList(),
             isEchoMode = false,
         )
@@ -83,7 +98,7 @@ class ApplyEquipmentRackLoadUseCaseTest {
 
         val result = useCase.calculate(
             programmedWeightPerCableKg = 30f,
-            displayMultiplier = 1,
+            physicalCableCount = 1,
             selectedItems = listOf(vest, chain, vest, assist),
             isEchoMode = false,
         )
@@ -98,7 +113,7 @@ class ApplyEquipmentRackLoadUseCaseTest {
     fun `echo keeps machine weight unchanged`() {
         val result = useCase.calculate(
             programmedWeightPerCableKg = 40f,
-            displayMultiplier = 1,
+            physicalCableCount = 1,
             selectedItems = listOf(rackItem("assist", 10f, RackItemBehavior.COUNTERWEIGHT)),
             isEchoMode = true,
         )

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/util/WeightDisplayFormatterTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/util/WeightDisplayFormatterTest.kt
@@ -6,16 +6,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-/**
- * Tests for WeightDisplayFormatter.
- *
- * Verifies cable-aware weight display logic:
- * - Dual cable exercises multiply per-cable weight by 2
- * - Single cable exercises pass through per-cable weight
- * - Null cableCount defaults to 1 (safe legacy default)
- * - Unit conversion (KG/LB) applied AFTER cable multiplication
- * - Formatting: integers show no decimals, fractional values show 1 decimal
- */
 class WeightDisplayFormatterTest {
 
     private companion object {
@@ -23,109 +13,38 @@ class WeightDisplayFormatterTest {
         const val FLOAT_TOLERANCE = 0.01f
     }
 
-    // ===== toDisplayWeight: Dual cable, KG =====
-
     @Test
-    fun toDisplayWeight_dualCable_kg_multipliesByTwo() {
+    fun toDisplayWeight_twoCableMetadata_kg_staysPerCable() {
         val result = WeightDisplayFormatter.toDisplayWeight(
             weightPerCableKg = 50f,
             cableCount = 2,
             unit = WeightUnit.KG,
         )
-        assertEquals(100f, result, "50kg per cable x 2 cables = 100kg total")
+
+        assertEquals(50f, result, "Official app displays selected load as per-cable weight")
     }
 
-    // ===== toDisplayWeight: Dual cable, LB =====
-
     @Test
-    fun toDisplayWeight_dualCable_lb_multipliesByTwoThenConverts() {
+    fun toDisplayWeight_twoCableMetadata_lb_convertsPerCableOnly() {
         val result = WeightDisplayFormatter.toDisplayWeight(
             weightPerCableKg = 50f,
             cableCount = 2,
             unit = WeightUnit.LB,
         )
-        val expected = 100f * KG_TO_LB // 220.462
+
         assertTrue(
-            abs(result - expected) < FLOAT_TOLERANCE,
-            "50kg per cable x 2 cables = 100kg → ${expected}lb, got $result",
+            abs(result - (50f * KG_TO_LB)) < FLOAT_TOLERANCE,
+            "Two-cable metadata must not double ordinary lb display",
         )
-    }
-
-    // ===== toDisplayWeight: Single cable, KG =====
-
-    @Test
-    fun toDisplayWeight_singleCable_kg_noMultiplication() {
-        val result = WeightDisplayFormatter.toDisplayWeight(
-            weightPerCableKg = 50f,
-            cableCount = 1,
-            unit = WeightUnit.KG,
-        )
-        assertEquals(50f, result, "50kg per cable x 1 cable = 50kg total")
-    }
-
-    // ===== toDisplayWeight: Single cable, LB =====
-
-    @Test
-    fun toDisplayWeight_singleCable_lb_convertsOnly() {
-        val result = WeightDisplayFormatter.toDisplayWeight(
-            weightPerCableKg = 50f,
-            cableCount = 1,
-            unit = WeightUnit.LB,
-        )
-        val expected = 50f * KG_TO_LB // 110.231
-        assertTrue(
-            abs(result - expected) < FLOAT_TOLERANCE,
-            "50kg per cable x 1 cable = 50kg → ${expected}lb, got $result",
-        )
-    }
-
-    // ===== toDisplayWeight: Null cable count (default single) =====
-
-    @Test
-    fun toDisplayWeight_nullCableCount_defaultsToSingle() {
-        val result = WeightDisplayFormatter.toDisplayWeight(
-            weightPerCableKg = 50f,
-            cableCount = null,
-            unit = WeightUnit.KG,
-        )
-        assertEquals(50f, result, "Null cableCount defaults to 1: 50kg per cable = 50kg total")
-    }
-
-    // ===== toDisplayWeight: Zero weight =====
-
-    @Test
-    fun toDisplayWeight_zeroWeight_returnsZero_kg() {
-        val result = WeightDisplayFormatter.toDisplayWeight(
-            weightPerCableKg = 0f,
-            cableCount = 2,
-            unit = WeightUnit.KG,
-        )
-        assertEquals(0f, result, "0kg per cable x 2 = 0kg total")
     }
 
     @Test
-    fun toDisplayWeight_zeroWeight_returnsZero_lb() {
-        val result = WeightDisplayFormatter.toDisplayWeight(
-            weightPerCableKg = 0f,
-            cableCount = 2,
-            unit = WeightUnit.LB,
-        )
-        assertEquals(0f, result, "0kg per cable in LB = 0lb")
+    fun toDisplayWeight_ignoresInvalidCableMetadata() {
+        assertEquals(80f, WeightDisplayFormatter.toDisplayWeight(80f, cableCount = 0, unit = WeightUnit.KG))
+        assertEquals(80f, WeightDisplayFormatter.toDisplayWeight(80f, cableCount = -1, unit = WeightUnit.KG))
+        assertEquals(80f, WeightDisplayFormatter.toDisplayWeight(80f, cableCount = 3, unit = WeightUnit.KG))
+        assertEquals(80f, WeightDisplayFormatter.toDisplayWeight(80f, cableCount = null, unit = WeightUnit.KG))
     }
-
-    // ===== toDisplayWeight: Max weight (220kg per cable for Trainer+) =====
-
-    @Test
-    fun toDisplayWeight_maxWeight_dualCable_kg() {
-        val result = WeightDisplayFormatter.toDisplayWeight(
-            weightPerCableKg = 220f,
-            cableCount = 2,
-            unit = WeightUnit.KG,
-        )
-        assertEquals(440f, result, "220kg per cable x 2 = 440kg total")
-    }
-
-    // ===== formatDisplayWeight: Integer values =====
 
     @Test
     fun formatDisplayWeight_integerResult_noDecimals() {
@@ -134,10 +53,9 @@ class WeightDisplayFormatterTest {
             cableCount = 2,
             unit = WeightUnit.KG,
         )
-        assertEquals("100", result, "100.0kg should display as '100'")
-    }
 
-    // ===== formatDisplayWeight: Decimal values =====
+        assertEquals("50", result)
+    }
 
     @Test
     fun formatDisplayWeight_decimalResult_oneDecimal() {
@@ -146,57 +64,40 @@ class WeightDisplayFormatterTest {
             cableCount = 2,
             unit = WeightUnit.KG,
         )
-        assertEquals("100.5", result, "50.25 x 2 = 100.5kg should display as '100.5'")
+
+        assertEquals("50.3", result)
     }
 
-    // ===== formatDisplayWeight: LB formatting =====
+    @Test
+    fun explicitTwoCableTotal_kg_doublesOnlyWhenCalledExplicitly() {
+        val result = WeightDisplayFormatter.toTwoCableTotalDisplayWeight(
+            weightPerCableKg = 50f,
+            unit = WeightUnit.KG,
+        )
+
+        assertEquals(100f, result, "Only the explicitly named total helper doubles")
+    }
 
     @Test
-    fun formatDisplayWeight_lb_showsConvertedValue() {
-        val result = WeightDisplayFormatter.formatDisplayWeight(
+    fun explicitTwoCableTotal_lb_doublesThenConverts() {
+        val result = WeightDisplayFormatter.toTwoCableTotalDisplayWeight(
             weightPerCableKg = 50f,
-            cableCount = 2,
             unit = WeightUnit.LB,
         )
-        // 50 * 2 = 100kg * 2.20462 = 220.462 → rounded to 1 decimal = "220.5"
-        assertEquals("220.5", result, "100kg → 220.462lb → formatted '220.5', got '$result'")
+
+        assertTrue(
+            abs(result - (100f * KG_TO_LB)) < FLOAT_TOLERANCE,
+            "Explicit total helper should show two-cable total in the selected unit",
+        )
     }
 
-    // ===== Pure function: per-cable value preserved =====
-
     @Test
-    fun toDisplayWeight_doesNotMutateInput() {
-        val perCable = 50f
-        val cableCount = 2
-        val unit = WeightUnit.KG
-
-        // Call multiple times with same input
-        val result1 = WeightDisplayFormatter.toDisplayWeight(perCable, cableCount, unit)
-        val result2 = WeightDisplayFormatter.toDisplayWeight(perCable, cableCount, unit)
-
-        assertEquals(result1, result2, "Pure function: same input produces same output")
-        assertEquals(100f, result1, "Value should be 100")
-    }
-
-    // ===== Edge: Small fractional weight =====
-
-    @Test
-    fun toDisplayWeight_smallFractionalWeight_kg() {
-        val result = WeightDisplayFormatter.toDisplayWeight(
-            weightPerCableKg = 0.5f,
-            cableCount = 2,
+    fun formatTwoCableTotalWeight_formatsExplicitHelper() {
+        val result = WeightDisplayFormatter.formatTwoCableTotalWeight(
+            weightPerCableKg = 37.5f,
             unit = WeightUnit.KG,
         )
-        assertEquals(1f, result, "0.5kg per cable x 2 = 1kg")
-    }
 
-    @Test
-    fun formatDisplayWeight_zeroWeight_showsZero() {
-        val result = WeightDisplayFormatter.formatDisplayWeight(
-            weightPerCableKg = 0f,
-            cableCount = 2,
-            unit = WeightUnit.KG,
-        )
-        assertEquals("0", result, "0kg should display as '0'")
+        assertEquals("75", result)
     }
 }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/util/WeightDisplayIntegrationTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/util/WeightDisplayIntegrationTest.kt
@@ -1,5 +1,6 @@
 package com.devil.phoenixproject.presentation.util
 
+import com.devil.phoenixproject.domain.model.WeightUnit
 import com.devil.phoenixproject.domain.usecase.BodyweightVolumeCalculator
 import com.devil.phoenixproject.util.UnitConverter
 import kotlin.math.abs
@@ -26,24 +27,29 @@ class WeightDisplayIntegrationTest {
 
     @Test
     fun formatterAndIncrementAlignmentDualCable() {
-        // Scenario: 55.5kg per-cable weight on a dual-cable exercise
-        // Total weight = 55.5 * 2 = 111.0kg (uses 0.5kg increments to avoid Float truncation)
         val perCableKg = 55.5f
-        val cableCount = 2
-        val totalKg = perCableKg * cableCount
+        val ordinaryFormatted = WeightDisplayFormatter.formatDisplayWeight(
+            weightPerCableKg = perCableKg,
+            cableCount = 2,
+            unit = WeightUnit.KG,
+        )
+        assertEquals("55.5", ordinaryFormatted, "Ordinary dual-cable display stays per-cable")
 
-        // UnitConverter.formatWeight operates on total weight (not per-cable)
-        val formatted = UnitConverter.formatWeight(totalKg, useLb = false)
+        val explicitTotalFormatted = WeightDisplayFormatter.formatTwoCableTotalWeight(
+            weightPerCableKg = perCableKg,
+            unit = WeightUnit.KG,
+        )
+        assertEquals("111", explicitTotalFormatted, "Explicit helper can show two-cable total")
 
-        // 55.5 * 2 = 111.0 (whole number) — verify it shows the total,
-        // not the per-cable value, and includes the unit suffix
-        assertEquals("111 kg", formatted, "Total weight for dual cable should be 111 kg")
-
-        // Also verify a fractional case with machine-safe 0.5kg granularity
         val fractionalPerCable = 27.5f
-        val fractionalTotal = fractionalPerCable * cableCount // 55.0
-        val fractionalFormatted = UnitConverter.formatWeight(fractionalTotal, useLb = false)
-        assertEquals("55 kg", fractionalFormatted, "27.5kg per cable x 2 = 55kg total")
+        assertEquals(
+            "27.5",
+            WeightDisplayFormatter.formatDisplayWeight(fractionalPerCable, cableCount = 2, unit = WeightUnit.KG),
+        )
+        assertEquals(
+            "55",
+            WeightDisplayFormatter.formatTwoCableTotalWeight(fractionalPerCable, WeightUnit.KG),
+        )
     }
 
     @Test
@@ -77,14 +83,21 @@ class WeightDisplayIntegrationTest {
 
     @Test
     fun bulkAdjustWithFormatterConsistency() {
-        // Scenario: 50kg per-cable + 10% bulk adjust = 55kg per-cable
-        // Total = 55 * 2 = 110kg
         val basePerCable = 50f
-        val adjustedPerCable = basePerCable * 1.10f // +10%
-        val totalKg = adjustedPerCable * 2
+        val adjustedPerCable = basePerCable * 1.10f
 
-        val formatted = UnitConverter.formatWeight(totalKg, useLb = false)
-        assertEquals("110 kg", formatted, "50kg + 10% = 55kg per cable, total 110kg")
+        val ordinaryFormatted = WeightDisplayFormatter.formatDisplayWeight(
+            weightPerCableKg = adjustedPerCable,
+            cableCount = 2,
+            unit = WeightUnit.KG,
+        )
+        assertEquals("55", ordinaryFormatted, "Bulk adjust changes per-cable load")
+
+        val explicitTotalFormatted = WeightDisplayFormatter.formatTwoCableTotalWeight(
+            weightPerCableKg = adjustedPerCable,
+            unit = WeightUnit.KG,
+        )
+        assertEquals("110", explicitTotalFormatted, "Explicit total helper doubles when requested")
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/util/WeightDisplayRegressionTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/util/WeightDisplayRegressionTest.kt
@@ -6,483 +6,138 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-/**
- * Comprehensive regression test suite for weight display across all surfaces.
- *
- * Tests cover the full matrix of:
- * - Cable configurations: single (1), dual (2), null (legacy)
- * - Weight units: KG, LB
- * - Boundary values: zero, minimum, maximum
- * - Edge cases: fractional weights, large values, cableCount=0
- *
- * These tests ensure that WeightDisplayFormatter produces consistent results
- * that match what every display surface in the app should show.
- */
 class WeightDisplayRegressionTest {
 
     private companion object {
         const val KG_TO_LB = 2.20462f
         const val FLOAT_TOLERANCE = 0.01f
-
-        // Hardware constants from Constants.kt
-        const val MAX_WEIGHT_KG = 220f // Trainer+ max per cable
-        const val MIN_WEIGHT_KG = 0.5f // Minimum weight increment
+        const val MAX_WEIGHT_KG = 220f
+        const val MIN_WEIGHT_KG = 0.5f
     }
 
-    // ===== 1. Dual-cable session: KG =====
-
     @Test
-    fun dualCable_kg_displaysDoubledWeight() {
+    fun dualCable_kg_displaysSelectedPerCableWeight() {
         val result = WeightDisplayFormatter.toDisplayWeight(
             weightPerCableKg = 80f,
             cableCount = 2,
             unit = WeightUnit.KG,
         )
-        assertEquals(160f, result, "80kg/cable x 2 cables = 160kg displayed")
+
+        assertEquals(80f, result)
     }
 
     @Test
-    fun dualCable_kg_formatsCorrectly() {
-        val result = WeightDisplayFormatter.formatDisplayWeight(
-            weightPerCableKg = 80f,
-            cableCount = 2,
-            unit = WeightUnit.KG,
-        )
-        assertEquals("160", result, "160kg should format as '160' (no decimals)")
-    }
-
-    // ===== 2. Dual-cable session: LB =====
-
-    @Test
-    fun dualCable_lb_displaysDoubledAndConverted() {
+    fun dualCable_lb_convertsSelectedPerCableWeightOnly() {
         val result = WeightDisplayFormatter.toDisplayWeight(
             weightPerCableKg = 80f,
             cableCount = 2,
             unit = WeightUnit.LB,
         )
-        val expected = 160f * KG_TO_LB // 352.7392
-        assertTrue(
-            abs(result - expected) < FLOAT_TOLERANCE,
-            "80kg/cable x 2 cables = 160kg -> ${expected}lb, got $result",
-        )
+
+        assertTrue(abs(result - (80f * KG_TO_LB)) < FLOAT_TOLERANCE)
     }
 
     @Test
-    fun dualCable_lb_formatsCorrectly() {
-        val result = WeightDisplayFormatter.formatDisplayWeight(
-            weightPerCableKg = 80f,
-            cableCount = 2,
-            unit = WeightUnit.LB,
-        )
-        // 160kg * 2.20462 = 352.7392 -> rounded to 1 decimal = "352.7"
-        assertEquals("352.7", result, "160kg -> 352.7392lb -> formatted '352.7', got '$result'")
-    }
-
-    // ===== 3. Single-cable session: KG =====
-
-    @Test
-    fun singleCable_kg_displaysUnchanged() {
+    fun singleCable_kg_displaysSelectedPerCableWeight() {
         val result = WeightDisplayFormatter.toDisplayWeight(
             weightPerCableKg = 80f,
             cableCount = 1,
             unit = WeightUnit.KG,
         )
-        assertEquals(80f, result, "80kg/cable x 1 cable = 80kg displayed")
+
+        assertEquals(80f, result)
     }
 
-    // ===== 4. Single-cable session: LB =====
-
     @Test
-    fun singleCable_lb_convertsOnly() {
-        val result = WeightDisplayFormatter.toDisplayWeight(
-            weightPerCableKg = 80f,
-            cableCount = 1,
-            unit = WeightUnit.LB,
-        )
-        val expected = 80f * KG_TO_LB
-        assertTrue(
-            abs(result - expected) < FLOAT_TOLERANCE,
-            "80kg x 1 cable -> ${expected}lb, got $result",
-        )
-    }
-
-    // ===== 5. Null cableCount (legacy data): defaults to 1 =====
-
-    @Test
-    fun nullCableCount_kg_defaultsToSingle() {
+    fun nullCableCount_kg_displaysStoredPerCableWeight() {
         val result = WeightDisplayFormatter.toDisplayWeight(
             weightPerCableKg = 80f,
             cableCount = null,
             unit = WeightUnit.KG,
         )
-        assertEquals(80f, result, "Null cableCount defaults to 1: 80kg unchanged")
+
+        assertEquals(80f, result)
     }
 
     @Test
-    fun nullCableCount_lb_defaultsToSingleThenConverts() {
-        val result = WeightDisplayFormatter.toDisplayWeight(
-            weightPerCableKg = 80f,
-            cableCount = null,
-            unit = WeightUnit.LB,
-        )
-        val expected = 80f * KG_TO_LB
-        assertTrue(
-            abs(result - expected) < FLOAT_TOLERANCE,
-            "Null cableCount + LB: 80kg -> ${expected}lb, got $result",
-        )
-    }
-
-    // ===== 6. Zero weight boundary =====
-
-    @Test
-    fun zeroWeight_dualCable_kg_returnsZero() {
-        val result = WeightDisplayFormatter.toDisplayWeight(
-            weightPerCableKg = 0f,
-            cableCount = 2,
-            unit = WeightUnit.KG,
-        )
-        assertEquals(0f, result, "0kg x 2 = 0kg")
+    fun zeroWeight_staysZero() {
+        assertEquals(0f, WeightDisplayFormatter.toDisplayWeight(0f, cableCount = 2, unit = WeightUnit.KG))
+        assertEquals("0", WeightDisplayFormatter.formatDisplayWeight(0f, cableCount = 2, unit = WeightUnit.KG))
     }
 
     @Test
-    fun zeroWeight_dualCable_lb_returnsZero() {
-        val result = WeightDisplayFormatter.toDisplayWeight(
-            weightPerCableKg = 0f,
-            cableCount = 2,
-            unit = WeightUnit.LB,
-        )
-        assertEquals(0f, result, "0kg x 2 = 0lb")
-    }
-
-    @Test
-    fun zeroWeight_formatsAsZero() {
-        val result = WeightDisplayFormatter.formatDisplayWeight(
-            weightPerCableKg = 0f,
-            cableCount = 2,
-            unit = WeightUnit.KG,
-        )
-        assertEquals("0", result, "0kg should display as '0'")
-    }
-
-    // ===== 7. Maximum weight boundary (220kg per cable on Trainer+) =====
-
-    @Test
-    fun maxWeight_dualCable_kg() {
+    fun maxWeight_dualCable_staysPerCable() {
         val result = WeightDisplayFormatter.toDisplayWeight(
             weightPerCableKg = MAX_WEIGHT_KG,
             cableCount = 2,
             unit = WeightUnit.KG,
         )
-        assertEquals(440f, result, "220kg/cable x 2 = 440kg max total")
+
+        assertEquals(MAX_WEIGHT_KG, result)
     }
 
     @Test
-    fun maxWeight_dualCable_lb() {
-        val result = WeightDisplayFormatter.toDisplayWeight(
-            weightPerCableKg = MAX_WEIGHT_KG,
-            cableCount = 2,
-            unit = WeightUnit.LB,
-        )
-        val expected = 440f * KG_TO_LB // 970.0328
-        assertTrue(
-            abs(result - expected) < FLOAT_TOLERANCE,
-            "440kg -> ${expected}lb, got $result",
-        )
-    }
-
-    @Test
-    fun maxWeight_singleCable_kg() {
-        val result = WeightDisplayFormatter.toDisplayWeight(
-            weightPerCableKg = MAX_WEIGHT_KG,
-            cableCount = 1,
-            unit = WeightUnit.KG,
-        )
-        assertEquals(220f, result, "220kg/cable x 1 = 220kg")
-    }
-
-    @Test
-    fun maxWeight_formatsAsInteger() {
-        val result = WeightDisplayFormatter.formatDisplayWeight(
-            weightPerCableKg = MAX_WEIGHT_KG,
-            cableCount = 2,
-            unit = WeightUnit.KG,
-        )
-        assertEquals("440", result, "440kg should format as '440'")
-    }
-
-    // ===== 8. PR weight display (PR lacks cableCount, passes null) =====
-
-    @Test
-    fun prWeight_nullCableCount_kg_showsPerCable() {
-        // PersonalRecord does NOT have cableCount field.
-        // All PR displays pass cableCount=null, which defaults to 1.
-        // This means PRs show per-cable weight, which is the current behavior.
-        val prWeightPerCableKg = 100f
-        val result = WeightDisplayFormatter.toDisplayWeight(
-            weightPerCableKg = prWeightPerCableKg,
-            cableCount = null,
-            unit = WeightUnit.KG,
-        )
-        assertEquals(100f, result, "PR with null cableCount shows per-cable weight: 100kg")
-    }
-
-    @Test
-    fun prWeight_nullCableCount_lb_convertsFromPerCable() {
-        val prWeightPerCableKg = 100f
-        val result = WeightDisplayFormatter.toDisplayWeight(
-            weightPerCableKg = prWeightPerCableKg,
-            cableCount = null,
-            unit = WeightUnit.LB,
-        )
-        val expected = 100f * KG_TO_LB
-        assertTrue(
-            abs(result - expected) < FLOAT_TOLERANCE,
-            "PR weight 100kg -> ${expected}lb, got $result",
-        )
-    }
-
-    // ===== 9. Fractional weight (0.5kg increments) =====
-
-    @Test
-    fun fractionalWeight_dualCable_kg() {
-        val result = WeightDisplayFormatter.toDisplayWeight(
-            weightPerCableKg = MIN_WEIGHT_KG,
-            cableCount = 2,
-            unit = WeightUnit.KG,
-        )
-        assertEquals(1f, result, "0.5kg/cable x 2 = 1.0kg")
-    }
-
-    @Test
-    fun fractionalWeight_formatsCleanly() {
-        val result = WeightDisplayFormatter.formatDisplayWeight(
-            weightPerCableKg = MIN_WEIGHT_KG,
-            cableCount = 2,
-            unit = WeightUnit.KG,
-        )
-        assertEquals("1", result, "1.0kg should format as '1' (no unnecessary decimals)")
-    }
-
-    @Test
-    fun oddFractionalWeight_showsOneDecimal() {
-        // 37.5kg per cable x 2 = 75.0kg -> "75"
-        val result = WeightDisplayFormatter.formatDisplayWeight(
-            weightPerCableKg = 37.5f,
-            cableCount = 2,
-            unit = WeightUnit.KG,
-        )
-        assertEquals("75", result, "37.5 x 2 = 75.0 -> '75'")
-    }
-
-    @Test
-    fun fractionalResult_showsOneDecimal() {
-        // 37.25kg per cable x 2 = 74.5kg -> "74.5"
-        val result = WeightDisplayFormatter.formatDisplayWeight(
-            weightPerCableKg = 37.25f,
-            cableCount = 2,
-            unit = WeightUnit.KG,
-        )
-        assertEquals("74.5", result, "37.25 x 2 = 74.5 -> '74.5'")
-    }
-
-    // ===== 10. Cross-surface consistency =====
-
-    @Test
-    fun sameInput_producesIdenticalOutput_acrossMultipleCalls() {
-        // Ensures WeightDisplayFormatter is a pure function with no hidden state.
-        // All display surfaces calling with the same inputs must get the same result.
-        val input = Triple(80f, 2, WeightUnit.KG)
-        val results = (1..5).map {
-            WeightDisplayFormatter.toDisplayWeight(input.first, input.second, input.third)
-        }
-        assertTrue(
-            results.all { it == results.first() },
-            "Pure function: 5 calls with same input must produce identical output. Got: $results",
-        )
-    }
-
-    @Test
-    fun formatAndToDisplay_areConsistent() {
-        // formatDisplayWeight should format the exact value from toDisplayWeight
-        val weightPerCable = 80f
-        val cableCount = 2
-        val unit = WeightUnit.KG
-
-        val numericResult = WeightDisplayFormatter.toDisplayWeight(weightPerCable, cableCount, unit)
-        val stringResult = WeightDisplayFormatter.formatDisplayWeight(weightPerCable, cableCount, unit)
-
-        // String representation should match numeric value
-        assertEquals(
-            numericResult.toInt().toString(),
-            stringResult,
-            "formatDisplayWeight('$stringResult') must match toDisplayWeight($numericResult)",
-        )
-    }
-
-    // ===== 11. Edge case: cableCount = 0 =====
-
-    @Test
-    fun cableCountZero_resultsInZeroWeight() {
-        // If cableCount is somehow 0 (data corruption), result should be 0.
-        // This is defensive; normal values are 1 or 2.
-        val result = WeightDisplayFormatter.toDisplayWeight(
-            weightPerCableKg = 80f,
-            cableCount = 0,
-            unit = WeightUnit.KG,
-        )
-        assertEquals(0f, result, "80kg x 0 cables = 0kg (defensive for corrupt data)")
-    }
-
-    // ===== 12. Unit conversion accuracy =====
-
-    @Test
-    fun unitConversion_kg_isIdentity() {
-        // KG display should be exactly the cable-multiplied value, no floating-point drift
+    fun prWeight_withCableCount_staysPerCable() {
         val result = WeightDisplayFormatter.toDisplayWeight(
             weightPerCableKg = 100f,
-            cableCount = 1,
+            cableCount = 2,
             unit = WeightUnit.KG,
         )
-        assertEquals(100f, result, "KG conversion should be identity (no floating-point drift)")
+
+        assertEquals(100f, result)
     }
 
     @Test
-    fun unitConversion_lb_matchesStandardFactor() {
-        // LB conversion must use the standard 2.20462 factor
+    fun fractionalWeight_dualCable_staysPerCable() {
         val result = WeightDisplayFormatter.toDisplayWeight(
-            weightPerCableKg = 1f,
-            cableCount = 1,
-            unit = WeightUnit.LB,
+            weightPerCableKg = MIN_WEIGHT_KG,
+            cableCount = 2,
+            unit = WeightUnit.KG,
         )
-        assertTrue(
-            abs(result - KG_TO_LB) < FLOAT_TOLERANCE,
-            "1kg -> ${KG_TO_LB}lb, got $result",
-        )
-    }
 
-    // ===== 13. No double-multiplication: toDisplayWeight applied once =====
-
-    @Test
-    fun applyingFormatterTwice_producesWrongResult() {
-        // Demonstrates that calling toDisplayWeight on an already-converted value
-        // produces an incorrect result. This is why the formatter must only be
-        // applied once at the display layer.
-        val firstPass = WeightDisplayFormatter.toDisplayWeight(50f, 2, WeightUnit.KG) // 100
-        val secondPass = WeightDisplayFormatter.toDisplayWeight(firstPass, 2, WeightUnit.KG) // 200 (WRONG)
-
-        assertEquals(100f, firstPass, "First pass: 50 x 2 = 100")
-        assertEquals(200f, secondPass, "Second pass: 100 x 2 = 200 (WRONG - double multiplication)")
-        assertTrue(
-            firstPass != secondPass,
-            "Double-applying the formatter produces a different (wrong) result. " +
-                "This is why each display surface must only call the formatter ONCE.",
-        )
-    }
-
-    // ===== 14. Formatting: integer vs decimal display =====
-
-    @Test
-    fun format_integerResult_noTrailingZero() {
-        val result = WeightDisplayFormatter.formatDisplayWeight(50f, 2, WeightUnit.KG)
-        assertEquals("100", result, "100.0 should format as '100', not '100.0'")
+        assertEquals(MIN_WEIGHT_KG, result)
     }
 
     @Test
-    fun format_oneDecimalResult_showsDecimal() {
-        // 50.25 x 2 = 100.5
-        val result = WeightDisplayFormatter.formatDisplayWeight(50.25f, 2, WeightUnit.KG)
-        assertEquals("100.5", result, "100.5 should format as '100.5'")
+    fun formatAndToDisplay_areConsistentForPerCableDisplay() {
+        val numericResult = WeightDisplayFormatter.toDisplayWeight(80f, 2, WeightUnit.KG)
+        val stringResult = WeightDisplayFormatter.formatDisplayWeight(80f, 2, WeightUnit.KG)
+
+        assertEquals("80", stringResult)
+        assertEquals(numericResult.toInt().toString(), stringResult)
     }
 
     @Test
-    fun format_lbConversion_showsOneDecimal() {
-        // 100kg * 2.20462 = 220.462 -> rounded to 1 decimal = "220.5"
-        val result = WeightDisplayFormatter.formatDisplayWeight(100f, 1, WeightUnit.LB)
-        assertEquals("220.5", result, "100kg -> 220.462lb -> formatted '220.5', got '$result'")
+    fun unusualCableCounts_doNotChangeOrdinaryDisplay() {
+        assertEquals(80f, WeightDisplayFormatter.toDisplayWeight(80f, 0, WeightUnit.KG))
+        assertEquals(80f, WeightDisplayFormatter.toDisplayWeight(80f, -1, WeightUnit.KG))
+        assertEquals(80f, WeightDisplayFormatter.toDisplayWeight(80f, 3, WeightUnit.KG))
     }
 
-    // ===== 15. Negative weight input =====
+    @Test
+    fun explicitTwoCableTotal_isSeparateFromOrdinaryDisplay() {
+        val ordinary = WeightDisplayFormatter.toDisplayWeight(50f, 2, WeightUnit.KG)
+        val total = WeightDisplayFormatter.toTwoCableTotalDisplayWeight(50f, WeightUnit.KG)
+
+        assertEquals(50f, ordinary)
+        assertEquals(100f, total)
+    }
 
     @Test
-    fun negativeWeight_passesThrough() {
-        // Negative weight is not physically possible but should not crash.
-        // Current behavior: passes through without clamping (no coerceAtLeast).
-        // Documenting rather than clamping: the caller (UI) should prevent negative input.
+    fun explicitTwoCableTotal_formatsFractionalValues() {
+        val result = WeightDisplayFormatter.formatTwoCableTotalWeight(27.5f, WeightUnit.KG)
+
+        assertEquals("55", result)
+    }
+
+    @Test
+    fun negativeWeight_passesThroughWithoutCableMultiplication() {
         val result = WeightDisplayFormatter.toDisplayWeight(
             weightPerCableKg = -50f,
             cableCount = 2,
             unit = WeightUnit.KG,
         )
-        assertEquals(-100f, result, "Negative weight passes through: -50 x 2 = -100")
-    }
 
-    @Test
-    fun negativeWeight_formatsWithMinus() {
-        val result = WeightDisplayFormatter.formatDisplayWeight(
-            weightPerCableKg = -50f,
-            cableCount = 2,
-            unit = WeightUnit.KG,
-        )
-        assertEquals("-100", result, "Negative result should format with minus sign")
-    }
-
-    // ===== 16. Unusual cableCount values =====
-
-    @Test
-    fun cableCountNegative_producesNegativeWeight() {
-        // cableCount = -1 is invalid data (corruption). Currently produces negative result.
-        // The formatter is a pure math function; input validation belongs at the call site.
-        val result = WeightDisplayFormatter.toDisplayWeight(
-            weightPerCableKg = 50f,
-            cableCount = -1,
-            unit = WeightUnit.KG,
-        )
-        assertEquals(-50f, result, "50 x -1 = -50 (invalid cableCount, no validation in formatter)")
-    }
-
-    @Test
-    fun cableCountThree_multipliesByThree() {
-        // cableCount = 3 is not physically possible on Vitruvian hardware (max 2 cables).
-        // Formatter treats cableCount as a pure multiplier without validation.
-        val result = WeightDisplayFormatter.toDisplayWeight(
-            weightPerCableKg = 50f,
-            cableCount = 3,
-            unit = WeightUnit.KG,
-        )
-        assertEquals(150f, result, "50 x 3 = 150 (no hardware validation in formatter)")
-    }
-
-    // ===== 17. Float modulo precision near integer boundary =====
-
-    @Test
-    fun floatModuloPrecision_nearIntegerBoundary() {
-        // 33.3333f * 3 = 99.9999 due to float precision — NOT exactly 100.
-        // This tests whether `display % 1f == 0f` incorrectly treats 99.9999 as integer.
-        val result = WeightDisplayFormatter.formatDisplayWeight(
-            weightPerCableKg = 33.3333f,
-            cableCount = 3,
-            unit = WeightUnit.KG,
-        )
-        // 33.3333 * 3 = 99.9999... which is NOT exactly 100
-        // So `display % 1f` is ~0.9999 (not 0), takes the format(1) path
-        // format(1) rounds: (99.9999 * 10).roundToInt() / 10 = 1000 / 10 = 100.0
-        // Then 100.0 % 1f == 0f, but we're already in the decimal path...
-        // Actually format(1) returns "100.0" since intPart=100, decPart=0, padded="0"
-        // The key: this must not crash and must produce a reasonable string.
-        assertTrue(
-            result == "100.0" || result == "100",
-            "Near-integer float: 33.3333 x 3 should produce ~100, got '$result'",
-        )
-    }
-
-    @Test
-    fun floatModuloPrecision_exactlyHalf() {
-        // 0.5 * 1 = 0.5 — should be detected as fractional
-        val result = WeightDisplayFormatter.formatDisplayWeight(
-            weightPerCableKg = 0.5f,
-            cableCount = 1,
-            unit = WeightUnit.KG,
-        )
-        assertEquals("0.5", result, "0.5 should format as '0.5'")
+        assertEquals(-50f, result)
     }
 }


### PR DESCRIPTION
## Summary
- Keep primary selected, live, history, analytics, and saved-session weight displays per cable to match the official Vitruvian app.
- Add explicit two-cable-total formatter helpers only for helper text that says "Total weight for 2 cables".
- Separate rack physical cable count from UI display semantics so rack adjustment logic can still split counterweights by real cable usage.
- Add formatter, regression, source guard, and rack tests that lock the per-cable contract.

## Root Cause
Phoenix was using cable count/display multiplier as a generic display multiplier, so two-cable exercises could show total two-cable load in places where the official app treats the selected/active weight as per-cable.

## Test Plan
- PASS: `./gradlew.bat :shared:testAndroidHostTest --tests "com.devil.phoenixproject.presentation.util.WeightDisplayFormatterTest" --tests "com.devil.phoenixproject.presentation.util.WeightDisplayRegressionTest" --tests "com.devil.phoenixproject.presentation.util.WeightDisplayIntegrationTest" --tests "com.devil.phoenixproject.presentation.util.WeightDisplaySourceGuardTest" --tests "com.devil.phoenixproject.domain.usecase.ApplyEquipmentRackLoadUseCaseTest" --console=plain --rerun-tasks '-Pskip.supabase.check=true'`
- PASS: `./gradlew.bat :shared:testAndroidHostTest --tests "com.devil.phoenixproject.util.BlePacketFactoryTest" --console=plain --rerun-tasks '-Pskip.supabase.check=true'`
- PASS: `./gradlew.bat :shared:testAndroidHostTest --console=plain --rerun-tasks '-Pskip.supabase.check=true'`
- PASS: `git diff --check main...HEAD`
- CHECKED: source sweep for accidental display multiplier usage; remaining hits are tests/guards, total-volume/health-export math, PR percentage scaling, and BLE per-cable command scaling.
- KNOWN PRE-EXISTING: `./gradlew.bat spotlessCheck --console=plain '-Pskip.supabase.check=true'` still fails on unrelated files outside this branch's diff.