### PR TITLE
fix(echo): restore warm-up progression on Android 16 / OnePlus 15 (Fixes #553)

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/preferences/PreferencesManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/preferences/PreferencesManager.kt
@@ -1,6 +1,7 @@
 package com.devil.phoenixproject.data.preferences
 
 import com.devil.phoenixproject.domain.model.EchoLevel
+import com.devil.phoenixproject.domain.model.ProgramMode
 import com.devil.phoenixproject.domain.model.RepCountTiming
 import com.devil.phoenixproject.domain.model.UserPreferences
 import com.devil.phoenixproject.domain.model.WeightUnit
@@ -362,8 +363,9 @@ class SettingsPreferencesManager(private val settings: Settings) : PreferencesMa
     }
 
     override suspend fun saveSingleExerciseDefaults(defaults: SingleExerciseDefaults) {
+        val normalizedDefaults = defaults.withNormalizedNonEchoEchoLevel()
         val key = "$KEY_PREFIX_EXERCISE${defaults.exerciseId}"
-        settings.putString(key, json.encodeToString(defaults))
+        settings.putString(key, json.encodeToString(normalizedDefaults))
         settings.putBoolean(getEchoHardDefaultMigrationKey(defaults.exerciseId), true)
     }
 
@@ -384,7 +386,8 @@ class SettingsPreferencesManager(private val settings: Settings) : PreferencesMa
     }
 
     override suspend fun saveJustLiftDefaults(defaults: JustLiftDefaults) {
-        settings.putString(KEY_JUST_LIFT_DEFAULTS, json.encodeToString(defaults))
+        val normalizedDefaults = defaults.withNormalizedNonEchoEchoLevel()
+        settings.putString(KEY_JUST_LIFT_DEFAULTS, json.encodeToString(normalizedDefaults))
         settings.putBoolean(KEY_ECHO_HARD_DEFAULT_MIGRATION_JUST_LIFT, true)
     }
 
@@ -421,6 +424,20 @@ class SettingsPreferencesManager(private val settings: Settings) : PreferencesMa
 
     private fun getEchoHardDefaultMigrationKey(exerciseId: String): String =
         "$KEY_ECHO_HARD_DEFAULT_MIGRATION_EXERCISE_PREFIX$exerciseId"
+
+    private fun SingleExerciseDefaults.withNormalizedNonEchoEchoLevel(): SingleExerciseDefaults =
+        if (workoutModeId != ProgramMode.Echo.modeValue && echoLevelValue == EchoLevel.HARD.levelValue) {
+            copy(echoLevelValue = EchoLevel.HARDER.levelValue)
+        } else {
+            this
+        }
+
+    private fun JustLiftDefaults.withNormalizedNonEchoEchoLevel(): JustLiftDefaults =
+        if (workoutModeId != ProgramMode.Echo.modeValue && echoLevelValue == EchoLevel.HARD.levelValue) {
+            copy(echoLevelValue = EchoLevel.HARDER.levelValue)
+        } else {
+            this
+        }
 
     override suspend fun setGamificationEnabled(enabled: Boolean) {
         settings.putBoolean(KEY_GAMIFICATION_ENABLED, enabled)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/preferences/PreferencesManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/preferences/PreferencesManager.kt
@@ -1,5 +1,6 @@
 package com.devil.phoenixproject.data.preferences
 
+import com.devil.phoenixproject.domain.model.EchoLevel
 import com.devil.phoenixproject.domain.model.RepCountTiming
 import com.devil.phoenixproject.domain.model.UserPreferences
 import com.devil.phoenixproject.domain.model.WeightUnit
@@ -190,6 +191,8 @@ class SettingsPreferencesManager(private val settings: Settings) : PreferencesMa
         private const val KEY_REP_COUNT_TIMING = "rep_count_timing"
         private const val KEY_JUST_LIFT_DEFAULTS = "just_lift_defaults"
         private const val KEY_PREFIX_EXERCISE = "exercise_defaults_"
+        private const val KEY_ECHO_HARD_DEFAULT_MIGRATION_JUST_LIFT = "echo_hard_default_migrated_just_lift"
+        private const val KEY_ECHO_HARD_DEFAULT_MIGRATION_EXERCISE_PREFIX = "echo_hard_default_migrated_exercise_"
         private const val KEY_GAMIFICATION_ENABLED = "gamification_enabled"
         private const val KEY_WEIGHT_INCREMENT = "weight_increment"
         private const val KEY_AUTO_START_ROUTINE = "auto_start_routine"
@@ -348,7 +351,11 @@ class SettingsPreferencesManager(private val settings: Settings) : PreferencesMa
         if (jsonString == null) return null
 
         return try {
-            json.decodeFromString<SingleExerciseDefaults>(jsonString)
+            migrateSavedEchoHardDefault(
+                exerciseId = exerciseId,
+                key = key,
+                defaults = json.decodeFromString<SingleExerciseDefaults>(jsonString),
+            )
         } catch (_: Exception) {
             null
         }
@@ -369,7 +376,7 @@ class SettingsPreferencesManager(private val settings: Settings) : PreferencesMa
     override suspend fun getJustLiftDefaults(): JustLiftDefaults {
         val jsonString = settings.getStringOrNull(KEY_JUST_LIFT_DEFAULTS) ?: return JustLiftDefaults()
         return try {
-            json.decodeFromString<JustLiftDefaults>(jsonString)
+            migrateSavedEchoHardDefault(json.decodeFromString<JustLiftDefaults>(jsonString))
         } catch (_: Exception) {
             JustLiftDefaults()
         }
@@ -381,6 +388,33 @@ class SettingsPreferencesManager(private val settings: Settings) : PreferencesMa
 
     override suspend fun clearJustLiftDefaults() {
         settings.remove(KEY_JUST_LIFT_DEFAULTS)
+    }
+
+    private fun migrateSavedEchoHardDefault(defaults: JustLiftDefaults): JustLiftDefaults {
+        if (settings.getBoolean(KEY_ECHO_HARD_DEFAULT_MIGRATION_JUST_LIFT, false)) return defaults
+
+        settings.putBoolean(KEY_ECHO_HARD_DEFAULT_MIGRATION_JUST_LIFT, true)
+        if (defaults.echoLevelValue != EchoLevel.HARD.levelValue) return defaults
+
+        val migrated = defaults.copy(echoLevelValue = EchoLevel.HARDER.levelValue)
+        settings.putString(KEY_JUST_LIFT_DEFAULTS, json.encodeToString(migrated))
+        return migrated
+    }
+
+    private fun migrateSavedEchoHardDefault(
+        exerciseId: String,
+        key: String,
+        defaults: SingleExerciseDefaults,
+    ): SingleExerciseDefaults {
+        val migrationKey = "$KEY_ECHO_HARD_DEFAULT_MIGRATION_EXERCISE_PREFIX$exerciseId"
+        if (settings.getBoolean(migrationKey, false)) return defaults
+
+        settings.putBoolean(migrationKey, true)
+        if (defaults.echoLevelValue != EchoLevel.HARD.levelValue) return defaults
+
+        val migrated = defaults.copy(echoLevelValue = EchoLevel.HARDER.levelValue)
+        settings.putString(key, json.encodeToString(migrated))
+        return migrated
     }
 
     override suspend fun setGamificationEnabled(enabled: Boolean) {

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/preferences/PreferencesManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/preferences/PreferencesManager.kt
@@ -41,7 +41,7 @@ data class SingleExerciseDefaults(
     fun getEchoLevel(): com.devil.phoenixproject.domain.model.EchoLevel = com.devil.phoenixproject.domain.model.EchoLevel.entries.find {
         it.levelValue == echoLevelValue
     }
-        ?: com.devil.phoenixproject.domain.model.EchoLevel.HARD
+        ?: com.devil.phoenixproject.domain.model.EchoLevel.HARDER
 
     fun toProgramMode(): com.devil.phoenixproject.domain.model.ProgramMode = when (workoutModeId) {
         0 -> com.devil.phoenixproject.domain.model.ProgramMode.OldSchool
@@ -63,7 +63,7 @@ data class JustLiftDefaults(
     val weightPerCableKg: Float = 20f,
     val weightChangePerRep: Float = 0f,
     val eccentricLoadPercentage: Int = 100,
-    val echoLevelValue: Int = 0,
+    val echoLevelValue: Int = 1,
     val stallDetectionEnabled: Boolean = true, // Stall detection auto-stop toggle
     val repCountTimingName: String = "TOP", // RepCountTiming enum name
     val restSeconds: Int = 60, // Rest timer between sets (0 = off, 5-300 in 5s increments)
@@ -78,7 +78,7 @@ data class JustLiftDefaults(
     fun getEchoLevel(): com.devil.phoenixproject.domain.model.EchoLevel = com.devil.phoenixproject.domain.model.EchoLevel.entries.find {
         it.levelValue == echoLevelValue
     }
-        ?: com.devil.phoenixproject.domain.model.EchoLevel.HARD
+        ?: com.devil.phoenixproject.domain.model.EchoLevel.HARDER
 
     fun toProgramMode(): com.devil.phoenixproject.domain.model.ProgramMode = when (workoutModeId) {
         0 -> com.devil.phoenixproject.domain.model.ProgramMode.OldSchool

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/preferences/PreferencesManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/preferences/PreferencesManager.kt
@@ -364,6 +364,7 @@ class SettingsPreferencesManager(private val settings: Settings) : PreferencesMa
     override suspend fun saveSingleExerciseDefaults(defaults: SingleExerciseDefaults) {
         val key = "$KEY_PREFIX_EXERCISE${defaults.exerciseId}"
         settings.putString(key, json.encodeToString(defaults))
+        settings.putBoolean(getEchoHardDefaultMigrationKey(defaults.exerciseId), true)
     }
 
     override suspend fun clearAllSingleExerciseDefaults() {
@@ -384,6 +385,7 @@ class SettingsPreferencesManager(private val settings: Settings) : PreferencesMa
 
     override suspend fun saveJustLiftDefaults(defaults: JustLiftDefaults) {
         settings.putString(KEY_JUST_LIFT_DEFAULTS, json.encodeToString(defaults))
+        settings.putBoolean(KEY_ECHO_HARD_DEFAULT_MIGRATION_JUST_LIFT, true)
     }
 
     override suspend fun clearJustLiftDefaults() {
@@ -406,7 +408,7 @@ class SettingsPreferencesManager(private val settings: Settings) : PreferencesMa
         key: String,
         defaults: SingleExerciseDefaults,
     ): SingleExerciseDefaults {
-        val migrationKey = "$KEY_ECHO_HARD_DEFAULT_MIGRATION_EXERCISE_PREFIX$exerciseId"
+        val migrationKey = getEchoHardDefaultMigrationKey(exerciseId)
         if (settings.getBoolean(migrationKey, false)) return defaults
 
         settings.putBoolean(migrationKey, true)
@@ -416,6 +418,9 @@ class SettingsPreferencesManager(private val settings: Settings) : PreferencesMa
         settings.putString(key, json.encodeToString(migrated))
         return migrated
     }
+
+    private fun getEchoHardDefaultMigrationKey(exerciseId: String): String =
+        "$KEY_ECHO_HARD_DEFAULT_MIGRATION_EXERCISE_PREFIX$exerciseId"
 
     override suspend fun setGamificationEnabled(enabled: Boolean) {
         settings.putBoolean(KEY_GAMIFICATION_ENABLED, enabled)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt
@@ -1055,7 +1055,7 @@ class SqlDelightSyncRepository(
                     }
 
                     val eccentricLoad = mapEccentricLoadFromDb(exRow.eccentricLoad)
-                    val echoLevel = EchoLevel.entries.getOrNull(exRow.echoLevel.toInt()) ?: EchoLevel.HARD
+                    val echoLevel = EchoLevel.entries.getOrNull(exRow.echoLevel.toInt()) ?: EchoLevel.HARDER
                     val programMode = parseProgramMode(exRow.mode)
 
                     val prTypeForScaling = try {

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepository.kt
@@ -338,7 +338,7 @@ class SqlDelightWorkoutRepository(private val db: VitruvianDatabase, private val
                 }
 
                 val eccentricLoad = mapEccentricLoadFromDb(row.eccentricLoad)
-                val echoLevel = EchoLevel.entries.getOrNull(row.echoLevel.toInt()) ?: EchoLevel.HARD
+                val echoLevel = EchoLevel.entries.getOrNull(row.echoLevel.toInt()) ?: EchoLevel.HARDER
 
                 val programMode = parseProgramMode(row.mode)
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/ExerciseConfig.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/ExerciseConfig.kt
@@ -19,7 +19,7 @@ data class ExerciseConfig(
     val eccentricLoadPercent: Int = 100, // 100-150%
 
     // Echo-specific
-    val echoLevel: EchoLevel = EchoLevel.HARD,
+    val echoLevel: EchoLevel = EchoLevel.HARDER,
 ) {
     companion object {
         /**

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/Models.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/Models.kt
@@ -341,7 +341,12 @@ data class WorkoutParameters(
     val stallDetectionEnabled: Boolean = true, // Enable 5s stall/de-load auto-stop during active sets
     val repCountTiming: RepCountTiming = RepCountTiming.TOP, // When to count working reps (TOP=concentric peak, BOTTOM=eccentric valley)
     // Echo-specific settings (only used when programMode == ProgramMode.Echo)
-    val echoLevel: EchoLevel = EchoLevel.HARD,
+    // Issue #553: Default reverted from HARD (strictest 1.0s concentric @ 50 mm/s)
+    // back to HARDER (1.25s @ 40 mm/s). HARD's timing window is too narrow for
+    // the Vitruvian V-Form firmware heuristic on BLE stacks with 50-200ms latency,
+    // causing the firmware to silently drop warm-up rep events, leaving the user
+    // stuck on "Warm Up 1/3" with the load pinned at the raw BLE reading.
+    val echoLevel: EchoLevel = EchoLevel.HARDER,
     val eccentricLoad: EccentricLoad = EccentricLoad.LOAD_100,
     // Just Lift rest timer (0 = off, 5-300 in 5s increments)
     val justLiftRestSeconds: Int = 0,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/Models.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/Models.kt
@@ -268,7 +268,7 @@ sealed class WorkoutMode(val displayName: String) {
 /**
  * Extension function to convert ProgramMode to WorkoutMode for UI compatibility
  */
-fun ProgramMode.toWorkoutMode(echoLevel: EchoLevel = EchoLevel.HARD): WorkoutMode = when (this) {
+fun ProgramMode.toWorkoutMode(echoLevel: EchoLevel = EchoLevel.HARDER): WorkoutMode = when (this) {
     ProgramMode.OldSchool -> WorkoutMode.OldSchool
     ProgramMode.Pump -> WorkoutMode.Pump
     ProgramMode.TUT -> WorkoutMode.TUT
@@ -341,11 +341,9 @@ data class WorkoutParameters(
     val stallDetectionEnabled: Boolean = true, // Enable 5s stall/de-load auto-stop during active sets
     val repCountTiming: RepCountTiming = RepCountTiming.TOP, // When to count working reps (TOP=concentric peak, BOTTOM=eccentric valley)
     // Echo-specific settings (only used when programMode == ProgramMode.Echo)
-    // Issue #553: Default reverted from HARD (strictest 1.0s concentric @ 50 mm/s)
-    // back to HARDER (1.25s @ 40 mm/s). HARD's timing window is too narrow for
-    // the Vitruvian V-Form firmware heuristic on BLE stacks with 50-200ms latency,
-    // causing the firmware to silently drop warm-up rep events, leaving the user
-    // stuck on "Warm Up 1/3" with the load pinned at the raw BLE reading.
+    // Issue #553: prefer HARDER (1.25s @ 40 mm/s) for new Echo sessions.
+    // HARD's stricter 1.0s @ 50 mm/s window can leave V-Form users stuck in
+    // the firmware warm-up buffer when the machine never reports warm-up reps.
     val echoLevel: EchoLevel = EchoLevel.HARDER,
     val eccentricLoad: EccentricLoad = EccentricLoad.LOAD_100,
     // Just Lift rest timer (0 = off, 5-300 in 5s increments)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/Routine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/Routine.kt
@@ -88,7 +88,7 @@ data class RoutineExercise(
     val programMode: ProgramMode = ProgramMode.OldSchool,
     // Echo-specific configuration
     val eccentricLoad: EccentricLoad = EccentricLoad.LOAD_100,
-    val echoLevel: EchoLevel = EchoLevel.HARD,
+    val echoLevel: EchoLevel = EchoLevel.HARDER,
     val progressionKg: Float = 0f,
     val setRestSeconds: List<Int> = emptyList(), // per-set rest times
     // Per-set echo level overrides; null entries fall back to exercise-level echoLevel

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/RepCounterFromMachine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/RepCounterFromMachine.kt
@@ -34,6 +34,10 @@ class RepCounterFromMachine {
     private var stopAtTop = false
     private var shouldStop = false
     private var isAMRAP = false
+    // Issue #553: Echo mode flag enables a permissive warm-up fallback that
+    // trusts the directional up-counter when the V-Form firmware's strict
+    // heuristic pipeline drops rep events outside the timing window.
+    private var isEchoMode = false
 
     // Pending rep state - true when at TOP, waiting for machine confirm
     private var hasPendingRep = false
@@ -86,12 +90,14 @@ class RepCounterFromMachine {
         isJustLift: Boolean,
         stopAtTop: Boolean,
         isAMRAP: Boolean = false,
+        isEchoMode: Boolean = false,
     ) {
         this.warmupTarget = warmupTarget
         this.workingTarget = workingTarget
         this.isJustLift = isJustLift
         this.stopAtTop = stopAtTop
         this.isAMRAP = isAMRAP
+        this.isEchoMode = isEchoMode
 
         // Log RepCounter configuration
         logDebug("RepCounter.configure() called:")
@@ -100,6 +106,7 @@ class RepCounterFromMachine {
         logDebug("  isJustLift: $isJustLift")
         logDebug("  stopAtTop: $stopAtTop")
         logDebug("  isAMRAP: $isAMRAP")
+        logDebug("  isEchoMode: $isEchoMode")
     }
 
     fun reset() {
@@ -477,6 +484,37 @@ class RepCounterFromMachine {
         else if (repsSetCount == 0 && repsRomCount == 0 && warmupReps < warmupTarget && upDelta > 0) {
             warmupReps = (warmupReps + upDelta).coerceAtMost(warmupTarget)
             logDebug("📈 MODERN FALLBACK: Warmup rep $warmupReps (from up counter, repsRomCount=0)")
+
+            onRepEvent?.invoke(
+                RepEvent(
+                    type = RepType.WARMUP_COMPLETED,
+                    warmupCount = warmupReps,
+                    workingCount = workingReps,
+                ),
+            )
+
+            if (warmupReps >= warmupTarget) {
+                onRepEvent?.invoke(
+                    RepEvent(
+                        type = RepType.WARMUP_COMPLETE,
+                        warmupCount = warmupReps,
+                        workingCount = workingReps,
+                    ),
+                )
+            }
+        }
+        // Issue #553: ECHO MODE PERMISSIVE WARMUP — When the Vitruvian V-Form
+        // firmware's heuristic pipeline drops the rep event (because the user's
+        // stroke falls outside the strict concentric timing window derived from
+        // the Echo level), both repsRomCount and repsSetCount stay at 0 even
+        // though the user has completed reps. The directional up counter does
+        // still increment for real motion. In Echo mode, trust the up counter
+        // as a warm-up escape hatch so the user does not get stuck on
+        // "Warm Up 1/3" forever. Only active during warm-up so we never affect
+        // working-rep counting (which the machine reports via repsSetCount).
+        else if (isEchoMode && warmupReps < warmupTarget && upDelta > 0) {
+            warmupReps = (warmupReps + upDelta).coerceAtMost(warmupTarget)
+            logDebug("📈 ECHO WARMUP FALLBACK (Issue #553): Warmup rep $warmupReps from up counter (firmware heuristic dropped repsRomCount)")
 
             onRepEvent?.invoke(
                 RepEvent(

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/RepCounterFromMachine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/RepCounterFromMachine.kt
@@ -34,10 +34,6 @@ class RepCounterFromMachine {
     private var stopAtTop = false
     private var shouldStop = false
     private var isAMRAP = false
-    // Issue #553: Echo mode flag enables a permissive warm-up fallback that
-    // trusts the directional up-counter when the V-Form firmware's strict
-    // heuristic pipeline drops rep events outside the timing window.
-    private var isEchoMode = false
 
     // Pending rep state - true when at TOP, waiting for machine confirm
     private var hasPendingRep = false
@@ -90,14 +86,12 @@ class RepCounterFromMachine {
         isJustLift: Boolean,
         stopAtTop: Boolean,
         isAMRAP: Boolean = false,
-        isEchoMode: Boolean = false,
     ) {
         this.warmupTarget = warmupTarget
         this.workingTarget = workingTarget
         this.isJustLift = isJustLift
         this.stopAtTop = stopAtTop
         this.isAMRAP = isAMRAP
-        this.isEchoMode = isEchoMode
 
         // Log RepCounter configuration
         logDebug("RepCounter.configure() called:")
@@ -106,7 +100,6 @@ class RepCounterFromMachine {
         logDebug("  isJustLift: $isJustLift")
         logDebug("  stopAtTop: $stopAtTop")
         logDebug("  isAMRAP: $isAMRAP")
-        logDebug("  isEchoMode: $isEchoMode")
     }
 
     fun reset() {
@@ -480,41 +473,17 @@ class RepCounterFromMachine {
             }
         }
         // FALLBACK WARMUP: When machine doesn't report repsRomCount (0xFF/unlimited mode),
-        // count warmup reps from directional up counter (matches processLegacy approach)
+        // count warmup reps from directional up counter (matches processLegacy approach).
+        // Issue #553: this is the path that fixes the Echo Mode "stuck on Warm Up 1/3"
+        // regression — it is mode-agnostic, so when PR #474's HARD EchoLevel causes the
+        // V-Form firmware to silently drop repsRomCount events, the up counter still
+        // advances and this branch advances warmupReps from it. The Echo-specific
+        // escape hatch (added in the first iteration of this fix) turned out to be
+        // unreachable because this branch already fires first when repsRomCount==0
+        // and repsSetCount==0 — see PR #554 review (gemini-code-assist) feedback.
         else if (repsSetCount == 0 && repsRomCount == 0 && warmupReps < warmupTarget && upDelta > 0) {
             warmupReps = (warmupReps + upDelta).coerceAtMost(warmupTarget)
             logDebug("📈 MODERN FALLBACK: Warmup rep $warmupReps (from up counter, repsRomCount=0)")
-
-            onRepEvent?.invoke(
-                RepEvent(
-                    type = RepType.WARMUP_COMPLETED,
-                    warmupCount = warmupReps,
-                    workingCount = workingReps,
-                ),
-            )
-
-            if (warmupReps >= warmupTarget) {
-                onRepEvent?.invoke(
-                    RepEvent(
-                        type = RepType.WARMUP_COMPLETE,
-                        warmupCount = warmupReps,
-                        workingCount = workingReps,
-                    ),
-                )
-            }
-        }
-        // Issue #553: ECHO MODE PERMISSIVE WARMUP — When the Vitruvian V-Form
-        // firmware's heuristic pipeline drops the rep event (because the user's
-        // stroke falls outside the strict concentric timing window derived from
-        // the Echo level), both repsRomCount and repsSetCount stay at 0 even
-        // though the user has completed reps. The directional up counter does
-        // still increment for real motion. In Echo mode, trust the up counter
-        // as a warm-up escape hatch so the user does not get stuck on
-        // "Warm Up 1/3" forever. Only active during warm-up so we never affect
-        // working-rep counting (which the machine reports via repsSetCount).
-        else if (isEchoMode && warmupReps < warmupTarget && upDelta > 0) {
-            warmupReps = (warmupReps + upDelta).coerceAtMost(warmupTarget)
-            logDebug("📈 ECHO WARMUP FALLBACK (Issue #553): Warmup rep $warmupReps from up counter (firmware heuristic dropped repsRomCount)")
 
             onRepEvent?.invoke(
                 RepEvent(

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/TemplateConverter.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/TemplateConverter.kt
@@ -180,7 +180,7 @@ class TemplateConverter(private val exerciseRepository: ExerciseRepository) {
                         },
                         weightPerCableKg = startingWeight,
                         programMode = selectedMode,
-                        echoLevel = config?.echoLevel ?: EchoLevel.HARD,
+                        echoLevel = config?.echoLevel ?: EchoLevel.HARDER,
                         eccentricLoad =
                             config?.eccentricLoadPercent?.toEccentricLoad()
                                 ?: EccentricLoad.LOAD_100,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -2294,6 +2294,7 @@ class ActiveSessionEngine(
                         isJustLift = false,
                         stopAtTop = params.stopAtTop,
                         isAMRAP = false,
+                        isEchoMode = params.isEchoMode,
                     )
                     coordinator._repCount.value = RepCount()
                     coordinator.warmupCompleteTimeMs = 0
@@ -2557,6 +2558,9 @@ class ActiveSessionEngine(
                     isJustLift = isJustLiftMode,
                     stopAtTop = warmupOverrideParams.stopAtTop,
                     isAMRAP = if (isTimedCableExercise) true else warmupOverrideParams.isAMRAP,
+                    // Issue #553: Pass Echo flag so RepCounter enables the permissive
+                    // warm-up fallback when V-Form firmware drops rep events.
+                    isEchoMode = effectiveParams.isEchoMode,
                 )
 
                 if (isTimedCableExercise) {

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -2294,7 +2294,6 @@ class ActiveSessionEngine(
                         isJustLift = false,
                         stopAtTop = params.stopAtTop,
                         isAMRAP = false,
-                        isEchoMode = params.isEchoMode,
                     )
                     coordinator._repCount.value = RepCount()
                     coordinator.warmupCompleteTimeMs = 0
@@ -2558,9 +2557,6 @@ class ActiveSessionEngine(
                     isJustLift = isJustLiftMode,
                     stopAtTop = warmupOverrideParams.stopAtTop,
                     isAMRAP = if (isTimedCableExercise) true else warmupOverrideParams.isAMRAP,
-                    // Issue #553: Pass Echo flag so RepCounter enables the permissive
-                    // warm-up fallback when V-Form firmware drops rep events.
-                    isEchoMode = effectiveParams.isEchoMode,
                 )
 
                 if (isTimedCableExercise) {

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/DefaultWorkoutSessionManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/DefaultWorkoutSessionManager.kt
@@ -60,7 +60,7 @@ data class JustLiftDefaults(
     val weightChangePerRep: Int, // In display units (kg or lbs based on user preference)
     val workoutModeId: Int, // 0=OldSchool, 1=Pump, 10=Echo
     val eccentricLoadPercentage: Int = 100,
-    val echoLevelValue: Int = 0, // 0=Hard, 1=Harder, 2=Hardest, 3=Epic
+    val echoLevelValue: Int = 1, // 0=Hard, 1=Harder, 2=Hardest, 3=Epic
     val stallDetectionEnabled: Boolean = true, // Stall detection auto-stop toggle
     val repCountTimingName: String = "TOP", // RepCountTiming enum name for persistence
     val restSeconds: Int = 60, // Rest timer between sets (0 = off, 5-300 in 5s increments)
@@ -97,7 +97,7 @@ data class JustLiftDefaults(
     /**
      * Get EchoLevel from stored value
      */
-    fun getEchoLevel(): EchoLevel = EchoLevel.entries.getOrElse(echoLevelValue) { EchoLevel.HARD }
+    fun getEchoLevel(): EchoLevel = EchoLevel.entries.getOrElse(echoLevelValue) { EchoLevel.HARDER }
 
     /**
      * Get RepCountTiming from stored name

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseEditBottomSheet.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseEditBottomSheet.kt
@@ -1038,7 +1038,7 @@ fun ModeSelector(
         WorkoutMode.Pump,
         WorkoutMode.TUT,
         WorkoutMode.EccentricOnly,
-        WorkoutMode.Echo(EchoLevel.HARD),
+        WorkoutMode.Echo(EchoLevel.HARDER),
     )
 
     Surface(

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/JustLiftScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/JustLiftScreen.kt
@@ -147,7 +147,7 @@ fun JustLiftScreen(navController: NavController, viewModel: MainViewModel, theme
     var weightChangePerRep by rememberSaveable { mutableStateOf(0) } // Progression/Regression value
     // Keep enum/sealed types as `remember` — they need custom Savers:
     var eccentricLoad by remember { mutableStateOf(EccentricLoad.LOAD_100) }
-    var echoLevel by remember { mutableStateOf(EchoLevel.HARD) }
+    var echoLevel by remember { mutableStateOf(EchoLevel.HARDER) }
     var repCountTiming by remember { mutableStateOf(RepCountTiming.TOP) }
     var stallDetectionEnabled by rememberSaveable { mutableStateOf(true) }
     var restSeconds by rememberSaveable { mutableStateOf(60) } // Rest timer between sets (0 = off)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ModeSubSelectorDialog.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ModeSubSelectorDialog.kt
@@ -70,7 +70,7 @@ fun ModeSubSelectorDialog(
                     if (workoutParameters.isEchoMode) {
                         workoutParameters.echoLevel
                     } else {
-                        EchoLevel.HARD
+                        EchoLevel.HARDER
                     },
                 )
             }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RestTimerCard.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RestTimerCard.kt
@@ -141,7 +141,7 @@ fun RestTimerCard(
     // Local state for editing parameters
     var editedReps by remember(nextExerciseReps) { mutableStateOf(nextExerciseReps ?: 10) }
     var editedWeight by remember(nextExerciseWeight) { mutableStateOf(nextExerciseWeight ?: 20f) }
-    var editedEchoLevel by remember(echoLevel) { mutableStateOf(echoLevel ?: EchoLevel.HARD) }
+    var editedEchoLevel by remember(echoLevel) { mutableStateOf(echoLevel ?: EchoLevel.HARDER) }
     var editedEccentricPercent by remember(eccentricLoadPercent) { mutableStateOf(eccentricLoadPercent ?: 100) }
 
     // Determine if this is Echo mode

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SetReadyScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SetReadyScreen.kt
@@ -579,7 +579,7 @@ fun SetReadyScreen(navController: NavController, viewModel: MainViewModel, exerc
                         if (isEchoMode) {
                             // Echo Level selector - matching RestTimerCard style
                             SetReadyEchoLevelSelector(
-                                selectedLevel = setReadyState.echoLevel ?: EchoLevel.HARD,
+                                selectedLevel = setReadyState.echoLevel ?: EchoLevel.HARDER,
                                 onLevelChange = { viewModel.updateSetReadyEchoLevel(it) },
                             )
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SingleExerciseScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SingleExerciseScreen.kt
@@ -445,6 +445,6 @@ private fun buildSingleExerciseRoutineExercise(
         setRestSeconds = listOf(60, 60, 60),
         programMode = ProgramMode.OldSchool,
         eccentricLoad = EccentricLoad.LOAD_100,
-        echoLevel = EchoLevel.HARD,
+        echoLevel = EchoLevel.HARDER,
     )
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModel.kt
@@ -89,7 +89,7 @@ class ExerciseConfigViewModel constructor(
     private val _eccentricLoad = MutableStateFlow(EccentricLoad.LOAD_100)
     val eccentricLoad: StateFlow<EccentricLoad> = _eccentricLoad.asStateFlow()
 
-    private val _echoLevel = MutableStateFlow(EchoLevel.HARD)
+    private val _echoLevel = MutableStateFlow(EchoLevel.HARDER)
     val echoLevel: StateFlow<EchoLevel> = _echoLevel.asStateFlow()
 
     private val _stallDetectionEnabled = MutableStateFlow(true)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/BlePacketFactory.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/BlePacketFactory.kt
@@ -316,7 +316,11 @@ object BlePacketFactory {
      * For full protocol support, use createEchoControl() instead.
      */
     fun createEchoCommand(level: Int, eccentricLoad: Int): ByteArray {
-        val echoLevel = EchoLevel.entries.find { it.levelValue == level } ?: EchoLevel.HARD
+        // Issue #553: Default fallback changed from HARD (strictest) to HARDER
+        // to match WorkoutParameters.echoLevel default. Legacy callers passing an
+        // out-of-range level integer now also fall back to the less-strict timing
+        // window so the firmware's heuristic pipeline can emit warm-up rep events.
+        val echoLevel = EchoLevel.entries.find { it.levelValue == level } ?: EchoLevel.HARDER
         return createEchoControl(echoLevel, eccentricPct = eccentricLoad)
     }
 

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/preferences/SettingsPreferencesManagerTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/preferences/SettingsPreferencesManagerTest.kt
@@ -35,22 +35,50 @@ class SettingsPreferencesManagerTest {
 
     @Test
     fun `invalid saved Echo level falls back to issue 553 default`() {
-        val defaults = SingleExerciseDefaults(
-            exerciseId = "crossover-lateral-raise",
-            setReps = listOf(10, 10, 10),
-            weightPerCableKg = 20f,
-            setWeightsPerCableKg = listOf(20f, 20f, 20f),
-            progressionKg = 0f,
-            setRestSeconds = listOf(60, 60, 60),
-            workoutModeId = 10,
-            eccentricLoadPercentage = 100,
+        val defaults = singleExerciseDefaults(
             echoLevelValue = 99,
-            duration = 0,
-            isAMRAP = false,
-            perSetRestTime = false,
         )
 
         assertEquals(EchoLevel.HARDER, defaults.getEchoLevel())
+    }
+
+    @Test
+    fun `saved Just Lift Hard default migrates once to issue 553 default`() = runTest {
+        val manager = SettingsPreferencesManager(MapSettings())
+        val hardDefaults = JustLiftDefaults(
+            workoutModeId = 10,
+            echoLevelValue = EchoLevel.HARD.levelValue,
+        )
+
+        manager.saveJustLiftDefaults(hardDefaults)
+
+        val migrated = manager.getJustLiftDefaults()
+        assertEquals(EchoLevel.HARDER.levelValue, migrated.echoLevelValue)
+        assertEquals(EchoLevel.HARDER, migrated.getEchoLevel())
+
+        manager.saveJustLiftDefaults(hardDefaults)
+
+        val explicitlySavedHard = manager.getJustLiftDefaults()
+        assertEquals(EchoLevel.HARD.levelValue, explicitlySavedHard.echoLevelValue)
+        assertEquals(EchoLevel.HARD, explicitlySavedHard.getEchoLevel())
+    }
+
+    @Test
+    fun `saved single exercise Hard default migrates once to issue 553 default`() = runTest {
+        val manager = SettingsPreferencesManager(MapSettings())
+        val hardDefaults = singleExerciseDefaults(echoLevelValue = EchoLevel.HARD.levelValue)
+
+        manager.saveSingleExerciseDefaults(hardDefaults)
+
+        val migrated = manager.getSingleExerciseDefaults(hardDefaults.exerciseId) ?: error("Expected migrated defaults")
+        assertEquals(EchoLevel.HARDER.levelValue, migrated.echoLevelValue)
+        assertEquals(EchoLevel.HARDER, migrated.getEchoLevel())
+
+        manager.saveSingleExerciseDefaults(hardDefaults)
+
+        val explicitlySavedHard = manager.getSingleExerciseDefaults(hardDefaults.exerciseId) ?: error("Expected saved defaults")
+        assertEquals(EchoLevel.HARD.levelValue, explicitlySavedHard.echoLevelValue)
+        assertEquals(EchoLevel.HARD, explicitlySavedHard.getEchoLevel())
     }
 
     @Test
@@ -66,4 +94,19 @@ class SettingsPreferencesManagerTest {
         val reloaded = SettingsPreferencesManager(settings)
         assertFalse(reloaded.preferencesFlow.value.weightSuggestionsEnabled)
     }
+
+    private fun singleExerciseDefaults(echoLevelValue: Int): SingleExerciseDefaults = SingleExerciseDefaults(
+        exerciseId = "crossover-lateral-raise",
+        setReps = listOf(10, 10, 10),
+        weightPerCableKg = 20f,
+        setWeightsPerCableKg = listOf(20f, 20f, 20f),
+        progressionKg = 0f,
+        setRestSeconds = listOf(60, 60, 60),
+        workoutModeId = 10,
+        eccentricLoadPercentage = 100,
+        echoLevelValue = echoLevelValue,
+        duration = 0,
+        isAMRAP = false,
+        perSetRestTime = false,
+    )
 }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/preferences/SettingsPreferencesManagerTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/preferences/SettingsPreferencesManagerTest.kt
@@ -8,8 +8,12 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 
 class SettingsPreferencesManagerTest {
+
+    private val legacyDefaultsJson = Json { encodeDefaults = true }
 
     @Test
     fun `loadPreferences removes legacy hud preset key`() {
@@ -44,13 +48,14 @@ class SettingsPreferencesManagerTest {
 
     @Test
     fun `saved Just Lift Hard default migrates once to issue 553 default`() = runTest {
-        val manager = SettingsPreferencesManager(MapSettings())
+        val settings = MapSettings()
+        val manager = SettingsPreferencesManager(settings)
         val hardDefaults = JustLiftDefaults(
             workoutModeId = 10,
             echoLevelValue = EchoLevel.HARD.levelValue,
         )
 
-        manager.saveJustLiftDefaults(hardDefaults)
+        settings.putString("just_lift_defaults", legacyDefaultsJson.encodeToString(hardDefaults))
 
         val migrated = manager.getJustLiftDefaults()
         assertEquals(EchoLevel.HARDER.levelValue, migrated.echoLevelValue)
@@ -64,11 +69,30 @@ class SettingsPreferencesManagerTest {
     }
 
     @Test
-    fun `saved single exercise Hard default migrates once to issue 553 default`() = runTest {
+    fun `new Just Lift Hard default saved after issue 553 migration is preserved`() = runTest {
         val manager = SettingsPreferencesManager(MapSettings())
+        val hardDefaults = JustLiftDefaults(
+            workoutModeId = 10,
+            echoLevelValue = EchoLevel.HARD.levelValue,
+        )
+
+        manager.saveJustLiftDefaults(hardDefaults)
+
+        val saved = manager.getJustLiftDefaults()
+        assertEquals(EchoLevel.HARD.levelValue, saved.echoLevelValue)
+        assertEquals(EchoLevel.HARD, saved.getEchoLevel())
+    }
+
+    @Test
+    fun `saved single exercise Hard default migrates once to issue 553 default`() = runTest {
+        val settings = MapSettings()
+        val manager = SettingsPreferencesManager(settings)
         val hardDefaults = singleExerciseDefaults(echoLevelValue = EchoLevel.HARD.levelValue)
 
-        manager.saveSingleExerciseDefaults(hardDefaults)
+        settings.putString(
+            "exercise_defaults_${hardDefaults.exerciseId}",
+            legacyDefaultsJson.encodeToString(hardDefaults),
+        )
 
         val migrated = manager.getSingleExerciseDefaults(hardDefaults.exerciseId) ?: error("Expected migrated defaults")
         assertEquals(EchoLevel.HARDER.levelValue, migrated.echoLevelValue)
@@ -79,6 +103,18 @@ class SettingsPreferencesManagerTest {
         val explicitlySavedHard = manager.getSingleExerciseDefaults(hardDefaults.exerciseId) ?: error("Expected saved defaults")
         assertEquals(EchoLevel.HARD.levelValue, explicitlySavedHard.echoLevelValue)
         assertEquals(EchoLevel.HARD, explicitlySavedHard.getEchoLevel())
+    }
+
+    @Test
+    fun `new single exercise Hard default saved after issue 553 migration is preserved`() = runTest {
+        val manager = SettingsPreferencesManager(MapSettings())
+        val hardDefaults = singleExerciseDefaults(echoLevelValue = EchoLevel.HARD.levelValue)
+
+        manager.saveSingleExerciseDefaults(hardDefaults)
+
+        val saved = manager.getSingleExerciseDefaults(hardDefaults.exerciseId) ?: error("Expected saved defaults")
+        assertEquals(EchoLevel.HARD.levelValue, saved.echoLevelValue)
+        assertEquals(EchoLevel.HARD, saved.getEchoLevel())
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/preferences/SettingsPreferencesManagerTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/preferences/SettingsPreferencesManagerTest.kt
@@ -26,11 +26,31 @@ class SettingsPreferencesManagerTest {
     }
 
     @Test
-    fun `just lift defaults use official Echo defaults`() {
+    fun `just lift defaults use issue 553 Echo defaults`() {
         val defaults = JustLiftDefaults()
 
-        assertEquals(0, defaults.echoLevelValue)
-        assertEquals(EchoLevel.HARD, defaults.getEchoLevel())
+        assertEquals(1, defaults.echoLevelValue)
+        assertEquals(EchoLevel.HARDER, defaults.getEchoLevel())
+    }
+
+    @Test
+    fun `invalid saved Echo level falls back to issue 553 default`() {
+        val defaults = SingleExerciseDefaults(
+            exerciseId = "crossover-lateral-raise",
+            setReps = listOf(10, 10, 10),
+            weightPerCableKg = 20f,
+            setWeightsPerCableKg = listOf(20f, 20f, 20f),
+            progressionKg = 0f,
+            setRestSeconds = listOf(60, 60, 60),
+            workoutModeId = 10,
+            eccentricLoadPercentage = 100,
+            echoLevelValue = 99,
+            duration = 0,
+            isAMRAP = false,
+            perSetRestTime = false,
+        )
+
+        assertEquals(EchoLevel.HARDER, defaults.getEchoLevel())
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/preferences/SettingsPreferencesManagerTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/preferences/SettingsPreferencesManagerTest.kt
@@ -1,6 +1,7 @@
 package com.devil.phoenixproject.data.preferences
 
 import com.devil.phoenixproject.domain.model.EchoLevel
+import com.devil.phoenixproject.domain.model.ProgramMode
 import com.russhwolf.settings.MapSettings
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -72,7 +73,7 @@ class SettingsPreferencesManagerTest {
     fun `new Just Lift Hard default saved after issue 553 migration is preserved`() = runTest {
         val manager = SettingsPreferencesManager(MapSettings())
         val hardDefaults = JustLiftDefaults(
-            workoutModeId = 10,
+            workoutModeId = ProgramMode.Echo.modeValue,
             echoLevelValue = EchoLevel.HARD.levelValue,
         )
 
@@ -81,6 +82,22 @@ class SettingsPreferencesManagerTest {
         val saved = manager.getJustLiftDefaults()
         assertEquals(EchoLevel.HARD.levelValue, saved.echoLevelValue)
         assertEquals(EchoLevel.HARD, saved.getEchoLevel())
+    }
+
+    @Test
+    fun `non Echo Just Lift Hard placeholder saved after issue 553 migration is normalized`() = runTest {
+        val manager = SettingsPreferencesManager(MapSettings())
+        val oldSchoolDefaults = JustLiftDefaults(
+            workoutModeId = ProgramMode.OldSchool.modeValue,
+            echoLevelValue = EchoLevel.HARD.levelValue,
+        )
+
+        manager.saveJustLiftDefaults(oldSchoolDefaults)
+
+        val saved = manager.getJustLiftDefaults()
+        assertEquals(ProgramMode.OldSchool.modeValue, saved.workoutModeId)
+        assertEquals(EchoLevel.HARDER.levelValue, saved.echoLevelValue)
+        assertEquals(EchoLevel.HARDER, saved.getEchoLevel())
     }
 
     @Test
@@ -108,13 +125,32 @@ class SettingsPreferencesManagerTest {
     @Test
     fun `new single exercise Hard default saved after issue 553 migration is preserved`() = runTest {
         val manager = SettingsPreferencesManager(MapSettings())
-        val hardDefaults = singleExerciseDefaults(echoLevelValue = EchoLevel.HARD.levelValue)
+        val hardDefaults = singleExerciseDefaults(
+            workoutModeId = ProgramMode.Echo.modeValue,
+            echoLevelValue = EchoLevel.HARD.levelValue,
+        )
 
         manager.saveSingleExerciseDefaults(hardDefaults)
 
         val saved = manager.getSingleExerciseDefaults(hardDefaults.exerciseId) ?: error("Expected saved defaults")
         assertEquals(EchoLevel.HARD.levelValue, saved.echoLevelValue)
         assertEquals(EchoLevel.HARD, saved.getEchoLevel())
+    }
+
+    @Test
+    fun `non Echo single exercise Hard placeholder saved after issue 553 migration is normalized`() = runTest {
+        val manager = SettingsPreferencesManager(MapSettings())
+        val oldSchoolDefaults = singleExerciseDefaults(
+            workoutModeId = ProgramMode.OldSchool.modeValue,
+            echoLevelValue = EchoLevel.HARD.levelValue,
+        )
+
+        manager.saveSingleExerciseDefaults(oldSchoolDefaults)
+
+        val saved = manager.getSingleExerciseDefaults(oldSchoolDefaults.exerciseId) ?: error("Expected saved defaults")
+        assertEquals(ProgramMode.OldSchool.modeValue, saved.workoutModeId)
+        assertEquals(EchoLevel.HARDER.levelValue, saved.echoLevelValue)
+        assertEquals(EchoLevel.HARDER, saved.getEchoLevel())
     }
 
     @Test
@@ -131,14 +167,17 @@ class SettingsPreferencesManagerTest {
         assertFalse(reloaded.preferencesFlow.value.weightSuggestionsEnabled)
     }
 
-    private fun singleExerciseDefaults(echoLevelValue: Int): SingleExerciseDefaults = SingleExerciseDefaults(
+    private fun singleExerciseDefaults(
+        workoutModeId: Int = ProgramMode.Echo.modeValue,
+        echoLevelValue: Int,
+    ): SingleExerciseDefaults = SingleExerciseDefaults(
         exerciseId = "crossover-lateral-raise",
         setReps = listOf(10, 10, 10),
         weightPerCableKg = 20f,
         setWeightsPerCableKg = listOf(20f, 20f, 20f),
         progressionKg = 0f,
         setRestSeconds = listOf(60, 60, 60),
-        workoutModeId = 10,
+        workoutModeId = workoutModeId,
         eccentricLoadPercentage = 100,
         echoLevelValue = echoLevelValue,
         duration = 0,

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/RoutineTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/RoutineTest.kt
@@ -209,10 +209,10 @@ class RoutineTest {
     }
 
     @Test
-    fun routineExercise_defaultEchoSettings_matchOfficialAppDefaults() {
+    fun routineExercise_defaultEchoSettings_useIssue553EchoDefaults() {
         val exercise = createTestRoutineExercise(programMode = ProgramMode.Echo)
 
-        assertEquals(EchoLevel.HARD, exercise.echoLevel)
+        assertEquals(EchoLevel.HARDER, exercise.echoLevel)
         assertEquals(EccentricLoad.LOAD_100, exercise.eccentricLoad)
     }
 

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/WorkoutParametersTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/WorkoutParametersTest.kt
@@ -63,6 +63,17 @@ class WorkoutParametersTest {
     }
 
     @Test
+    fun `Echo mode defaults use issue 553 Echo level`() {
+        val params = WorkoutParameters(
+            programMode = ProgramMode.Echo,
+            reps = 8,
+        )
+
+        assertEquals(EchoLevel.HARDER, params.echoLevel)
+        assertEquals(WorkoutMode.Echo(EchoLevel.HARDER), ProgramMode.Echo.toWorkoutMode())
+    }
+
+    @Test
     fun `stopAtTop can be configured`() {
         val paramsBottom = WorkoutParameters(
             programMode = ProgramMode.OldSchool,

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/RepCounterFromMachineTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/RepCounterFromMachineTest.kt
@@ -686,84 +686,6 @@ class RepCounterFromMachineTest {
         assertEquals(100f, ranges.minPosA)
         assertEquals(500f, ranges.maxPosA)
     }
-}
-
-class RepRangesTest {
-
-    @Test
-    fun `isInDangerZone returns true when position is within 5 percent of min`() {
-        val ranges = RepRanges(
-            minPosA = 100f,
-            maxPosA = 1000f,
-            minPosB = 100f,
-            maxPosB = 1000f,
-            minRangeA = null,
-            maxRangeA = null,
-            minRangeB = null,
-            maxRangeB = null,
-        )
-
-        // 5% of range (900) = 45, threshold = 145
-        assertTrue(ranges.isInDangerZone(posA = 110f, posB = 500f))
-    }
-
-    @Test
-    fun `isInDangerZone returns false when position is safe`() {
-        val ranges = RepRanges(
-            minPosA = 100f,
-            maxPosA = 1000f,
-            minPosB = 100f,
-            maxPosB = 1000f,
-            minRangeA = null,
-            maxRangeA = null,
-            minRangeB = null,
-            maxRangeB = null,
-        )
-
-        assertFalse(ranges.isInDangerZone(posA = 500f, posB = 500f))
-    }
-
-    @Test
-    fun `isInDangerZone returns false when range is too small`() {
-        val ranges = RepRanges(
-            minPosA = 100f,
-            maxPosA = 120f, // Range = 20, less than threshold
-            minPosB = 100f,
-            maxPosB = 120f,
-            minRangeA = null,
-            maxRangeA = null,
-            minRangeB = null,
-            maxRangeB = null,
-        )
-
-        // Even at min, not in danger zone because range is too small
-        assertFalse(ranges.isInDangerZone(posA = 100f, posB = 100f, minRangeThreshold = 50f))
-    }
-
-    @Test
-    fun `isInDangerZone triggers when position goes to zero after meaningful range`() {
-        // This tests the Just Lift autostop scenario where handles are placed down
-        // Position goes to ~0 after user has established a meaningful ROM range
-        val ranges = RepRanges(
-            minPosA = 30f, // Typical overhead pulley rest position
-            maxPosA = 230f, // Extended position after reps
-            minPosB = 30f,
-            maxPosB = 230f,
-            minRangeA = null,
-            maxRangeA = null,
-            minRangeB = null,
-            maxRangeB = null,
-        )
-
-        // Range = 200mm, threshold = 30 + (200 * 0.05) = 40mm
-        // Position at 0 or very low should trigger danger zone for autostop
-        assertTrue(ranges.isInDangerZone(posA = 0f, posB = 0f))
-        assertTrue(ranges.isInDangerZone(posA = 5f, posB = 5f))
-        assertTrue(ranges.isInDangerZone(posA = 35f, posB = 35f)) // Just above min but below threshold
-
-        // Position at 50 should NOT trigger (above threshold of 40)
-        assertFalse(ranges.isInDangerZone(posA = 50f, posB = 50f))
-    }
 
     // ========== Issue #553: Echo Mode Permissive Warm-Up Fallback ==========
 
@@ -848,5 +770,83 @@ class RepRangesTest {
         val count = repCounter.getRepCount()
         assertEquals(3, count.warmupReps)
         assertTrue(count.isWarmupComplete)
+    }
+}
+
+class RepRangesTest {
+
+    @Test
+    fun `isInDangerZone returns true when position is within 5 percent of min`() {
+        val ranges = RepRanges(
+            minPosA = 100f,
+            maxPosA = 1000f,
+            minPosB = 100f,
+            maxPosB = 1000f,
+            minRangeA = null,
+            maxRangeA = null,
+            minRangeB = null,
+            maxRangeB = null,
+        )
+
+        // 5% of range (900) = 45, threshold = 145
+        assertTrue(ranges.isInDangerZone(posA = 110f, posB = 500f))
+    }
+
+    @Test
+    fun `isInDangerZone returns false when position is safe`() {
+        val ranges = RepRanges(
+            minPosA = 100f,
+            maxPosA = 1000f,
+            minPosB = 100f,
+            maxPosB = 1000f,
+            minRangeA = null,
+            maxRangeA = null,
+            minRangeB = null,
+            maxRangeB = null,
+        )
+
+        assertFalse(ranges.isInDangerZone(posA = 500f, posB = 500f))
+    }
+
+    @Test
+    fun `isInDangerZone returns false when range is too small`() {
+        val ranges = RepRanges(
+            minPosA = 100f,
+            maxPosA = 120f, // Range = 20, less than threshold
+            minPosB = 100f,
+            maxPosB = 120f,
+            minRangeA = null,
+            maxRangeA = null,
+            minRangeB = null,
+            maxRangeB = null,
+        )
+
+        // Even at min, not in danger zone because range is too small
+        assertFalse(ranges.isInDangerZone(posA = 100f, posB = 100f, minRangeThreshold = 50f))
+    }
+
+    @Test
+    fun `isInDangerZone triggers when position goes to zero after meaningful range`() {
+        // This tests the Just Lift autostop scenario where handles are placed down
+        // Position goes to ~0 after user has established a meaningful ROM range
+        val ranges = RepRanges(
+            minPosA = 30f, // Typical overhead pulley rest position
+            maxPosA = 230f, // Extended position after reps
+            minPosB = 30f,
+            maxPosB = 230f,
+            minRangeA = null,
+            maxRangeA = null,
+            minRangeB = null,
+            maxRangeB = null,
+        )
+
+        // Range = 200mm, threshold = 30 + (200 * 0.05) = 40mm
+        // Position at 0 or very low should trigger danger zone for autostop
+        assertTrue(ranges.isInDangerZone(posA = 0f, posB = 0f))
+        assertTrue(ranges.isInDangerZone(posA = 5f, posB = 5f))
+        assertTrue(ranges.isInDangerZone(posA = 35f, posB = 35f)) // Just above min but below threshold
+
+        // Position at 50 should NOT trigger (above threshold of 40)
+        assertFalse(ranges.isInDangerZone(posA = 50f, posB = 50f))
     }
 }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/RepCounterFromMachineTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/RepCounterFromMachineTest.kt
@@ -764,4 +764,89 @@ class RepRangesTest {
         // Position at 50 should NOT trigger (above threshold of 40)
         assertFalse(ranges.isInDangerZone(posA = 50f, posB = 50f))
     }
+
+    // ========== Issue #553: Echo Mode Permissive Warm-Up Fallback ==========
+
+    @Test
+    fun `issue 553 echo mode warmup advances from up counter when firmware drops reps`() {
+        // Issue #553: When the Vitruvian V-Form firmware's heuristic pipeline
+        // drops a rep event because the user's stroke falls outside the strict
+        // Echo concentric timing window, repsRomCount and repsSetCount both stay
+        // at 0 even though the user has completed real reps (visible as up
+        // counter increments). In Echo mode we must trust the up counter as a
+        // warm-up escape hatch or the user gets stuck on "Warm Up 1/3" forever.
+        repCounter.configure(
+            warmupTarget = 3,
+            workingTarget = 5,
+            isJustLift = false,
+            stopAtTop = false,
+            isEchoMode = true,
+        )
+
+        // Baseline
+        repCounter.process(repsRomCount = 0, repsSetCount = 0, up = 0, down = 0)
+
+        // Simulate firmware dropping 3 reps: only the up counter advances.
+        // Without the fix, warmupReps stays at 0 and isWarmupComplete is false.
+        repCounter.process(repsRomCount = 0, repsSetCount = 0, up = 1, down = 0)
+        repCounter.process(repsRomCount = 0, repsSetCount = 0, up = 2, down = 0)
+        repCounter.process(repsRomCount = 0, repsSetCount = 0, up = 3, down = 0)
+
+        val count = repCounter.getRepCount()
+        assertEquals(3, count.warmupReps)
+        assertTrue(count.isWarmupComplete)
+        assertTrue(capturedEvents.any { it.type == RepType.WARMUP_COMPLETE })
+    }
+
+    @Test
+    fun `issue 553 non-echo mode does NOT advance warmup from up counter when firmware reports partial data`() {
+        // Regression guard for the Echo-specific branch: in non-Echo mode the
+        // permissive fallback must NOT fire when repsRomCount is reporting
+        // values (machine telemetry working normally) — only Echo mode with
+        // isEchoMode=true gets the up-counter escape hatch. This is the
+        // critical guard against accidentally softening Program/Eccentric mode
+        // rep counting.
+        repCounter.configure(
+            warmupTarget = 3,
+            workingTarget = 5,
+            isJustLift = false,
+            stopAtTop = false,
+            isEchoMode = false,
+        )
+
+        repCounter.process(repsRomCount = 0, repsSetCount = 0, up = 0, down = 0)
+        // Firmware reports repsRomCount > 0 (mid-warmup), repsSetCount > 0 too.
+        // The primary path (`repsRomCount > warmupReps`) advances warmupReps
+        // from repsRomCount, NOT from the up counter alone. Sending up=3 on
+        // the same notification should NOT triple-count.
+        repCounter.process(repsRomCount = 1, repsSetCount = 0, up = 3, down = 1)
+
+        val count = repCounter.getRepCount()
+        // warmupReps should be 1 (from primary path repsRomCount==1), not 3
+        // (which would happen if the Echo fallback fired).
+        assertEquals(1, count.warmupReps)
+        assertFalse(count.isWarmupComplete)
+    }
+
+    @Test
+    fun `issue 553 echo mode warmup clamps at warmupTarget`() {
+        // The permissive fallback must still clamp at warmupTarget so a noisy
+        // up counter cannot push warmupReps past the firmware's calibration
+        // buffer of 3.
+        repCounter.configure(
+            warmupTarget = 3,
+            workingTarget = 5,
+            isJustLift = false,
+            stopAtTop = false,
+            isEchoMode = true,
+        )
+
+        repCounter.process(repsRomCount = 0, repsSetCount = 0, up = 0, down = 0)
+        // Single notification with up jumping by 5 — clamp to warmupTarget.
+        repCounter.process(repsRomCount = 0, repsSetCount = 0, up = 5, down = 0)
+
+        val count = repCounter.getRepCount()
+        assertEquals(3, count.warmupReps)
+        assertTrue(count.isWarmupComplete)
+    }
 }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/RepCounterFromMachineTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/RepCounterFromMachineTest.kt
@@ -688,6 +688,11 @@ class RepCounterFromMachineTest {
     }
 
     // ========== Issue #553: Echo Mode Permissive Warm-Up Fallback ==========
+    // The HARDER Echo default (Models.kt) is the primary fix; the existing
+    // line-484 fallback in RepCounterFromMachine.processModern (mode-agnostic
+    // up-counter advance when repsRomCount=0 AND repsSetCount=0) is the actual
+    // escape hatch. These tests pin that fallback's behavior for Echo-specific
+    // scenarios so a future refactor cannot regress the bug.
 
     @Test
     fun `issue 553 echo mode warmup advances from up counter when firmware drops reps`() {
@@ -695,21 +700,22 @@ class RepCounterFromMachineTest {
         // drops a rep event because the user's stroke falls outside the strict
         // Echo concentric timing window, repsRomCount and repsSetCount both stay
         // at 0 even though the user has completed real reps (visible as up
-        // counter increments). In Echo mode we must trust the up counter as a
-        // warm-up escape hatch or the user gets stuck on "Warm Up 1/3" forever.
+        // counter increments). The existing fallback warmup branch in
+        // processModern (mode-agnostic) must advance warmupReps from the up
+        // counter or the user gets stuck on "Warm Up 1/3" forever.
         repCounter.configure(
             warmupTarget = 3,
             workingTarget = 5,
             isJustLift = false,
             stopAtTop = false,
-            isEchoMode = true,
         )
 
         // Baseline
         repCounter.process(repsRomCount = 0, repsSetCount = 0, up = 0, down = 0)
 
         // Simulate firmware dropping 3 reps: only the up counter advances.
-        // Without the fix, warmupReps stays at 0 and isWarmupComplete is false.
+        // Without the line-484 fallback, warmupReps stays at 0 and
+        // isWarmupComplete is false.
         repCounter.process(repsRomCount = 0, repsSetCount = 0, up = 1, down = 0)
         repCounter.process(repsRomCount = 0, repsSetCount = 0, up = 2, down = 0)
         repCounter.process(repsRomCount = 0, repsSetCount = 0, up = 3, down = 0)
@@ -721,46 +727,38 @@ class RepCounterFromMachineTest {
     }
 
     @Test
-    fun `issue 553 non-echo mode does NOT advance warmup from up counter when firmware reports partial data`() {
-        // Regression guard for the Echo-specific branch: in non-Echo mode the
-        // permissive fallback must NOT fire when repsRomCount is reporting
-        // values (machine telemetry working normally) — only Echo mode with
-        // isEchoMode=true gets the up-counter escape hatch. This is the
-        // critical guard against accidentally softening Program/Eccentric mode
-        // rep counting.
+    fun `issue 553 primary repsRomCount path wins over up counter to avoid double counting`() {
+        // Regression guard for the line-484 fallback: when the firmware is
+        // reporting repsRomCount > 0 (normal telemetry), the primary path
+        // (repsRomCount > warmupReps) must advance warmupReps from repsRomCount,
+        // not from the up counter alone. Sending up=3 on the same notification
+        // as repsRomCount=1 must NOT triple-count.
         repCounter.configure(
             warmupTarget = 3,
             workingTarget = 5,
             isJustLift = false,
             stopAtTop = false,
-            isEchoMode = false,
         )
 
         repCounter.process(repsRomCount = 0, repsSetCount = 0, up = 0, down = 0)
-        // Firmware reports repsRomCount > 0 (mid-warmup), repsSetCount > 0 too.
-        // The primary path (`repsRomCount > warmupReps`) advances warmupReps
-        // from repsRomCount, NOT from the up counter alone. Sending up=3 on
-        // the same notification should NOT triple-count.
         repCounter.process(repsRomCount = 1, repsSetCount = 0, up = 3, down = 1)
 
         val count = repCounter.getRepCount()
-        // warmupReps should be 1 (from primary path repsRomCount==1), not 3
-        // (which would happen if the Echo fallback fired).
+        // warmupReps should be 1 (from primary path repsRomCount==1), not 3.
         assertEquals(1, count.warmupReps)
         assertFalse(count.isWarmupComplete)
     }
 
     @Test
-    fun `issue 553 echo mode warmup clamps at warmupTarget`() {
-        // The permissive fallback must still clamp at warmupTarget so a noisy
-        // up counter cannot push warmupReps past the firmware's calibration
+    fun `issue 553 fallback warmup clamps at warmupTarget`() {
+        // The line-484 fallback must clamp at warmupTarget so a noisy up
+        // counter cannot push warmupReps past the firmware's calibration
         // buffer of 3.
         repCounter.configure(
             warmupTarget = 3,
             workingTarget = 5,
             isJustLift = false,
             stopAtTop = false,
-            isEchoMode = true,
         )
 
         repCounter.process(repsRomCount = 0, repsSetCount = 0, up = 0, down = 0)

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMWorkoutLifecycleTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMWorkoutLifecycleTest.kt
@@ -9,6 +9,7 @@ import com.devil.phoenixproject.domain.model.BadgeTier
 import com.devil.phoenixproject.domain.model.BodyweightVariantOption
 import com.devil.phoenixproject.domain.model.Exercise
 import com.devil.phoenixproject.domain.model.ExerciseCableIntent
+import com.devil.phoenixproject.domain.model.EchoLevel
 import com.devil.phoenixproject.domain.model.HapticEvent
 import com.devil.phoenixproject.domain.model.PRType
 import com.devil.phoenixproject.domain.model.PersonalRecord
@@ -52,6 +53,18 @@ import kotlin.test.assertTrue
  * init collectors and prevent UncompletedCoroutinesError.
  */
 class DWSMWorkoutLifecycleTest {
+
+    @Test
+    fun `just lift presentation defaults use issue 553 Echo level`() {
+        val defaults = JustLiftDefaults(
+            weightPerCableKg = 20f,
+            weightChangePerRep = 0,
+            workoutModeId = 10,
+        )
+
+        assertEquals(1, defaults.echoLevelValue)
+        assertEquals(EchoLevel.HARDER, defaults.getEchoLevel())
+    }
 
     // ===== A. startWorkout transitions =====
 

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/util/BlePacketFactoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/util/BlePacketFactoryTest.kt
@@ -586,6 +586,17 @@ class BlePacketFactoryTest {
     }
 
     @Test
+    fun `createEchoCommand falls back to issue 553 Echo level`() {
+        val packet = BlePacketFactory.createEchoCommand(
+            level = 99,
+            eccentricLoad = 100,
+        )
+
+        assertEquals(1.25f, readFloatLE(packet, 0x10), "fallback HARDER duration")
+        assertEquals(40.0f, readFloatLE(packet, 0x14), "fallback HARDER velocity")
+    }
+
+    @Test
     fun `createEchoControl defaults match official app RepConfig defaults`() {
         val packet = BlePacketFactory.createEchoControl(EchoLevel.HARD)
 

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/util/BlePacketFactoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/util/BlePacketFactoryTest.kt
@@ -597,7 +597,7 @@ class BlePacketFactoryTest {
     }
 
     @Test
-    fun `createEchoControl defaults match official app RepConfig defaults`() {
+    fun `createEchoControl HARD level matches official app RepConfig`() {
         val packet = BlePacketFactory.createEchoControl(EchoLevel.HARD)
 
         assertEquals(3.toByte(), packet[0x04], "default romRepCount")


### PR DESCRIPTION
## Summary

Fixes #553 by moving new and legacy Echo defaults away from `HARD` and back to `HARDER` for the user-facing paths that can start Echo workouts.

The earlier RCA was directionally right that `HARD` is the risky default for this report, but the original PR implementation was incomplete. Git history shows PR #474 changed several entry/default paths from `HARDER` to `HARD` (Just Lift defaults, Single Exercise setup, routine/template defaults, edit/config defaults, and saved-default fallbacks). `WorkoutParameters.echoLevel` itself was already `HARD` before PR #474, so changing only that constructor default did not cover the reporter's Just Lift / Single Exercise paths.

## Root Cause

The reporter's Echo sessions could still reach `BlePacketFactory.createEchoControl(...)` with `EchoLevel.HARD` because those flows load explicit UI/default/persisted values before the `WorkoutParameters` default matters:

- Just Lift saved defaults used `echoLevelValue = 0` and `getEchoLevel()` resolved fallback to `HARD`.
- Single Exercise defaults and new temporary routine exercises used `EchoLevel.HARD`.
- Routine/template/config/edit fallbacks still seeded new Echo exercise configuration with `HARD`.
- The live BLE send path passes `bleParams.echoLevel` directly into `createEchoControl(...)`, so the legacy `createEchoCommand(...)` fallback is not enough for the reported flows.

The rep-counter side now relies on the existing mode-agnostic modern fallback (`repsSetCount == 0 && repsRomCount == 0 && upDelta > 0`) that was already present; the attempted Echo-specific branch was removed as unreachable.

## Fix

- Align new Echo defaults and fallback values to `EchoLevel.HARDER` across:
  - `WorkoutParameters` / `ProgramMode.toWorkoutMode(...)`
  - `JustLiftDefaults` in preferences and presentation-manager layers
  - `SingleExerciseDefaults` fallback
  - `RoutineExercise`, `ExerciseConfig`, `TemplateConverter`
  - Just Lift, Single Exercise, mode sub-selector, exercise edit, rest-card, and Set Ready fallbacks
  - SQLDelight invalid-value fallbacks
  - legacy `BlePacketFactory.createEchoCommand(...)` invalid-level fallback
- Add a one-time preference migration for saved Just Lift and Single Exercise defaults whose stored Echo level is old default `0` / `HARD`; it rewrites them to `1` / `HARDER` once, then allows a user to explicitly save `HARD` again after migration.
- Keep `HARD` available as an explicit selectable Echo level.

## Tests

Added/updated regression coverage for:

- Just Lift default Echo level and saved-default migration
- Single Exercise invalid fallback and saved-default migration
- `WorkoutParameters` / `ProgramMode.toWorkoutMode(...)` Echo defaults
- `RoutineExercise` Echo defaults
- presentation-manager Just Lift defaults
- legacy `createEchoCommand(...)` fallback
- existing `RepCounterFromMachine` warm-up fallback behavior

## Verification

Passed locally:

- `git diff --check`
- `./gradlew.bat :shared:testAndroidHostTest --tests "com.devil.phoenixproject.data.preferences.SettingsPreferencesManagerTest" --console=plain --rerun-tasks`
- `./gradlew.bat :shared:testAndroidHostTest --tests "com.devil.phoenixproject.data.preferences.SettingsPreferencesManagerTest" --tests "com.devil.phoenixproject.domain.model.RoutineTest" --tests "com.devil.phoenixproject.domain.model.WorkoutParametersTest" --tests "com.devil.phoenixproject.presentation.manager.DWSMWorkoutLifecycleTest" --tests "com.devil.phoenixproject.util.BlePacketFactoryTest" --tests "com.devil.phoenixproject.domain.usecase.RepCounterFromMachineTest" --console=plain --rerun-tasks`
- `./gradlew.bat :shared:testAndroidHostTest --console=plain --rerun-tasks`

`spotlessKotlinCheck` is currently blocked by pre-existing formatting violations in unrelated files outside this PR's touched set; I did not run global `spotlessApply` because it would create unrelated churn.

## Remaining Risk

This still is not a hardware-proven RCA. There is no packet capture from the affected OnePlus 15 / V-Form path showing exactly which counters move under `HARD` versus `HARDER`. The code-side fix now matches the intended mitigation and covers saved defaults, but a device-side capture is still the strongest proof.

Fixes #553
