### PR TITLE
fix(ios): relocate rest timer liveRegion off zero-size AX node (#565)

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RestTimerCard.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RestTimerCard.kt
@@ -202,17 +202,11 @@ fun RestTimerCard(
             label = "pulse",
         )
 
-        // Accessibility: hidden node that announces countdown at key intervals.
-        // Uses liveRegion(Polite) so TalkBack/VoiceOver reads changes without
-        // interrupting other speech. Only fires when lastAnnouncedText changes.
-        Box(
-            modifier = Modifier
-                .size(0.dp)
-                .semantics {
-                    liveRegion = LiveRegionMode.Polite
-                    contentDescription = lastAnnouncedText
-                },
-        )
+        // Accessibility: countdown announcements are now driven by the visible
+        // timer Text below (see liveRegion semantics there). The previous zero-size
+        // liveRegion Box was removed (issue #565) because the 0.dp AX node increased
+        // element-disposal churn during 1Hz recomposition, racing iOS UIAccessibility
+        // and triggering an EXC_BAD_ACCESS in Compose's accessibility bounds path.
 
         Column(
             modifier = Modifier
@@ -276,6 +270,13 @@ fun RestTimerCard(
                 )
 
                 // Timer text - dimmed when paused
+                // Accessibility: liveRegion semantics relocated here from the removed
+                // 0.dp Box (issue #565). Attaching liveRegion=Polite + contentDescription
+                // to this stable, visible, non-zero-size element preserves throttled
+                // VoiceOver/TalkBack countdown announcements (5s/10s/0s/paused) while
+                // eliminating the zero-size AX node that raced iOS UIAccessibility.
+                // contentDescription overrides the raw time string so liveRegion only
+                // fires when lastAnnouncedText changes (not every 1Hz tick).
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
                     Text(
                         text = formatRestTime(restSecondsRemaining),
@@ -285,6 +286,10 @@ fun RestTimerCard(
                             MaterialTheme.colorScheme.primary.copy(alpha = 0.5f)
                         } else {
                             MaterialTheme.colorScheme.primary
+                        },
+                        modifier = Modifier.semantics {
+                            liveRegion = LiveRegionMode.Polite
+                            contentDescription = lastAnnouncedText
                         },
                     )
                     if (isRestPaused) {

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RestTimerCard.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RestTimerCard.kt
@@ -202,11 +202,20 @@ fun RestTimerCard(
             label = "pulse",
         )
 
-        // Accessibility: countdown announcements are now driven by the visible
-        // timer Text below (see liveRegion semantics there). The previous zero-size
-        // liveRegion Box was removed (issue #565) because the 0.dp AX node increased
-        // element-disposal churn during 1Hz recomposition, racing iOS UIAccessibility
-        // and triggering an EXC_BAD_ACCESS in Compose's accessibility bounds path.
+        // Accessibility: hidden node that announces countdown at key intervals.
+        // Uses liveRegion(Polite) so TalkBack/VoiceOver reads changes without
+        // interrupting other speech. Only fires when lastAnnouncedText changes.
+        // Uses 1.dp (not 0.dp) to avoid zero-size AX node crashes on iOS (issue #565);
+        // keeping announcements on a separate node lets the visible timer Text read
+        // its actual displayed time when focused by a screen reader.
+        Box(
+            modifier = Modifier
+                .size(1.dp)
+                .semantics {
+                    liveRegion = LiveRegionMode.Polite
+                    contentDescription = lastAnnouncedText
+                },
+        )
 
         Column(
             modifier = Modifier
@@ -270,13 +279,6 @@ fun RestTimerCard(
                 )
 
                 // Timer text - dimmed when paused
-                // Accessibility: liveRegion semantics relocated here from the removed
-                // 0.dp Box (issue #565). Attaching liveRegion=Polite + contentDescription
-                // to this stable, visible, non-zero-size element preserves throttled
-                // VoiceOver/TalkBack countdown announcements (5s/10s/0s/paused) while
-                // eliminating the zero-size AX node that raced iOS UIAccessibility.
-                // contentDescription overrides the raw time string so liveRegion only
-                // fires when lastAnnouncedText changes (not every 1Hz tick).
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
                     Text(
                         text = formatRestTime(restSecondsRemaining),
@@ -286,10 +288,6 @@ fun RestTimerCard(
                             MaterialTheme.colorScheme.primary.copy(alpha = 0.5f)
                         } else {
                             MaterialTheme.colorScheme.primary
-                        },
-                        modifier = Modifier.semantics {
-                            liveRegion = LiveRegionMode.Polite
-                            contentDescription = lastAnnouncedText
                         },
                     )
                     if (isRestPaused) {


### PR DESCRIPTION
## Summary

Restores the standalone liveRegion `Box` in `RestTimerCard.kt` but changes its size from `0.dp` to `1.dp` (non-zero). This eliminates the zero-size AX node that triggered the iOS `EXC_BAD_ACCESS` crash while preserving the original announcement/focus behavior. Bounded to `RestTimerCard.kt` only.

Fixes #565

## Root cause (from GPT-5.5 xhigh RCA — [issuecomment-4734439771](https://github.com/9thLevelSoftware/Project-Phoenix-MP/issues/565#issuecomment-4734439771))

Use-after-free in the Compose Multiplatform iOS accessibility bridge. `AccessibilityElement.contentOffset()` (`Accessibility.uikit.kt:726`) dereferences `node.scrollContentOffset` without an `isAlive`/disposed guard; when iOS `AXRuntime` queries `accessibilityFrame` → `bounds()` → `contentOffset()` on an element disposed during recomposition, the `node.semanticsNode` dereference hits freed memory → `EXC_BAD_ACCESS (SIGSEGV)` at `0x8`.

The rest-between-sets screen triggered it because `RestTimerCard.kt` mounted a **zero-size** `liveRegion = Polite` `Box` whose `contentDescription` churned during the 1 Hz rest-timer recomposition, racing iOS UIAccessibility's AX-tree poll (upstream match: [JetBrains/compose-multiplatform#5543](https://github.com/JetBrains/compose-multiplatform/issues/5543), ~83% on iOS 26.x).

## Fix

Change the announcement `Box` size from `0.dp` to `1.dp`. A non-zero-size element:
- Avoids the zero-size AX node disposal churn that raced iOS UIAccessibility.
- Satisfies the RCA acceptance criteria: "an equivalent stable, non-zero-size composable that persists across ticks."
- Preserves the original announcement/focus behavior — `liveRegion` + `contentDescription = lastAnnouncedText` stay on the separate hidden node, so the visible timer `Text` reads its actual displayed time when focused by a screen reader.

This is safer than relocating `contentDescription` onto the visible timer `Text` (the initial approach in commit `af7d47c`), which caused a screen-reader focus regression: focusing the timer read stale announcement text instead of the actual time. The `1.dp` approach avoids both the crash and that regression.

CMP `1.10.3 → 1.11.1` upgrade already on `main` (commit `360b592`) adds the upstream `isAlive`/hit-test guard (PR #2760), providing an additional layer of protection against the underlying UAF.

## Follow-up commit (e1b0c35)

Addresses Gemini Code Assist review feedback: the initial commit (`af7d47c`) relocated `liveRegion` + `contentDescription = lastAnnouncedText` onto the visible timer `Text`, which caused a screen-reader focus regression (stale announcement text read on focus instead of actual time). This follow-up reverts that relocation and instead changes the original `0.dp` Box to `1.dp`, keeping announcements on a separate non-zero-size node. The outdated comment block was removed as suggested.

## Non-goals (per RCA)

- Does not modify upstream CMP source (library dependency).
- Does not remove accessibility/announcement support — VoiceOver/TalkBack functionality preserved.
- Does not bundle a CMP version change (the 1.11.1 upgrade already landed separately on `main`).
- Does not change rest-timer logic, pause/extend/skip controls, or announcement throttling.

## Test plan

- [x] Local: `:shared:testAndroidHostTest` PASS (184 suites, 2058 tests, 0 failures) with `-Pskip.supabase.check=true`.
- [ ] CI: all checks green.
- [ ] Manual: TestFlight build on iOS 26.x with VoiceOver enabled, rest between sets, no `EXC_BAD_ACCESS` in accessibility bounds path.
