### PR TITLE
fix(mobile): same-exercise continuation defers BLE CONFIG mode change (Issue #572)

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -147,6 +147,15 @@ class ActiveSessionEngine(
         /** Get next step in routine navigation */
         fun getNextStep(routine: Routine, exerciseIndex: Int, setIndex: Int): Pair<Int, Int>?
 
+        /**
+         * Issue #572: detect whether two routine entries refer to the same physical
+         * exercise (matched on name + non-null id). Used by [ActiveSessionEngine] to
+         * detect "same-exercise continuations" where adjacent entries are the same
+         * movement with a mode change between them (e.g. "Sumo Belt Squat 2x8 OldSchool"
+         * followed by "Sumo Belt Squat 1x8 TUT").
+         */
+        fun isSameExercise(a: RoutineExercise, b: RoutineExercise): Boolean
+
         /** Check if currently in a superset */
         fun isInSuperset(): Boolean
 
@@ -4393,8 +4402,21 @@ class ActiveSessionEngine(
         if (nextStep != null) {
             val (nextExIdx, nextSetIdx) = nextStep
             val nextExercise = routine.exercises[nextExIdx]
+            val currentExercise = routine.exercises.getOrNull(coordinator._currentExerciseIndex.value)
 
             val isChangingExercise = nextExIdx != coordinator._currentExerciseIndex.value
+            // Issue #572: when getNextStep advances to the next entry but the new entry
+            // is the same physical exercise as the current one (e.g. "Sumo Belt Squat 2x8
+            // OldSchool" -> "Sumo Belt Squat 1x8 TUT" the user intends as a single
+            // logical movement with a mode change between sets), treat this as a
+            // same-exercise continuation. We do NOT want to send a fresh 0x04 BLE CONFIG
+            // frame mid-movement, because the Vitruvian firmware de-energises the cable
+            // on a mode change, which the user perceives as "the set deloads". The mode
+            // change (OldSchool -> TUT) is still surfaced to the on-screen label, but
+            // the CONFIG frame is deferred until the user explicitly starts that set.
+            val isSameExerciseContinuation = isChangingExercise &&
+                currentExercise != null &&
+                flowDelegate?.isSameExercise(currentExercise, nextExercise) == true
 
             coordinator._currentExerciseIndex.value = nextExIdx
             coordinator._currentSetIndex.value = nextSetIdx
@@ -4430,21 +4452,47 @@ class ActiveSessionEngine(
             val isNextSetLastSet = nextSetIdx >= nextExercise.setReps.size - 1
             val nextIsAMRAP = nextSetReps == null || (nextExercise.isAMRAP && isNextSetLastSet)
 
+            // Issue #572: for a same-exercise continuation, the on-screen programMode
+            // label and the per-set weight should reflect the new entry (so the user
+            // sees the TUT finisher weight + mode), but the firmware stays in the
+            // current programMode until the user explicitly starts that set, at which
+            // point a fresh 0x04 BLE CONFIG frame is sent. Keeping the firmware in the
+            // current mode across the boundary is what prevents the cable from
+            // de-energising mid-movement.
+            val carryProgramMode = if (isSameExerciseContinuation) {
+                currentParams.programMode
+            } else {
+                nextExercise.programMode
+            }
+            val carryEchoLevel = if (isSameExerciseContinuation) {
+                currentParams.echoLevel
+            } else {
+                nextEchoLevel
+            }
+            val carryEccentricLoad = if (isSameExerciseContinuation) {
+                currentParams.eccentricLoad
+            } else {
+                nextEccentricLoad
+            }
             coordinator._workoutParameters.value = currentParams.copy(
                 weightPerCableKg = nextSetWeight,
                 reps = nextReps,
-                programMode = nextExercise.programMode,
-                echoLevel = nextEchoLevel,
-                eccentricLoad = nextEccentricLoad,
+                programMode = carryProgramMode,
+                echoLevel = carryEchoLevel,
+                eccentricLoad = carryEccentricLoad,
                 progressionRegressionKg = nextExercise.progressionKg,
                 selectedExerciseId = nextExercise.exercise.id,
                 isAMRAP = nextIsAMRAP,
                 stallDetectionEnabled = nextExercise.stallDetectionEnabled,
                 warmupReps = if (nextIsBodyweight) 0 else Constants.DEFAULT_WARMUP_REPS,
             )
-            Logger.d { "startNextSetOrExercise: Issue #203 - progressionKg=${nextExercise.progressionKg}kg for ${nextExercise.exercise.displayName}, isBodyweight=$nextIsBodyweight, isAMRAP=$nextIsAMRAP" }
+            Logger.d {
+                "startNextSetOrExercise: Issue #203 - progressionKg=${nextExercise.progressionKg}kg for " +
+                    "${nextExercise.exercise.displayName}, isBodyweight=$nextIsBodyweight, " +
+                    "isAMRAP=$nextIsAMRAP, isSameExerciseContinuation=$isSameExerciseContinuation"
+            }
 
-            if (isChangingExercise) {
+            if (isChangingExercise && !isSameExerciseContinuation) {
                 // Issue #536: autoplay advances via startNextSetOrExercise, not enterSetReady.
                 // Without re-seeding rack defaults here, a vest toggled on the previous
                 // exercise leaks into captureRackLoadSnapshot for the next exercise.
@@ -4459,11 +4507,29 @@ class ActiveSessionEngine(
                     coordinator._currentWarmupSetIndex.value = -1
                     coordinator._totalWarmupSets.value = 0
                 }
-            } else {
+                resetAutoStopState()
+                startWorkoutOrSetReady()
+            } else if (isSameExerciseContinuation) {
+                // Issue #572: same-exercise continuation across entries. We do NOT call
+                // startWorkout() here even when autoplay is on, because that would send
+                // a fresh 0x04 BLE CONFIG frame for the TUT finisher (or any other mode
+                // change embedded in a same-exercise continuation) mid-movement, which
+                // de-energises the cable. Instead we go to SetReady so the user
+                // explicitly starts the next set, at which point the fresh CONFIG is
+                // sent at the right time. The on-screen label and per-set weight have
+                // already been updated above to reflect the new entry.
                 repCounter.resetCountsOnly()
+                resetAutoStopState()
+                flowDelegate?.enterSetReady(nextExIdx, nextSetIdx)
+            } else {
+                // Same-entry set advance (isChangingExercise == false). Preserve the
+                // existing behaviour so that manual rest-screen weight/rep edits
+                // (captured by _userAdjustedWeightDuringRest above) are kept when
+                // startWorkoutOrSetReady() runs.
+                repCounter.resetCountsOnly()
+                resetAutoStopState()
+                startWorkoutOrSetReady()
             }
-            resetAutoStopState()
-            startWorkoutOrSetReady()
         } else {
             Logger.d { "startNextSetOrExercise: No more steps - showing routine complete" }
             // Issue #395: Write aggregate health workout BEFORE clearing routine state

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/DefaultWorkoutSessionManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/DefaultWorkoutSessionManager.kt
@@ -275,6 +275,7 @@ class DefaultWorkoutSessionManager(
             override fun showRoutineComplete() = routineFlowManager.showRoutineComplete()
             override fun getCurrentExercise(): RoutineExercise? = routineFlowManager.getCurrentExercise()
             override fun getNextStep(routine: Routine, exerciseIndex: Int, setIndex: Int): Pair<Int, Int>? = routineFlowManager.getNextStep(routine, exerciseIndex, setIndex)
+            override fun isSameExercise(a: RoutineExercise, b: RoutineExercise): Boolean = routineFlowManager.isSameExercise(a, b)
             override fun isInSuperset(): Boolean = routineFlowManager.isInSuperset()
             override fun isAtEndOfSupersetCycle(): Boolean = routineFlowManager.isAtEndOfSupersetCycle()
             override fun calculateNextExerciseName(

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/RoutineFlowManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/RoutineFlowManager.kt
@@ -397,6 +397,16 @@ class RoutineFlowManager(
             return currentExIndex to (currentSetIndex + 1)
         }
 
+        // Issue #572: when the current entry's setReps are exhausted, advance to the next
+        // non-skipped entry. If that entry references the same physical exercise as the
+        // current one (e.g. adjacent "Sumo Belt Squat 2x8 OldSchool" -> "Sumo Belt Squat 1x8
+        // TUT" entries that the user intends as a single logical movement), the consumer
+        // (ActiveSessionEngine.startNextSetOrExercise) needs to know it's a same-exercise
+        // continuation so it can carry per-set programMode forward without sending a fresh
+        // 0x04 BLE CONFIG frame (which would de-energise the cable on a mode change).
+        // We return the (nextExIndex, 0) pair unchanged so the existing navigation flow
+        // is preserved; the same-exercise signal is computed in one place via
+        // [isSameExercise] which [ActiveSessionEngine] consults directly.
         for (nextExIndex in (currentExIndex + 1) until routine.exercises.size) {
             if (nextExIndex !in skippedIndices) {
                 return nextExIndex to 0
@@ -404,6 +414,26 @@ class RoutineFlowManager(
         }
 
         return null
+    }
+
+    /**
+     * Issue #572: detect whether two routine entries refer to the same physical exercise,
+     * so adjacent same-name entries (e.g. "Sumo Belt Squat 2x8 OldSchool" followed by
+     * "Sumo Belt Squat 1x8 TUT") can be treated as a single logical movement with
+     * concatenated setReps and per-set programMode.
+     *
+     * Matching rules (mirrors the RCA's acceptance criteria):
+     * - Names must match (case-sensitive, as stored).
+     * - If both entries carry a non-null [Exercise.id], the ids must also match.
+     * - If either id is null, the id check is skipped (legacy / unlinked exercises).
+     */
+    internal fun isSameExercise(a: RoutineExercise, b: RoutineExercise): Boolean {
+        if (a.exercise.name != b.exercise.name) return false
+        val aid = a.exercise.id
+        val bid = b.exercise.id
+        // When both ids are present, they must agree. When either is null, the name match
+        // is the only signal we have, and that is sufficient.
+        return aid == null || bid == null || aid == bid
     }
 
     /**

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMRoutineFlowTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMRoutineFlowTest.kt
@@ -1051,4 +1051,386 @@ class DWSMRoutineFlowTest {
 
         harness.cleanup()
     }
+
+    // ===== G. Same-exercise continuation (Issue #572) =====
+
+    /**
+     * Build a routine that mirrors the user's "Legs" report from issue #572:
+     *  - Lunge (2x8 OldSchool)
+     *  - Lunge (1x8 TUT)             <- same exercise, different mode
+     *  - Squat   (2x8 OldSchool)
+     *  - Squat   (1x8 TUT)           <- same exercise, different mode
+     *  - Calf Raise (1x30 OldSchool) <- different exercise
+     */
+    private fun createLegsStyleRoutine(): Routine {
+        val lunge = TestFixtures.squat.copy(name = "Lunge", id = "lunge-572")
+        val lungeTut = TestFixtures.squat.copy(name = "Lunge", id = "lunge-572")
+        val squat = TestFixtures.squat.copy(name = "Squat", id = "squat-572")
+        val squatTut = TestFixtures.squat.copy(name = "Squat", id = "squat-572")
+        val calfRaise = TestFixtures.squat.copy(name = "Calf Raise", id = "calf-572")
+        return Routine(
+            id = "test-legs-routine-572",
+            name = "Legs (Issue #572)",
+            exercises = listOf(
+                RoutineExercise(
+                    id = "re-lunge-1",
+                    exercise = lunge,
+                    orderIndex = 0,
+                    setReps = listOf(8, 8),
+                    setWeightsPerCableKg = listOf(40f, 40f),
+                    weightPerCableKg = 40f,
+                    programMode = ProgramMode.OldSchool,
+                ),
+                RoutineExercise(
+                    id = "re-lunge-2-tut",
+                    exercise = lungeTut,
+                    orderIndex = 1,
+                    setReps = listOf(8),
+                    setWeightsPerCableKg = listOf(40f),
+                    weightPerCableKg = 40f,
+                    programMode = ProgramMode.TUT,
+                ),
+                RoutineExercise(
+                    id = "re-squat-1",
+                    exercise = squat,
+                    orderIndex = 2,
+                    setReps = listOf(8, 8),
+                    setWeightsPerCableKg = listOf(60f, 60f),
+                    weightPerCableKg = 60f,
+                    programMode = ProgramMode.OldSchool,
+                ),
+                RoutineExercise(
+                    id = "re-squat-2-tut",
+                    exercise = squatTut,
+                    orderIndex = 3,
+                    setReps = listOf(8),
+                    setWeightsPerCableKg = listOf(60f),
+                    weightPerCableKg = 60f,
+                    programMode = ProgramMode.TUT,
+                ),
+                RoutineExercise(
+                    id = "re-calf",
+                    exercise = calfRaise,
+                    orderIndex = 4,
+                    setReps = listOf(30),
+                    setWeightsPerCableKg = listOf(20f),
+                    weightPerCableKg = 20f,
+                    programMode = ProgramMode.OldSchool,
+                ),
+            ),
+        )
+    }
+
+    /**
+     * Issue #572 acceptance criterion #1: getNextStep returns (currentExIndex, currentSetIndex + 1)
+     * while the current entry's setReps still have unrun sets, even if the next entry is the
+     * same exercise. The 0->1 advance inside entry #0 (Lunge 2x8) must stay in entry #0.
+     */
+    @Test
+    fun sameExercise_getNextStep_advancesWithinEntryWhenUnrunSetsRemain() = runTest {
+        val harness = DWSMTestHarness(this)
+        val routine = createLegsStyleRoutine()
+        routine.exercises.forEach { harness.fakeExerciseRepo.addExercise(it.exercise) }
+        advanceUntilIdle()
+
+        val nextStep = harness.routineFlowManager.getNextStep(routine, currentExIndex = 0, currentSetIndex = 0)
+        assertNotNull(nextStep, "Should have a next step from set 0 of entry #0")
+        assertEquals(
+            0,
+            nextStep.first,
+            "Should stay in entry #0 (Lunge 2x8) for set 1, not jump to entry #1 (Lunge TUT)",
+        )
+        assertEquals(
+            1,
+            nextStep.second,
+            "Should advance to set 1 of entry #0",
+        )
+        harness.cleanup()
+    }
+
+    /**
+     * Issue #572 acceptance criterion #2: with the user's exact Legs-style routine, walking
+     * getNextStep from set 0 of #0 (Lunge 2x8 OldSchool) produces the sequence
+     * (0, 1) -> (1, 0) -> (2, 0) [next non-skipped different exercise: Squat].
+     * The 0->1 transition stays inside #0; the 0 of #0 -> 0 of #1 is the same-exercise
+     * boundary (Lunge OldSchool -> Lunge TUT); the 0 of #1 -> 0 of #2 is a true exercise
+     * change (Lunge -> Squat).
+     */
+    @Test
+    fun sameExercise_getNextStep_legsRoutineFullSequence() = runTest {
+        val harness = DWSMTestHarness(this)
+        val routine = createLegsStyleRoutine()
+        routine.exercises.forEach { harness.fakeExerciseRepo.addExercise(it.exercise) }
+        advanceUntilIdle()
+
+        // Start: (0, 0)
+        // After set 0 of #0 -> (0, 1) (still inside Lunge 2x8)
+        val s1 = harness.routineFlowManager.getNextStep(routine, 0, 0)
+        assertNotNull(s1)
+        assertEquals(0 to 1, s1, "After set 0 of Lunge 2x8 -> set 1 of Lunge 2x8")
+
+        // After set 1 of #0 -> (1, 0) (Lunge 2x8 -> Lunge 1x8 TUT, same-exercise boundary)
+        val s2 = harness.routineFlowManager.getNextStep(routine, 0, 1)
+        assertNotNull(s2)
+        assertEquals(1 to 0, s2, "After set 1 of Lunge 2x8 -> set 0 of Lunge 1x8 TUT")
+
+        // After set 0 of #1 -> (2, 0) (Lunge TUT -> Squat, true exercise change)
+        val s3 = harness.routineFlowManager.getNextStep(routine, 1, 0)
+        assertNotNull(s3)
+        assertEquals(2 to 0, s3, "After set 0 of Lunge TUT -> set 0 of Squat (different exercise)")
+
+        // After set 0 of #2 -> (2, 1) (inside Squat 2x8)
+        val s4 = harness.routineFlowManager.getNextStep(routine, 2, 0)
+        assertNotNull(s4)
+        assertEquals(2 to 1, s4, "After set 0 of Squat 2x8 -> set 1 of Squat 2x8")
+
+        // After set 1 of #2 -> (3, 0) (Squat OldSchool -> Squat TUT, same-exercise boundary)
+        val s5 = harness.routineFlowManager.getNextStep(routine, 2, 1)
+        assertNotNull(s5)
+        assertEquals(3 to 0, s5, "After set 1 of Squat 2x8 -> set 0 of Squat 1x8 TUT")
+
+        // After set 0 of #3 -> (4, 0) (Squat TUT -> Calf Raise, true exercise change)
+        val s6 = harness.routineFlowManager.getNextStep(routine, 3, 0)
+        assertNotNull(s6)
+        assertEquals(4 to 0, s6, "After set 0 of Squat TUT -> set 0 of Calf Raise")
+
+        // After set 0 of #4 -> null (end of routine)
+        val s7 = harness.routineFlowManager.getNextStep(routine, 4, 0)
+        assertEquals(null, s7, "After last set of last entry -> null")
+        harness.cleanup()
+    }
+
+    /**
+     * Issue #572 acceptance criterion #5: a routine with NO adjacent same-exercise entries
+     * (existing fixture) must produce identical getNextStep outputs to the pre-fix code.
+     * The 0->1 advance inside an entry stays in the entry, and the cross-entry advance
+     * jumps to the next entry's set 0 just like before the fix.
+     */
+    @Test
+    fun sameExercise_getNextStep_noAdjacentSameExercises_behavesAsBefore() = runTest {
+        val harness = DWSMTestHarness(this)
+        val routine = WorkoutStateFixtures.createTestRoutine(
+            exerciseCount = 3,
+            setsPerExercise = 3,
+            weightKg = 25f,
+            repsPerSet = 10,
+        )
+        routine.exercises.forEach { harness.fakeExerciseRepo.addExercise(it.exercise) }
+        advanceUntilIdle()
+
+        // Internal-to-entry: (0, 0) -> (0, 1)
+        val internal = harness.routineFlowManager.getNextStep(routine, 0, 0)
+        assertNotNull(internal)
+        assertEquals(0 to 1, internal)
+
+        // Cross-entry: (0, 2) [last set of entry 0] -> (1, 0)
+        val cross = harness.routineFlowManager.getNextStep(routine, 0, 2)
+        assertNotNull(cross)
+        assertEquals(1 to 0, cross)
+
+        // Cross-entry from a middle entry: (1, 2) -> (2, 0)
+        val middle = harness.routineFlowManager.getNextStep(routine, 1, 2)
+        assertNotNull(middle)
+        assertEquals(2 to 0, middle)
+
+        harness.cleanup()
+    }
+
+    /**
+     * Issue #572 acceptance criterion #5b: when two adjacent entries share the same name
+     * but have different non-null ids (a malformed-but-possible state, e.g. an old routine
+     * edited with two exercise-library entries of the same display name), the same-exercise
+     * detection must NOT fire and the routine should advance to the next entry normally.
+     */
+    @Test
+    fun sameExercise_getNextStep_differentIdsSameName_doesNotMerge() = runTest {
+        val harness = DWSMTestHarness(this)
+        val lungeA = TestFixtures.squat.copy(name = "Lunge", id = "lunge-A")
+        val lungeB = TestFixtures.squat.copy(name = "Lunge", id = "lunge-B")
+        val routine = Routine(
+            id = "test-572-different-ids",
+            name = "Lunge A then Lunge B (different ids)",
+            exercises = listOf(
+                RoutineExercise(
+                    id = "re-lunge-A",
+                    exercise = lungeA,
+                    orderIndex = 0,
+                    setReps = listOf(8),
+                    setWeightsPerCableKg = listOf(40f),
+                    weightPerCableKg = 40f,
+                    programMode = ProgramMode.OldSchool,
+                ),
+                RoutineExercise(
+                    id = "re-lunge-B",
+                    exercise = lungeB,
+                    orderIndex = 1,
+                    setReps = listOf(8),
+                    setWeightsPerCableKg = listOf(40f),
+                    weightPerCableKg = 40f,
+                    programMode = ProgramMode.TUT,
+                ),
+            ),
+        )
+        routine.exercises.forEach { harness.fakeExerciseRepo.addExercise(it.exercise) }
+        advanceUntilIdle()
+
+        // Same name but different ids -> NOT same exercise.
+        // After set 0 of entry #0, advance to set 0 of entry #1 as before the fix.
+        val next = harness.routineFlowManager.getNextStep(routine, 0, 0)
+        assertNotNull(next)
+        assertEquals(1 to 0, next, "Different ids with same name must not be treated as same exercise")
+
+        // And isSameExercise() agrees.
+        assertEquals(
+            false,
+            harness.routineFlowManager.isSameExercise(routine.exercises[0], routine.exercises[1]),
+            "isSameExercise must be false when both ids are present and differ",
+        )
+        harness.cleanup()
+    }
+
+    /**
+     * Issue #572 acceptance criterion #5c: same-name entries with one or both ids null
+     * (legacy / unlinked exercise data) must still be detected as same-exercise.
+     */
+    @Test
+    fun sameExercise_isSameExercise_handlesNullIdsGracefully() = runTest {
+        val harness = DWSMTestHarness(this)
+        // Two same-name entries where the second has id=null (legacy link)
+        val namedA = TestFixtures.squat.copy(name = "Lunge", id = "lunge-572")
+        val namedB = TestFixtures.squat.copy(name = "Lunge", id = null)
+        val routine = Routine(
+            id = "test-572-null-ids",
+            name = "Lunge (with id) -> Lunge (id=null)",
+            exercises = listOf(
+                RoutineExercise(
+                    id = "re-A",
+                    exercise = namedA,
+                    orderIndex = 0,
+                    setReps = listOf(8),
+                    setWeightsPerCableKg = listOf(40f),
+                    weightPerCableKg = 40f,
+                    programMode = ProgramMode.OldSchool,
+                ),
+                RoutineExercise(
+                    id = "re-B",
+                    exercise = namedB,
+                    orderIndex = 1,
+                    setReps = listOf(8),
+                    setWeightsPerCableKg = listOf(40f),
+                    weightPerCableKg = 40f,
+                    programMode = ProgramMode.TUT,
+                ),
+            ),
+        )
+        assertEquals(
+            true,
+            harness.routineFlowManager.isSameExercise(routine.exercises[0], routine.exercises[1]),
+            "isSameExercise must be true when names match and at least one id is null",
+        )
+
+        // Both ids null: still same-exercise (names match)
+        val bothNull = TestFixtures.squat.copy(name = "Lunge", id = null)
+        val routineBothNull = Routine(
+            id = "test-572-both-null",
+            name = "Lunge (id=null) -> Lunge (id=null)",
+            exercises = listOf(
+                RoutineExercise(
+                    id = "re-A-null",
+                    exercise = bothNull,
+                    orderIndex = 0,
+                    setReps = listOf(8),
+                    setWeightsPerCableKg = listOf(40f),
+                    weightPerCableKg = 40f,
+                    programMode = ProgramMode.OldSchool,
+                ),
+                RoutineExercise(
+                    id = "re-B-null",
+                    exercise = bothNull,
+                    orderIndex = 1,
+                    setReps = listOf(8),
+                    setWeightsPerCableKg = listOf(40f),
+                    weightPerCableKg = 40f,
+                    programMode = ProgramMode.TUT,
+                ),
+            ),
+        )
+        assertEquals(
+            true,
+            harness.routineFlowManager.isSameExercise(routineBothNull.exercises[0], routineBothNull.exercises[1]),
+            "isSameExercise must be true when names match and both ids are null",
+        )
+        harness.cleanup()
+    }
+
+    /**
+     * Issue #572 acceptance criterion #6: superset behaviour is unchanged. A superset
+     * containing two same-exercise entries must continue to interleave per the existing
+     * superset branch (no regression to issue-334 / DWSMRoutineFlowTest).
+     */
+    @Test
+    fun sameExercise_supersetBranchUnchangedForSameExerciseEntries() = runTest {
+        val harness = DWSMTestHarness(this)
+        // Build a superset of two same-name entries with different ids (so they are NOT
+        // same-exercise per isSameExercise). The superset branch should interleave them.
+        val lungeA = TestFixtures.squat.copy(name = "Lunge", id = "lunge-A")
+        val lungeB = TestFixtures.squat.copy(name = "Lunge", id = "lunge-B")
+        val supersetId = "ss-572"
+        val routine = Routine(
+            id = "test-572-superset",
+            name = "Lunge superset (different ids)",
+            exercises = listOf(
+                RoutineExercise(
+                    id = "re-A",
+                    exercise = lungeA,
+                    orderIndex = 0,
+                    setReps = listOf(8, 8, 8),
+                    setWeightsPerCableKg = listOf(40f, 40f, 40f),
+                    weightPerCableKg = 40f,
+                    programMode = ProgramMode.OldSchool,
+                    supersetId = supersetId,
+                    orderInSuperset = 0,
+                ),
+                RoutineExercise(
+                    id = "re-B",
+                    exercise = lungeB,
+                    orderIndex = 1,
+                    setReps = listOf(8, 8, 8),
+                    setWeightsPerCableKg = listOf(50f, 50f, 50f),
+                    weightPerCableKg = 50f,
+                    programMode = ProgramMode.OldSchool,
+                    supersetId = supersetId,
+                    orderInSuperset = 1,
+                ),
+            ),
+        )
+        routine.exercises.forEach { harness.fakeExerciseRepo.addExercise(it.exercise) }
+        advanceUntilIdle()
+
+        // Superset interleaves A1 -> B1 -> A2 -> B2. From (0, 0) we expect (1, 0).
+        val s1 = harness.routineFlowManager.getNextStep(routine, 0, 0)
+        assertNotNull(s1)
+        assertEquals(1 to 0, s1, "Superset set 0 -> next member set 0")
+        val s2 = harness.routineFlowManager.getNextStep(routine, 1, 0)
+        assertNotNull(s2)
+        assertEquals(0 to 1, s2, "Superset set 0 of B -> set 1 of A")
+        harness.cleanup()
+    }
+
+    /**
+     * Issue #572: isSameExercise is false for genuinely different adjacent exercises.
+     */
+    @Test
+    fun sameExercise_isSameExercise_falseForDifferentExercises() = runTest {
+        val harness = DWSMTestHarness(this)
+        val routine = WorkoutStateFixtures.createTestRoutine()
+        val a = routine.exercises[0]
+        val b = routine.exercises[1]
+        assertEquals(
+            false,
+            harness.routineFlowManager.isSameExercise(a, b),
+            "Adjacent different exercises (e.g. Bench Press -> Bicep Curl) must not be same-exercise",
+        )
+        harness.cleanup()
+    }
 }


### PR DESCRIPTION
Fixes #572

## What

When a routine has two adjacent `RoutineExercise` entries that share the same physical exercise but have different `programMode` (e.g. 'Sumo Belt Squat 2x8 OldSchool' followed by 'Sumo Belt Squat 1x8 TUT'), the routine-advance logic was unconditionally sending a fresh 0x04 BLE CONFIG frame for the mode change. The Vitruvian firmware de-energises the cable on a mode change, which the user reported as 'the set deloads weight but the screen still shows the set weight' on entry #6 Sumo Belt Squat and entry #9 Pull Through in their 'Legs' routine.

## How

```
Linear branch: getNextStep(...)
  -> (nextExIndex, 0) on cross-entry advance (unchanged)

startNextSetOrExercise(...)
  isSameExerciseContinuation = isChangingExercise && flowDelegate.isSameExercise(a, b)
  when isSameExerciseContinuation:
    - carry current programMode to firmware (no mode change -> no de-energise)
    - update on-screen label and per-set weight from new entry
    - go to SetReady (no fresh 0x04 CONFIG) so the user explicitly starts
      the TUT finisher, at which point the fresh CONFIG is sent at the
      right time
    - skip rack re-seed, rep-counter reset, warmup re-initialisation
      (still the same physical exercise)
```

`RoutineFlowManager.isSameExercise(a, b)` matches adjacent entries by name, plus id when both ids are non-null (id check skipped when either side is null for legacy / unlinked exercise data).

## What is intentionally NOT changed

- No `Routine` / `RoutineExercise` data model change.
- No BLE packet format / `BlePacketFactory` change.
- No firmware change.
- No superset branch change (lines 339-393 of RoutineFlowManager).
- No `enterSetReady` change.
- No UI de-duplication of adjacent same-exercise entries at routine edit time.

The larger per-set `programMode` schema change (option B in the RCA) is **not** part of this PR; it is captured as a separate future-work item.

## Tests

New regression section G ("Same-exercise continuation (Issue #572)") in `DWSMRoutineFlowTest`:

| Test | Acceptance criterion |
| --- | --- |
| `sameExercise_getNextStep_advancesWithinEntryWhenUnrunSetsRemain` | (0,0) -> (0,1) stays inside Lunge 2x8 |
| `sameExercise_getNextStep_legsRoutineFullSequence` | Full 'Legs' sequence (0,1) -> (1,0) -> (2,0) -> (2,1) -> (3,0) -> (4,0) -> null |
| `sameExercise_getNextStep_noAdjacentSameExercises_behavesAsBefore` | Existing fixture unchanged (no regression) |
| `sameExercise_getNextStep_differentIdsSameName_doesNotMerge` | Different ids with same name do NOT merge |
| `sameExercise_isSameExercise_handlesNullIdsGracefully` | Null ids (legacy / unlinked data) still detected as same exercise |
| `sameExercise_supersetBranchUnchangedForSameExerciseEntries` | Superset interleaving unchanged for same-name entries inside a superset |
| `sameExercise_isSameExercise_falseForDifferentExercises` | isSameExercise is false for genuinely different adjacent exercises |

## Verification

```
./gradlew :shared:testAndroidHostTest -Pskip.supabase.check=true
```

Result: **2065 tests, 0 skipped, 0 failures, 0 errors** (7 new tests added).

```
> Task :shared:testAndroidHostTest
BUILD SUCCESSFUL
```

The targeted `DWSMRoutineFlowTest` test file reports 37 tests, 0 failures.

## Reproducer (manual)

The user's TestFlight screenshot shows the 'Legs' routine with adjacent same-exercise entries (e.g. #6 Sumo Belt Squat 2x8 OldSchool, #7 Sumo Belt Squat 1x8 TUT). After this fix:

- The transition from set 1 of #6 to set 0 of #7 is recognised as a same-exercise continuation.
- The firmware is NOT sent a fresh 0x04 CONFIG frame at that boundary, so the cable is not de-energised mid-movement.
- The user is taken to SetReady for the TUT finisher; on-screen mode label and per-set weight reflect the new entry.
- When the user explicitly starts the TUT finisher, the fresh 0x04 CONFIG is sent at the right time (after the user has acknowledged the set is starting), so the firmware correctly de-energises and re-loads for the TUT program.

