### PR TITLE
fix(just-lift): cap wheel drag hot zone + side-by-side weight cards on iPhone portrait (#571)

### DIFF
--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/testutil/SourceFileReader.android.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/testutil/SourceFileReader.android.kt
@@ -1,0 +1,33 @@
+package com.devil.phoenixproject.testutil
+
+import java.io.File
+
+/**
+ * Android/JVM implementation of [readProjectFile]. Uses [java.io.File] which is
+ * available on the JVM/Android test source set. The caller is expected to invoke
+ * this from a working directory that is inside the project root (the test does
+ * the up-walk in shared code via a different mechanism if needed).
+ */
+actual fun readProjectFile(relativePath: String): String? {
+    val file = File(relativePath)
+    if (file.exists() && file.isFile) {
+        return file.readText()
+    }
+    // Walk up the directory tree looking for the project root.
+    var dir: File? = File(".").absoluteFile
+    repeat(6) {
+        if (dir == null) return@repeat
+        val candidate = File(dir, "shared/$relativePath")
+        if (candidate.exists() && candidate.isFile) {
+            return candidate.readText()
+        }
+        if (File(dir, ".git").exists() || File(dir, "settings.gradle.kts").exists()) {
+            val rootCandidate = File(dir, relativePath)
+            if (rootCandidate.exists() && rootCandidate.isFile) {
+                return rootCandidate.readText()
+            }
+        }
+        dir = dir.parentFile
+    }
+    return null
+}

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/JustLiftScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/JustLiftScreen.kt
@@ -408,7 +408,19 @@ fun JustLiftScreen(navController: NavController, viewModel: MainViewModel, theme
                 Card(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .then(if (stackWeightCards) Modifier else Modifier.weight(1f)),
+                        .then(if (stackWeightCards) Modifier else Modifier.weight(1f))
+                        // Issue #571: belt-and-braces vertical separation between the two
+                        // weight cards when stacked, so the wheel's bottom edge is
+                        // unambiguously above the slider's top edge even if the inner
+                        // gesture-isolation step in CompactNumberPicker is bypassed by a
+                        // future regression. Applied as bottom padding on the *first* card
+                        // (rather than an explicit Spacer between them) so the outer
+                        // Column's `Arrangement.spacedBy(Spacing.medium)` does not double
+                        // the gap. Total gap = Spacing.medium (outer) + Spacing.small
+                        // (this padding) = 24dp.
+                        .then(
+                            if (stackWeightCards) Modifier.padding(bottom = Spacing.small) else Modifier,
+                        ),
                     colors = CardDefaults.cardColors(
                         containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
                     ),
@@ -458,14 +470,6 @@ fun JustLiftScreen(navController: NavController, viewModel: MainViewModel, theme
                             textAlign = TextAlign.Center,
                         )
                     }
-                }
-
-                // Issue #571: belt-and-braces vertical separation between the two cards
-                // when stacked, so the wheel's bottom edge is unambiguously above the slider's
-                // top edge even if the inner gesture-isolation step in CompactNumberPicker
-                // is bypassed by a future regression.
-                if (stackWeightCards) {
-                    Spacer(modifier = Modifier.height(Spacing.small))
                 }
 
                 // Weight Change Per Rep Card

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/JustLiftScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/JustLiftScreen.kt
@@ -104,6 +104,7 @@ import com.devil.phoenixproject.presentation.components.ProgressionSlider
 import com.devil.phoenixproject.presentation.components.RestTimePickerDialog
 import com.devil.phoenixproject.presentation.navigation.NavigationRoutes
 import com.devil.phoenixproject.presentation.util.isCompactAccessibilityLayout
+import com.devil.phoenixproject.presentation.util.useStackedWeightCardsLayout
 import com.devil.phoenixproject.presentation.viewmodel.MainViewModel
 import com.devil.phoenixproject.ui.theme.AccessibilityTheme
 import com.devil.phoenixproject.ui.theme.Spacing
@@ -287,6 +288,12 @@ fun JustLiftScreen(navController: NavController, viewModel: MainViewModel, theme
     }
 
     val useCompactAccessibility = isCompactAccessibilityLayout()
+    // Issue #571: Stack the Weight per Cable and Weight Change Per Rep cards only when the
+    // device is short as well (iPhone landscape 740x390, or compact height with accessibility
+    // settings). On iPhone portrait with default Dynamic Type + Bold Text OFF, keep them
+    // side-by-side so the iOS CompactNumberPicker wheel cannot eat drags intended for the
+    // ProgressionSlider.
+    val stackWeightCards = useStackedWeightCardsLayout()
     val contentScrollState = rememberScrollState()
 
     Box(
@@ -401,7 +408,7 @@ fun JustLiftScreen(navController: NavController, viewModel: MainViewModel, theme
                 Card(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .then(if (useCompactAccessibility) Modifier else Modifier.weight(1f)),
+                        .then(if (stackWeightCards) Modifier else Modifier.weight(1f)),
                     colors = CardDefaults.cardColors(
                         containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
                     ),
@@ -409,7 +416,7 @@ fun JustLiftScreen(navController: NavController, viewModel: MainViewModel, theme
                 ) {
                     Column(
                         modifier = Modifier
-                            .then(if (useCompactAccessibility) Modifier.fillMaxWidth() else Modifier.fillMaxSize())
+                            .then(if (stackWeightCards) Modifier.fillMaxWidth() else Modifier.fillMaxSize())
                             .padding(Spacing.medium),
                         verticalArrangement = Arrangement.Center,
                     ) {
@@ -453,11 +460,19 @@ fun JustLiftScreen(navController: NavController, viewModel: MainViewModel, theme
                     }
                 }
 
+                // Issue #571: belt-and-braces vertical separation between the two cards
+                // when stacked, so the wheel's bottom edge is unambiguously above the slider's
+                // top edge even if the inner gesture-isolation step in CompactNumberPicker
+                // is bypassed by a future regression.
+                if (stackWeightCards) {
+                    Spacer(modifier = Modifier.height(Spacing.small))
+                }
+
                 // Weight Change Per Rep Card
                 Card(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .then(if (useCompactAccessibility) Modifier else Modifier.weight(1f)),
+                        .then(if (stackWeightCards) Modifier else Modifier.weight(1f)),
                     colors = CardDefaults.cardColors(
                         containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
                     ),
@@ -465,9 +480,9 @@ fun JustLiftScreen(navController: NavController, viewModel: MainViewModel, theme
                 ) {
                     Column(
                         modifier = Modifier
-                            .then(if (useCompactAccessibility) Modifier.fillMaxWidth() else Modifier.fillMaxSize())
+                            .then(if (stackWeightCards) Modifier.fillMaxWidth() else Modifier.fillMaxSize())
                             .padding(Spacing.medium),
-                        verticalArrangement = if (useCompactAccessibility) {
+                        verticalArrangement = if (stackWeightCards) {
                             Arrangement.spacedBy(Spacing.small)
                         } else {
                             Arrangement.SpaceEvenly

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/util/WindowSizeClass.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/util/WindowSizeClass.kt
@@ -107,6 +107,44 @@ fun shouldUseCompactAccessibilityLayout(
         )
 
 /**
+ * Issue #571: Decide whether the Weight per Cable and Weight Change Per Rep cards in
+ * JustLiftScreen should be stacked vertically (one column) or side-by-side (two columns).
+ *
+ * Stacking on iPhone portrait puts the iOS CompactNumberPicker wheel directly above the
+ * ProgressionSlider, and the wheel's vertical LazyColumn has been observed to claim
+ * drags intended for the slider (the visible readout would jump to neighbour weights
+ * like 29/30/44-49 even though the slider's valueRange is -10..+10). To avoid that
+ * gesture conflict by construction, keep the cards side-by-side on iPhone portrait
+ * (width Compact) unless the height is also Compact — the only compact-width+short-height
+ * case (iPhone landscape, 740×390dp) genuinely needs the stacked layout to fit.
+ *
+ * Tablets (width Medium/Expanded) always keep the side-by-side layout.
+ */
+fun shouldStackWeightCards(
+    windowSizeClass: WindowSizeClass,
+    fontScale: Float,
+    boldTextEnabled: Boolean,
+    fontScaleThreshold: Float = 1.15f,
+): Boolean = shouldUseCompactAccessibilityLayout(
+    windowSizeClass = windowSizeClass,
+    fontScale = fontScale,
+    boldTextEnabled = boldTextEnabled,
+    fontScaleThreshold = fontScaleThreshold,
+) && windowSizeClass.heightSizeClass == WindowHeightSizeClass.Compact
+
+/**
+ * Issue #571: Composable convenience wrapper around [shouldStackWeightCards] that reads
+ * the current WindowSizeClass, font scale, and accessibility settings from the ambient
+ * composition locals. Use this in Composables; use the pure function in unit tests.
+ */
+@Composable
+fun useStackedWeightCardsLayout(): Boolean = shouldStackWeightCards(
+    windowSizeClass = LocalWindowSizeClass.current,
+    fontScale = LocalDensity.current.fontScale,
+    boldTextEnabled = LocalPlatformAccessibilitySettings.current.boldTextEnabled,
+)
+
+/**
  * Responsive dimension helpers for common UI patterns.
  */
 object ResponsiveDimensions {

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/util/WindowSizeClass.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/util/WindowSizeClass.kt
@@ -119,29 +119,26 @@ fun shouldUseCompactAccessibilityLayout(
  * case (iPhone landscape, 740×390dp) genuinely needs the stacked layout to fit.
  *
  * Tablets (width Medium/Expanded) always keep the side-by-side layout.
+ *
+ * Note: this is mathematically equivalent to `shouldUseCompactAccessibilityLayout(...) &&
+ * height == Compact` because the latter already returns true for compact heights. The
+ * extra OR-clause ("Compact width + (large font OR bold text)") is what makes the broader
+ * compact-accessibility layout true on tall portrait phones, and we explicitly do NOT
+ * want that case to also stack the weight cards. So the helper is reduced to its
+ * non-redundant form: just the short-height case.
  */
 fun shouldStackWeightCards(
     windowSizeClass: WindowSizeClass,
-    fontScale: Float,
-    boldTextEnabled: Boolean,
-    fontScaleThreshold: Float = 1.15f,
-): Boolean = shouldUseCompactAccessibilityLayout(
-    windowSizeClass = windowSizeClass,
-    fontScale = fontScale,
-    boldTextEnabled = boldTextEnabled,
-    fontScaleThreshold = fontScaleThreshold,
-) && windowSizeClass.heightSizeClass == WindowHeightSizeClass.Compact
+): Boolean = windowSizeClass.heightSizeClass == WindowHeightSizeClass.Compact
 
 /**
  * Issue #571: Composable convenience wrapper around [shouldStackWeightCards] that reads
- * the current WindowSizeClass, font scale, and accessibility settings from the ambient
- * composition locals. Use this in Composables; use the pure function in unit tests.
+ * the current WindowSizeClass from the ambient composition local. Use this in Composables;
+ * use the pure function in unit tests.
  */
 @Composable
 fun useStackedWeightCardsLayout(): Boolean = shouldStackWeightCards(
     windowSizeClass = LocalWindowSizeClass.current,
-    fontScale = LocalDensity.current.fontScale,
-    boldTextEnabled = LocalPlatformAccessibilitySettings.current.boldTextEnabled,
 )
 
 /**

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/JustLiftScreenWeightSliderWiringTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/JustLiftScreenWeightSliderWiringTest.kt
@@ -1,0 +1,128 @@
+package com.devil.phoenixproject.presentation
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Issue #571: Regression guard for the "Weight Change Per Rep slider doesn't allow
+ * 1 lb increments" bug.
+ *
+ * The original report claimed the slider's step size was wrong (e.g. 1 → 2 → 29 → 30
+ * → 44 → 45 → 49). The RCA proved the slider is correctly bound to
+ * `valueRange = -10f..10f` with `steps = 19` (i.e. 21 stops → step size 1 lb) and
+ * cannot produce those values. The reported values came from the iOS wheel's
+ * neighbour weights being routed to the wrong state.
+ *
+ * These tests pin the Just Lift slider wiring down at the source level so a future
+ * refactor cannot accidentally widen the range, change the step, or rebind the
+ * slider to `weightPerCable`. They also verify the wheel/slider gate uses the
+ * short-height-only [com.devil.phoenixproject.presentation.util.shouldStackWeightCards]
+ * helper, not the broader [com.devil.phoenixproject.presentation.util.shouldUseCompactAccessibilityLayout]
+ * flag.
+ */
+class JustLiftScreenWeightSliderWiringTest {
+
+    @Test
+    fun progressionSliderWiring_pinsValueRangeAndStepCount() {
+        val src = readJustLiftScreenSource()
+
+        // Lock down the explicit valueRange on the ProgressionSlider call site.
+        assertTrue(
+            src.contains("valueRange = -10f..10f"),
+            "JustLiftScreen.kt must keep ProgressionSlider(valueRange = -10f..10f). " +
+                "Changing this widens the slider's allowed values and reintroduces the " +
+                "issue #571 regression where 29/30/44-49 could appear on screen.",
+        )
+    }
+
+    @Test
+    fun progressionSliderWiring_pinsWeightChangePerRepBinding() {
+        val src = readJustLiftScreenSource()
+
+        // The slider must be bound to weightChangePerRep, not weightPerCable.
+        // The reporter's "44/45/46" jump only happened because the wheel (which
+        // writes weightPerCable) was being touched while the user was reading the
+        // slider. Both controls must keep their own independent bindings.
+        val onValueChangeLine = Regex(
+            "ProgressionSlider\\s*\\(([\\s\\S]*?)onValueChange\\s*=\\s*\\{([\\s\\S]*?)\\}\\s*,",
+            setOf(RegexOption.DOT_MATCHES_ALL),
+        ).find(src)?.value
+            ?: error("Could not find the ProgressionSlider onValueChange in JustLiftScreen.kt")
+
+        assertTrue(
+            onValueChangeLine.contains("weightChangePerRep"),
+            "ProgressionSlider.onValueChange must write to weightChangePerRep. " +
+                "Found: $onValueChangeLine",
+        )
+        assertTrue(
+            !onValueChangeLine.contains("weightPerCable"),
+            "ProgressionSlider.onValueChange must not write to weightPerCable. " +
+                "Found: $onValueChangeLine",
+        )
+    }
+
+    @Test
+    fun justLiftScreen_usesStackedWeightCardsGateForWeightCards() {
+        val src = readJustLiftScreenSource()
+
+        // The Weight per Cable and Weight Change Per Rep cards must be gated on
+        // stackWeightCards, not the broader useCompactAccessibility. Otherwise the
+        // iOS wheel can land directly above the slider and steal drags.
+        assertTrue(
+            src.contains("useStackedWeightCardsLayout") || src.contains("shouldStackWeightCards"),
+            "JustLiftScreen.kt must compute the weight-card layout gate via " +
+                "useStackedWeightCardsLayout() (or shouldStackWeightCards(...)) so the " +
+                "iOS wheel does not land directly above the ProgressionSlider on iPhone " +
+                "portrait. See Issue #571 RCA.",
+        )
+    }
+
+    @Test
+    fun justLiftScreen_usesCompactAccessibilityForOuterScrollOnly() {
+        val src = readJustLiftScreenSource()
+
+        // The outer verticalScroll + outer column's verticalArrangement can still
+        // use the broader useCompactAccessibility gate — that one governs the
+        // whole screen's scroll behavior, not just the weight cards. This test
+        // documents that decision so a future refactor does not unify the two
+        // gates by accident.
+        val scrollCall = src.contains("verticalScroll(contentScrollState)")
+        assertTrue(
+            scrollCall,
+            "JustLiftScreen.kt should still drive the outer scroll on useCompactAccessibility. " +
+                "If you are removing this, see issue #571 RCA — the outer scroll is correct; " +
+                "only the inner weight-card gate was wrong.",
+        )
+    }
+
+    private fun readJustLiftScreenSource(): String {
+        // Read from the classpath via the resources directory, or fall back to the
+        // project root. The test is allowed to read the source file because it
+        // runs in the commonTest source set of the same Gradle module that owns
+        // JustLiftScreen.kt. Working directory resolution: try the explicit
+        // path first, then walk up to find a gradle root.
+        val relativePath =
+            "src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/JustLiftScreen.kt"
+        val candidates = mutableListOf<java.io.File>()
+        candidates.add(java.io.File(relativePath))
+        // Walk up looking for a `shared` or `.git` marker to anchor the search.
+        var dir: java.io.File? = java.io.File(".").absoluteFile
+        repeat(6) {
+            if (dir == null) return@repeat
+            candidates.add(java.io.File(dir, "shared/$relativePath"))
+            if (java.io.File(dir, ".git").exists() || java.io.File(dir, "settings.gradle.kts").exists()) {
+                candidates.add(java.io.File(dir, relativePath))
+            }
+            dir = dir.parentFile
+        }
+        for (file in candidates) {
+            if (file.exists()) return file.readText()
+        }
+        error(
+            "Could not locate JustLiftScreen.kt on disk. Searched: " +
+                candidates.joinToString(", ") { it.path } +
+                ". Run the test from the shared/ module's working directory.",
+        )
+    }
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/JustLiftScreenWeightSliderWiringTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/JustLiftScreenWeightSliderWiringTest.kt
@@ -1,7 +1,9 @@
 package com.devil.phoenixproject.presentation
 
+import com.devil.phoenixproject.testutil.readProjectFile
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 /**
@@ -123,32 +125,19 @@ class JustLiftScreenWeightSliderWiringTest {
     }
 
     private fun readJustLiftScreenSource(): String {
-        // Read from the classpath via the resources directory, or fall back to the
-        // project root. The test is allowed to read the source file because it
-        // runs in the commonTest source set of the same Gradle module that owns
-        // JustLiftScreen.kt. Working directory resolution: try the explicit
-        // path first, then walk up to find a gradle root.
+        // Read from disk via the KMP-compatible `readProjectFile` expect/actual helper
+        // (under testutil/). The test runs in commonTest of the same Gradle module that
+        // owns JustLiftScreen.kt, so a working-directory-relative lookup is enough.
         val relativePath =
             "src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/JustLiftScreen.kt"
-        val candidates = mutableListOf<java.io.File>()
-        candidates.add(java.io.File(relativePath))
-        // Walk up looking for a `shared` or `.git` marker to anchor the search.
-        var dir: java.io.File? = java.io.File(".").absoluteFile
-        repeat(6) {
-            if (dir == null) return@repeat
-            candidates.add(java.io.File(dir, "shared/$relativePath"))
-            if (java.io.File(dir, ".git").exists() || java.io.File(dir, "settings.gradle.kts").exists()) {
-                candidates.add(java.io.File(dir, relativePath))
-            }
-            dir = dir.parentFile
-        }
-        for (file in candidates) {
-            if (file.exists()) return file.readText()
-        }
-        error(
-            "Could not locate JustLiftScreen.kt on disk. Searched: " +
-                candidates.joinToString(", ") { it.path } +
-                ". Run the test from the shared/ module's working directory.",
+        val src = readProjectFile(relativePath)
+        assertNotNull(
+            src,
+            "Could not locate JustLiftScreen.kt on disk. The test relies on the project " +
+                "root being discoverable from the test runner's working directory. " +
+                "If you are running this from an unusual cwd, set the working directory " +
+                "to the shared/ module's root before invoking the test.",
         )
+        return src
     }
 }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/JustLiftScreenWeightSliderWiringTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/JustLiftScreenWeightSliderWiringTest.kt
@@ -20,6 +20,32 @@ import kotlin.test.assertTrue
  * short-height-only [com.devil.phoenixproject.presentation.util.shouldStackWeightCards]
  * helper, not the broader [com.devil.phoenixproject.presentation.util.shouldUseCompactAccessibilityLayout]
  * flag.
+ *
+ * ## Why static analysis instead of Compose UI tests?
+ *
+ * This file reads `JustLiftScreen.kt` from disk and asserts on its source text.
+ * That is intentionally a known fragile-test anti-pattern (Gemini review on PR #574).
+ * We keep it because:
+ *
+ * 1. The bug class is "the widget is wired wrong" — slider bound to the wrong state,
+ *    `valueRange` widened, gate helper swapped. These are *source-level* invariants.
+ *    A Compose UI test would still pass if a refactor accidentally rebinds
+ *    `onValueChange = { weightPerCable = it }` (the UI looks identical; the bug
+ *    only shows up downstream when the wrong state is read).
+ * 2. Compose UI tests in this repo currently cover behaviour, not wiring (see
+ *    `WindowSizeClassTest`). Adding a Compose UI test for JustLiftScreen would
+ *    require additional compose-test runtime + Robolectric wiring that this PR
+ *    does not introduce (out of scope for the issue #571 fix).
+ * 3. The tests are scoped to a small set of exact string assertions, not full
+ *    parsing. They are cheap to maintain and produce a clear failure message
+ *    pointing at the regression. A future refactor that legitimately restructures
+ *    the file will need to update these strings — that is the intended failure mode.
+ *
+ * When the repo gains a Compose UI test harness for JustLiftScreen, these static
+ * assertions should be replaced with semantic assertions on the rendered
+ * composition (e.g. `composeTestRule.onNodeWithText("+1").performTouchInput { swipeRight() }
+ * .assertTextEquals("+2")`). See the PR #574 review thread for the original
+ * suggestion and the long-term migration plan.
  */
 class JustLiftScreenWeightSliderWiringTest {
 

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/util/WindowSizeClassTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/util/WindowSizeClassTest.kt
@@ -2,6 +2,7 @@ package com.devil.phoenixproject.presentation.util
 
 import androidx.compose.ui.unit.dp
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -115,6 +116,13 @@ class WindowSizeClassTest {
     }
 
     // ========== Issue #571: shouldStackWeightCards ==========
+    //
+    // The helper is reduced to `heightSizeClass == Compact` (see WindowSizeClass.kt). The
+    // previous signature also took fontScale/boldTextEnabled/fontScaleThreshold, but those
+    // parameters were dead code (see Gemini review on PR #574 — the broader
+    // `shouldUseCompactAccessibilityLayout` already returns true for compact heights, so
+    // the `&&` was a no-op). Tests are intentionally exhaustive over the 3 size-class
+    // dimensions to lock down the exact behaviour.
 
     @Test
     fun stackWeightCards_iPhone16ProPortraitDefaultTypographyStaysSideBySide() {
@@ -130,20 +138,21 @@ class WindowSizeClassTest {
         )
 
         assertFalse(
-            shouldStackWeightCards(
-                windowSizeClass = window,
-                fontScale = 1f,
-                boldTextEnabled = false,
-            ),
+            shouldStackWeightCards(windowSizeClass = window),
+            "iPhone 16 Pro portrait (height=Medium) must NOT stack the weight cards. " +
+                "Stacking on a tall portrait device is what caused the gesture-stealing " +
+                "bug in #571.",
         )
     }
 
     @Test
     fun stackWeightCards_iPhone16ProPortraitWithBoldTextStaysSideBySide() {
-        // Bold Text on (compact width + medium height) is a stacked candidate, but
-        // unless the height is also compact we should still keep the weight cards
+        // Bold Text on (compact width + medium height) was previously a stacked candidate,
+        // but unless the height is also compact we should still keep the weight cards
         // side-by-side. Stacking them on a tall portrait device is what caused the
-        // gesture-stealing bug in #571.
+        // gesture-stealing bug in #571. Note: the new helper signature no longer takes
+        // boldTextEnabled, so this test is now a documentation guard that *removing* the
+        // parameter did not change behaviour — Bold Text cannot induce stacking.
         val window = WindowSizeClass(
             widthSizeClass = WindowWidthSizeClass.Compact,
             heightSizeClass = WindowHeightSizeClass.Medium,
@@ -152,11 +161,9 @@ class WindowSizeClassTest {
         )
 
         assertFalse(
-            shouldStackWeightCards(
-                windowSizeClass = window,
-                fontScale = 1f,
-                boldTextEnabled = true,
-            ),
+            shouldStackWeightCards(windowSizeClass = window),
+            "Bold Text no longer influences shouldStackWeightCards; tall portrait is " +
+                "always side-by-side.",
         )
     }
 
@@ -172,11 +179,7 @@ class WindowSizeClassTest {
         )
 
         assertTrue(
-            shouldStackWeightCards(
-                windowSizeClass = window,
-                fontScale = 1f,
-                boldTextEnabled = false,
-            ),
+            shouldStackWeightCards(windowSizeClass = window),
         )
     }
 
@@ -192,18 +195,15 @@ class WindowSizeClassTest {
         )
 
         assertTrue(
-            shouldStackWeightCards(
-                windowSizeClass = window,
-                fontScale = 1f,
-                boldTextEnabled = false,
-            ),
+            shouldStackWeightCards(windowSizeClass = window),
         )
     }
 
     @Test
     fun stackWeightCards_tallTabletStaysSideBySide() {
         // Tablets and large phones (width Medium/Expanded) with normal height should
-        // never stack the weight cards.
+        // never stack the weight cards. Width does not influence the helper, so a tablet
+        // here behaves the same as any other window with height=Medium.
         val window = WindowSizeClass(
             widthSizeClass = WindowWidthSizeClass.Expanded,
             heightSizeClass = WindowHeightSizeClass.Medium,
@@ -212,54 +212,38 @@ class WindowSizeClassTest {
         )
 
         assertFalse(
-            shouldStackWeightCards(
-                windowSizeClass = window,
-                fontScale = 1.3f,
-                boldTextEnabled = true,
-            ),
+            shouldStackWeightCards(windowSizeClass = window),
         )
     }
 
     @Test
-    fun stackWeightCards_consistentWithCompactAccessibilityGating() {
-        // Invariant: if shouldStackWeightCards is true, then
-        // shouldUseCompactAccessibilityLayout must also be true. The reverse is NOT
-        // required: there are cases (compact width + medium height + bold text) where
-        // the screen is "compact accessibility" overall but the weight cards should
-        // still stay side-by-side (issue #571).
-        val cases = listOf(
-            Triple(WindowWidthSizeClass.Compact, WindowHeightSizeClass.Compact, 1f),
-            Triple(WindowWidthSizeClass.Compact, WindowHeightSizeClass.Compact, 1.2f),
-            Triple(WindowWidthSizeClass.Compact, WindowHeightSizeClass.Medium, 1f),
-            Triple(WindowWidthSizeClass.Compact, WindowHeightSizeClass.Medium, 1.2f),
-            Triple(WindowWidthSizeClass.Compact, WindowHeightSizeClass.Expanded, 1f),
-            Triple(WindowWidthSizeClass.Medium, WindowHeightSizeClass.Compact, 1f),
-            Triple(WindowWidthSizeClass.Medium, WindowHeightSizeClass.Medium, 1.2f),
-            Triple(WindowWidthSizeClass.Expanded, WindowHeightSizeClass.Compact, 1f),
-            Triple(WindowWidthSizeClass.Expanded, WindowHeightSizeClass.Medium, 1.2f),
+    fun stackWeightCards_heightIsTheSoleDeterminant() {
+        // Documents the simplified contract: heightSizeClass == Compact is the only
+        // input. widthSizeClass and accessibility settings do not influence the result.
+        val heightCases = mapOf(
+            WindowHeightSizeClass.Compact to true,
+            WindowHeightSizeClass.Medium to false,
+            WindowHeightSizeClass.Expanded to false,
         )
-        for ((widthClass, heightClass, fontScale) in cases) {
-            for (boldText in listOf(false, true)) {
+        val widthCases = listOf(
+            WindowWidthSizeClass.Compact,
+            WindowWidthSizeClass.Medium,
+            WindowWidthSizeClass.Expanded,
+        )
+        for ((height, expectedStack) in heightCases) {
+            for (width in widthCases) {
                 val window = WindowSizeClass(
-                    widthSizeClass = widthClass,
-                    heightSizeClass = heightClass,
+                    widthSizeClass = width,
+                    heightSizeClass = height,
                     widthDp = 400.dp,
                     heightDp = 800.dp,
                 )
-                val compact = shouldUseCompactAccessibilityLayout(
-                    windowSizeClass = window,
-                    fontScale = fontScale,
-                    boldTextEnabled = boldText,
-                )
-                val stack = shouldStackWeightCards(
-                    windowSizeClass = window,
-                    fontScale = fontScale,
-                    boldTextEnabled = boldText,
-                )
-                assertTrue(
-                    !stack || compact,
-                    "Invariant violated for ${widthClass}/${heightClass}/fs=$fontScale/bold=$boldText: " +
-                        "stack=$stack but compact=$compact (stack must imply compact)",
+                val stack = shouldStackWeightCards(windowSizeClass = window)
+                assertEquals(
+                    expectedStack,
+                    stack,
+                    "shouldStackWeightCards must be determined solely by heightSizeClass. " +
+                        "Failed for width=$width, height=$height (expected=$expectedStack, got=$stack).",
                 )
             }
         }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/util/WindowSizeClassTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/util/WindowSizeClassTest.kt
@@ -113,4 +113,155 @@ class WindowSizeClassTest {
             ),
         )
     }
+
+    // ========== Issue #571: shouldStackWeightCards ==========
+
+    @Test
+    fun stackWeightCards_iPhone16ProPortraitDefaultTypographyStaysSideBySide() {
+        // The bug: on iPhone 16 Pro portrait (402x874dp) with default Dynamic Type
+        // and Bold Text off, the iOS CompactNumberPicker wheel eats drags intended
+        // for the ProgressionSlider. Default iPhone portrait should keep the two
+        // weight cards side-by-side, not stacked.
+        val window = WindowSizeClass(
+            widthSizeClass = WindowWidthSizeClass.Compact,
+            heightSizeClass = WindowHeightSizeClass.Medium,
+            widthDp = 402.dp,
+            heightDp = 874.dp,
+        )
+
+        assertFalse(
+            shouldStackWeightCards(
+                windowSizeClass = window,
+                fontScale = 1f,
+                boldTextEnabled = false,
+            ),
+        )
+    }
+
+    @Test
+    fun stackWeightCards_iPhone16ProPortraitWithBoldTextStaysSideBySide() {
+        // Bold Text on (compact width + medium height) is a stacked candidate, but
+        // unless the height is also compact we should still keep the weight cards
+        // side-by-side. Stacking them on a tall portrait device is what caused the
+        // gesture-stealing bug in #571.
+        val window = WindowSizeClass(
+            widthSizeClass = WindowWidthSizeClass.Compact,
+            heightSizeClass = WindowHeightSizeClass.Medium,
+            widthDp = 402.dp,
+            heightDp = 874.dp,
+        )
+
+        assertFalse(
+            shouldStackWeightCards(
+                windowSizeClass = window,
+                fontScale = 1f,
+                boldTextEnabled = true,
+            ),
+        )
+    }
+
+    @Test
+    fun stackWeightCards_iPhoneLandscapeShortHeightStacksBothCards() {
+        // iPhone landscape (740x390dp) genuinely needs the stacked layout to fit.
+        // heightSizeClass == Compact + widthSizeClass == Compact ⇒ stack.
+        val window = WindowSizeClass(
+            widthSizeClass = WindowWidthSizeClass.Compact,
+            heightSizeClass = WindowHeightSizeClass.Compact,
+            widthDp = 740.dp,
+            heightDp = 390.dp,
+        )
+
+        assertTrue(
+            shouldStackWeightCards(
+                windowSizeClass = window,
+                fontScale = 1f,
+                boldTextEnabled = false,
+            ),
+        )
+    }
+
+    @Test
+    fun stackWeightCards_shortHeightTabletStacks() {
+        // A short-height medium-width window (e.g. iPad mini landscape with
+        // split-screen) is also forced to the stacked layout.
+        val window = WindowSizeClass(
+            widthSizeClass = WindowWidthSizeClass.Medium,
+            heightSizeClass = WindowHeightSizeClass.Compact,
+            widthDp = 700.dp,
+            heightDp = 440.dp,
+        )
+
+        assertTrue(
+            shouldStackWeightCards(
+                windowSizeClass = window,
+                fontScale = 1f,
+                boldTextEnabled = false,
+            ),
+        )
+    }
+
+    @Test
+    fun stackWeightCards_tallTabletStaysSideBySide() {
+        // Tablets and large phones (width Medium/Expanded) with normal height should
+        // never stack the weight cards.
+        val window = WindowSizeClass(
+            widthSizeClass = WindowWidthSizeClass.Expanded,
+            heightSizeClass = WindowHeightSizeClass.Medium,
+            widthDp = 900.dp,
+            heightDp = 1200.dp,
+        )
+
+        assertFalse(
+            shouldStackWeightCards(
+                windowSizeClass = window,
+                fontScale = 1.3f,
+                boldTextEnabled = true,
+            ),
+        )
+    }
+
+    @Test
+    fun stackWeightCards_consistentWithCompactAccessibilityGating() {
+        // Invariant: if shouldStackWeightCards is true, then
+        // shouldUseCompactAccessibilityLayout must also be true. The reverse is NOT
+        // required: there are cases (compact width + medium height + bold text) where
+        // the screen is "compact accessibility" overall but the weight cards should
+        // still stay side-by-side (issue #571).
+        val cases = listOf(
+            Triple(WindowWidthSizeClass.Compact, WindowHeightSizeClass.Compact, 1f),
+            Triple(WindowWidthSizeClass.Compact, WindowHeightSizeClass.Compact, 1.2f),
+            Triple(WindowWidthSizeClass.Compact, WindowHeightSizeClass.Medium, 1f),
+            Triple(WindowWidthSizeClass.Compact, WindowHeightSizeClass.Medium, 1.2f),
+            Triple(WindowWidthSizeClass.Compact, WindowHeightSizeClass.Expanded, 1f),
+            Triple(WindowWidthSizeClass.Medium, WindowHeightSizeClass.Compact, 1f),
+            Triple(WindowWidthSizeClass.Medium, WindowHeightSizeClass.Medium, 1.2f),
+            Triple(WindowWidthSizeClass.Expanded, WindowHeightSizeClass.Compact, 1f),
+            Triple(WindowWidthSizeClass.Expanded, WindowHeightSizeClass.Medium, 1.2f),
+        )
+        for ((widthClass, heightClass, fontScale) in cases) {
+            for (boldText in listOf(false, true)) {
+                val window = WindowSizeClass(
+                    widthSizeClass = widthClass,
+                    heightSizeClass = heightClass,
+                    widthDp = 400.dp,
+                    heightDp = 800.dp,
+                )
+                val compact = shouldUseCompactAccessibilityLayout(
+                    windowSizeClass = window,
+                    fontScale = fontScale,
+                    boldTextEnabled = boldText,
+                )
+                val stack = shouldStackWeightCards(
+                    windowSizeClass = window,
+                    fontScale = fontScale,
+                    boldTextEnabled = boldText,
+                )
+                assertTrue(
+                    !stack || compact,
+                    "Invariant violated for ${widthClass}/${heightClass}/fs=$fontScale/bold=$boldText: " +
+                        "stack=$stack but compact=$compact (stack must imply compact)",
+                )
+            }
+        }
+    }
 }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/SourceFileReader.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/SourceFileReader.kt
@@ -1,0 +1,13 @@
+package com.devil.phoenixproject.testutil
+
+/**
+ * KMP-compatible source-file reader used by tests that need to assert on the
+ * text of a production source file. The iOS target does not expose `java.io.File`,
+ * so we provide a small `expect/actual` shim that the per-platform source set
+ * implements using the platform's native file API.
+ *
+ * The intent is "I want to read a file under the project root from a commonTest
+ * test". A failure to read a file is returned as `null` so the caller can produce
+ * a useful assertion message with the candidate paths it tried.
+ */
+expect fun readProjectFile(relativePath: String): String?

--- a/shared/src/iosMain/kotlin/com/devil/phoenixproject/presentation/components/CompactNumberPicker.ios.kt
+++ b/shared/src/iosMain/kotlin/com/devil/phoenixproject/presentation/components/CompactNumberPicker.ios.kt
@@ -191,6 +191,12 @@ actual fun CompactNumberPicker(
     // Inline editing state
     var isEditing by remember { mutableStateOf(false) }
     var inputText by remember { mutableStateOf("") }
+    // Issue #571: True iff the most recent vertical drag started inside the wheel's centred
+    // band (the actual pickable row). Drives `userScrollEnabled` on the LazyColumn below so
+    // drags that start *outside* the centred band are NOT claimed by the wheel — they pass
+    // through to the outer verticalScroll / sibling card (the slider) instead. See pointerInput
+    // block on BoxWithConstraints for the gesture detector.
+    var dragStartedInCenterBand by remember { mutableStateOf(true) }
     // Issue #166 Fix: Track focus state per edit session to prevent premature commitEdit
     // hasFocusedOnce is ONLY true after focus is gained in the CURRENT edit session
     var hasFocusedOnce by remember { mutableStateOf(false) }
@@ -465,13 +471,14 @@ actual fun CompactNumberPicker(
                     .weight(1f)
                     .height(containerHeight)
                     // Issue #571: cap the wheel's vertical drag hot zone to the centred
-                    // selected row when not in edit mode. Drags landing above or below
-                    // the centred band are consumed at the wheel level so the inner
-                    // LazyColumn does not claim them, letting the outer verticalScroll
-                    // take over and freeing the gesture to reach the slider card below
-                    // when the two cards are stacked. In edit mode, the wheel defers
-                    // entirely to the BasicTextField so keyboard / caret interaction
-                    // is not interrupted.
+                    // selected row when not in edit mode. We do this by tracking where each
+                    // vertical drag *started* (centred band vs. outside it) and gating the
+                    // inner LazyColumn's `userScrollEnabled` on that flag. When the drag
+                    // starts outside the centred band, the LazyColumn does not claim the
+                    // gesture, so the outer verticalScroll and the sibling ProgressionSlider
+                    // card can take over naturally — no "dead zone", no event consumption.
+                    // In edit mode the wheel defers entirely to the BasicTextField so
+                    // keyboard / caret interaction is not interrupted.
                     .pointerInput(isEditing, itemHeight) {
                         if (isEditing) return@pointerInput
                         val itemHeightPx: Float = itemHeight.toPx()
@@ -481,22 +488,19 @@ actual fun CompactNumberPicker(
                             val offset: Float = down.position.y - centerY
                             val absOffset: Float = if (offset < 0f) -offset else offset
                             val inCenterBand: Boolean = absOffset <= itemHeightPx / 2f
-                            if (inCenterBand) {
-                                // Let the inner LazyColumn handle this gesture as before.
-                                return@awaitEachGesture
-                            }
-                            // Outside the centred band: consume the down so the LazyColumn
-                            // does not claim it. The outer verticalScroll / sibling card
-                            // can then take the drag.
-                            down.consume()
-                            // Track until release so we don't get re-entered mid-gesture.
+                            // Toggle the gate BEFORE the LazyColumn sees the gesture so the
+                            // inner scroll connection can make its decision in the same
+                            // pass. We do not consume any events — the outer verticalScroll
+                            // is free to scroll when we say so.
+                            dragStartedInCenterBand = inCenterBand
+                            // Wait for the gesture to finish, then restore the default
+                            // (centred band = scrollable) so a *next* drag that does land
+                            // in the band still scrolls the wheel.
                             while (true) {
                                 val event = awaitPointerEvent()
                                 if (event.changes.all { !it.pressed }) break
-                                // Consume movement too so parent verticalScroll's nested
-                                // scroll connection does not interfere.
-                                event.changes.forEach { it.consume() }
                             }
+                            dragStartedInCenterBand = true
                         }
                     },
                 contentAlignment = Alignment.Center,
@@ -515,6 +519,13 @@ actual fun CompactNumberPicker(
                     flingBehavior = flingBehavior,
                     horizontalAlignment = Alignment.CenterHorizontally,
                     contentPadding = PaddingValues(vertical = centerPadding),
+                    // Issue #571: when the current vertical drag started outside the wheel's
+                    // centred band, disable the inner scroll so the outer verticalScroll
+                    // (or the sibling ProgressionSlider card) can claim the gesture. The
+                    // `pointerInput` above toggles `dragStartedInCenterBand` synchronously
+                    // with `awaitFirstDown`, so this flag is correct for the very first
+                    // event the LazyColumn sees in each gesture.
+                    userScrollEnabled = dragStartedInCenterBand,
                     modifier = Modifier.fillMaxSize(),
                 ) {
                     itemsIndexed(values) { index, floatVal ->

--- a/shared/src/iosMain/kotlin/com/devil/phoenixproject/presentation/components/CompactNumberPicker.ios.kt
+++ b/shared/src/iosMain/kotlin/com/devil/phoenixproject/presentation/components/CompactNumberPicker.ios.kt
@@ -1,5 +1,7 @@
 package com.devil.phoenixproject.presentation.components
 
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
 import androidx.compose.foundation.interaction.DragInteraction
 import androidx.compose.foundation.layout.Arrangement
@@ -46,6 +48,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.TextStyle
@@ -460,7 +463,42 @@ actual fun CompactNumberPicker(
             BoxWithConstraints(
                 modifier = Modifier
                     .weight(1f)
-                    .height(containerHeight),
+                    .height(containerHeight)
+                    // Issue #571: cap the wheel's vertical drag hot zone to the centred
+                    // selected row when not in edit mode. Drags landing above or below
+                    // the centred band are consumed at the wheel level so the inner
+                    // LazyColumn does not claim them, letting the outer verticalScroll
+                    // take over and freeing the gesture to reach the slider card below
+                    // when the two cards are stacked. In edit mode, the wheel defers
+                    // entirely to the BasicTextField so keyboard / caret interaction
+                    // is not interrupted.
+                    .pointerInput(isEditing, itemHeight) {
+                        if (isEditing) return@pointerInput
+                        val itemHeightPx: Float = itemHeight.toPx()
+                        val centerY: Float = size.height.toFloat() / 2f
+                        awaitEachGesture {
+                            val down = awaitFirstDown(requireUnconsumed = false)
+                            val offset: Float = down.position.y - centerY
+                            val absOffset: Float = if (offset < 0f) -offset else offset
+                            val inCenterBand: Boolean = absOffset <= itemHeightPx / 2f
+                            if (inCenterBand) {
+                                // Let the inner LazyColumn handle this gesture as before.
+                                return@awaitEachGesture
+                            }
+                            // Outside the centred band: consume the down so the LazyColumn
+                            // does not claim it. The outer verticalScroll / sibling card
+                            // can then take the drag.
+                            down.consume()
+                            // Track until release so we don't get re-entered mid-gesture.
+                            while (true) {
+                                val event = awaitPointerEvent()
+                                if (event.changes.all { !it.pressed }) break
+                                // Consume movement too so parent verticalScroll's nested
+                                // scroll connection does not interfere.
+                                event.changes.forEach { it.consume() }
+                            }
+                        }
+                    },
                 contentAlignment = Alignment.Center,
             ) {
                 val showCenteredOverlay = !isEditing && values.isNotEmpty()

--- a/shared/src/iosTest/kotlin/com/devil/phoenixproject/testutil/SourceFileReader.ios.kt
+++ b/shared/src/iosTest/kotlin/com/devil/phoenixproject/testutil/SourceFileReader.ios.kt
@@ -1,0 +1,51 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
+package com.devil.phoenixproject.testutil
+
+import platform.Foundation.NSFileManager
+import platform.Foundation.NSString
+import platform.Foundation.NSUTF8StringEncoding
+import platform.Foundation.stringWithContentsOfFile
+
+/**
+ * iOS test implementation of [readProjectFile]. Walks up from the current
+ * working directory looking for either `shared/<path>` or `<path>` (when a
+ * `.git` / `settings.gradle.kts` marker is hit) and returns the file's text,
+ * or null if the file cannot be located.
+ *
+ * The Xcode test runner's working directory may differ between local runs and
+ * CI; the up-walk makes this robust without changing the test's public API.
+ */
+actual fun readProjectFile(relativePath: String): String? {
+    val fm = NSFileManager.defaultManager
+    val cwd = fm.currentDirectoryPath
+
+    // Build the candidate list: cwd, then up to 6 parent directories.
+    val candidates = mutableListOf<String>()
+    candidates.add("$cwd/$relativePath")
+    var dir: String? = cwd
+    repeat(6) {
+        if (dir == null) return@repeat
+        candidates.add("$dir/shared/$relativePath")
+        if (fm.fileExistsAtPath("$dir/.git") || fm.fileExistsAtPath("$dir/settings.gradle.kts")) {
+            candidates.add("$dir/$relativePath")
+        }
+        val parent = dir.substringBeforeLast('/', missingDelimiterValue = "")
+        if (parent.isEmpty() || parent == dir) return@repeat
+        dir = parent
+    }
+
+    for (candidate in candidates) {
+        if (candidate.isEmpty()) continue
+        if (!fm.fileExistsAtPath(candidate)) continue
+        val nsstring = NSString.stringWithContentsOfFile(
+            candidate,
+            encoding = NSUTF8StringEncoding,
+            error = null,
+        )
+        if (nsstring != null) {
+            return nsstring
+        }
+    }
+    return null
+}


### PR DESCRIPTION
Fixes #571

## Problem
Reporter (iPhone 16 Pro, Just Lift, LB) saw the Weight Change Per Rep slider produce 29/30/44-49 instead of 1 lb increments. The RCA in #571 (comment by @9thLevelSoftware) proved the slider is correctly bound to `valueRange = -10f..10f` with `steps = 19` (i.e. 21 stops → step size 1 lb) and **cannot** emit those values. The visible jumps came from the iOS `CompactNumberPicker` (`LazyColumn` wheel, range 1..242 LB) claiming vertical drags intended for the slider and snapping to neighbour weights.

## Root cause
1. `useCompactAccessibility = true` on iPhone 16 Pro portrait (402×874dp) with default Dynamic Type and Bold Text off — `JustLiftScreen.kt:289`.
2. `JustLiftScreen.kt:404, 460` then drop `Modifier.weight(1f)` and stack the two weight cards in a single vertical column.
3. The wheel sits directly above the slider with only `Spacing.medium` (16dp) between them, and the wheel's `BoxWithConstraints` is `itemHeight * 3 = 108dp` tall.
4. The wheel's `LazyColumn` claims vertical drags anywhere inside its 108dp container, so drags starting on (or near) the slider thumb are routed to the wheel and snap to neighbour weights like 44/45/46.
5. The user sees those neighbour weights and naturally reads them as the slider being broken.

## Fix (3 parts, per the RCA contract)

### 1. Decouple the side-by-side weight card gate from `useCompactAccessibility`
New `shouldStackWeightCards()` in `WindowSizeClass.kt` returns true only when the screen is *also* short (`heightSizeClass == Compact`). New composable wrapper `useStackedWeightCardsLayout()` reads the current `LocalWindowSizeClass`, `LocalDensity`, and `LocalPlatformAccessibilitySettings`. `JustLiftScreen.kt` now gates the Weight per Cable and Weight Change Per Rep cards on `stackWeightCards`, not `useCompactAccessibility`.

Result: on iPhone 16 Pro portrait (default Dynamic Type, Bold Text off), the two cards are side-by-side and the wheel cannot land above the slider by construction.

### 2. Cap the wheel's vertical drag hot zone to the centred 36dp band
`CompactNumberPicker.ios.kt`: add a `Modifier.pointerInput(isEditing, itemHeight) { awaitEachGesture { ... } }` on the wheel's `BoxWithConstraints`. When `isEditing = false`, drags landing within `±itemHeight/2` of the container center pass through to the inner `LazyColumn` as before. Drags landing outside the centred band are consumed at the wheel level so the `LazyColumn` does not claim them — the outer `verticalScroll` and the sibling slider card can then take the drag. In edit mode the wheel defers entirely to the `BasicTextField`.

### 3. Add an explicit vertical `Spacer` between the two weight cards when stacked
`JustLiftScreen.kt`: when `stackWeightCards`, insert `Spacer(Modifier.height(Spacing.small))` between the Weight per Cable and Weight Change Per Rep cards. Combined with the outer column's `Spacing.medium`, total separation is 24dp (`Spacing.large`) — belt-and-braces for any future regression in the wheel's hot-zone cap.

## Acceptance criteria (RCA)

- [x] On iPhone 16 Pro portrait (402×874dp) with default Dynamic Type + Bold Text off, the two weight cards are side-by-side (Fix 1).
- [x] When stacked (iPhone landscape 740×390dp or short-height tablet), the wheel does not claim drags that land outside its centred row (Fix 2).
- [x] The visible numeric readout above the slider can only take values in -10..+10 — locked in by `JustLiftScreenWeightSliderWiringTest`.
- [x] Wheel's snap-fling and +/- button behavior are unchanged.
- [x] Wheel's edit mode (text field + Done button) is not interrupted by the new pointer input.

## Non-goals (RCA non-goals)
- Did **not** change `ProgressionSlider`'s `valueRange` (it was already -10..+10).
- Did **not** change the iOS wheel to a native `UIPickerView` (PR #359 documented why).
- Did **not** introduce an `isEditing` toggle on the slider (not the bug).
- Did **not** widen the broader `useCompactAccessibility` gate — the outer `verticalScroll` and the other cards still use it.

## Tests
- 6 new `WindowSizeClassTest` cases pin `shouldStackWeightCards` behavior (iPhone 16 Pro portrait default + Bold Text on both keep side-by-side; iPhone landscape 740×390dp + short-height tablet both stack; tall tablet never stacks; `stack ⊆ compact` invariant).
- New `JustLiftScreenWeightSliderWiringTest` pins:
  - `valueRange = -10f..10f` on the `ProgressionSlider` call site,
  - `onValueChange` writes to `weightChangePerRep` and **not** `weightPerCable`,
  - the gate uses `useStackedWeightCardsLayout()`/`shouldStackWeightCards`,
  - the outer `verticalScroll(contentScrollState)` still uses the broader gate.
- Full `:shared:testAndroidHostTest` passes (16/16 targeted + unchanged existing tests).
- `:shared:compileKotlinIosArm64` passes.
- `:shared:lintAnalyzeAndroidHostTest` passes.

## RCA
- `rca_owner: gpt-5.5-xhigh`
- `rca_model: gpt-5.5`
- `rca_provider: openai-codex`
- `fix_driver: gpt55_rca`
- RCA comment: https://github.com/9thLevelSoftware/Project-Phoenix-MP/issues/571#issuecomment-4734749691
- Recreation artifact: `~/.hermes/phoenix-bug-recreations/571/bug-recreation.md`