### PR TITLE
[codex] Add equipment rack behavior overrides

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -208,8 +208,8 @@ sqldelight {
     databases {
         create("VitruvianDatabase") {
             packageName.set("com.devil.phoenixproject.database")
-            // Version 35 = initial schema (1) + 34 migrations (1.sqm through 34.sqm).
-            version = 35
+            // Version 36 = initial schema (1) + 35 migrations (1.sqm through 35.sqm).
+            version = 36
         }
     }
 }

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/local/SchemaParityTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/local/SchemaParityTest.kt
@@ -290,10 +290,51 @@ class SchemaParityTest {
         assertEquals("[]", defaultRackItemIds)
     }
 
+    @Test
+    fun `migration 35 adds routine exercise rack behavior overrides`() {
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        buildSchemaAtVersion(driver, 35)
+
+        assertEquals(false, columnExistsInDriver(driver, "RoutineExercise", "rackBehaviorOverrides"))
+        driver.execute(
+            null,
+            "INSERT INTO Routine (id, name, createdAt) VALUES ('routine-rack-overrides', 'Rack Overrides', 1)",
+            0,
+        )
+        driver.execute(
+            null,
+            """
+            INSERT INTO RoutineExercise (
+                id, routineId, exerciseName, exerciseMuscleGroup, orderIndex, weightPerCableKg
+            ) VALUES (
+                'rex-rack-overrides', 'routine-rack-overrides', 'Bench Press', 'Chest', 0, 20.0
+            )
+            """.trimIndent(),
+            0,
+        )
+
+        VitruvianDatabase.Schema.migrate(driver, 35, 36)
+
+        assertEquals(true, columnExistsInDriver(driver, "RoutineExercise", "rackBehaviorOverrides"))
+        var rackBehaviorOverrides = ""
+        driver.executeQuery(
+            identifier = null,
+            sql = "SELECT rackBehaviorOverrides FROM RoutineExercise WHERE id = 'rex-rack-overrides'",
+            mapper = { cursor ->
+                if (cursor.next().value) {
+                    rackBehaviorOverrides = cursor.getString(0).orEmpty()
+                }
+                QueryResult.Value(Unit)
+            },
+            parameters = 0,
+        )
+        assertEquals("{}", rackBehaviorOverrides)
+    }
+
     // ==================== HELPERS ====================
 
     companion object {
-        private const val CURRENT_VERSION = 35L
+        private const val CURRENT_VERSION = 36L
 
         /**
          * Transient tables are intermediate artifacts of table-rebuild migrations

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/migration/MigrationManagerTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/migration/MigrationManagerTest.kt
@@ -561,6 +561,7 @@ class MigrationManagerTest {
             setEchoLevels = "",
             warmupSets = "",
             defaultRackItemIds = "[]",
+            rackBehaviorOverrides = "{}",
         )
     }
 

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightCompletedSetRepositoryTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightCompletedSetRepositoryTest.kt
@@ -150,6 +150,7 @@ class SqlDelightCompletedSetRepositoryTest {
             setEchoLevels = "",
             warmupSets = "",
             defaultRackItemIds = "[]",
+            rackBehaviorOverrides = "{}",
         )
     }
 

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepositoryTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepositoryTest.kt
@@ -424,6 +424,7 @@ class SqlDelightSyncRepositoryTest {
             setEchoLevels = "",
             warmupSets = "",
             defaultRackItemIds = """["vest"]""",
+            rackBehaviorOverrides = "{}",
         )
 
         repository.mergePortalRoutines(

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightTrainingCycleRepositoryTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightTrainingCycleRepositoryTest.kt
@@ -238,6 +238,7 @@ class SqlDelightTrainingCycleRepositoryTest {
             setEchoLevels = "",
             warmupSets = "",
             defaultRackItemIds = "[]",
+            rackBehaviorOverrides = "{}",
         )
     }
 }

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModelTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModelTest.kt
@@ -8,6 +8,7 @@ import com.devil.phoenixproject.data.repository.SettingsEquipmentRackRepository
 import com.devil.phoenixproject.domain.model.ConnectionState
 import com.devil.phoenixproject.domain.model.Exercise
 import com.devil.phoenixproject.domain.model.ProgramMode
+import com.devil.phoenixproject.domain.model.RackItemBehavior
 import com.devil.phoenixproject.domain.model.Routine
 import com.devil.phoenixproject.domain.model.RoutineExercise
 import com.devil.phoenixproject.domain.model.UserPreferences
@@ -382,6 +383,52 @@ class MainViewModelTest {
         val found = viewModel.getRoutineById("non-existent")
 
         assertNull(found)
+    }
+
+    @Test
+    fun `saveRackBehaviorOverridesForExercise does not persist launch-time routine modifiers`() = runTest(testCoroutineRule.dispatcher) {
+        val storedExercise = RoutineExercise(
+            id = "routine-ex-1",
+            exercise = Exercise(
+                id = "bench",
+                name = "Bench Press",
+                muscleGroup = "Chest",
+                equipment = "HANDLES",
+            ),
+            orderIndex = 0,
+            setReps = listOf(8),
+            weightPerCableKg = 40f,
+        )
+        val storedRoutine = Routine(
+            id = "routine-modifier-safe-rack-save",
+            name = "Modifier Safe Rack Save",
+            exercises = listOf(storedExercise),
+        )
+        val launchRoutine = storedRoutine.copy(
+            exercises = listOf(
+                storedExercise.copy(
+                    setReps = listOf(4),
+                    weightPerCableKg = 20f,
+                ),
+            ),
+        )
+        fakeWorkoutRepository.addRoutine(storedRoutine)
+        viewModel.loadRoutine(launchRoutine)
+        advanceUntilIdle()
+
+        val overrides = mapOf("vest" to RackItemBehavior.COUNTERWEIGHT)
+        viewModel.saveRackBehaviorOverridesForExercise(0, overrides)
+        advanceUntilIdle()
+
+        val persisted = fakeWorkoutRepository.getRoutineById(storedRoutine.id)!!
+        assertEquals(40f, persisted.exercises.single().weightPerCableKg)
+        assertEquals(listOf(8), persisted.exercises.single().setReps)
+        assertEquals(overrides, persisted.exercises.single().rackBehaviorOverrides)
+
+        val activeRoutine = viewModel.loadedRoutine.value!!
+        assertEquals(20f, activeRoutine.exercises.single().weightPerCableKg)
+        assertEquals(listOf(4), activeRoutine.exercises.single().setReps)
+        assertEquals(overrides, activeRoutine.exercises.single().rackBehaviorOverrides)
     }
 
     // ========== Workout History Tests ==========

--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -663,5 +663,12 @@
     <string name="equipment_rack_behavior_added">Zusätzlicher Widerstand</string>
     <string name="equipment_rack_behavior_counterweight">Gegengewicht</string>
     <string name="equipment_rack_behavior_display_only">Nur Anzeige</string>
+    <string name="equipment_rack_behavior_added_short">+Last</string>
+    <string name="equipment_rack_behavior_counterweight_short">-Geg.</string>
+    <string name="equipment_rack_behavior_display_only_short">Anzeige</string>
+    <string name="equipment_rack_save_override_title">Überschreibung speichern?</string>
+    <string name="equipment_rack_save_override_message">Diese Verhaltenskonfiguration als Standard für %1$s in dieser Routine speichern?</string>
+    <string name="equipment_rack_save_override_confirm">Speichern</string>
+    <string name="equipment_rack_save_override_dismiss">Nur dieses Mal</string>
     <string name="cd_equipment_rack">Equipment-Rack</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-es/strings.xml
+++ b/shared/src/commonMain/composeResources/values-es/strings.xml
@@ -663,5 +663,12 @@
     <string name="equipment_rack_behavior_added">Resistencia añadida</string>
     <string name="equipment_rack_behavior_counterweight">Contrapeso</string>
     <string name="equipment_rack_behavior_display_only">Solo visualización</string>
+    <string name="equipment_rack_behavior_added_short">+Carga</string>
+    <string name="equipment_rack_behavior_counterweight_short">-Contra</string>
+    <string name="equipment_rack_behavior_display_only_short">Mostrar</string>
+    <string name="equipment_rack_save_override_title">¿Guardar ajuste?</string>
+    <string name="equipment_rack_save_override_message">¿Guardar esta configuración de comportamiento como predeterminada para %1$s en esta rutina?</string>
+    <string name="equipment_rack_save_override_confirm">Guardar</string>
+    <string name="equipment_rack_save_override_dismiss">Solo esta vez</string>
     <string name="cd_equipment_rack">Rack de equipamiento</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-fr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fr/strings.xml
@@ -663,5 +663,12 @@
     <string name="equipment_rack_behavior_added">Résistance ajoutée</string>
     <string name="equipment_rack_behavior_counterweight">Contrepoids</string>
     <string name="equipment_rack_behavior_display_only">Affichage uniquement</string>
+    <string name="equipment_rack_behavior_added_short">+Charge</string>
+    <string name="equipment_rack_behavior_counterweight_short">-CP</string>
+    <string name="equipment_rack_behavior_display_only_short">Affichage</string>
+    <string name="equipment_rack_save_override_title">Enregistrer le réglage ?</string>
+    <string name="equipment_rack_save_override_message">Enregistrer cette configuration de comportement comme valeur par défaut pour %1$s dans cette routine ?</string>
+    <string name="equipment_rack_save_override_confirm">Enregistrer</string>
+    <string name="equipment_rack_save_override_dismiss">Seulement cette fois</string>
     <string name="cd_equipment_rack">Rack d\'équipement</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-nl/strings.xml
+++ b/shared/src/commonMain/composeResources/values-nl/strings.xml
@@ -642,5 +642,12 @@
     <string name="equipment_rack_behavior_added">Toegevoegde weerstand</string>
     <string name="equipment_rack_behavior_counterweight">Contragewicht</string>
     <string name="equipment_rack_behavior_display_only">Alleen weergave</string>
+    <string name="equipment_rack_behavior_added_short">+Last</string>
+    <string name="equipment_rack_behavior_counterweight_short">-CW</string>
+    <string name="equipment_rack_behavior_display_only_short">Weergave</string>
+    <string name="equipment_rack_save_override_title">Override opslaan?</string>
+    <string name="equipment_rack_save_override_message">Deze gedragsconfiguratie als standaard opslaan voor %1$s in deze routine?</string>
+    <string name="equipment_rack_save_override_confirm">Opslaan</string>
+    <string name="equipment_rack_save_override_dismiss">Alleen deze keer</string>
     <string name="cd_equipment_rack">Equipment rack</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -731,5 +731,12 @@
     <string name="equipment_rack_behavior_added">Added resistance</string>
     <string name="equipment_rack_behavior_counterweight">Counterweight</string>
     <string name="equipment_rack_behavior_display_only">Display only</string>
+    <string name="equipment_rack_behavior_added_short">+Load</string>
+    <string name="equipment_rack_behavior_counterweight_short">-CW</string>
+    <string name="equipment_rack_behavior_display_only_short">Display</string>
+    <string name="equipment_rack_save_override_title">Save override?</string>
+    <string name="equipment_rack_save_override_message">Save this behavior configuration as the default for %1$s in this routine?</string>
+    <string name="equipment_rack_save_override_confirm">Save</string>
+    <string name="equipment_rack_save_override_dismiss">Just this time</string>
     <string name="cd_equipment_rack">Equipment rack</string>
 </resources>

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/MigrationStatements.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/MigrationStatements.kt
@@ -856,5 +856,10 @@ WHERE gs.rowid = (
         "ALTER TABLE RoutineExercise ADD COLUMN defaultRackItemIds TEXT NOT NULL DEFAULT '[]'",
     )
 
+    // Migration 35: Persist per-exercise equipment rack behavior overrides.
+    35 -> listOf(
+        "ALTER TABLE RoutineExercise ADD COLUMN rackBehaviorOverrides TEXT NOT NULL DEFAULT '{}'",
+    )
+
     else -> emptyList()
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/SchemaManifest.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/SchemaManifest.kt
@@ -910,6 +910,7 @@ internal val manifestTables: List<SchemaTableOperation> = listOf(
                 setEchoLevels TEXT NOT NULL DEFAULT '',
                 warmupSets TEXT NOT NULL DEFAULT '',
                 defaultRackItemIds TEXT NOT NULL DEFAULT '[]',
+                rackBehaviorOverrides TEXT NOT NULL DEFAULT '{}',
                 FOREIGN KEY (routineId) REFERENCES Routine(id) ON DELETE CASCADE,
                 FOREIGN KEY (exerciseId) REFERENCES Exercise(id) ON DELETE SET NULL,
                 FOREIGN KEY (supersetId) REFERENCES Superset(id) ON DELETE SET NULL
@@ -1219,7 +1220,9 @@ internal val manifestColumns: List<SchemaHealOperation> = listOf(
     SchemaHealOperation("RoutineExercise", "warmupSets", "ALTER TABLE RoutineExercise ADD COLUMN warmupSets TEXT NOT NULL DEFAULT ''"),
     // Migration 34: equipment rack routine defaults
     SchemaHealOperation("RoutineExercise", "defaultRackItemIds", "ALTER TABLE RoutineExercise ADD COLUMN defaultRackItemIds TEXT NOT NULL DEFAULT '[]'"),
-    // Migration 20 (healed outside .sqm): per-exercise behavior overrides
+    // Migration 35: equipment rack behavior overrides
+    SchemaHealOperation("RoutineExercise", "rackBehaviorOverrides", "ALTER TABLE RoutineExercise ADD COLUMN rackBehaviorOverrides TEXT NOT NULL DEFAULT '{}'"),
+    // Migration 20 (healed outside .sqm): rep detection behavior
     SchemaHealOperation("RoutineExercise", "stallDetectionEnabled", "ALTER TABLE RoutineExercise ADD COLUMN stallDetectionEnabled INTEGER NOT NULL DEFAULT 1"),
     SchemaHealOperation("RoutineExercise", "stopAtTop", "ALTER TABLE RoutineExercise ADD COLUMN stopAtTop INTEGER NOT NULL DEFAULT 0"),
     SchemaHealOperation("RoutineExercise", "repCountTiming", "ALTER TABLE RoutineExercise ADD COLUMN repCountTiming TEXT NOT NULL DEFAULT 'TOP'"),

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt
@@ -20,6 +20,7 @@ import com.devil.phoenixproject.domain.model.EccentricLoad
 import com.devil.phoenixproject.domain.model.EchoLevel
 import com.devil.phoenixproject.domain.model.Exercise
 import com.devil.phoenixproject.domain.model.PRType
+import com.devil.phoenixproject.domain.model.RackItemBehavior
 import com.devil.phoenixproject.domain.model.PersonalRecord
 import com.devil.phoenixproject.domain.model.ProgramMode
 import com.devil.phoenixproject.domain.model.RepCountTiming
@@ -554,10 +555,13 @@ class SqlDelightSyncRepository(
                     // partial response, or deserialization issue). Deleting local exercises
                     // when we have nothing to replace them with causes permanent data loss.
                     if (portalRoutine.exercises.isNotEmpty()) {
-                        val localRackDefaultsByExerciseId = queries
+                        val localExerciseRows = queries
                             .selectExercisesByRoutine(portalRoutine.id)
                             .executeAsList()
+                        val localRackDefaultsByExerciseId = localExerciseRows
                             .associate { it.id to it.defaultRackItemIds }
+                        val localRackOverridesByExerciseId = localExerciseRows
+                            .associate { it.id to it.rackBehaviorOverrides }
 
                         // Replace routine exercises and supersets: delete existing then insert portal versions
                         queries.deleteRoutineExercises(portalRoutine.id)
@@ -690,6 +694,9 @@ class SqlDelightSyncRepository(
                                 setEchoLevels = setEchoLevels,
                                 warmupSets = exercise.warmupSets ?: "",
                                 defaultRackItemIds = localRackDefaultsByExerciseId[exercise.id] ?: "[]",
+                                rackBehaviorOverrides = exercise.rackBehaviorOverrides
+                                    ?: localRackOverridesByExerciseId[exercise.id]
+                                    ?: "{}",
                             )
                         }
                     } else {
@@ -1096,6 +1103,16 @@ class SqlDelightSyncRepository(
                         emptyList()
                     }
 
+                    val rackBehaviorOverrides: Map<String, RackItemBehavior> = try {
+                        if (exRow.rackBehaviorOverrides.isBlank() || exRow.rackBehaviorOverrides == "{}") {
+                            emptyMap()
+                        } else {
+                            json.decodeFromString<Map<String, RackItemBehavior>>(exRow.rackBehaviorOverrides)
+                        }
+                    } catch (_: Exception) {
+                        emptyMap()
+                    }
+
                     RoutineExercise(
                         id = exRow.id,
                         exercise = exercise,
@@ -1129,6 +1146,7 @@ class SqlDelightSyncRepository(
                         setWeightsPercentOfPR = setWeightsPercentOfPR,
                         warmupSets = warmupSets,
                         defaultRackItemIds = defaultRackItemIds,
+                        rackBehaviorOverrides = rackBehaviorOverrides,
                     )
                 } catch (e: Exception) {
                     Logger.e(e) { "Failed to map routine exercise: ${exRow.exerciseId}" }
@@ -1684,10 +1702,13 @@ class SqlDelightSyncRepository(
 
                     // Replace exercises if portal provided them (non-empty list)
                     if (portalRoutine.exercises.isNotEmpty()) {
-                        val localRackDefaultsByExerciseId = queries
+                        val localExerciseRows2 = queries
                             .selectExercisesByRoutine(portalRoutine.id)
                             .executeAsList()
+                        val localRackDefaultsByExerciseId = localExerciseRows2
                             .associate { it.id to it.defaultRackItemIds }
+                        val localRackOverridesByExerciseId = localExerciseRows2
+                            .associate { it.id to it.rackBehaviorOverrides }
 
                         queries.deleteRoutineExercises(portalRoutine.id)
                         queries.deleteSupersetsByRoutine(portalRoutine.id)
@@ -1807,6 +1828,9 @@ class SqlDelightSyncRepository(
                                 setEchoLevels = setEchoLevels,
                                 warmupSets = exercise.warmupSets ?: "",
                                 defaultRackItemIds = localRackDefaultsByExerciseId[exercise.id] ?: "[]",
+                                rackBehaviorOverrides = exercise.rackBehaviorOverrides
+                                    ?: localRackOverridesByExerciseId[exercise.id]
+                                    ?: "{}",
                             )
                         }
                     }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepository.kt
@@ -9,6 +9,7 @@ import com.devil.phoenixproject.domain.model.EchoLevel
 import com.devil.phoenixproject.domain.model.Exercise
 import com.devil.phoenixproject.domain.model.PRType
 import com.devil.phoenixproject.domain.model.ProgramMode
+import com.devil.phoenixproject.domain.model.RackItemBehavior
 import com.devil.phoenixproject.domain.model.Routine
 import com.devil.phoenixproject.domain.model.RoutineExercise
 import com.devil.phoenixproject.domain.model.RoutineGroup
@@ -337,6 +338,19 @@ class SqlDelightWorkoutRepository(private val db: VitruvianDatabase, private val
                     emptyList()
                 }
 
+                val rackBehaviorOverrides: Map<String, RackItemBehavior> = try {
+                    if (row.rackBehaviorOverrides.isBlank() || row.rackBehaviorOverrides == "{}") {
+                        emptyMap()
+                    } else {
+                        json.decodeFromString<Map<String, RackItemBehavior>>(row.rackBehaviorOverrides)
+                    }
+                } catch (e: Exception) {
+                    Logger.w(e) {
+                        "Failed to parse rackBehaviorOverrides '${row.rackBehaviorOverrides}' for exercise ${row.exerciseName}, using empty map"
+                    }
+                    emptyMap()
+                }
+
                 val eccentricLoad = mapEccentricLoadFromDb(row.eccentricLoad)
                 val echoLevel = EchoLevel.entries.getOrNull(row.echoLevel.toInt()) ?: EchoLevel.HARDER
 
@@ -398,6 +412,7 @@ class SqlDelightWorkoutRepository(private val db: VitruvianDatabase, private val
                     setWeightsPercentOfPR = setWeightsPercentOfPR,
                     warmupSets = warmupSets,
                     defaultRackItemIds = defaultRackItemIds,
+                    rackBehaviorOverrides = rackBehaviorOverrides,
                 )
             } catch (e: Exception) {
                 Logger.e(e) { "Failed to map routine exercise: ${row.exerciseId}" }
@@ -706,6 +721,11 @@ class SqlDelightWorkoutRepository(private val db: VitruvianDatabase, private val
             defaultRackItemIds = json.encodeToString(
                 exercise.defaultRackItemIds.filter { it.isNotBlank() }.distinct(),
             ),
+            rackBehaviorOverrides = if (exercise.rackBehaviorOverrides.isEmpty()) {
+                "{}"
+            } else {
+                json.encodeToString(exercise.rackBehaviorOverrides)
+            },
         )
     }
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapter.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapter.kt
@@ -555,6 +555,12 @@ object PortalSyncAdapter {
                     },
                 warmupSets = ex.warmupSets.takeIf { it.isNotEmpty() }
                     ?.let { Json.encodeToString(it) },
+                rackBehaviorOverrides = ex.rackBehaviorOverrides.takeIf { it.isNotEmpty() }
+                    ?.let { overrides ->
+                        Json.encodeToString(
+                            overrides.mapValues { (_, v) -> v.name },
+                        )
+                    },
             )
         }
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncDtos.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncDtos.kt
@@ -231,6 +231,7 @@ data class PortalRoutineExerciseSyncDto(
     val echoLevel: String? = null,
     val perSetEchoLevels: String? = null, // JSON array of echo level names
     val warmupSets: String? = null, // JSON array of {reps, percentOfWorking}
+    val rackBehaviorOverrides: String? = null, // JSON map of rackItemId -> behavior name
 )
 
 // ─── Training Cycle Sync DTOs ─────────────────────────────────────
@@ -759,6 +760,7 @@ data class PullRoutineExerciseDto(
     val echoLevel: String? = null,
     val perSetEchoLevels: String? = null, // JSON array of echo level names
     val warmupSets: String? = null, // JSON array of {reps, percentOfWorking}
+    val rackBehaviorOverrides: String? = null, // JSON map of rackItemId -> behavior name
 )
 
 /**

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/Routine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/Routine.kt
@@ -119,6 +119,10 @@ data class RoutineExercise(
     val warmupSets: List<WarmupSet> = emptyList(),
     // Local equipment rack defaults to preselect when this exercise opens Set Ready.
     val defaultRackItemIds: List<String> = emptyList(),
+    // Per-item behavior overrides for equipment rack (Issues #521/#526).
+    // Map of rackItemId -> RackItemBehavior. Items not in the map fall through
+    // to the global RackItem.behavior. Serialized as JSON in the DB.
+    val rackBehaviorOverrides: Map<String, RackItemBehavior> = emptyMap(),
 ) {
     /** Returns true if this exercise is part of a superset */
     val isInSuperset: Boolean get() = supersetId != null

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/ApplyEquipmentRackLoadUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/ApplyEquipmentRackLoadUseCase.kt
@@ -12,11 +12,12 @@ class ApplyEquipmentRackLoadUseCase {
         selectedItems: List<RackItem>,
         isEchoMode: Boolean,
         validatorMinimumPerCableKg: Float = Constants.MIN_WEIGHT_KG,
+        behaviorOverrides: Map<String, RackItemBehavior> = emptyMap(),
     ): RackLoadAdjustment {
         val cableCount = physicalCableCount.coerceIn(1, 2)
         val uniqueItems = selectedItems.distinctBy { it.id }
-        val externalAddedLoadKg = uniqueItems.loadFor(RackItemBehavior.ADDED_RESISTANCE)
-        val counterweightKg = uniqueItems.loadFor(RackItemBehavior.COUNTERWEIGHT)
+        val externalAddedLoadKg = uniqueItems.loadFor(RackItemBehavior.ADDED_RESISTANCE, behaviorOverrides)
+        val counterweightKg = uniqueItems.loadFor(RackItemBehavior.COUNTERWEIGHT, behaviorOverrides)
         val displayLoadKg = (
             programmedWeightPerCableKg.coerceAtLeast(0f) * cableCount +
                 externalAddedLoadKg -
@@ -45,17 +46,25 @@ class ApplyEquipmentRackLoadUseCase {
         bodyWeightKg: Float,
         percentage: Float,
         selectedItems: List<RackItem>,
+        behaviorOverrides: Map<String, RackItemBehavior> = emptyMap(),
     ): Float {
         if (bodyWeightKg <= 0f || percentage <= 0f) return 0f
         val uniqueItems = selectedItems.distinctBy { it.id }
         return (
             bodyWeightKg * percentage +
-                uniqueItems.loadFor(RackItemBehavior.ADDED_RESISTANCE) -
-                uniqueItems.loadFor(RackItemBehavior.COUNTERWEIGHT)
+                uniqueItems.loadFor(RackItemBehavior.ADDED_RESISTANCE, behaviorOverrides) -
+                uniqueItems.loadFor(RackItemBehavior.COUNTERWEIGHT, behaviorOverrides)
             ).coerceAtLeast(0f)
     }
 
-    private fun List<RackItem>.loadFor(behavior: RackItemBehavior): Float = filter {
-        it.enabled && it.behavior == behavior
+    /**
+     * Resolve effective behavior: override if present, otherwise global.
+     */
+    private fun List<RackItem>.loadFor(
+        behavior: RackItemBehavior,
+        overrides: Map<String, RackItemBehavior> = emptyMap(),
+    ): Float = filter { item ->
+        val effectiveBehavior = overrides[item.id] ?: item.behavior
+        item.enabled && effectiveBehavior == behavior
     }.sumOf { it.weightKg.toDouble() }.toFloat()
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/EquipmentRackSelectionCard.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/EquipmentRackSelectionCard.kt
@@ -4,12 +4,15 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -162,7 +165,13 @@ fun EquipmentRackSelectionCard(
                 enter = expandVertically(),
                 exit = shrinkVertically(),
             ) {
-                Column(verticalArrangement = Arrangement.spacedBy(Spacing.small)) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = 260.dp)
+                        .verticalScroll(rememberScrollState()),
+                    verticalArrangement = Arrangement.spacedBy(Spacing.small),
+                ) {
                     enabledItems.forEach { item ->
                         val selected = item.id in activeIdSet
                         val effectiveBehavior = behaviorOverrides[item.id] ?: item.behavior

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/EquipmentRackSelectionCard.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/EquipmentRackSelectionCard.kt
@@ -1,22 +1,37 @@
 package com.devil.phoenixproject.presentation.components
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -29,22 +44,25 @@ import com.devil.phoenixproject.ui.theme.Spacing
 import org.jetbrains.compose.resources.stringResource
 import vitruvianprojectphoenix.shared.generated.resources.Res
 import vitruvianprojectphoenix.shared.generated.resources.equipment_rack_active_selection
-import vitruvianprojectphoenix.shared.generated.resources.equipment_rack_display_only_count
 import vitruvianprojectphoenix.shared.generated.resources.equipment_rack_manage
 import vitruvianprojectphoenix.shared.generated.resources.equipment_rack_no_enabled_items
 import vitruvianprojectphoenix.shared.generated.resources.equipment_rack_none_selected
-import vitruvianprojectphoenix.shared.generated.resources.equipment_rack_selected_count
-import vitruvianprojectphoenix.shared.generated.resources.equipment_rack_selected_summary
 
+/**
+ * Collapsible equipment rack summary row with optional per-item behavior overrides.
+ */
 @Composable
 fun EquipmentRackSelectionCard(
     rackItems: List<RackItem>,
     activeRackItemIds: List<String>,
+    behaviorOverrides: Map<String, RackItemBehavior> = emptyMap(),
     weightUnit: WeightUnit,
     formatWeight: (Float, WeightUnit) -> String,
     onSelectionChange: (List<String>) -> Unit,
+    onBehaviorOverrideChange: (Map<String, RackItemBehavior>) -> Unit = {},
     modifier: Modifier = Modifier,
     onManageRack: (() -> Unit)? = null,
+    showBehaviorOverrides: Boolean = false,
 ) {
     val enabledItems = remember(rackItems) {
         rackItems
@@ -52,33 +70,52 @@ fun EquipmentRackSelectionCard(
             .sortedWith(compareBy<RackItem> { it.sortOrder }.thenBy { it.name.lowercase() })
     }
     val activeIdSet = remember(activeRackItemIds) { activeRackItemIds.toSet() }
-    val selectedItems = remember(enabledItems, activeIdSet) { enabledItems.filter { it.id in activeIdSet } }
+    val selectedItems = remember(enabledItems, activeIdSet) {
+        enabledItems.filter { it.id in activeIdSet }
+    }
+
+    var expanded by remember { mutableStateOf(false) }
 
     Card(
         modifier = modifier.fillMaxWidth(),
         shape = RoundedCornerShape(16.dp),
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHighest),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+        ),
     ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .heightIn(max = 240.dp)
-                .verticalScroll(rememberScrollState())
                 .padding(Spacing.medium),
             verticalArrangement = Arrangement.spacedBy(Spacing.small),
         ) {
             Row(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { expanded = !expanded },
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Text(
-                    stringResource(Res.string.equipment_rack_active_selection),
-                    style = MaterialTheme.typography.labelLarge,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    letterSpacing = 1.sp,
-                )
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        stringResource(Res.string.equipment_rack_active_selection),
+                        style = MaterialTheme.typography.labelLarge,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        letterSpacing = 1.sp,
+                    )
+                    Spacer(Modifier.width(4.dp))
+                    Icon(
+                        imageVector = if (expanded) {
+                            Icons.Default.KeyboardArrowUp
+                        } else {
+                            Icons.Default.KeyboardArrowDown
+                        },
+                        contentDescription = if (expanded) "Collapse" else "Expand",
+                        modifier = Modifier.size(20.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
                 if (onManageRack != null) {
                     TextButton(onClick = onManageRack) {
                         Text(stringResource(Res.string.equipment_rack_manage))
@@ -86,81 +123,144 @@ fun EquipmentRackSelectionCard(
                 }
             }
 
-            if (enabledItems.isEmpty()) {
-                Text(
-                    stringResource(Res.string.equipment_rack_no_enabled_items),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            } else {
-                enabledItems.forEach { item ->
-                    val selected = item.id in activeIdSet
-                    FilterChip(
-                        selected = selected,
-                        onClick = {
-                            val updated = if (selected) {
-                                activeRackItemIds.filterNot { it == item.id }
-                            } else {
-                                activeRackItemIds + item.id
-                            }
-                            onSelectionChange(updated)
-                        },
-                        label = {
-                            Text(
-                                "${item.name} - ${formatRackChipDetail(item, weightUnit, formatWeight)}",
-                                maxLines = 1,
-                            )
-                        },
-                        modifier = Modifier.fillMaxWidth(),
+            when {
+                enabledItems.isEmpty() -> {
+                    Text(
+                        stringResource(Res.string.equipment_rack_no_enabled_items),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
 
-                Text(
-                    if (selectedItems.isEmpty()) {
-                        stringResource(Res.string.equipment_rack_none_selected)
-                    } else {
-                        stringResource(
-                            Res.string.equipment_rack_selected_summary,
-                            rackSelectionSummary(selectedItems, weightUnit, formatWeight),
-                        )
-                    },
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
+                selectedItems.isEmpty() -> {
+                    Text(
+                        stringResource(Res.string.equipment_rack_none_selected),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+
+                !expanded -> {
+                    Text(
+                        text = buildCollapsedSummary(
+                            selectedItems = selectedItems,
+                            behaviorOverrides = behaviorOverrides,
+                            weightUnit = weightUnit,
+                            formatWeight = formatWeight,
+                        ),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                }
+            }
+
+            AnimatedVisibility(
+                visible = expanded && enabledItems.isNotEmpty(),
+                enter = expandVertically(),
+                exit = shrinkVertically(),
+            ) {
+                Column(verticalArrangement = Arrangement.spacedBy(Spacing.small)) {
+                    enabledItems.forEach { item ->
+                        val selected = item.id in activeIdSet
+                        val effectiveBehavior = behaviorOverrides[item.id] ?: item.behavior
+
+                        Column {
+                            FilterChip(
+                                selected = selected,
+                                onClick = {
+                                    val updated = if (selected) {
+                                        activeRackItemIds.filterNot { it == item.id }
+                                    } else {
+                                        activeRackItemIds + item.id
+                                    }
+                                    onSelectionChange(updated)
+                                },
+                                label = {
+                                    Text(
+                                        "${item.name} - ${formatRackChipDetail(item, effectiveBehavior, weightUnit, formatWeight)}",
+                                        maxLines = 1,
+                                    )
+                                },
+                                modifier = Modifier.fillMaxWidth(),
+                            )
+
+                            if (selected && showBehaviorOverrides) {
+                                Spacer(Modifier.height(4.dp))
+                                RackItemBehaviorPicker(
+                                    currentBehavior = effectiveBehavior,
+                                    globalBehavior = item.behavior,
+                                    onBehaviorChange = { newBehavior ->
+                                        val updatedOverrides = if (newBehavior == item.behavior) {
+                                            behaviorOverrides - item.id
+                                        } else {
+                                            behaviorOverrides + (item.id to newBehavior)
+                                        }
+                                        onBehaviorOverrideChange(updatedOverrides)
+                                    },
+                                )
+                            }
+                        }
+                    }
+                }
             }
         }
     }
 }
 
-private fun formatRackChipDetail(
-    item: RackItem,
+@Composable
+private fun RackItemBehaviorPicker(
+    currentBehavior: RackItemBehavior,
+    globalBehavior: RackItemBehavior,
+    onBehaviorChange: (RackItemBehavior) -> Unit,
+) {
+    val options = RackItemBehavior.entries
+    val selectedIndex = options.indexOf(currentBehavior)
+
+    SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+        options.forEachIndexed { index, behavior ->
+            SegmentedButton(
+                selected = index == selectedIndex,
+                onClick = { onBehaviorChange(behavior) },
+                shape = SegmentedButtonDefaults.itemShape(index = index, count = options.size),
+                label = {
+                    val label = when (behavior) {
+                        RackItemBehavior.ADDED_RESISTANCE -> "+Load"
+                        RackItemBehavior.COUNTERWEIGHT -> "-CW"
+                        RackItemBehavior.DISPLAY_ONLY -> "Display"
+                    }
+                    Text(
+                        text = if (behavior == globalBehavior) "$label *" else label,
+                        style = MaterialTheme.typography.labelSmall,
+                        maxLines = 1,
+                    )
+                },
+            )
+        }
+    }
+}
+
+private fun buildCollapsedSummary(
+    selectedItems: List<RackItem>,
+    behaviorOverrides: Map<String, RackItemBehavior>,
     weightUnit: WeightUnit,
     formatWeight: (Float, WeightUnit) -> String,
-): String = when (item.behavior) {
+): String = selectedItems.joinToString(", ") { item ->
+    val effectiveBehavior = behaviorOverrides[item.id] ?: item.behavior
+    val behaviorSuffix = when (effectiveBehavior) {
+        RackItemBehavior.ADDED_RESISTANCE -> "+"
+        RackItemBehavior.COUNTERWEIGHT -> "-"
+        RackItemBehavior.DISPLAY_ONLY -> "display"
+    }
+    "${item.name} ${formatWeight(item.weightKg, weightUnit)} $behaviorSuffix"
+}
+
+private fun formatRackChipDetail(
+    item: RackItem,
+    effectiveBehavior: RackItemBehavior,
+    weightUnit: WeightUnit,
+    formatWeight: (Float, WeightUnit) -> String,
+): String = when (effectiveBehavior) {
     RackItemBehavior.ADDED_RESISTANCE -> "+${formatWeight(item.weightKg, weightUnit)}"
     RackItemBehavior.COUNTERWEIGHT -> "-${formatWeight(item.weightKg, weightUnit)}"
     RackItemBehavior.DISPLAY_ONLY -> formatWeight(item.weightKg, weightUnit)
-}
-
-@Composable
-private fun rackSelectionSummary(
-    items: List<RackItem>,
-    weightUnit: WeightUnit,
-    formatWeight: (Float, WeightUnit) -> String,
-): String {
-    val addedKg = items.filter { it.behavior == RackItemBehavior.ADDED_RESISTANCE }.sumOf { it.weightKg.toDouble() }.toFloat()
-    val counterweightKg = items.filter { it.behavior == RackItemBehavior.COUNTERWEIGHT }.sumOf { it.weightKg.toDouble() }.toFloat()
-    val displayOnlyCount = items.count { it.behavior == RackItemBehavior.DISPLAY_ONLY }
-    val displayOnlyLabel = if (displayOnlyCount > 0) {
-        stringResource(Res.string.equipment_rack_display_only_count, displayOnlyCount)
-    } else {
-        null
-    }
-    val selectedCountLabel = stringResource(Res.string.equipment_rack_selected_count, items.size)
-    val parts = buildList {
-        if (addedKg > 0f) add("+${formatWeight(addedKg, weightUnit)}")
-        if (counterweightKg > 0f) add("-${formatWeight(counterweightKg, weightUnit)}")
-        displayOnlyLabel?.let(::add)
-    }
-    return parts.ifEmpty { listOf(selectedCountLabel) }.joinToString(" / ")
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/EquipmentRackSelectionCard.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/EquipmentRackSelectionCard.kt
@@ -44,6 +44,9 @@ import com.devil.phoenixproject.ui.theme.Spacing
 import org.jetbrains.compose.resources.stringResource
 import vitruvianprojectphoenix.shared.generated.resources.Res
 import vitruvianprojectphoenix.shared.generated.resources.equipment_rack_active_selection
+import vitruvianprojectphoenix.shared.generated.resources.equipment_rack_behavior_added_short
+import vitruvianprojectphoenix.shared.generated.resources.equipment_rack_behavior_counterweight_short
+import vitruvianprojectphoenix.shared.generated.resources.equipment_rack_behavior_display_only_short
 import vitruvianprojectphoenix.shared.generated.resources.equipment_rack_manage
 import vitruvianprojectphoenix.shared.generated.resources.equipment_rack_no_enabled_items
 import vitruvianprojectphoenix.shared.generated.resources.equipment_rack_none_selected
@@ -224,9 +227,9 @@ private fun RackItemBehaviorPicker(
                 shape = SegmentedButtonDefaults.itemShape(index = index, count = options.size),
                 label = {
                     val label = when (behavior) {
-                        RackItemBehavior.ADDED_RESISTANCE -> "+Load"
-                        RackItemBehavior.COUNTERWEIGHT -> "-CW"
-                        RackItemBehavior.DISPLAY_ONLY -> "Display"
+                        RackItemBehavior.ADDED_RESISTANCE -> stringResource(Res.string.equipment_rack_behavior_added_short)
+                        RackItemBehavior.COUNTERWEIGHT -> stringResource(Res.string.equipment_rack_behavior_counterweight_short)
+                        RackItemBehavior.DISPLAY_ONLY -> stringResource(Res.string.equipment_rack_behavior_display_only_short)
                     }
                     Text(
                         text = if (behavior == globalBehavior) "$label *" else label,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -1988,8 +1988,6 @@ class ActiveSessionEngine(
             ?.exercises
             ?.getOrNull(coordinator._currentExerciseIndex.value)
             ?: return
-        val isBodyweight = currentExercise.exercise.isBodyweight
-        if (!isBodyweight) return
 
         val activeIds = coordinator._activeRackItemIds.value
         val resolvedItems = equipmentRackRepository.rackItems.value

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -32,6 +32,7 @@ import com.devil.phoenixproject.domain.model.HapticEvent
 import com.devil.phoenixproject.domain.model.IntegrationProvider
 import com.devil.phoenixproject.domain.model.ProgramMode
 import com.devil.phoenixproject.domain.model.RackItem
+import com.devil.phoenixproject.domain.model.RackItemBehavior
 import com.devil.phoenixproject.domain.model.RepCount
 import com.devil.phoenixproject.domain.model.RepCountTiming
 import com.devil.phoenixproject.domain.model.RepMetricData
@@ -481,6 +482,7 @@ class ActiveSessionEngine(
             selectedItems = selectedItems,
             isEchoMode = params.isEchoMode,
             validatorMinimumPerCableKg = validatorSafeMinimum(params),
+            behaviorOverrides = coordinator._activeRackBehaviorOverrides.value,
         )
         coordinator._currentRackLoadAdjustment.value = adjustment
         coordinator.currentRackItemsJson = rackJson.encodeToString(selectedItems)
@@ -497,6 +499,7 @@ class ActiveSessionEngine(
         params: WorkoutParameters,
         physicalCableCount: Int,
         selectedItems: List<RackItem>,
+        behaviorOverrides: Map<String, RackItemBehavior> = emptyMap(),
     ): WorkoutParameters {
         val adjustment = applyEquipmentRackLoadUseCase.calculate(
             programmedWeightPerCableKg = params.weightPerCableKg,
@@ -504,6 +507,7 @@ class ActiveSessionEngine(
             selectedItems = selectedItems,
             isEchoMode = params.isEchoMode,
             validatorMinimumPerCableKg = validatorSafeMinimum(params),
+            behaviorOverrides = behaviorOverrides,
         )
         return params.copy(
             weightPerCableKg = if (params.isEchoMode) {
@@ -1961,6 +1965,7 @@ class ActiveSessionEngine(
                 selectedItems = resolvedItems,
                 isEchoMode = currentParams.isEchoMode,
                 validatorMinimumPerCableKg = validatorSafeMinimum(currentParams),
+                behaviorOverrides = coordinator._activeRackBehaviorOverrides.value,
             )
             val itemsJson = rackJson.encodeToString(
                 ListSerializer(RackItem.serializer()),
@@ -1974,6 +1979,39 @@ class ActiveSessionEngine(
         } else {
             coordinator.setActiveRackSelection(distinctIds)
         }
+    }
+
+    fun updateActiveRackBehaviorOverrides(overrides: Map<String, RackItemBehavior>) {
+        coordinator._activeRackBehaviorOverrides.value = overrides
+
+        val currentExercise = coordinator._loadedRoutine.value
+            ?.exercises
+            ?.getOrNull(coordinator._currentExerciseIndex.value)
+            ?: return
+        val isBodyweight = currentExercise.exercise.isBodyweight
+        if (!isBodyweight) return
+
+        val activeIds = coordinator._activeRackItemIds.value
+        val resolvedItems = equipmentRackRepository.rackItems.value
+            .filter { it.enabled && it.id in activeIds }
+        val currentParams = coordinator._workoutParameters.value
+        val adjustment = applyEquipmentRackLoadUseCase.calculate(
+            programmedWeightPerCableKg = currentParams.weightPerCableKg,
+            physicalCableCount = currentExercise.exercise.preferredCableCount ?: 1,
+            selectedItems = resolvedItems,
+            isEchoMode = currentParams.isEchoMode,
+            validatorMinimumPerCableKg = validatorSafeMinimum(currentParams),
+            behaviorOverrides = overrides,
+        )
+        val itemsJson = rackJson.encodeToString(
+            ListSerializer(RackItem.serializer()),
+            resolvedItems,
+        )
+        coordinator.setActiveRackSelection(
+            itemIds = activeIds,
+            precomputedAdjustment = adjustment,
+            precomputedItemsJson = itemsJson,
+        )
     }
 
     fun clearActiveRackSelection() {
@@ -2506,6 +2544,7 @@ class ActiveSessionEngine(
                         params = paramsForBle,
                         physicalCableCount = rackPhysicalCableCount,
                         selectedItems = rackSnapshotItems,
+                        behaviorOverrides = coordinator._activeRackBehaviorOverrides.value,
                     )
                 }
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/DefaultWorkoutSessionManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/DefaultWorkoutSessionManager.kt
@@ -23,6 +23,7 @@ import com.devil.phoenixproject.domain.model.EchoLevel
 import com.devil.phoenixproject.domain.model.Exercise
 import com.devil.phoenixproject.domain.model.HapticEvent
 import com.devil.phoenixproject.domain.model.ProgramMode
+import com.devil.phoenixproject.domain.model.RackItemBehavior
 import com.devil.phoenixproject.domain.model.RepCount
 import com.devil.phoenixproject.domain.model.RepCountTiming
 import com.devil.phoenixproject.domain.model.Routine
@@ -664,6 +665,9 @@ class DefaultWorkoutSessionManager(
     fun updateWorkoutParameters(params: WorkoutParameters) = activeSessionEngine.updateWorkoutParameters(params)
     fun setWorkoutParametersInternal(params: WorkoutParameters) = activeSessionEngine.setWorkoutParametersInternal(params)
     fun updateActiveRackSelection(itemIds: List<String>) = activeSessionEngine.updateActiveRackSelection(itemIds)
+    fun updateActiveRackBehaviorOverrides(
+        overrides: Map<String, RackItemBehavior>,
+    ) = activeSessionEngine.updateActiveRackBehaviorOverrides(overrides)
     fun clearActiveRackSelection() = activeSessionEngine.clearActiveRackSelection()
     fun startWorkout(skipCountdown: Boolean = false, isJustLiftMode: Boolean = false) = activeSessionEngine.startWorkout(skipCountdown, isJustLiftMode)
     fun skipCountdown() = activeSessionEngine.skipCountdown()

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/RoutineFlowManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/RoutineFlowManager.kt
@@ -864,6 +864,7 @@ class RoutineFlowManager(
         val distinctIds = exercise.defaultRackItemIds
             .filter { it.isNotBlank() }
             .distinct()
+        coordinator._activeRackBehaviorOverrides.value = exercise.rackBehaviorOverrides
         val resolvedItems = equipmentRackRepository.rackItems.value
             .filter { it.enabled && it.id in distinctIds }
         // Use the exercise's own weight — not the coordinator's currently-mirrored
@@ -874,8 +875,9 @@ class RoutineFlowManager(
             programmedWeightPerCableKg = programmedWeightPerCableKg,
             physicalCableCount = physicalCableCount,
             selectedItems = resolvedItems,
-            isEchoMode = false,
+            isEchoMode = exercise.programMode is ProgramMode.Echo,
             validatorMinimumPerCableKg = Constants.DEFAULT_WEIGHT_INCREMENT_KG,
+            behaviorOverrides = exercise.rackBehaviorOverrides,
         )
         val itemsJson = rackJson.encodeToString(
             ListSerializer(serializer<RackItem>()),

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutCoordinator.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutCoordinator.kt
@@ -6,6 +6,7 @@ import com.devil.phoenixproject.domain.model.BiomechanicsRepResult
 import com.devil.phoenixproject.domain.model.BodyweightVariantOption
 import com.devil.phoenixproject.domain.model.HapticEvent
 import com.devil.phoenixproject.domain.model.ProgramMode
+import com.devil.phoenixproject.domain.model.RackItemBehavior
 import com.devil.phoenixproject.domain.model.RackLoadAdjustment
 import com.devil.phoenixproject.domain.model.RepCount
 import com.devil.phoenixproject.domain.model.RepMetricData
@@ -191,6 +192,9 @@ class WorkoutCoordinator(
     internal val _activeRackItemIds = MutableStateFlow<List<String>>(emptyList())
     val activeRackItemIds: StateFlow<List<String>> = _activeRackItemIds.asStateFlow()
 
+    internal val _activeRackBehaviorOverrides = MutableStateFlow<Map<String, RackItemBehavior>>(emptyMap())
+    val activeRackBehaviorOverrides: StateFlow<Map<String, RackItemBehavior>> = _activeRackBehaviorOverrides.asStateFlow()
+
     /**
      * Rack-load adjustment for the current set. Machine-facing counterweight
      * math uses physical cable count, while display code decides separately
@@ -239,6 +243,7 @@ class WorkoutCoordinator(
 
     internal fun clearActiveRackSelection() {
         _activeRackItemIds.value = emptyList()
+        _activeRackBehaviorOverrides.value = emptyMap()
         _currentRackLoadAdjustment.value = RackLoadAdjustment()
         currentRackItemsJson = "[]"
         _workoutParameters.value = _workoutParameters.value.copy(

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseEditBottomSheet.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseEditBottomSheet.kt
@@ -158,6 +158,7 @@ fun ExerciseEditBottomSheet(
     val repCountTiming by viewModel.repCountTiming.collectAsState()
     val stopAtTop by viewModel.stopAtTop.collectAsState()
     val defaultRackItemIds by viewModel.defaultRackItemIds.collectAsState()
+    val rackBehaviorOverrides by viewModel.rackBehaviorOverrides.collectAsState()
 
     // Warm-up sets state (Issue #30)
     val warmupSets by viewModel.warmupSets.collectAsState()
@@ -325,9 +326,12 @@ fun ExerciseEditBottomSheet(
                 EquipmentRackSelectionCard(
                     rackItems = rackItems,
                     activeRackItemIds = defaultRackItemIds,
+                    behaviorOverrides = rackBehaviorOverrides,
                     weightUnit = weightUnit,
                     formatWeight = formatWeight,
                     onSelectionChange = viewModel::onDefaultRackItemIdsChange,
+                    onBehaviorOverrideChange = viewModel::onRackBehaviorOverridesChange,
+                    showBehaviorOverrides = true,
                 )
 
                 // Weight Configuration Section (PR Percentage Scaling - Issue #57)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SetReadyScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SetReadyScreen.kt
@@ -86,6 +86,10 @@ import vitruvianprojectphoenix.shared.generated.resources.action_exit
 import vitruvianprojectphoenix.shared.generated.resources.cd_next
 import vitruvianprojectphoenix.shared.generated.resources.cd_previous
 import vitruvianprojectphoenix.shared.generated.resources.cd_stop
+import vitruvianprojectphoenix.shared.generated.resources.equipment_rack_save_override_confirm
+import vitruvianprojectphoenix.shared.generated.resources.equipment_rack_save_override_dismiss
+import vitruvianprojectphoenix.shared.generated.resources.equipment_rack_save_override_message
+import vitruvianprojectphoenix.shared.generated.resources.equipment_rack_save_override_title
 import vitruvianprojectphoenix.shared.generated.resources.exit_routine_message
 import vitruvianprojectphoenix.shared.generated.resources.exit_routine_title
 import vitruvianprojectphoenix.shared.generated.resources.target_reps
@@ -711,11 +715,13 @@ fun SetReadyScreen(navController: NavController, viewModel: MainViewModel, exerc
     if (showSaveOverridePrompt) {
         AlertDialog(
             onDismissRequest = { showSaveOverridePrompt = false },
-            title = { Text("Save Override?") },
+            title = { Text(stringResource(Res.string.equipment_rack_save_override_title)) },
             text = {
                 Text(
-                    "Save this behavior configuration as the default for " +
-                        "${currentExercise.exercise.name} in this routine?",
+                    stringResource(
+                        Res.string.equipment_rack_save_override_message,
+                        currentExercise.exercise.name,
+                    ),
                 )
             },
             confirmButton = {
@@ -728,12 +734,12 @@ fun SetReadyScreen(navController: NavController, viewModel: MainViewModel, exerc
                         )
                     },
                 ) {
-                    Text("Save")
+                    Text(stringResource(Res.string.equipment_rack_save_override_confirm))
                 }
             },
             dismissButton = {
                 TextButton(onClick = { showSaveOverridePrompt = false }) {
-                    Text("Just this time")
+                    Text(stringResource(Res.string.equipment_rack_save_override_dismiss))
                 }
             },
         )

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SetReadyScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SetReadyScreen.kt
@@ -29,7 +29,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.FilledTonalIconButton
-import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
@@ -64,7 +63,6 @@ import com.devil.phoenixproject.data.repository.ExerciseVideoEntity
 import com.devil.phoenixproject.domain.model.ConnectionState
 import com.devil.phoenixproject.domain.model.EchoLevel
 import com.devil.phoenixproject.domain.model.ProgramMode
-import com.devil.phoenixproject.domain.model.RackItem
 import com.devil.phoenixproject.domain.model.RackItemBehavior
 import com.devil.phoenixproject.domain.model.RackLoadAdjustment
 import com.devil.phoenixproject.domain.model.RoutineFlowState
@@ -88,13 +86,6 @@ import vitruvianprojectphoenix.shared.generated.resources.action_exit
 import vitruvianprojectphoenix.shared.generated.resources.cd_next
 import vitruvianprojectphoenix.shared.generated.resources.cd_previous
 import vitruvianprojectphoenix.shared.generated.resources.cd_stop
-import vitruvianprojectphoenix.shared.generated.resources.equipment_rack_active_selection
-import vitruvianprojectphoenix.shared.generated.resources.equipment_rack_display_only_count
-import vitruvianprojectphoenix.shared.generated.resources.equipment_rack_manage
-import vitruvianprojectphoenix.shared.generated.resources.equipment_rack_no_enabled_items
-import vitruvianprojectphoenix.shared.generated.resources.equipment_rack_none_selected
-import vitruvianprojectphoenix.shared.generated.resources.equipment_rack_selected_count
-import vitruvianprojectphoenix.shared.generated.resources.equipment_rack_selected_summary
 import vitruvianprojectphoenix.shared.generated.resources.exit_routine_message
 import vitruvianprojectphoenix.shared.generated.resources.exit_routine_title
 import vitruvianprojectphoenix.shared.generated.resources.target_reps
@@ -131,6 +122,12 @@ fun SetReadyScreen(navController: NavController, viewModel: MainViewModel, exerc
     if (currentExercise == null) {
         return
     }
+
+    var runtimeBehaviorOverrides by remember(setReadyState.exerciseIndex) {
+        mutableStateOf(currentExercise.rackBehaviorOverrides)
+    }
+    var showSaveOverridePrompt by remember { mutableStateOf(false) }
+    var pendingOverridesToSave by remember { mutableStateOf<Map<String, RackItemBehavior>>(emptyMap()) }
 
     val isEchoMode = currentExercise.programMode is ProgramMode.Echo
     val isAMRAP = currentExercise.isAMRAP
@@ -534,10 +531,18 @@ fun SetReadyScreen(navController: NavController, viewModel: MainViewModel, exerc
             EquipmentRackSelectionCard(
                 rackItems = rackItems,
                 activeRackItemIds = activeRackItemIds,
+                behaviorOverrides = runtimeBehaviorOverrides,
                 weightUnit = weightUnit,
                 formatWeight = viewModel::formatWeight,
                 onSelectionChange = viewModel::updateActiveRackSelection,
+                onBehaviorOverrideChange = { newOverrides ->
+                    runtimeBehaviorOverrides = newOverrides
+                    viewModel.updateActiveRackBehaviorOverrides(newOverrides)
+                    pendingOverridesToSave = newOverrides
+                    showSaveOverridePrompt = true
+                },
                 onManageRack = { navController.navigate(NavigationRoutes.EquipmentRack.route) },
+                showBehaviorOverrides = true,
             )
 
             Spacer(Modifier.height(12.dp))
@@ -702,130 +707,37 @@ fun SetReadyScreen(navController: NavController, viewModel: MainViewModel, exerc
             },
         )
     }
-}
 
-@Composable
-private fun SetReadyRackSelectionCard(
-    rackItems: List<RackItem>,
-    activeRackItemIds: List<String>,
-    weightUnit: WeightUnit,
-    formatWeight: (Float, WeightUnit) -> String,
-    onSelectionChange: (List<String>) -> Unit,
-    onManageRack: () -> Unit,
-) {
-    val enabledItems = remember(rackItems) {
-        rackItems
-            .filter { it.enabled }
-            .sortedWith(compareBy<RackItem> { it.sortOrder }.thenBy { it.name.lowercase() })
-    }
-    val activeIdSet = remember(activeRackItemIds) { activeRackItemIds.toSet() }
-    val selectedItems = remember(enabledItems, activeIdSet) { enabledItems.filter { it.id in activeIdSet } }
-
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(16.dp),
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHighest),
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(Spacing.medium),
-            verticalArrangement = Arrangement.spacedBy(Spacing.small),
-        ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
+    if (showSaveOverridePrompt) {
+        AlertDialog(
+            onDismissRequest = { showSaveOverridePrompt = false },
+            title = { Text("Save Override?") },
+            text = {
                 Text(
-                    stringResource(Res.string.equipment_rack_active_selection),
-                    style = MaterialTheme.typography.labelLarge,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    letterSpacing = 1.sp,
+                    "Save this behavior configuration as the default for " +
+                        "${currentExercise.exercise.name} in this routine?",
                 )
-                TextButton(onClick = onManageRack) {
-                    Text(stringResource(Res.string.equipment_rack_manage))
-                }
-            }
-
-            if (enabledItems.isEmpty()) {
-                Text(
-                    stringResource(Res.string.equipment_rack_no_enabled_items),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            } else {
-                enabledItems.forEach { item ->
-                    val selected = item.id in activeIdSet
-                    FilterChip(
-                        selected = selected,
-                        onClick = {
-                            val updated = if (selected) {
-                                activeRackItemIds.filterNot { it == item.id }
-                            } else {
-                                activeRackItemIds + item.id
-                            }
-                            onSelectionChange(updated)
-                        },
-                        label = {
-                            Text(
-                                "${item.name} - ${formatRackChipDetail(item, weightUnit, formatWeight)}",
-                                maxLines = 1,
-                            )
-                        },
-                        modifier = Modifier.fillMaxWidth(),
-                    )
-                }
-
-                Text(
-                    if (selectedItems.isEmpty()) {
-                        stringResource(Res.string.equipment_rack_none_selected)
-                    } else {
-                        stringResource(
-                            Res.string.equipment_rack_selected_summary,
-                            rackSelectionSummary(selectedItems, weightUnit, formatWeight),
+            },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        showSaveOverridePrompt = false
+                        viewModel.saveRackBehaviorOverridesForExercise(
+                            setReadyState.exerciseIndex,
+                            pendingOverridesToSave,
                         )
                     },
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-        }
+                ) {
+                    Text("Save")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showSaveOverridePrompt = false }) {
+                    Text("Just this time")
+                }
+            },
+        )
     }
-}
-
-private fun formatRackChipDetail(
-    item: RackItem,
-    weightUnit: WeightUnit,
-    formatWeight: (Float, WeightUnit) -> String,
-): String = when (item.behavior) {
-    RackItemBehavior.ADDED_RESISTANCE -> "+${formatWeight(item.weightKg, weightUnit)}"
-    RackItemBehavior.COUNTERWEIGHT -> "-${formatWeight(item.weightKg, weightUnit)}"
-    RackItemBehavior.DISPLAY_ONLY -> formatWeight(item.weightKg, weightUnit)
-}
-
-@Composable
-private fun rackSelectionSummary(
-    items: List<RackItem>,
-    weightUnit: WeightUnit,
-    formatWeight: (Float, WeightUnit) -> String,
-): String {
-    val addedKg = items.filter { it.behavior == RackItemBehavior.ADDED_RESISTANCE }.sumOf { it.weightKg.toDouble() }.toFloat()
-    val counterweightKg = items.filter { it.behavior == RackItemBehavior.COUNTERWEIGHT }.sumOf { it.weightKg.toDouble() }.toFloat()
-    val displayOnlyCount = items.count { it.behavior == RackItemBehavior.DISPLAY_ONLY }
-    val displayOnlyLabel = if (displayOnlyCount > 0) {
-        stringResource(Res.string.equipment_rack_display_only_count, displayOnlyCount)
-    } else {
-        null
-    }
-    val selectedCountLabel = stringResource(Res.string.equipment_rack_selected_count, items.size)
-    val parts = buildList {
-        if (addedKg > 0f) add("+${formatWeight(addedKg, weightUnit)}")
-        if (counterweightKg > 0f) add("-${formatWeight(counterweightKg, weightUnit)}")
-        displayOnlyLabel?.let(::add)
-    }
-    return parts.ifEmpty { listOf(selectedCountLabel) }.joinToString(" / ")
 }
 
 /**

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModel.kt
@@ -9,6 +9,7 @@ import com.devil.phoenixproject.domain.model.EccentricLoad
 import com.devil.phoenixproject.domain.model.EchoLevel
 import com.devil.phoenixproject.domain.model.PRType
 import com.devil.phoenixproject.domain.model.PersonalRecord
+import com.devil.phoenixproject.domain.model.RackItemBehavior
 import com.devil.phoenixproject.domain.model.RepCountTiming
 import com.devil.phoenixproject.domain.model.RoutineExercise
 import com.devil.phoenixproject.domain.model.WarmupSet
@@ -121,6 +122,9 @@ class ExerciseConfigViewModel constructor(
     private val _defaultRackItemIds = MutableStateFlow<List<String>>(emptyList())
     val defaultRackItemIds: StateFlow<List<String>> = _defaultRackItemIds.asStateFlow()
 
+    private val _rackBehaviorOverrides = MutableStateFlow<Map<String, RackItemBehavior>>(emptyMap())
+    val rackBehaviorOverrides: StateFlow<Map<String, RackItemBehavior>> = _rackBehaviorOverrides.asStateFlow()
+
     init {
     }
 
@@ -231,6 +235,7 @@ class ExerciseConfigViewModel constructor(
         // Warm-up sets (Issue #30)
         _warmupSets.value = exercise.warmupSets
         _defaultRackItemIds.value = exercise.defaultRackItemIds.filter { it.isNotBlank() }.distinct()
+        _rackBehaviorOverrides.value = exercise.rackBehaviorOverrides
 
         // Load PR for the current exercise and mode
         exercise.exercise.id?.let { exerciseId ->
@@ -411,6 +416,10 @@ class ExerciseConfigViewModel constructor(
 
     fun onDefaultRackItemIdsChange(itemIds: List<String>) {
         _defaultRackItemIds.value = itemIds.filter { it.isNotBlank() }.distinct()
+    }
+
+    fun onRackBehaviorOverridesChange(overrides: Map<String, RackItemBehavior>) {
+        _rackBehaviorOverrides.value = overrides
     }
 
     /**
@@ -646,6 +655,7 @@ class ExerciseConfigViewModel constructor(
             // Warm-up sets (Issue #30)
             warmupSets = _warmupSets.value,
             defaultRackItemIds = _defaultRackItemIds.value,
+            rackBehaviorOverrides = _rackBehaviorOverrides.value,
         )
 
         logDebug("Updated exercise to save:")

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
@@ -32,6 +32,7 @@ import com.devil.phoenixproject.domain.model.HapticEvent
 import com.devil.phoenixproject.domain.model.PRCelebrationEvent
 import com.devil.phoenixproject.domain.model.PersonalRecord
 import com.devil.phoenixproject.domain.model.RackItem
+import com.devil.phoenixproject.domain.model.RackItemBehavior
 import com.devil.phoenixproject.domain.model.RackLoadAdjustment
 import com.devil.phoenixproject.domain.model.RepCount
 import com.devil.phoenixproject.domain.model.RepCountTiming
@@ -182,6 +183,7 @@ class MainViewModel constructor(
     val workoutParameters: StateFlow<WorkoutParameters> get() = workoutSessionManager.coordinator.workoutParameters
     val rackItems get() = equipmentRackRepository.rackItems
     val activeRackItemIds: StateFlow<List<String>> get() = workoutSessionManager.coordinator.activeRackItemIds
+    val activeRackBehaviorOverrides: StateFlow<Map<String, RackItemBehavior>> get() = workoutSessionManager.coordinator.activeRackBehaviorOverrides
     val currentRackLoadAdjustment: StateFlow<RackLoadAdjustment> get() = workoutSessionManager.coordinator.currentRackLoadAdjustment
     val repCount: StateFlow<RepCount> get() = workoutSessionManager.coordinator.repCount
     val timedExerciseRemainingSeconds: StateFlow<Int?> get() = workoutSessionManager.coordinator.timedExerciseRemainingSeconds
@@ -324,6 +326,7 @@ class MainViewModel constructor(
 
     fun updateWorkoutParameters(params: WorkoutParameters) = workoutSessionManager.updateWorkoutParameters(params)
     fun updateActiveRackSelection(itemIds: List<String>) = workoutSessionManager.updateActiveRackSelection(itemIds)
+    fun updateActiveRackBehaviorOverrides(overrides: Map<String, RackItemBehavior>) = workoutSessionManager.updateActiveRackBehaviorOverrides(overrides)
     fun clearActiveRackSelection() = workoutSessionManager.clearActiveRackSelection()
     fun saveRackItem(item: RackItem) {
         viewModelScope.launch {
@@ -377,6 +380,19 @@ class MainViewModel constructor(
     fun getRoutineById(routineId: String): Routine? = workoutSessionManager.getRoutineById(routineId)
     fun saveRoutine(routine: Routine) = workoutSessionManager.saveRoutine(routine)
     fun updateRoutine(routine: Routine) = workoutSessionManager.updateRoutine(routine)
+    fun saveRackBehaviorOverridesForExercise(
+        exerciseIndex: Int,
+        overrides: Map<String, RackItemBehavior>,
+    ) {
+        val routine = loadedRoutine.value ?: return
+        val exercises = routine.exercises.toMutableList()
+        val exercise = exercises.getOrNull(exerciseIndex) ?: return
+        exercises[exerciseIndex] = exercise.copy(rackBehaviorOverrides = overrides)
+        val updatedRoutine = routine.copy(exercises = exercises)
+        workoutSessionManager.coordinator._loadedRoutine.value = updatedRoutine
+        updateActiveRackBehaviorOverrides(overrides)
+        updateRoutine(updatedRoutine)
+    }
     fun deleteRoutine(routineId: String) = workoutSessionManager.deleteRoutine(routineId)
     fun deleteRoutines(routineIds: Set<String>) = workoutSessionManager.deleteRoutines(routineIds)
     fun moveRoutinesToProfile(routineIds: Set<String>, targetProfileId: String) = workoutSessionManager.moveRoutinesToProfile(routineIds, targetProfileId)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
@@ -63,6 +63,7 @@ import com.devil.phoenixproject.presentation.manager.SettingsManager
 import com.devil.phoenixproject.presentation.manager.WorkoutServiceController
 import com.devil.phoenixproject.util.BackupStats
 import com.devil.phoenixproject.util.DataBackupManager
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -385,14 +386,62 @@ class MainViewModel constructor(
         overrides: Map<String, RackItemBehavior>,
     ) {
         val routine = loadedRoutine.value ?: return
-        val exercises = routine.exercises.toMutableList()
-        val exercise = exercises.getOrNull(exerciseIndex) ?: return
-        exercises[exerciseIndex] = exercise.copy(rackBehaviorOverrides = overrides)
-        val updatedRoutine = routine.copy(exercises = exercises)
-        workoutSessionManager.coordinator._loadedRoutine.value = updatedRoutine
+        val exercise = routine.exercises.getOrNull(exerciseIndex) ?: return
+        val updatedActiveRoutine = routine.withRackBehaviorOverrides(
+            exerciseIndex = exerciseIndex,
+            exerciseId = exercise.id,
+            overrides = overrides,
+        ) ?: return
+        workoutSessionManager.coordinator._loadedRoutine.value = updatedActiveRoutine
         updateActiveRackBehaviorOverrides(overrides)
-        updateRoutine(updatedRoutine)
+        viewModelScope.launch {
+            try {
+                val storedRoutine = workoutRepository.getRoutineById(routine.id)
+                if (storedRoutine == null) {
+                    Logger.w { "Rack override save skipped: stored routine not found for id=${routine.id}" }
+                    return@launch
+                }
+                val updatedStoredRoutine = storedRoutine.withRackBehaviorOverrides(
+                    exerciseIndex = exerciseIndex,
+                    exerciseId = exercise.id,
+                    overrides = overrides,
+                )
+                if (updatedStoredRoutine == null) {
+                    Logger.w { "Rack override save skipped: exercise id=${exercise.id} not found in stored routine id=${routine.id}" }
+                    return@launch
+                }
+                workoutRepository.updateRoutine(updatedStoredRoutine)
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                Logger.e(e) { "Failed to save rack behavior overrides for routine id=${routine.id}, exercise id=${exercise.id}" }
+            }
+        }
     }
+    private fun Routine.withRackBehaviorOverrides(
+        exerciseIndex: Int,
+        exerciseId: String,
+        overrides: Map<String, RackItemBehavior>,
+    ): Routine? {
+        val targetIndex = exercises.indexOfFirst { it.id == exerciseId }
+            .takeIf { it >= 0 }
+            ?: if (exerciseId.isBlank()) {
+                exerciseIndex.takeIf { it in exercises.indices }
+            } else {
+                null
+            }
+            ?: return null
+
+        return copy(
+            exercises = exercises.mapIndexed { index, routineExercise ->
+                if (index == targetIndex) {
+                    routineExercise.copy(rackBehaviorOverrides = overrides)
+                } else {
+                    routineExercise
+                }
+            },
+        )
+    }
+
     fun deleteRoutine(routineId: String) = workoutSessionManager.deleteRoutine(routineId)
     fun deleteRoutines(routineIds: Set<String>) = workoutSessionManager.deleteRoutines(routineIds)
     fun moveRoutinesToProfile(routineIds: Set<String>, targetProfileId: String) = workoutSessionManager.moveRoutinesToProfile(routineIds, targetProfileId)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/BackupModels.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/BackupModels.kt
@@ -169,6 +169,8 @@ data class RoutineExerciseBackup(
     val warmupSets: String = "",
     // Local equipment rack defaults (backup schema v4)
     val defaultRackItemIds: List<String> = emptyList(),
+    // Per-exercise rack behavior overrides (Issues #521/#526)
+    val rackBehaviorOverrides: String = "{}",
 )
 
 /**

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/DataBackupManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/DataBackupManager.kt
@@ -611,6 +611,7 @@ abstract class BaseDataBackupManager(
                                 setEchoLevels = exercise.setEchoLevels,
                                 warmupSets = exercise.warmupSets,
                                 defaultRackItemIds = sanitizeRackItemIds(exercise.defaultRackItemIds),
+                                rackBehaviorOverrides = exercise.rackBehaviorOverrides,
                             )
                         }
                         if (inserted != null) routineExercisesImported++
@@ -1332,6 +1333,7 @@ abstract class BaseDataBackupManager(
                                                         setEchoLevels = exercise.setEchoLevels,
                                                         warmupSets = exercise.warmupSets,
                                                         defaultRackItemIds = sanitizeRackItemIds(exercise.defaultRackItemIds),
+                                                        rackBehaviorOverrides = exercise.rackBehaviorOverrides,
                                                     )
                                                 }
                                                 if (inserted != null) {
@@ -2325,6 +2327,7 @@ abstract class BaseDataBackupManager(
         repCountTiming = exercise.repCountTiming,
         warmupSets = exercise.warmupSets,
         defaultRackItemIds = decodeRackItemIds(exercise.defaultRackItemIds),
+        rackBehaviorOverrides = exercise.rackBehaviorOverrides,
     )
 
     private fun decodeRackItemIds(encoded: String): List<String> = runCatching {

--- a/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
+++ b/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
@@ -246,6 +246,7 @@ CREATE TABLE RoutineExercise (
     setEchoLevels TEXT NOT NULL DEFAULT '',
     warmupSets TEXT NOT NULL DEFAULT '',
     defaultRackItemIds TEXT NOT NULL DEFAULT '[]',
+    rackBehaviorOverrides TEXT NOT NULL DEFAULT '{}',
     FOREIGN KEY (routineId) REFERENCES Routine(id) ON DELETE CASCADE,
     FOREIGN KEY (exerciseId) REFERENCES Exercise(id) ON DELETE SET NULL,
     FOREIGN KEY (supersetId) REFERENCES Superset(id) ON DELETE SET NULL
@@ -918,9 +919,10 @@ INSERT INTO RoutineExercise (
     eccentricLoad, echoLevel, progressionKg, restSeconds, duration, setRestSeconds,
     perSetRestTime, isAMRAP, supersetId, orderInSuperset,
     usePercentOfPR, weightPercentOfPR, prTypeForScaling, setWeightsPercentOfPR,
-    stallDetectionEnabled, stopAtTop, repCountTiming, setEchoLevels, warmupSets, defaultRackItemIds
+    stallDetectionEnabled, stopAtTop, repCountTiming, setEchoLevels, warmupSets, defaultRackItemIds,
+    rackBehaviorOverrides
 )
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 -- Insert with IGNORE for import (won't overwrite existing)
 insertRoutineExerciseIgnore:
@@ -930,9 +932,10 @@ INSERT OR IGNORE INTO RoutineExercise (
     eccentricLoad, echoLevel, progressionKg, restSeconds, duration, setRestSeconds,
     perSetRestTime, isAMRAP, supersetId, orderInSuperset,
     usePercentOfPR, weightPercentOfPR, prTypeForScaling, setWeightsPercentOfPR,
-    stallDetectionEnabled, stopAtTop, repCountTiming, setEchoLevels, warmupSets, defaultRackItemIds
+    stallDetectionEnabled, stopAtTop, repCountTiming, setEchoLevels, warmupSets, defaultRackItemIds,
+    rackBehaviorOverrides
 )
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 deleteRoutineExercises:
 DELETE FROM RoutineExercise WHERE routineId = ?;

--- a/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/migrations/35.sqm
+++ b/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/migrations/35.sqm
@@ -1,0 +1,3 @@
+-- Migration 35: Per-exercise equipment rack behavior overrides (Issues #521/#526).
+-- Stores JSON map of rackItemId -> RackItemBehavior override.
+ALTER TABLE RoutineExercise ADD COLUMN rackBehaviorOverrides TEXT NOT NULL DEFAULT '{}';

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/ConflictResolutionTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/ConflictResolutionTest.kt
@@ -236,6 +236,7 @@ class ConflictResolutionTest {
             setEchoLevels = "",
             warmupSets = "",
             defaultRackItemIds = "[]",
+            rackBehaviorOverrides = "{}",
         )
 
         // Verify exercise exists

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/ApplyEquipmentRackLoadUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/ApplyEquipmentRackLoadUseCaseTest.kt
@@ -137,6 +137,105 @@ class ApplyEquipmentRackLoadUseCaseTest {
         assertEquals(80f, result)
     }
 
+    // ===================== Behavior Override Tests (Issues #521/#526) =====================
+
+    @Test
+    fun `no overrides - uses global behavior`() {
+        val vest = rackItem("item-1", 5f, RackItemBehavior.ADDED_RESISTANCE)
+        val result = useCase.calculate(
+            programmedWeightPerCableKg = 50f,
+            physicalCableCount = 2,
+            selectedItems = listOf(vest),
+            isEchoMode = false,
+        )
+        assertEquals(5f, result.externalAddedLoadKg)
+        assertEquals(0f, result.counterweightKg)
+    }
+
+    @Test
+    fun `override flips ADDED_RESISTANCE to COUNTERWEIGHT`() {
+        val vest = rackItem("vest-1", 5f, RackItemBehavior.ADDED_RESISTANCE)
+        val overrides = mapOf("vest-1" to RackItemBehavior.COUNTERWEIGHT)
+        val result = useCase.calculate(
+            programmedWeightPerCableKg = 50f,
+            physicalCableCount = 2,
+            selectedItems = listOf(vest),
+            isEchoMode = false,
+            behaviorOverrides = overrides,
+        )
+        assertEquals(0f, result.externalAddedLoadKg)
+        assertEquals(5f, result.counterweightKg)
+    }
+
+    @Test
+    fun `override to DISPLAY_ONLY excludes from load math`() {
+        val vest = rackItem("vest-1", 5f, RackItemBehavior.ADDED_RESISTANCE)
+        val overrides = mapOf("vest-1" to RackItemBehavior.DISPLAY_ONLY)
+        val result = useCase.calculate(
+            programmedWeightPerCableKg = 50f,
+            physicalCableCount = 2,
+            selectedItems = listOf(vest),
+            isEchoMode = false,
+            behaviorOverrides = overrides,
+        )
+        assertEquals(0f, result.externalAddedLoadKg)
+        assertEquals(0f, result.counterweightKg)
+        // displayLoadKg = (50 * 2 + 0 - 0).coerceAtLeast(0) = 100
+        assertEquals(100f, result.displayLoadKg)
+    }
+
+    @Test
+    fun `override only applies to matching item ID`() {
+        val vest = rackItem("vest-1", 5f, RackItemBehavior.ADDED_RESISTANCE)
+        val ankle = rackItem("ankle-1", 2f, RackItemBehavior.ADDED_RESISTANCE)
+        // Override vest to COUNTERWEIGHT, ankle stays ADDED_RESISTANCE
+        val overrides = mapOf("vest-1" to RackItemBehavior.COUNTERWEIGHT)
+        val result = useCase.calculate(
+            programmedWeightPerCableKg = 50f,
+            physicalCableCount = 2,
+            selectedItems = listOf(vest, ankle),
+            isEchoMode = false,
+            behaviorOverrides = overrides,
+        )
+        assertEquals(2f, result.externalAddedLoadKg) // ankle only
+        assertEquals(5f, result.counterweightKg) // vest only
+    }
+
+    @Test
+    fun `empty overrides map has no effect`() {
+        val vest = rackItem("vest-1", 5f, RackItemBehavior.ADDED_RESISTANCE)
+        val withOverrides = useCase.calculate(
+            programmedWeightPerCableKg = 50f,
+            physicalCableCount = 2,
+            selectedItems = listOf(vest),
+            isEchoMode = false,
+            behaviorOverrides = emptyMap(),
+        )
+        val without = useCase.calculate(
+            programmedWeightPerCableKg = 50f,
+            physicalCableCount = 2,
+            selectedItems = listOf(vest),
+            isEchoMode = false,
+        )
+        assertEquals(without.externalAddedLoadKg, withOverrides.externalAddedLoadKg)
+        assertEquals(without.counterweightKg, withOverrides.counterweightKg)
+    }
+
+    @Test
+    fun `bodyweight effective load respects overrides`() {
+        val vest = rackItem("vest-1", 5f, RackItemBehavior.ADDED_RESISTANCE)
+        // Override vest to COUNTERWEIGHT for bodyweight
+        val overrides = mapOf("vest-1" to RackItemBehavior.COUNTERWEIGHT)
+        val result = useCase.calculateBodyweightEffectiveLoadKg(
+            bodyWeightKg = 80f,
+            percentage = 1.0f,
+            selectedItems = listOf(vest),
+            behaviorOverrides = overrides,
+        )
+        // 80 * 1.0 + 0 (no added resistance) - 5 (counterweight via override) = 75
+        assertEquals(75f, result)
+    }
+
     private fun rackItem(id: String, weightKg: Float, behavior: RackItemBehavior): RackItem = RackItem(
         id = id,
         name = id,

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMEquipmentRackTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMEquipmentRackTest.kt
@@ -48,6 +48,40 @@ class DWSMEquipmentRackTest {
     }
 
     @Test
+    fun `runtime behavior override adjusts non Echo set start packet`() = runTest {
+        val harness = DWSMTestHarness(this)
+        harness.fakeBleRepo.simulateConnect("Vee_Test")
+        harness.fakeEquipmentRackRepo.saveItems(
+            listOf(rackItem("vest", 10f, RackItemBehavior.ADDED_RESISTANCE)),
+        )
+
+        harness.dwsm.updateWorkoutParameters(
+            WorkoutParameters(
+                programMode = ProgramMode.OldSchool,
+                reps = 8,
+                warmupReps = 0,
+                weightPerCableKg = 40f,
+            ),
+        )
+        harness.dwsm.updateActiveRackSelection(listOf("vest"))
+        harness.dwsm.updateActiveRackBehaviorOverrides(
+            mapOf("vest" to RackItemBehavior.COUNTERWEIGHT),
+        )
+
+        harness.dwsm.startWorkout(skipCountdown = true)
+        advanceUntilIdle()
+
+        val command = harness.fakeBleRepo.commandsReceived.single()
+        assertEquals(30f, readFloatLE(command, BleConstants.ActivationPacket.OFFSET_TARGET_WEIGHT))
+        assertEquals(40f, harness.dwsm.coordinator.workoutParameters.value.weightPerCableKg)
+        assertEquals(
+            mapOf("vest" to RackItemBehavior.COUNTERWEIGHT),
+            harness.dwsm.coordinator.activeRackBehaviorOverrides.value,
+        )
+        harness.cleanup()
+    }
+
+    @Test
     fun `active rack edits during active set do not send mid set command and saved session uses set start snapshot`() = runTest {
         val harness = DWSMTestHarness(this)
         harness.fakeBleRepo.simulateConnect("Vee_Test")

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMEquipmentRackTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMEquipmentRackTest.kt
@@ -48,32 +48,36 @@ class DWSMEquipmentRackTest {
     }
 
     @Test
-    fun `runtime behavior override adjusts non Echo set start packet`() = runTest {
+    fun `runtime behavior override recalculates non Echo rack adjustment`() = runTest {
         val harness = DWSMTestHarness(this)
         harness.fakeBleRepo.simulateConnect("Vee_Test")
         harness.fakeEquipmentRackRepo.saveItems(
             listOf(rackItem("vest", 10f, RackItemBehavior.ADDED_RESISTANCE)),
         )
-
-        harness.dwsm.updateWorkoutParameters(
-            WorkoutParameters(
-                programMode = ProgramMode.OldSchool,
-                reps = 8,
-                warmupReps = 0,
-                weightPerCableKg = 40f,
+        val routine = Routine(
+            id = "routine-rack-overrides",
+            name = "Rack Overrides",
+            exercises = listOf(
+                routineExercise("rex-1", "Bench Press", listOf("vest")),
             ),
         )
-        harness.dwsm.updateActiveRackSelection(listOf("vest"))
+
+        assertTrue(harness.dwsm.loadRoutineAsync(routine))
+        advanceUntilIdle()
+        harness.dwsm.enterSetReady(0, 0)
+        advanceUntilIdle()
+        assertEquals(10f, harness.dwsm.coordinator.currentRackLoadAdjustment.value.externalAddedLoadKg)
+        assertEquals(0f, harness.dwsm.coordinator.currentRackLoadAdjustment.value.counterweightKg)
+
         harness.dwsm.updateActiveRackBehaviorOverrides(
             mapOf("vest" to RackItemBehavior.COUNTERWEIGHT),
         )
+        assertEquals(0f, harness.dwsm.coordinator.currentRackLoadAdjustment.value.externalAddedLoadKg)
+        assertEquals(10f, harness.dwsm.coordinator.currentRackLoadAdjustment.value.counterweightKg)
 
-        harness.dwsm.startWorkout(skipCountdown = true)
-        advanceUntilIdle()
-
-        val command = harness.fakeBleRepo.commandsReceived.single()
-        assertEquals(30f, readFloatLE(command, BleConstants.ActivationPacket.OFFSET_TARGET_WEIGHT))
         assertEquals(40f, harness.dwsm.coordinator.workoutParameters.value.weightPerCableKg)
+        assertEquals(0f, harness.dwsm.coordinator.workoutParameters.value.externalAddedLoadKg)
+        assertEquals(10f, harness.dwsm.coordinator.workoutParameters.value.counterweightKg)
         assertEquals(
             mapOf("vest" to RackItemBehavior.COUNTERWEIGHT),
             harness.dwsm.coordinator.activeRackBehaviorOverrides.value,


### PR DESCRIPTION
## Summary
- Adds per-exercise equipment rack behavior overrides from persistence through sync DTOs, routine-builder editing, SetReady runtime editing, and rack load calculations.
- Replaces the always-expanded rack selector with a collapsible summary row and per-selected-item behavior picker.
- Adds schema safety-net coverage and regression tests for migration/default behavior and runtime override load math.

## Why
Issues #521 and #526 need exercises to treat the same rack item differently per routine exercise or per SetReady session without changing the global RackItem behavior.

## Validation
- `./gradlew.bat :shared:compileKotlinMetadata`
- `./gradlew.bat :shared:compileAndroidMain`
- `./gradlew.bat --% :shared:testAndroidHostTest --tests com.devil.phoenixproject.domain.usecase.ApplyEquipmentRackLoadUseCaseTest`
- `./gradlew.bat --% :shared:testAndroidHostTest --tests com.devil.phoenixproject.data.local.SchemaParityTest --rerun-tasks`
- `./gradlew.bat --% :shared:testAndroidHostTest --tests com.devil.phoenixproject.presentation.manager.DWSMEquipmentRackTest`
- `./gradlew.bat :shared:testAndroidHostTest`
- `./gradlew.bat :androidApp:assembleDebug`

## Notes
- The plan's `:shared:compileKotlinJvm` command is stale in this repo; the current shared compile targets are covered above.
- Portal-side storage/edge-function changes remain out of scope for this mobile PR.