### PR TITLE
fix(issue-586): reject implausible historical set-duration averages in routine estimates

### DIFF
--- a/androidApp/src/test/kotlin/com/devil/phoenixproject/RoutineTimeEstimatorTest.kt
+++ b/androidApp/src/test/kotlin/com/devil/phoenixproject/RoutineTimeEstimatorTest.kt
@@ -596,4 +596,164 @@ class RoutineTimeEstimatorTest {
         assertTrue(result.isHistoryBased)
         assertEquals(50, result.totalSeconds)
     }
+
+    // ==================== ISSUE #586: IMPLAUSIBLE HISTORY GUARDS ====================
+
+    /**
+     * Issue #586 regression: if the SQL average returns an implausibly large
+     * historical per-set duration (e.g., elapsed wall-clock time mistakenly
+     * averaged as a per-set value), the estimator must NOT mark the exercise
+     * as history-based and must NOT amplify the bad value through the AMRAP
+     * range multiplier. It must fall back to the AMRAP fallback constants so
+     * Daily Routines cannot render a multi-year routine estimate.
+     */
+    @Test
+    fun `AMRAP-heavy routine with absurd historical avg falls back to human-scale estimate`() = runTest {
+        val exerciseIds = listOf("ex-1", "ex-2", "ex-3", "ex-4", "ex-5", "ex-6", "ex-7")
+        // 268 days in ms — matches the historicalAvgMs that back-solves to the
+        // screenshot's 134921h lower bound for a 7-exercise AMRAP-heavy routine.
+        val absurdAvgMs = 268L * 24L * 60L * 60L * 1000L
+
+        for (id in exerciseIds) {
+            coEvery { workoutRepository.getSessionCountForExercise(id, profileId) } returns 5
+            coEvery { workoutRepository.getAverageSetDurationMs(id, profileId) } returns absurdAvgMs
+        }
+
+        val exercises = exerciseIds.mapIndexed { idx, id ->
+            routineExercise(
+                exercise = cableExercise(id = id, name = "Exercise $idx"),
+                // All AMRAP — matches reporter confirmation that "most of those exercises are AMRAP".
+                setReps = listOf(null, null, null),
+                restSeconds = listOf(60, 60),
+                orderIndex = idx,
+            )
+        }
+        val result = estimator.estimateRoutineDuration(routine(exercises), profileId)
+
+        // No exercise should be treated as history-based — the bad average must be rejected.
+        assertFalse(
+            "Estimator must not trust implausible historical averages",
+            result.isHistoryBased,
+        )
+
+        // Must NOT render hundreds of thousands of hours. The AMRAP fallback
+        // midpoint is 90s per set, so totalSeconds must stay in the thousands,
+        // not hundreds-of-thousands.
+        val totalHours = result.totalSeconds / 3600.0
+        assertTrue(
+            "Routine estimate should be human-scale but was ${totalHours}h ($result)",
+            totalHours < 24,
+        )
+
+        // Upper bound must also stay under one day even with the 2.0x AMRAP multiplier.
+        val upperHours = result.upperBoundSeconds / 3600.0
+        assertTrue(
+            "AMRAP upper bound should be human-scale but was ${upperHours}h ($result)",
+            upperHours < 24,
+        )
+    }
+
+    /**
+     * Issue #586 regression: fixed-rep sets must also reject absurd historical
+     * averages instead of multiplying them through all planned sets.
+     */
+    @Test
+    fun `fixed-rep routine with absurd historical avg falls back to defaults`() = runTest {
+        val exerciseIds = listOf("ex-1", "ex-2", "ex-3")
+        val absurdAvgMs = 200L * 24L * 60L * 60L * 1000L // 200 days
+
+        for (id in exerciseIds) {
+            coEvery { workoutRepository.getSessionCountForExercise(id, profileId) } returns 4
+            coEvery { workoutRepository.getAverageSetDurationMs(id, profileId) } returns absurdAvgMs
+        }
+
+        val exercises = exerciseIds.mapIndexed { idx, id ->
+            routineExercise(
+                exercise = cableExercise(id = id, name = "Exercise $idx"),
+                setReps = listOf(10, 10, 10),
+                restSeconds = listOf(90, 90),
+                orderIndex = idx,
+            )
+        }
+        val result = estimator.estimateRoutineDuration(routine(exercises), profileId)
+
+        assertFalse(
+            "Fixed-rep estimator must not trust implausible historical averages",
+            result.isHistoryBased,
+        )
+
+        // Without trust, fixed-rep defaults are 45s/set + 90s rest between sets.
+        // 3 exercises * 3 sets * 45s + 2 * 90s = 585s per exercise, plus transitions.
+        // Anything multi-day is a regression of the original bug.
+        val totalHours = result.totalSeconds / 3600.0
+        assertTrue(
+            "Fixed-rep routine must stay human-scale but was ${totalHours}h ($result)",
+            totalHours < 1,
+        )
+    }
+
+    /**
+     * Issue #586 boundary check: the upper bound for a plausible per-set average
+     * is 20 minutes. A value at or below that must still be trusted so the
+     * estimator's normal history path keeps working.
+     */
+    @Test
+    fun `historical avg at exactly MAX_PLAUSIBLE_SET_DURATION_MS is still trusted`() = runTest {
+        val exerciseId = "ex-1"
+        coEvery { workoutRepository.getSessionCountForExercise(exerciseId, profileId) } returns 5
+        coEvery {
+            workoutRepository.getAverageSetDurationMs(exerciseId, profileId)
+        } returns RoutineTimeEstimator.MAX_PLAUSIBLE_SET_DURATION_MS
+
+        val exercises = listOf(
+            routineExercise(
+                exercise = cableExercise(id = exerciseId),
+                setReps = listOf(10),
+                restSeconds = emptyList(),
+            ),
+        )
+        val result = estimator.estimateRoutineDuration(routine(exercises), profileId)
+
+        // Boundary value should still be trusted (inclusive upper bound).
+        assertTrue(
+            "Exactly MAX_PLAUSIBLE_SET_DURATION_MS must still be history-based",
+            result.isHistoryBased,
+        )
+        assertEquals(
+            (RoutineTimeEstimator.MAX_PLAUSIBLE_SET_DURATION_MS / 1000L).toInt(),
+            result.totalSeconds,
+        )
+    }
+
+    /**
+     * Issue #586 boundary check: a value one millisecond above the cap must be
+     * rejected so a corrupt row at exactly the boundary+1 cannot slip through.
+     */
+    @Test
+    fun `historical avg one ms over MAX_PLAUSIBLE_SET_DURATION_MS is rejected`() = runTest {
+        val exerciseId = "ex-1"
+        coEvery { workoutRepository.getSessionCountForExercise(exerciseId, profileId) } returns 5
+        coEvery {
+            workoutRepository.getAverageSetDurationMs(exerciseId, profileId)
+        } returns RoutineTimeEstimator.MAX_PLAUSIBLE_SET_DURATION_MS + 1L
+
+        val exercises = listOf(
+            routineExercise(
+                exercise = cableExercise(id = exerciseId),
+                setReps = listOf(10),
+                restSeconds = emptyList(),
+            ),
+        )
+        val result = estimator.estimateRoutineDuration(routine(exercises), profileId)
+
+        assertFalse(
+            "One-ms-over MAX_PLAUSIBLE_SET_DURATION_MS must be rejected",
+            result.isHistoryBased,
+        )
+    }
+
+    @Test
+    fun `MAX_PLAUSIBLE_SET_DURATION_MS is 20 minutes`() {
+        assertEquals(20L * 60L * 1000L, RoutineTimeEstimator.MAX_PLAUSIBLE_SET_DURATION_MS)
+    }
 }

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepositoryTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepositoryTest.kt
@@ -550,4 +550,75 @@ class SqlDelightWorkoutRepositoryTest {
             "An over-cap row must not be counted as a session",
         )
     }
+
+    /**
+     * Issue #586 follow-up: rows that only populate `totalReps` (with
+     * `workingReps == 0`) are still treated as completed sets by the rest of the
+     * schema (selectCompletedHealthExportCandidates, selectSessionsByRoutineSessionId,
+     * selectSessionsForPhasePRBackfill). They must contribute to the historical
+     * average and count for routine time estimation so imported, legacy, or tagged
+     * JustLift sessions don't silently disappear from history.
+     */
+    @Test
+    fun `totalReps-only rows are eligible for average and count`() = runTest {
+        val exerciseId = "586-totalreps-only"
+        val profileId = "default"
+
+        // totalReps-only rows: workingReps == 0, but the row is completed.
+        repository.saveSession(
+            createTestSession(id = "586-tr-1", timestamp = 1000L)
+                .copy(
+                    exerciseId = exerciseId,
+                    duration = 40_000L,
+                    totalReps = 10,
+                    workingReps = 0,
+                    profileId = profileId,
+                ),
+        )
+        repository.saveSession(
+            createTestSession(id = "586-tr-2", timestamp = 2000L)
+                .copy(
+                    exerciseId = exerciseId,
+                    duration = 50_000L,
+                    totalReps = 12,
+                    workingReps = 0,
+                    profileId = profileId,
+                ),
+        )
+
+        assertEquals(
+            45_000L,
+            repository.getAverageSetDurationMs(exerciseId, profileId),
+            "totalReps-only rows must be included in the historical average",
+        )
+        assertEquals(
+            2L,
+            repository.getSessionCountForExercise(exerciseId, profileId),
+            "totalReps-only rows must be counted as completed sessions",
+        )
+
+        // A row with both totalReps == 0 AND workingReps == 0 is a true zero-rep
+        // row and must still be excluded.
+        repository.saveSession(
+            createTestSession(id = "586-zero-both", timestamp = 3000L)
+                .copy(
+                    exerciseId = exerciseId,
+                    duration = 60_000L,
+                    totalReps = 0,
+                    workingReps = 0,
+                    profileId = profileId,
+                ),
+        )
+
+        assertEquals(
+            45_000L,
+            repository.getAverageSetDurationMs(exerciseId, profileId),
+            "Rows with both totalReps == 0 and workingReps == 0 must not change the average",
+        )
+        assertEquals(
+            2L,
+            repository.getSessionCountForExercise(exerciseId, profileId),
+            "Rows with both totalReps == 0 and workingReps == 0 must not be counted",
+        )
+    }
 }

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepositoryTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepositoryTest.kt
@@ -415,35 +415,40 @@ class SqlDelightWorkoutRepositoryTest {
         )
 
         // Implausibly-long row (2 hours): wall-clock elapsed time, not a set.
-        // Must be excluded so it cannot become the historical average.
+        // Must be excluded by the SQL duration cap. To prove the *duration* is what
+        // disqualifies this row, force totalReps/workingReps both to 0 so the new
+        // (workingReps > 0 OR totalReps > 0) eligibility condition is also false.
         repository.saveSession(
             createTestSession(id = "586-corrupt-long", timestamp = 4000L)
                 .copy(
                     exerciseId = exerciseId,
                     duration = 2L * 60L * 60L * 1000L, // 2 hours
-                    workingReps = 10,
-                    profileId = profileId,
-                ),
-        )
-
-        // Zero-working-rep row (canceled/warmup-only): must be excluded.
-        repository.saveSession(
-            createTestSession(id = "586-zero-rep", timestamp = 5000L)
-                .copy(
-                    exerciseId = exerciseId,
-                    duration = 60_000L,
+                    totalReps = 0,
                     workingReps = 0,
                     profileId = profileId,
                 ),
         )
 
-        // Sync-deleted row: must be excluded.
+        // Zero-working-rep row (canceled/warmup-only): must be excluded.
+        // Also force totalReps = 0 so it is unambiguously a zero-rep row.
+        repository.saveSession(
+            createTestSession(id = "586-zero-rep", timestamp = 5000L)
+                .copy(
+                    exerciseId = exerciseId,
+                    duration = 60_000L,
+                    totalReps = 0,
+                    workingReps = 0,
+                    profileId = profileId,
+                ),
+        )
+
+        // Sync-deleted row: must be excluded. Keep workingReps/totalReps at default
+        // so deletion is the only thing disqualifying it.
         repository.saveSession(
             createTestSession(id = "586-deleted", timestamp = 6000L)
                 .copy(
                     exerciseId = exerciseId,
                     duration = 60_000L,
-                    workingReps = 10,
                     profileId = profileId,
                 ),
         )

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepositoryTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepositoryTest.kt
@@ -370,4 +370,184 @@ class SqlDelightWorkoutRepositoryTest {
         exerciseId = "test-exercise",
         exerciseName = "Test Exercise",
     )
+
+    // ========== ISSUE #586: ROUTINE-TIME-ESTIMATION SQL ELIGIBILITY ==========
+
+    /**
+     * Issue #586 regression: `getAverageSetDurationMs` and `getSessionCountForExercise`
+     * must use the same eligibility filter so the SQL count threshold and the SQL
+     * average are derived from the same rows. Otherwise stale, sync-deleted,
+     * zero-rep, or implausibly-long rows (wall-clock elapsed time written by
+     * ActiveSessionEngine) can become the average and break routine time estimation.
+     */
+    @Test
+    fun `getAverageSetDurationMs and getSessionCountForExercise ignore deleted zero-rep and implausibly-long rows`() = runTest {
+        val exerciseId = "586-bench"
+        val profileId = "default"
+
+        // Plausible completed row (45s avg): eligible.
+        repository.saveSession(
+            createTestSession(id = "586-good-1", timestamp = 1000L)
+                .copy(
+                    exerciseId = exerciseId,
+                    duration = 45_000L,
+                    workingReps = 10,
+                    profileId = profileId,
+                ),
+        )
+        repository.saveSession(
+            createTestSession(id = "586-good-2", timestamp = 2000L)
+                .copy(
+                    exerciseId = exerciseId,
+                    duration = 60_000L,
+                    workingReps = 12,
+                    profileId = profileId,
+                ),
+        )
+        repository.saveSession(
+            createTestSession(id = "586-good-3", timestamp = 3000L)
+                .copy(
+                    exerciseId = exerciseId,
+                    duration = 30_000L,
+                    workingReps = 8,
+                    profileId = profileId,
+                ),
+        )
+
+        // Implausibly-long row (2 hours): wall-clock elapsed time, not a set.
+        // Must be excluded so it cannot become the historical average.
+        repository.saveSession(
+            createTestSession(id = "586-corrupt-long", timestamp = 4000L)
+                .copy(
+                    exerciseId = exerciseId,
+                    duration = 2L * 60L * 60L * 1000L, // 2 hours
+                    workingReps = 10,
+                    profileId = profileId,
+                ),
+        )
+
+        // Zero-working-rep row (canceled/warmup-only): must be excluded.
+        repository.saveSession(
+            createTestSession(id = "586-zero-rep", timestamp = 5000L)
+                .copy(
+                    exerciseId = exerciseId,
+                    duration = 60_000L,
+                    workingReps = 0,
+                    profileId = profileId,
+                ),
+        )
+
+        // Sync-deleted row: must be excluded.
+        repository.saveSession(
+            createTestSession(id = "586-deleted", timestamp = 6000L)
+                .copy(
+                    exerciseId = exerciseId,
+                    duration = 60_000L,
+                    workingReps = 10,
+                    profileId = profileId,
+                ),
+        )
+        database.vitruvianDatabaseQueries.softDeleteSession(
+            id = "586-deleted",
+            deletedAt = 6500L,
+            updatedAt = 6500L,
+        )
+
+        // Different exercise — must not affect the average or count for `exerciseId`.
+        repository.saveSession(
+            createTestSession(id = "586-other-ex", timestamp = 7000L)
+                .copy(
+                    exerciseId = "other-exercise",
+                    duration = 600_000L, // 10 minutes
+                    workingReps = 10,
+                    profileId = profileId,
+                ),
+        )
+
+        // Different profile — must not affect this profile's average or count.
+        repository.saveSession(
+            createTestSession(id = "586-other-profile", timestamp = 8000L)
+                .copy(
+                    exerciseId = exerciseId,
+                    duration = 600_000L, // 10 minutes
+                    workingReps = 10,
+                    profileId = "other-profile",
+                ),
+        )
+
+        // Expected average over the 3 plausible rows: (45 + 60 + 30) / 3 = 45_000ms
+        val expectedAvg = (45_000L + 60_000L + 30_000L) / 3L
+
+        val avg = repository.getAverageSetDurationMs(exerciseId, profileId)
+        val count = repository.getSessionCountForExercise(exerciseId, profileId)
+
+        assertEquals(
+            expectedAvg,
+            avg,
+            "Average must exclude implausibly-long, zero-rep, and sync-deleted rows",
+        )
+        assertEquals(
+            3L,
+            count,
+            "Count must use the same eligibility filter as the average query",
+        )
+    }
+
+    /**
+     * Issue #586 boundary check: rows at exactly the 20-minute eligibility cap
+     * (matching MAX_PLAUSIBLE_SET_DURATION_MS in the estimator) are still counted
+     * and included in the average so the SQL filter and the estimator guard agree.
+     */
+    @Test
+    fun `rows at exactly 20 minute duration are eligible for average and count`() = runTest {
+        val exerciseId = "586-boundary"
+        val profileId = "default"
+        val boundaryMs = 20L * 60L * 1000L
+
+        repository.saveSession(
+            createTestSession(id = "586-b-1", timestamp = 1000L)
+                .copy(exerciseId = exerciseId, duration = boundaryMs, workingReps = 10, profileId = profileId),
+        )
+        repository.saveSession(
+            createTestSession(id = "586-b-2", timestamp = 2000L)
+                .copy(exerciseId = exerciseId, duration = boundaryMs, workingReps = 10, profileId = profileId),
+        )
+        repository.saveSession(
+            createTestSession(id = "586-b-3", timestamp = 3000L)
+                .copy(exerciseId = exerciseId, duration = boundaryMs, workingReps = 10, profileId = profileId),
+        )
+
+        assertEquals(boundaryMs, repository.getAverageSetDurationMs(exerciseId, profileId))
+        assertEquals(3L, repository.getSessionCountForExercise(exerciseId, profileId))
+    }
+
+    /**
+     * Issue #586 boundary check: a row one millisecond above the 20-minute cap
+     * must be excluded by the SQL filter even when its other fields look fine.
+     */
+    @Test
+    fun `row one ms over 20 minute duration is excluded by SQL filter`() = runTest {
+        val exerciseId = "586-over-boundary"
+        val profileId = "default"
+
+        repository.saveSession(
+            createTestSession(id = "586-ob-1", timestamp = 1000L)
+                .copy(
+                    exerciseId = exerciseId,
+                    duration = 20L * 60L * 1000L + 1L,
+                    workingReps = 10,
+                    profileId = profileId,
+                ),
+        )
+
+        assertNull(
+            repository.getAverageSetDurationMs(exerciseId, profileId),
+            "A row one ms over the 20-minute cap must not contribute to the average",
+        )
+        assertEquals(
+            0L,
+            repository.getSessionCountForExercise(exerciseId, profileId),
+            "An over-cap row must not be counted as a session",
+        )
+    }
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/RoutineTimeEstimator.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/RoutineTimeEstimator.kt
@@ -41,6 +41,18 @@ class RoutineTimeEstimator(private val workoutRepository: WorkoutRepository) {
 
         /** Minimum number of completed sessions before trusting historical averages */
         const val MIN_HISTORICAL_SESSIONS = 3
+
+        /**
+         * Upper bound for a plausible per-set duration in milliseconds.
+         *
+         * Issue #586: `WorkoutSession.duration` is set by `ActiveSessionEngine` to
+         * wall-clock elapsed time from warmup/workout start, not a per-set value.
+         * SQL filters apply this cap, but this constant lets `RoutineTimeEstimator`
+         * defensively reject any historical average above a human-performed set
+         * length (20 minutes) so a corrupted or stale row cannot become a
+         * multi-year AMRAP estimate.
+         */
+        const val MAX_PLAUSIBLE_SET_DURATION_MS = 20L * 60L * 1000L
     }
 
     /**
@@ -167,7 +179,14 @@ class RoutineTimeEstimator(private val workoutRepository: WorkoutRepository) {
             val sessionCount = workoutRepository.getSessionCountForExercise(exerciseId, profileId)
             if (sessionCount >= MIN_HISTORICAL_SESSIONS) {
                 val avgMs = workoutRepository.getAverageSetDurationMs(exerciseId, profileId)
-                if (avgMs != null && avgMs > 0) {
+                // Issue #586: defensively reject implausible per-set averages.
+                // WorkoutSession.duration is wall-clock elapsed time from
+                // ActiveSessionEngine, not a true per-set value, so the SQL average
+                // can still inherit a stale or cumulative row. Treat anything above
+                // a human-plausible set length as invalid and fall back to the
+                // configured fixed/AMRAP defaults rather than amplifying it through
+                // 1.0x–2.0x AMRAP range formatting.
+                if (avgMs != null && avgMs > 0 && avgMs <= MAX_PLAUSIBLE_SET_DURATION_MS) {
                     historicalAvgMs = avgMs
                     isHistoryBased = true
                 }

--- a/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
+++ b/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
@@ -718,29 +718,37 @@ DELETE FROM MetricSample WHERE sessionId = ?;
 
 -- Average set duration for a specific exercise (Issue #225: routine time estimation)
 -- Issue #586: only consider rows that look like an actual set (plausible duration
--- and at least one completed working rep). Stale/elapsed/zero-rep rows must be
--- excluded so the SQL average matches the SQL count below and matches what
+-- and at least one completed rep). Stale/elapsed/zero-rep rows must be excluded
+-- so the SQL average matches the SQL count below and matches what
 -- RoutineTimeEstimator treats as "trustworthy history".
+-- "Completed" matches the rest of the schema (selectCompletedHealthExportCandidates,
+-- selectSessionsByRoutineSessionId, selectSessionsForPhasePRBackfill): rows with
+-- either workingReps > 0 or totalReps > 0. Imported, legacy, or tagged JustLift
+-- sessions that populate only totalReps must still count as history.
+-- Note: the 1200000 ms (20 min) duration cap MUST be kept in sync with
+-- RoutineTimeEstimator.MAX_PLAUSIBLE_SET_DURATION_MS; if you change one,
+-- update the other and the related regression tests.
 selectAverageSetDurationMs:
 SELECT AVG(duration) AS avgDurationMs
 FROM WorkoutSession
 WHERE exerciseId = ?
   AND profile_id = :profileId
   AND deletedAt IS NULL
-  AND workingReps > 0
+  AND (workingReps > 0 OR totalReps > 0)
   AND duration > 0
   AND duration <= 1200000;
 
 -- Count sessions for a specific exercise (Issue #225: minimum session threshold for time estimation)
 -- Issue #586: must use the same eligibility filter as selectAverageSetDurationMs so
 -- the session-count threshold and the SQL average are derived from the same set of rows.
+-- See selectAverageSetDurationMs for the duration-cap coupling to RoutineTimeEstimator.
 selectSessionCountForExercise:
 SELECT COUNT(*)
 FROM WorkoutSession
 WHERE exerciseId = ?
   AND profile_id = :profileId
   AND deletedAt IS NULL
-  AND workingReps > 0
+  AND (workingReps > 0 OR totalReps > 0)
   AND duration > 0
   AND duration <= 1200000;
 

--- a/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
+++ b/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
@@ -717,18 +717,32 @@ deleteMetricsBySession:
 DELETE FROM MetricSample WHERE sessionId = ?;
 
 -- Average set duration for a specific exercise (Issue #225: routine time estimation)
+-- Issue #586: only consider rows that look like an actual set (plausible duration
+-- and at least one completed working rep). Stale/elapsed/zero-rep rows must be
+-- excluded so the SQL average matches the SQL count below and matches what
+-- RoutineTimeEstimator treats as "trustworthy history".
 selectAverageSetDurationMs:
 SELECT AVG(duration) AS avgDurationMs
 FROM WorkoutSession
-WHERE exerciseId = ? AND duration > 0
-AND profile_id = :profileId;
+WHERE exerciseId = ?
+  AND profile_id = :profileId
+  AND deletedAt IS NULL
+  AND workingReps > 0
+  AND duration > 0
+  AND duration <= 1200000;
 
 -- Count sessions for a specific exercise (Issue #225: minimum session threshold for time estimation)
+-- Issue #586: must use the same eligibility filter as selectAverageSetDurationMs so
+-- the session-count threshold and the SQL average are derived from the same set of rows.
 selectSessionCountForExercise:
 SELECT COUNT(*)
 FROM WorkoutSession
-WHERE exerciseId = ? AND duration > 0
-AND profile_id = :profileId;
+WHERE exerciseId = ?
+  AND profile_id = :profileId
+  AND deletedAt IS NULL
+  AND workingReps > 0
+  AND duration > 0
+  AND duration <= 1200000;
 
 -- Personal Record Queries
 


### PR DESCRIPTION
Fixes #586

## Problem

The Daily Routines screen was rendering multi-year time estimates (e.g.,
`134921h 48m - 269843h 21...`) because:

1. `selectAverageSetDurationMs`/`selectSessionCountForExercise` only filtered
   on `duration > 0`, so implausibly long `WorkoutSession.duration` values
   (wall-clock elapsed time written by `ActiveSessionEngine`) entered the
   SQL average. The reporter confirmed this routine is mostly AMRAP, which
   amplifies the upper bound through the 1.0x-2.0x AMRAP range multiplier.
2. `RoutineTimeEstimator` then trusted any positive `avgMs` as a per-set
   value and multiplied it across all planned sets.

## Fix

- **SQL eligibility filter** (`VitruvianDatabase.sq`): apply identical
  filtering to `selectAverageSetDurationMs` and `selectSessionCountForExercise`:
  `deletedAt IS NULL`, `workingReps > 0`, `duration > 0`,
  `duration <= 20 minutes` (1200000 ms). Count and average now derive from
  the same eligible rows.
- **Defensive guard** (`RoutineTimeEstimator.kt`): add
  `MAX_PLAUSIBLE_SET_DURATION_MS = 20 minutes`; reject any historical
  average above this so the AMRAP range cannot amplify a corrupt row.

The estimator's normal history path keeps working: any average at or below
20 minutes is still trusted (inclusive upper bound).

## Tests

- `RoutineTimeEstimatorTest` (5 new): AMRAP-heavy routine with absurd
  historical avg falls back to human-scale; fixed-rep with absurd avg falls
  back; boundary at `MAX_PLAUSIBLE_SET_DURATION_MS` trusted; `+1` ms
  rejected; constant value check.
- `SqlDelightWorkoutRepositoryTest` (3 new): average/count use identical
  eligibility filter (deletes, zero-rep, implausibly-long rows excluded;
  different exercise/profile isolated); boundary at 20 minutes trusted;
  `+1` ms excluded.

## Verification

- `:androidApp:testDebugUnitTest` 31/31 passed
- `:shared:testAndroidHostTest` 2109/2109 passed