### PR TITLE
Keep screen awake throughout Just Lift

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutCoordinator.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutCoordinator.kt
@@ -107,6 +107,17 @@ class WorkoutCoordinator(
     internal val _workoutState = MutableStateFlow<WorkoutState>(WorkoutState.Idle)
     val workoutState: StateFlow<WorkoutState> = _workoutState.asStateFlow()
 
+    // ===== Just Lift Rest Timer (Issue #113) =====
+
+    // Visual-only "egg timer" countdown displayed while user rests between Just Lift sets.
+    // null = no timer active, 0+ = seconds remaining. Picking up handles cancels it.
+    internal val _justLiftRestCountdown = MutableStateFlow<Int?>(null)
+    val justLiftRestCountdown: StateFlow<Int?> = _justLiftRestCountdown.asStateFlow()
+    internal var justLiftRestTimerJob: Job? = null
+
+    @Volatile
+    internal var justLiftRestDeadlineElapsedRealtimeMs: Long? = null
+
     /**
      * Returns true if a workout is currently in progress (not idle or completed).
      * Use this to prevent actions that shouldn't happen during active workouts,
@@ -130,11 +141,17 @@ class WorkoutCoordinator(
      * Unlike [isWorkoutActive], this covers the full session lifecycle:
      * - Active workout states (Initializing, Countdown, Active, Resting, SetSummary)
      * - Between-set routine states (SetReady screen where workoutState is Idle)
+     * - Just Lift visual rest countdown where workoutState is Idle between sets
      */
-    val isInWorkoutSession = combine(_workoutState, _routineFlowState) { ws, rfs ->
+    val isInWorkoutSession = combine(
+        _workoutState,
+        _routineFlowState,
+        _justLiftRestCountdown,
+    ) { ws, rfs, restCountdown ->
         val workoutInProgress = ws !is WorkoutState.Idle && ws !is WorkoutState.Completed
         val betweenRoutineSets = rfs is RoutineFlowState.SetReady
-        workoutInProgress || betweenRoutineSets
+        val betweenJustLiftSets = ws is WorkoutState.Idle && (restCountdown ?: 0) > 0
+        workoutInProgress || betweenRoutineSets || betweenJustLiftSets
     }
 
     // ===== Metrics State =====
@@ -162,17 +179,6 @@ class WorkoutCoordinator(
     // Null means motion start is not active (feature disabled or not in countdown)
     internal val _motionStartHoldProgress = MutableStateFlow<Float?>(null)
     val motionStartHoldProgress: StateFlow<Float?> = _motionStartHoldProgress.asStateFlow()
-
-    // ===== Just Lift Rest Timer (Issue #113) =====
-
-    // Visual-only "egg timer" countdown displayed while user rests between Just Lift sets.
-    // null = no timer active, 0+ = seconds remaining. Picking up handles cancels it.
-    internal val _justLiftRestCountdown = MutableStateFlow<Int?>(null)
-    val justLiftRestCountdown: StateFlow<Int?> = _justLiftRestCountdown.asStateFlow()
-    internal var justLiftRestTimerJob: Job? = null
-
-    @Volatile
-    internal var justLiftRestDeadlineElapsedRealtimeMs: Long? = null
 
     // ===== Workout Parameters =====
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/EnhancedMainScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/EnhancedMainScreen.kt
@@ -185,11 +185,12 @@ fun EnhancedMainScreen(
 
     // Issue #348: Session-scoped wake lock — keeps screen on across ALL workout screens
     // (ActiveWorkout, SetReady, rest timers) instead of just ActiveWorkoutScreen.
-    // The isInWorkoutSession flow combines workoutState and routineFlowState so
-    // the wake lock stays active during between-set navigation in routines.
+    // Just Lift also keeps the screen awake on its ready/setup screen because
+    // it is armed for handle-based auto-start before workoutState becomes Active.
     val isInWorkoutSession by viewModel.isInWorkoutSession.collectAsState(initial = false)
-    DisposableEffect(isInWorkoutSession) {
-        setKeepScreenOn(isInWorkoutSession)
+    val shouldKeepScreenOn = shouldKeepScreenOnForRoute(currentRoute, isInWorkoutSession)
+    DisposableEffect(shouldKeepScreenOn) {
+        setKeepScreenOn(shouldKeepScreenOn)
         onDispose {
             setKeepScreenOn(false)
         }
@@ -862,6 +863,9 @@ private fun ConnectionStatusIndicator(
  */
 private fun isSingleExerciseRoute(route: String): Boolean = route == NavigationRoutes.SingleExercise.route ||
     route.startsWith("${NavigationRoutes.SingleExercise.route}/")
+
+internal fun shouldKeepScreenOnForRoute(route: String, isInWorkoutSession: Boolean): Boolean =
+    isInWorkoutSession || route == NavigationRoutes.JustLift.route
 
 private fun getScreenTitle(route: String, routineName: String = "", exerciseName: String = "", cycleName: String = ""): String = when {
     // Main tabs (static titles)

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutCoordinatorEventTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutCoordinatorEventTest.kt
@@ -1,11 +1,16 @@
 package com.devil.phoenixproject.presentation.manager
 
 import com.devil.phoenixproject.domain.model.HapticEvent
+import com.devil.phoenixproject.domain.model.RoutineFlowState
+import com.devil.phoenixproject.domain.model.WorkoutState
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
+import kotlin.test.assertTrue
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -113,5 +118,58 @@ class WorkoutCoordinatorEventTest {
         )
 
         job.cancel()
+    }
+
+    @Test
+    fun justLiftRestCountdownKeepsWorkoutSessionActiveWhileIdle() = runTest {
+        val (coordinator, _) = createCoordinator()
+
+        assertFalse(
+            coordinator.isInWorkoutSession.first(),
+            "Idle without a Just Lift rest countdown should not keep the screen awake",
+        )
+
+        coordinator._justLiftRestCountdown.value = 30
+
+        assertTrue(
+            coordinator.isInWorkoutSession.first(),
+            "Just Lift rest countdown should keep the workout session active while state is Idle",
+        )
+
+        coordinator._justLiftRestCountdown.value = 0
+
+        assertFalse(
+            coordinator.isInWorkoutSession.first(),
+            "Expired Just Lift rest countdown should release the workout session wake lock",
+        )
+    }
+
+    @Test
+    fun routineSetReadyKeepsWorkoutSessionActiveWhileIdle() = runTest {
+        val (coordinator, _) = createCoordinator()
+
+        coordinator._routineFlowState.value = RoutineFlowState.SetReady(
+            exerciseIndex = 0,
+            setIndex = 0,
+            adjustedWeight = 20f,
+            adjustedReps = 8,
+        )
+
+        assertTrue(
+            coordinator.isInWorkoutSession.first(),
+            "Routine SetReady should keep the workout session active while state is Idle",
+        )
+    }
+
+    @Test
+    fun activeWorkoutStateKeepsWorkoutSessionActive() = runTest {
+        val (coordinator, _) = createCoordinator()
+
+        coordinator._workoutState.value = WorkoutState.Active
+
+        assertTrue(
+            coordinator.isInWorkoutSession.first(),
+            "Active workout state should keep the workout session active",
+        )
     }
 }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/screen/EnhancedMainScreenKeepScreenOnTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/screen/EnhancedMainScreenKeepScreenOnTest.kt
@@ -1,0 +1,41 @@
+package com.devil.phoenixproject.presentation.screen
+
+import com.devil.phoenixproject.presentation.navigation.NavigationRoutes
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class EnhancedMainScreenKeepScreenOnTest {
+    @Test
+    fun justLiftRouteKeepsScreenAwakeBeforeWorkoutSessionStarts() {
+        assertTrue(
+            shouldKeepScreenOnForRoute(
+                route = NavigationRoutes.JustLift.route,
+                isInWorkoutSession = false,
+            ),
+            "Just Lift setup/ready screen should keep Auto-Lock disabled before the first set starts",
+        )
+    }
+
+    @Test
+    fun nonWorkoutRouteWithoutSessionAllowsScreenToSleep() {
+        assertFalse(
+            shouldKeepScreenOnForRoute(
+                route = NavigationRoutes.Home.route,
+                isInWorkoutSession = false,
+            ),
+            "Home should not keep Auto-Lock disabled when no workout session is active",
+        )
+    }
+
+    @Test
+    fun activeWorkoutSessionKeepsScreenAwakeFromAnyRoute() {
+        assertTrue(
+            shouldKeepScreenOnForRoute(
+                route = NavigationRoutes.Home.route,
+                isInWorkoutSession = true,
+            ),
+            "Active workout session should keep Auto-Lock disabled across workout navigation",
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- keep the screen awake for the entire Just Lift flow, starting as soon as the user enters Just Lift
- preserve the existing session-scoped wake-lock behavior for active workouts, routine SetReady screens, and Just Lift rest countdowns
- add focused regression tests for both the Just Lift setup/ready screen and the between-set/rest countdown state

## Why
We primarily use Just Lift, and we often do other things during workouts or between sets. Having the phone dim or go to the lock screen after kicking off Just Lift was annoying because the app would lose focus while we were still in the middle of the workout flow.

This keeps the device and app enabled and focused during the entire Just Lift session, regardless of breaks or how long it takes to start lifting after entering Just Lift.

## Covered scenarios
- **Before the first set:** entering Just Lift now disables Auto-Lock even while `workoutState` is still idle, so the device stays awake while waiting to start.
- **Between sets/rest periods:** Just Lift rest countdowns now keep the workout session active even when `workoutState` returns to idle between sets.

## Tests
- `WorkoutCoordinatorEventTest` covers active workout state, routine SetReady, and Just Lift rest countdown behavior.
- `EnhancedMainScreenKeepScreenOnTest` covers the Just Lift setup/ready screen before a workout session starts.

## Verification
- `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ANDROID_HOME="/Users/jeffreybozek/Library/Android/sdk" ./gradlew -Pskip.supabase.check=true :shared:testAndroidHostTest --tests com.devil.phoenixproject.presentation.manager.WorkoutCoordinatorEventTest --tests com.devil.phoenixproject.presentation.screen.EnhancedMainScreenKeepScreenOnTest`
- `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ANDROID_HOME="/Users/jeffreybozek/Library/Android/sdk" ./gradlew -Pskip.supabase.check=true :shared:linkDebugFrameworkIosArm64`
- iOS device Debug build installed and launched on physical iPhone

## Device validation
Validated on a physical iPhone using a locally signed Debug build. After entering Just Lift and waiting without touching the device, the screen did not dim or lock.