### PR TITLE
fix(slider): round-to-nearest-integer in ProgressionSlider to prevent skipped values (#571 continued)

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/ExpressiveComponents.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/ExpressiveComponents.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.devil.phoenixproject.presentation.util.rememberIsTvRemoteInputMode
 import com.devil.phoenixproject.presentation.util.tvSliderKeys
+import kotlin.math.roundToInt
 
 /**
  * A Material 3 Expressive Card wrapper.
@@ -120,8 +121,11 @@ fun ProgressionSlider(
     valueRange: ClosedFloatingPointRange<Float> = -10f..10f,
     modifier: Modifier = Modifier,
 ) {
-    val isNegative = value < 0
-    val isPositive = value > 0
+    // Snap to nearest integer to guard against float imprecision from the
+    // Material3 Slider's pixel→value mapping (Issue #571 continued).
+    val intVal = value.roundToInt()
+    val isNegative = intVal < 0
+    val isPositive = intVal > 0
 
     val activeColor = when {
         isNegative -> MaterialTheme.colorScheme.error
@@ -140,7 +144,7 @@ fun ProgressionSlider(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             Text(
-                text = if (value > 0) "+${value.toInt()}" else "${value.toInt()}",
+                text = if (intVal > 0) "+$intVal" else "$intVal",
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
                 color = activeColor,
@@ -154,7 +158,7 @@ fun ProgressionSlider(
 
         ExpressiveSlider(
             value = value,
-            onValueChange = onValueChange,
+            onValueChange = { raw -> onValueChange(raw.roundToInt().toFloat()) },
             valueRange = valueRange,
             steps = (valueRange.endInclusive - valueRange.start).toInt() - 1,
             trackColor = activeColor,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseEditBottomSheet.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseEditBottomSheet.kt
@@ -417,7 +417,7 @@ fun ExerciseEditBottomSheet(
 
                             ProgressionSlider(
                                 value = weightChange.toFloat(),
-                                onValueChange = { viewModel.onWeightChange(it.toInt()) },
+                                onValueChange = { viewModel.onWeightChange(it.roundToInt()) },
                                 valueRange = -maxWeightChange.toFloat()..maxWeightChange.toFloat(),
                                 modifier = Modifier.fillMaxWidth(),
                             )

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/JustLiftScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/JustLiftScreen.kt
@@ -92,6 +92,7 @@ import com.devil.phoenixproject.domain.model.RepCount
 import com.devil.phoenixproject.domain.model.RepCountTiming
 import com.devil.phoenixproject.domain.model.WeightUnit
 import com.devil.phoenixproject.domain.model.WorkoutMetric
+import kotlin.math.roundToInt
 import com.devil.phoenixproject.domain.model.WorkoutMode
 import com.devil.phoenixproject.domain.model.WorkoutState
 import com.devil.phoenixproject.domain.model.eccentricLoadLabel
@@ -501,7 +502,7 @@ fun JustLiftScreen(navController: NavController, viewModel: MainViewModel, theme
 
                         ProgressionSlider(
                             value = weightChangePerRep.toFloat(),
-                            onValueChange = { weightChangePerRep = it.toInt() },
+                            onValueChange = { weightChangePerRep = it.roundToInt() },
                             valueRange = -10f..10f,
                             modifier = Modifier.fillMaxWidth(),
                         )


### PR DESCRIPTION
## Summary

The Progression/Regression slider (`-10` to `+10`) consistently skips specific integer values while dragging: **-6, -2, 4, 9**. This affects **all screens** that use `ProgressionSlider`, not just Just Lift. The original #571 was a gesture conflict; this is a different root cause.

## Root Cause

Material3 `Slider`'s pixel→value mapping can emit floats just below the target integer due to floating-point arithmetic on the device's specific slider track width. For example, the slider position for `-6.0` might be computed as `-5.99999`.

The code used `.toInt()` (truncates toward zero) for both display and value propagation:
- `-5.99999.toInt() = -5` — silently skips `-6`
- `-1.99999.toInt() = -1` — silently skips `-2`
- `3.99999.toInt() = 3` — silently skips `4`
- `8.99999.toInt() = 8` — silently skips `9`

## Fix

### 1. `ProgressionSlider` (ExpressiveComponents.kt) — internal snapping

Since `ProgressionSlider` is always used for integer values, it now **snaps to nearest integer** via `roundToInt()` before:
- Emitting values through `onValueChange`
- Displaying the current value in the text label

This single change fixes all screens that use `ProgressionSlider`.

### 2. Callers — belt-and-braces

Both call sites also switched from `.toInt()` to `.roundToInt()`:
- `JustLiftScreen.kt` — `weightChangePerRep = it.roundToInt()`
- `ExerciseEditBottomSheet.kt` — `viewModel.onWeightChange(it.roundToInt())`

## Verification

- [x] `:shared:compileKotlinIosArm64` — BUILD SUCCESSFUL
- [x] `:shared:testAndroidHostTest --tests *.JustLiftScreenWeightSliderWiringTest` — BUILD SUCCESSFUL
- [x] `:shared:testAndroidHostTest --tests *.DpadSliderSemanticsTest` — BUILD SUCCESSFUL
- [x] `:shared:testAndroidHostTest --tests *.WindowSizeClassTest` — BUILD SUCCESSFUL

## Refs

- Closes #571 (continued regression)
- Original #571 RCA/fix: PR #574 (gesture conflict)

Co-authored-by: phoenix-bot <bot@phoenix.local>