### PR TITLE
fix(sync,history): preserve local metrics across pull + exclude ghost rows (Fixes #591)

### DIFF
--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/util/DataBackupManagerRoutineNameTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/util/DataBackupManagerRoutineNameTest.kt
@@ -18,6 +18,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.junit.Before
@@ -63,6 +64,39 @@ class DataBackupManagerRoutineNameTest {
         val exportedSession = backup.data.workoutSessions.first { it.id == "session-legacy-1" }
         assertEquals("Upper Day", exportedSession.routineName)
         assertNull(exportedSession.routineSessionId, "Should not fabricate routineSessionId for legacy sessions")
+    }
+
+    @Test
+    fun `full backup excludes soft-deleted workout sessions`() = runTest {
+        workoutRepository.saveSession(
+            WorkoutSession(
+                id = "active-session",
+                routineSessionId = "active-routine",
+                exerciseName = "Bench Press",
+                totalReps = 10,
+                workingReps = 10,
+            ),
+        )
+        workoutRepository.saveSession(
+            WorkoutSession(
+                id = "deleted-session",
+                routineSessionId = "deleted-routine",
+                exerciseName = "Incline Fly",
+                totalReps = 0,
+                workingReps = 0,
+            ),
+        )
+        database.vitruvianDatabaseQueries.softDeleteSessionsByRoutineSessionId(
+            deletedAt = 1_700_000_123_000L,
+            updatedAt = 1_700_000_123_000L,
+            routineSessionId = "deleted-routine",
+        )
+
+        val legacyBackup = backupManager.exportAllData()
+        val streamedBackup = testJson.decodeFromString<BackupData>(backupManager.exportToJson())
+
+        assertEquals(listOf("active-session"), legacyBackup.data.workoutSessions.map { it.id })
+        assertEquals(listOf("active-session"), streamedBackup.data.workoutSessions.map { it.id })
     }
 
     @Test

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -721,6 +721,7 @@
     <string name="equipment_rack_display_only_count">%1$d display-only</string>
     <string name="equipment_rack_selected_count">%1$d selected</string>
     <string name="equipment_rack_inline_context">Rack: %1$s</string>
+    <string name="detailed_metrics_not_captured">Detailed metrics were not captured for this set</string>
     <string name="equipment_rack_category_weighted_vest">Weighted vest</string>
     <string name="equipment_rack_category_dip_belt">Dip belt</string>
     <string name="equipment_rack_category_chains">Chains</string>

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt
@@ -51,6 +51,18 @@ class SqlDelightSyncRepository(
 
     private fun personalRecordSessionKey(exerciseId: String, timestamp: Long): String = "$exerciseId:$timestamp"
 
+    /**
+     * Issue #591 follow-up (chatgpt-codex-connector P2): SQLite host
+     * parameter limit is implementation-defined (999 on Android,
+     * 32766 on desktop). For initial/full pulls of large histories the
+     * batched preservation SELECTs would otherwise throw
+     * `SQLITE_RANGE: too many SQL variables`. 500 keeps us safely under
+     * the stricter limit and still eliminates the per-row round-trips.
+     */
+    private companion object {
+        const val BATCH_LOOKUP_CHUNK_SIZE = 500
+    }
+
     // === Push Operations ===
 
     override suspend fun getSessionsModifiedSince(timestamp: Long, profileId: String): List<WorkoutSessionSyncDto> = withContext(Dispatchers.IO) {
@@ -2071,15 +2083,30 @@ class SqlDelightSyncRepository(
             // batched round-trip per concern. For a 20-set routine this
             // drops 40+ queries (one LWW gate read + one full-row read per
             // incoming pull) down to two queries total.
+            //
+            // chatgpt-codex-connector P2 (follow-up): chunk the batched
+            // SELECTs because SQLite's host-parameter limit is
+            // implementation-defined (commonly 999 on Android, 32766 on
+            // desktop). For initial/full pulls of large histories the id
+            // list can exceed the limit and throw "too many SQL variables".
+            // Chunking at CHUNK_SIZE 500 keeps us safely under both
+            // limits while still eliminating the per-row round-trips.
             val ids = sessions.map { it.id }
             val existingUpdatedAtById: Map<String, Long?> =
-                queries.selectSessionsUpdatedAtByIds(ids)
-                    .executeAsList()
+                ids.chunked(BATCH_LOOKUP_CHUNK_SIZE)
+                    .flatMap { chunk ->
+                        queries.selectSessionsUpdatedAtByIds(chunk)
+                            .executeAsList()
+                    }
                     .associate { it.id to it.updatedAt }
             val preservationRowsById: Map<String, PreservationRow> =
-                queries.selectSessionsMetricsForPreservationByIds(ids)
-                    .executeAsList()
-                    .associate { it.id to it.toPreservationRow() }
+                ids.chunked(BATCH_LOOKUP_CHUNK_SIZE)
+                    .flatMap { chunk ->
+                        queries.selectSessionsMetricsForPreservationByIds(chunk)
+                            .executeAsList()
+                            .map { it.toPreservationRow() }
+                    }
+                    .associate { it.id to it }
 
             for (session in sessions) {
                 val existingTs = existingUpdatedAtById[session.id]

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt
@@ -2191,6 +2191,13 @@ class SqlDelightSyncRepository(
      * existing local value whenever the incoming pull is null. All other
      * columns use the incoming value (LWW semantics).
      *
+     * Exception: `PortalPullAdapter` can only hydrate per-cable concentric
+     * peaks from `leftForceAvg` / `rightForceAvg`, which are average-force
+     * proxies from the push DTO rather than true peak captures. If a local
+     * row already has true per-cable peak values, keep those instead of
+     * replacing them with the pull-side proxy. First-time pulls still keep
+     * the proxy value because there is no local capture to preserve.
+     *
      * Backed by `selectSessionsMetricsForPreservationByIds` so the LWW
      * gate does not issue a full-row read per incoming pull. The column
      * list here must stay in sync with that SQL query.
@@ -2213,8 +2220,8 @@ class SqlDelightSyncRepository(
         existing: PreservationRow,
         incoming: WorkoutSession,
     ): WorkoutSession = incoming.copy(
-        peakForceConcentricA = incoming.peakForceConcentricA ?: existing.peakForceConcentricA?.toFloat(),
-        peakForceConcentricB = incoming.peakForceConcentricB ?: existing.peakForceConcentricB?.toFloat(),
+        peakForceConcentricA = existing.peakForceConcentricA?.toFloat() ?: incoming.peakForceConcentricA,
+        peakForceConcentricB = existing.peakForceConcentricB?.toFloat() ?: incoming.peakForceConcentricB,
         peakForceEccentricA = incoming.peakForceEccentricA ?: existing.peakForceEccentricA?.toFloat(),
         peakForceEccentricB = incoming.peakForceEccentricB ?: existing.peakForceEccentricB?.toFloat(),
         avgForceConcentricA = incoming.avgForceConcentricA ?: existing.avgForceConcentricA?.toFloat(),

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt
@@ -2066,24 +2066,40 @@ class SqlDelightSyncRepository(
     ) = withContext(Dispatchers.IO) {
         if (sessions.isEmpty()) return@withContext
         db.transaction {
+            // Issue #591 follow-up: collapse the per-row
+            // selectSessionUpdatedAt + selectSessionById pair into a single
+            // batched round-trip per concern. For a 20-set routine this
+            // drops 40+ queries (one LWW gate read + one full-row read per
+            // incoming pull) down to two queries total.
+            val ids = sessions.map { it.id }
+            val existingUpdatedAtById: Map<String, Long?> =
+                queries.selectSessionsUpdatedAtByIds(ids)
+                    .executeAsList()
+                    .associate { it.id to it.updatedAt }
+            val preservationRowsById: Map<String, PreservationRow> =
+                queries.selectSessionsMetricsForPreservationByIds(ids)
+                    .executeAsList()
+                    .associate { it.id to it.toPreservationRow() }
+
             for (session in sessions) {
-                val existingTs = queries.selectSessionUpdatedAt(session.id)
-                    .executeAsOneOrNull()
-                    ?.updatedAt
+                val existingTs = existingUpdatedAtById[session.id]
                 val incomingTs = updatedAtBySessionId[session.id] ?: 0L
                 val accept = existingTs == null || incomingTs >= existingTs
                 if (!accept) continue
 
                 // Issue #591: Preserve non-null detailed metric columns from
-                // the existing local row when the incoming pull is null. The
-                // pull path does not (yet) populate peakForce* / avgForce* /
-                // biomechanics fields from PullSetDto.repSummaries for every
+                // the existing local row when the incoming pull is null.
+                // The pull path does not (yet) populate peakForce* / avgForce*
+                // / biomechanics fields from PullSetDto.repSummaries for every
                 // session; without this guard, an incoming row with null
                 // metrics would clobber locally captured metrics and force
                 // HistoryTab to render the stale "after v0.2.1" placeholder.
-                val existing = queries.selectSessionById(session.id, ::mapToWorkoutSession)
-                    .executeAsOneOrNull()
-                val preserved = if (existing != null) preserveMetrics(existing, session) else session
+                val preservation = preservationRowsById[session.id]
+                val preserved = if (preservation != null) {
+                    preserveMetrics(preservation, session)
+                } else {
+                    session
+                }
 
                 queries.mergeSessionLww(
                     id = preserved.id,
@@ -2148,6 +2164,10 @@ class SqlDelightSyncRepository(
      * existing local value whenever the incoming pull is null. All other
      * columns use the incoming value (LWW semantics).
      *
+     * Backed by `selectSessionsMetricsForPreservationByIds` so the LWW
+     * gate does not issue a full-row read per incoming pull. The column
+     * list here must stay in sync with that SQL query.
+     *
      * Columns preserved when local is non-null and incoming is null:
      *   - peakForce* / avgForce* (concentric + eccentric, A + B)
      *   - heaviestLiftKg, totalVolumeKg
@@ -2163,34 +2183,104 @@ class SqlDelightSyncRepository(
      * the row matches whatever the server / push thinks the workout was.
      */
     private fun preserveMetrics(
-        existing: WorkoutSession,
+        existing: PreservationRow,
         incoming: WorkoutSession,
     ): WorkoutSession = incoming.copy(
-        peakForceConcentricA = incoming.peakForceConcentricA ?: existing.peakForceConcentricA,
-        peakForceConcentricB = incoming.peakForceConcentricB ?: existing.peakForceConcentricB,
-        peakForceEccentricA = incoming.peakForceEccentricA ?: existing.peakForceEccentricA,
-        peakForceEccentricB = incoming.peakForceEccentricB ?: existing.peakForceEccentricB,
-        avgForceConcentricA = incoming.avgForceConcentricA ?: existing.avgForceConcentricA,
-        avgForceConcentricB = incoming.avgForceConcentricB ?: existing.avgForceConcentricB,
-        avgForceEccentricA = incoming.avgForceEccentricA ?: existing.avgForceEccentricA,
-        avgForceEccentricB = incoming.avgForceEccentricB ?: existing.avgForceEccentricB,
-        heaviestLiftKg = incoming.heaviestLiftKg ?: existing.heaviestLiftKg,
-        totalVolumeKg = incoming.totalVolumeKg ?: existing.totalVolumeKg,
-        cableCount = incoming.cableCount ?: existing.cableCount,
-        displayMultiplier = incoming.displayMultiplier ?: existing.displayMultiplier,
-        estimatedCalories = incoming.estimatedCalories ?: existing.estimatedCalories,
-        warmupAvgWeightKg = incoming.warmupAvgWeightKg ?: existing.warmupAvgWeightKg,
-        workingAvgWeightKg = incoming.workingAvgWeightKg ?: existing.workingAvgWeightKg,
-        burnoutAvgWeightKg = incoming.burnoutAvgWeightKg ?: existing.burnoutAvgWeightKg,
-        peakWeightKg = incoming.peakWeightKg ?: existing.peakWeightKg,
-        rpe = incoming.rpe ?: existing.rpe,
-        avgMcvMmS = incoming.avgMcvMmS ?: existing.avgMcvMmS,
-        avgAsymmetryPercent = incoming.avgAsymmetryPercent ?: existing.avgAsymmetryPercent,
-        totalVelocityLossPercent = incoming.totalVelocityLossPercent ?: existing.totalVelocityLossPercent,
+        peakForceConcentricA = incoming.peakForceConcentricA ?: existing.peakForceConcentricA?.toFloat(),
+        peakForceConcentricB = incoming.peakForceConcentricB ?: existing.peakForceConcentricB?.toFloat(),
+        peakForceEccentricA = incoming.peakForceEccentricA ?: existing.peakForceEccentricA?.toFloat(),
+        peakForceEccentricB = incoming.peakForceEccentricB ?: existing.peakForceEccentricB?.toFloat(),
+        avgForceConcentricA = incoming.avgForceConcentricA ?: existing.avgForceConcentricA?.toFloat(),
+        avgForceConcentricB = incoming.avgForceConcentricB ?: existing.avgForceConcentricB?.toFloat(),
+        avgForceEccentricA = incoming.avgForceEccentricA ?: existing.avgForceEccentricA?.toFloat(),
+        avgForceEccentricB = incoming.avgForceEccentricB ?: existing.avgForceEccentricB?.toFloat(),
+        heaviestLiftKg = incoming.heaviestLiftKg ?: existing.heaviestLiftKg?.toFloat(),
+        totalVolumeKg = incoming.totalVolumeKg ?: existing.totalVolumeKg?.toFloat(),
+        cableCount = incoming.cableCount ?: existing.cableCount?.toInt(),
+        displayMultiplier = incoming.displayMultiplier ?: existing.displayMultiplier?.toInt(),
+        estimatedCalories = incoming.estimatedCalories ?: existing.estimatedCalories?.toFloat(),
+        warmupAvgWeightKg = incoming.warmupAvgWeightKg ?: existing.warmupAvgWeightKg?.toFloat(),
+        workingAvgWeightKg = incoming.workingAvgWeightKg ?: existing.workingAvgWeightKg?.toFloat(),
+        burnoutAvgWeightKg = incoming.burnoutAvgWeightKg ?: existing.burnoutAvgWeightKg?.toFloat(),
+        peakWeightKg = incoming.peakWeightKg ?: existing.peakWeightKg?.toFloat(),
+        rpe = incoming.rpe ?: existing.rpe?.toInt(),
+        avgMcvMmS = incoming.avgMcvMmS ?: existing.avgMcvMmS?.toFloat(),
+        avgAsymmetryPercent = incoming.avgAsymmetryPercent ?: existing.avgAsymmetryPercent?.toFloat(),
+        totalVelocityLossPercent = incoming.totalVelocityLossPercent ?: existing.totalVelocityLossPercent?.toFloat(),
         dominantSide = incoming.dominantSide ?: existing.dominantSide,
         strengthProfile = incoming.strengthProfile ?: existing.strengthProfile,
-        formScore = incoming.formScore ?: existing.formScore,
+        formScore = incoming.formScore ?: existing.formScore?.toInt(),
     )
+
+    /**
+     * Issue #591 follow-up: in-memory projection of the
+     * `selectSessionsMetricsForPreservationByIds` SQL row, holding only
+     * the metric / biomechanics columns the LWW preservation guard
+     * consumes. Keeps [preserveMetrics] free of SqlDelight-generated
+     * row types so the column contract lives in one obvious place.
+     */
+    private data class PreservationRow(
+        val id: String,
+        val peakForceConcentricA: Double?,
+        val peakForceConcentricB: Double?,
+        val peakForceEccentricA: Double?,
+        val peakForceEccentricB: Double?,
+        val avgForceConcentricA: Double?,
+        val avgForceConcentricB: Double?,
+        val avgForceEccentricA: Double?,
+        val avgForceEccentricB: Double?,
+        val heaviestLiftKg: Double?,
+        val totalVolumeKg: Double?,
+        val cableCount: Long?,
+        val displayMultiplier: Long?,
+        val estimatedCalories: Double?,
+        val warmupAvgWeightKg: Double?,
+        val workingAvgWeightKg: Double?,
+        val burnoutAvgWeightKg: Double?,
+        val peakWeightKg: Double?,
+        val rpe: Long?,
+        val avgMcvMmS: Double?,
+        val avgAsymmetryPercent: Double?,
+        val totalVelocityLossPercent: Double?,
+        val dominantSide: String?,
+        val strengthProfile: String?,
+        val formScore: Long?,
+    )
+
+    /**
+     * Bridge the SqlDelight-generated row into [PreservationRow]. The
+     * generated row type name follows the SQL query name
+     * (`SelectSessionsMetricsForPreservationByIds`). If the SQL column
+     * list changes, regenerate and update this helper.
+     */
+    private fun com.devil.phoenixproject.database.SelectSessionsMetricsForPreservationByIds.toPreservationRow(): PreservationRow =
+        PreservationRow(
+            id = id,
+            peakForceConcentricA = peakForceConcentricA,
+            peakForceConcentricB = peakForceConcentricB,
+            peakForceEccentricA = peakForceEccentricA,
+            peakForceEccentricB = peakForceEccentricB,
+            avgForceConcentricA = avgForceConcentricA,
+            avgForceConcentricB = avgForceConcentricB,
+            avgForceEccentricA = avgForceEccentricA,
+            avgForceEccentricB = avgForceEccentricB,
+            heaviestLiftKg = heaviestLiftKg,
+            totalVolumeKg = totalVolumeKg,
+            cableCount = cableCount,
+            displayMultiplier = display_multiplier,
+            estimatedCalories = estimatedCalories,
+            warmupAvgWeightKg = warmupAvgWeightKg,
+            workingAvgWeightKg = workingAvgWeightKg,
+            burnoutAvgWeightKg = burnoutAvgWeightKg,
+            peakWeightKg = peakWeightKg,
+            rpe = rpe,
+            avgMcvMmS = avgMcvMmS,
+            avgAsymmetryPercent = avgAsymmetryPercent,
+            totalVelocityLossPercent = totalVelocityLossPercent,
+            dominantSide = dominantSide,
+            strengthProfile = strengthProfile,
+            formScore = formScore,
+        )
 
     override suspend fun mergeSessionNotes(
         notes: Map<String, SessionNotesEntry>,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt
@@ -2049,6 +2049,16 @@ class SqlDelightSyncRepository(
      * (== portal exercise id; one portal session expands to N mobile rows
      * in PortalPullAdapter.toWorkoutSessionsWithLookup). Missing entries
      * default to "older" so first-time pulls always write.
+     *
+     * Issue #591: When the incoming pull row is null in detailed metric
+     * columns (`peakForce*`, `avgForce*`, biomechanics, etc.) but the
+     * local row captured real measurements during recording, do not erase
+     * the locally captured metrics. LWW still applies for non-metric
+     * columns (timestamps, reps, mode, exercise tags) — only metric
+     * columns fall back to the existing local value when the incoming is
+     * null. This prevents the History "after v0.2.1" placeholder from
+     * appearing for current sessions whose metrics were lost during sync
+     * rehydration.
      */
     override suspend fun mergeSessionsLww(
         sessions: List<WorkoutSession>,
@@ -2064,63 +2074,123 @@ class SqlDelightSyncRepository(
                 val accept = existingTs == null || incomingTs >= existingTs
                 if (!accept) continue
 
+                // Issue #591: Preserve non-null detailed metric columns from
+                // the existing local row when the incoming pull is null. The
+                // pull path does not (yet) populate peakForce* / avgForce* /
+                // biomechanics fields from PullSetDto.repSummaries for every
+                // session; without this guard, an incoming row with null
+                // metrics would clobber locally captured metrics and force
+                // HistoryTab to render the stale "after v0.2.1" placeholder.
+                val existing = queries.selectSessionById(session.id, ::mapToWorkoutSession)
+                    .executeAsOneOrNull()
+                val preserved = if (existing != null) preserveMetrics(existing, session) else session
+
                 queries.mergeSessionLww(
-                    id = session.id,
-                    timestamp = session.timestamp,
-                    mode = session.mode,
-                    targetReps = session.reps.toLong(),
-                    weightPerCableKg = session.weightPerCableKg.toDouble(),
-                    progressionKg = session.progressionKg.toDouble(),
-                    duration = session.duration,
-                    totalReps = session.totalReps.toLong(),
-                    warmupReps = session.warmupReps.toLong(),
-                    workingReps = session.workingReps.toLong(),
-                    isJustLift = if (session.isJustLift) 1L else 0L,
-                    stopAtTop = if (session.stopAtTop) 1L else 0L,
-                    eccentricLoad = session.eccentricLoad.toLong(),
-                    echoLevel = session.echoLevel.toLong(),
-                    exerciseId = session.exerciseId,
-                    exerciseName = session.exerciseName,
-                    routineSessionId = session.routineSessionId,
-                    routineName = session.routineName,
-                    routineId = session.routineId,
-                    safetyFlags = session.safetyFlags.toLong(),
-                    deloadWarningCount = session.deloadWarningCount.toLong(),
-                    romViolationCount = session.romViolationCount.toLong(),
-                    spotterActivations = session.spotterActivations.toLong(),
-                    peakForceConcentricA = session.peakForceConcentricA?.toDouble(),
-                    peakForceConcentricB = session.peakForceConcentricB?.toDouble(),
-                    peakForceEccentricA = session.peakForceEccentricA?.toDouble(),
-                    peakForceEccentricB = session.peakForceEccentricB?.toDouble(),
-                    avgForceConcentricA = session.avgForceConcentricA?.toDouble(),
-                    avgForceConcentricB = session.avgForceConcentricB?.toDouble(),
-                    avgForceEccentricA = session.avgForceEccentricA?.toDouble(),
-                    avgForceEccentricB = session.avgForceEccentricB?.toDouble(),
-                    heaviestLiftKg = session.heaviestLiftKg?.toDouble(),
-                    totalVolumeKg = session.totalVolumeKg?.toDouble(),
-                    cableCount = session.cableCount?.toLong(),
-                    estimatedCalories = session.estimatedCalories?.toDouble(),
-                    warmupAvgWeightKg = session.warmupAvgWeightKg?.toDouble(),
-                    workingAvgWeightKg = session.workingAvgWeightKg?.toDouble(),
-                    burnoutAvgWeightKg = session.burnoutAvgWeightKg?.toDouble(),
-                    peakWeightKg = session.peakWeightKg?.toDouble(),
-                    rpe = session.rpe?.toLong(),
-                    avgMcvMmS = session.avgMcvMmS?.toDouble(),
-                    avgAsymmetryPercent = session.avgAsymmetryPercent?.toDouble(),
-                    totalVelocityLossPercent = session.totalVelocityLossPercent?.toDouble(),
-                    dominantSide = session.dominantSide,
-                    strengthProfile = session.strengthProfile,
-                    formScore = session.formScore?.toLong(),
+                    id = preserved.id,
+                    timestamp = preserved.timestamp,
+                    mode = preserved.mode,
+                    targetReps = preserved.reps.toLong(),
+                    weightPerCableKg = preserved.weightPerCableKg.toDouble(),
+                    progressionKg = preserved.progressionKg.toDouble(),
+                    duration = preserved.duration,
+                    totalReps = preserved.totalReps.toLong(),
+                    warmupReps = preserved.warmupReps.toLong(),
+                    workingReps = preserved.workingReps.toLong(),
+                    isJustLift = if (preserved.isJustLift) 1L else 0L,
+                    stopAtTop = if (preserved.stopAtTop) 1L else 0L,
+                    eccentricLoad = preserved.eccentricLoad.toLong(),
+                    echoLevel = preserved.echoLevel.toLong(),
+                    exerciseId = preserved.exerciseId,
+                    exerciseName = preserved.exerciseName,
+                    routineSessionId = preserved.routineSessionId,
+                    routineName = preserved.routineName,
+                    routineId = preserved.routineId,
+                    safetyFlags = preserved.safetyFlags.toLong(),
+                    deloadWarningCount = preserved.deloadWarningCount.toLong(),
+                    romViolationCount = preserved.romViolationCount.toLong(),
+                    spotterActivations = preserved.spotterActivations.toLong(),
+                    peakForceConcentricA = preserved.peakForceConcentricA?.toDouble(),
+                    peakForceConcentricB = preserved.peakForceConcentricB?.toDouble(),
+                    peakForceEccentricA = preserved.peakForceEccentricA?.toDouble(),
+                    peakForceEccentricB = preserved.peakForceEccentricB?.toDouble(),
+                    avgForceConcentricA = preserved.avgForceConcentricA?.toDouble(),
+                    avgForceConcentricB = preserved.avgForceConcentricB?.toDouble(),
+                    avgForceEccentricA = preserved.avgForceEccentricA?.toDouble(),
+                    avgForceEccentricB = preserved.avgForceEccentricB?.toDouble(),
+                    heaviestLiftKg = preserved.heaviestLiftKg?.toDouble(),
+                    totalVolumeKg = preserved.totalVolumeKg?.toDouble(),
+                    cableCount = preserved.cableCount?.toLong(),
+                    estimatedCalories = preserved.estimatedCalories?.toDouble(),
+                    warmupAvgWeightKg = preserved.warmupAvgWeightKg?.toDouble(),
+                    workingAvgWeightKg = preserved.workingAvgWeightKg?.toDouble(),
+                    burnoutAvgWeightKg = preserved.burnoutAvgWeightKg?.toDouble(),
+                    peakWeightKg = preserved.peakWeightKg?.toDouble(),
+                    rpe = preserved.rpe?.toLong(),
+                    avgMcvMmS = preserved.avgMcvMmS?.toDouble(),
+                    avgAsymmetryPercent = preserved.avgAsymmetryPercent?.toDouble(),
+                    totalVelocityLossPercent = preserved.totalVelocityLossPercent?.toDouble(),
+                    dominantSide = preserved.dominantSide,
+                    strengthProfile = preserved.strengthProfile,
+                    formScore = preserved.formScore?.toLong(),
                     updatedAt = incomingTs,
-                    profile_id = session.profileId,
-                    display_multiplier = session.displayMultiplier?.toLong(),
-                    externalAddedLoadKg = session.externalAddedLoadKg.toDouble(),
-                    counterweightKg = session.counterweightKg.toDouble(),
-                    rackItemsJson = session.rackItemsJson,
+                    profile_id = preserved.profileId,
+                    display_multiplier = preserved.displayMultiplier?.toLong(),
+                    externalAddedLoadKg = preserved.externalAddedLoadKg.toDouble(),
+                    counterweightKg = preserved.counterweightKg.toDouble(),
+                    rackItemsJson = preserved.rackItemsJson,
                 )
             }
         }
     }
+
+    /**
+     * Issue #591: For detailed metric / biomechanics columns, prefer the
+     * existing local value whenever the incoming pull is null. All other
+     * columns use the incoming value (LWW semantics).
+     *
+     * Columns preserved when local is non-null and incoming is null:
+     *   - peakForce* / avgForce* (concentric + eccentric, A + B)
+     *   - heaviestLiftKg, totalVolumeKg
+     *   - estimatedCalories, warmupAvgWeightKg, workingAvgWeightKg,
+     *     burnoutAvgWeightKg, peakWeightKg
+     *   - avgMcvMmS, avgAsymmetryPercent, totalVelocityLossPercent
+     *   - dominantSide, strengthProfile
+     *   - cableCount, displayMultiplier
+     *   - rpe, formScore
+     *
+     * Note: `weightPerCableKg`, `totalReps`, `duration`, and exercise/routine
+     * identity are intentionally NOT preserved — those should follow LWW so
+     * the row matches whatever the server / push thinks the workout was.
+     */
+    private fun preserveMetrics(
+        existing: WorkoutSession,
+        incoming: WorkoutSession,
+    ): WorkoutSession = incoming.copy(
+        peakForceConcentricA = incoming.peakForceConcentricA ?: existing.peakForceConcentricA,
+        peakForceConcentricB = incoming.peakForceConcentricB ?: existing.peakForceConcentricB,
+        peakForceEccentricA = incoming.peakForceEccentricA ?: existing.peakForceEccentricA,
+        peakForceEccentricB = incoming.peakForceEccentricB ?: existing.peakForceEccentricB,
+        avgForceConcentricA = incoming.avgForceConcentricA ?: existing.avgForceConcentricA,
+        avgForceConcentricB = incoming.avgForceConcentricB ?: existing.avgForceConcentricB,
+        avgForceEccentricA = incoming.avgForceEccentricA ?: existing.avgForceEccentricA,
+        avgForceEccentricB = incoming.avgForceEccentricB ?: existing.avgForceEccentricB,
+        heaviestLiftKg = incoming.heaviestLiftKg ?: existing.heaviestLiftKg,
+        totalVolumeKg = incoming.totalVolumeKg ?: existing.totalVolumeKg,
+        cableCount = incoming.cableCount ?: existing.cableCount,
+        displayMultiplier = incoming.displayMultiplier ?: existing.displayMultiplier,
+        estimatedCalories = incoming.estimatedCalories ?: existing.estimatedCalories,
+        warmupAvgWeightKg = incoming.warmupAvgWeightKg ?: existing.warmupAvgWeightKg,
+        workingAvgWeightKg = incoming.workingAvgWeightKg ?: existing.workingAvgWeightKg,
+        burnoutAvgWeightKg = incoming.burnoutAvgWeightKg ?: existing.burnoutAvgWeightKg,
+        peakWeightKg = incoming.peakWeightKg ?: existing.peakWeightKg,
+        rpe = incoming.rpe ?: existing.rpe,
+        avgMcvMmS = incoming.avgMcvMmS ?: existing.avgMcvMmS,
+        avgAsymmetryPercent = incoming.avgAsymmetryPercent ?: existing.avgAsymmetryPercent,
+        totalVelocityLossPercent = incoming.totalVelocityLossPercent ?: existing.totalVelocityLossPercent,
+        dominantSide = incoming.dominantSide ?: existing.dominantSide,
+        strengthProfile = incoming.strengthProfile ?: existing.strengthProfile,
+        formScore = incoming.formScore ?: existing.formScore,
+    )
 
     override suspend fun mergeSessionNotes(
         notes: Map<String, SessionNotesEntry>,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepository.kt
@@ -602,11 +602,7 @@ class SqlDelightWorkoutRepository(private val db: VitruvianDatabase, private val
 
     override suspend fun deleteSessionsByRoutineSessionId(routineSessionId: String) {
         withContext(Dispatchers.IO) {
-            queries.softDeleteSessionsByRoutineSessionId(
-                deletedAt = currentTimeMillis(),
-                updatedAt = currentTimeMillis(),
-                routineSessionId = routineSessionId,
-            )
+            queries.deleteSessionsByRoutineSessionId(routineSessionId)
         }
     }
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepository.kt
@@ -515,6 +515,11 @@ class SqlDelightWorkoutRepository(private val db: VitruvianDatabase, private val
         .asFlow()
         .mapToList(Dispatchers.IO)
 
+    override fun getHistoryVisibleSessions(profileId: String): Flow<List<WorkoutSession>> =
+        queries.selectHistoryVisibleSessions(profileId = profileId, mapper = ::mapToSession)
+            .asFlow()
+            .mapToList(Dispatchers.IO)
+
     override suspend fun saveSession(session: WorkoutSession) {
         withContext(Dispatchers.IO) {
             queries.insertSession(

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepository.kt
@@ -600,6 +600,16 @@ class SqlDelightWorkoutRepository(private val db: VitruvianDatabase, private val
         }
     }
 
+    override suspend fun deleteSessionsByRoutineSessionId(routineSessionId: String) {
+        withContext(Dispatchers.IO) {
+            queries.softDeleteSessionsByRoutineSessionId(
+                deletedAt = currentTimeMillis(),
+                updatedAt = currentTimeMillis(),
+                routineSessionId = routineSessionId,
+            )
+        }
+    }
+
     override suspend fun deleteAllSessions() {
         withContext(Dispatchers.IO) {
             queries.deleteAllSessions()

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/WorkoutRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/WorkoutRepository.kt
@@ -29,13 +29,13 @@ interface WorkoutRepository {
     suspend fun deleteAllSessions()
 
     /**
-     * Issue #591 follow-up (chatgpt-codex-connector P2): soft-delete
-     * every WorkoutSession row that belongs to the given routine
-     * session id. Used by the History "Delete All Sets" affordance so
-     * zero-rep / ghost rows hidden by `getHistoryVisibleSessions` do
-     * not survive the user-level deletion. Soft-delete (vs hard
-     * `DELETE`) keeps the rows visible to the sync server and matches
-     * the existing `softDeleteSession` pattern used by DataBackup.
+     * Issue #591 follow-up (chatgpt-codex-connector P2): delete every
+     * WorkoutSession row that belongs to the given routine session id.
+     * Used by the History "Delete All Sets" affordance so zero-rep /
+     * ghost rows hidden by `getHistoryVisibleSessions` do not survive
+     * the user-level deletion. This mirrors `deleteSession`'s local
+     * hard-delete semantics; workout-session tombstone sync is not
+     * currently implemented.
      */
     suspend fun deleteSessionsByRoutineSessionId(routineSessionId: String)
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/WorkoutRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/WorkoutRepository.kt
@@ -36,6 +36,21 @@ interface WorkoutRepository {
     fun getRecentSessions(profileId: String, limit: Int = 10): Flow<List<WorkoutSession>>
 
     /**
+     * Issue #591: Workout sessions that should appear in the Analytics /
+     * History UI. Excludes soft-deleted rows and rows with zero recorded
+     * reps (workingReps == 0 AND totalReps == 0), which historically come
+     * from pre-completion saves, routine restart mid-set, and zero-rep
+     * import paths. Counting those as sets inflates routine set totals
+     * (e.g. "Incline Fly 0 reps / 6 sets") and triggers the misleading
+     * pre-v0.2.1 placeholder card in per-set drill-down.
+     *
+     * Mirrors the eligibility guards used by
+     * `selectCompletedHealthExportCandidates` /
+     * `selectSessionsByRoutineSessionId` / `selectSessionsForPhasePRBackfill`.
+     */
+    fun getHistoryVisibleSessions(profileId: String): Flow<List<WorkoutSession>>
+
+    /**
      * Get a specific workout session by ID
      */
     suspend fun getSession(sessionId: String): WorkoutSession?

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/WorkoutRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/WorkoutRepository.kt
@@ -29,6 +29,17 @@ interface WorkoutRepository {
     suspend fun deleteAllSessions()
 
     /**
+     * Issue #591 follow-up (chatgpt-codex-connector P2): soft-delete
+     * every WorkoutSession row that belongs to the given routine
+     * session id. Used by the History "Delete All Sets" affordance so
+     * zero-rep / ghost rows hidden by `getHistoryVisibleSessions` do
+     * not survive the user-level deletion. Soft-delete (vs hard
+     * `DELETE`) keeps the rows visible to the sync server and matches
+     * the existing `softDeleteSession` pattern used by DataBackup.
+     */
+    suspend fun deleteSessionsByRoutineSessionId(routineSessionId: String)
+
+    /**
      * Get recent workout sessions
      * @param profileId Profile to filter by
      * @param limit Maximum number of sessions to return

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalPullAdapter.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalPullAdapter.kt
@@ -61,6 +61,14 @@ object PortalPullAdapter {
             // Attempt to resolve exerciseId from local catalog (ID-first, then name-based)
             val resolvedExerciseId = exerciseLookup(exercise.name, exercise.muscleGroup, exercise.exerciseId)
 
+            // Issue #591: Hydrate detailed metric columns from rep-level
+            // telemetry when the portal pull DTO carries them. Without this,
+            // a freshly recorded local row would be overwritten by a pull
+            // row whose peakForce* / avgForce* fields are null, and History
+            // would render the stale "after v0.2.1" placeholder. Pull DTO
+            // forces are in Newtons; mobile fields are in kg-load.
+            val metricHydration = aggregateSetMetrics(exercise.sets)
+
             WorkoutSession(
                 id = exercise.id,
                 timestamp = timestamp,
@@ -78,8 +86,87 @@ object PortalPullAdapter {
                 heaviestLiftKg = maxWeight,
                 totalVolumeKg = null, // Let effectiveTotalVolumeKg() compute from weightPerCableKg * cableCount * totalReps
                 cableCount = null, // Let effectiveTotalVolumeKg() use session-level cableCount if available
+                // Issue #591: best-effort hydration from per-set rep summaries.
+                // Any field that the portal does not supply stays null and
+                // falls back to the locally captured value at LWW merge time.
+                peakForceConcentricA = metricHydration.peakForceConcentricA,
+                peakForceConcentricB = metricHydration.peakForceConcentricB,
+                peakForceEccentricA = metricHydration.peakForceEccentricA,
+                peakForceEccentricB = metricHydration.peakForceEccentricB,
+                avgForceConcentricA = metricHydration.avgForceConcentricA,
+                avgForceConcentricB = metricHydration.avgForceConcentricB,
+                avgForceEccentricA = metricHydration.avgForceEccentricA,
+                avgForceEccentricB = metricHydration.avgForceEccentricB,
+                avgAsymmetryPercent = exercise.sets.flatMap { it.repSummaries }
+                    .mapNotNull { it.asymmetryPct }
+                    .takeIf { it.isNotEmpty() }?.average()?.toFloat(),
                 profileId = profileId,
             )
+        }
+    }
+
+    /**
+     * Issue #591: Aggregate per-set rep summaries into the summary-level
+     * peak/avg force fields stored on `WorkoutSession`.
+     *
+     * The portal stores per-rep telemetry in `PullRepSummaryDto`:
+     *   - `leftForceAvg` / `rightForceAvg` (Newtons) → per-rep averages for
+     *     cable A / cable B during the concentric or eccentric phase.
+     *     Cable A maps to "left", cable B maps to "right"
+     *     (see PortalSyncAdapter.kt:363-364).
+     *   - `meanForceN` / `peakForceN` (Newtons, combined cables) — set-level
+     *     aggregates already supplied by the portal set DTO.
+     *
+     * Mobile `peakForceConcentric*` / `avgForceConcentric*` columns store
+     * kg-load (i.e., Newtons / 9.80665). Conversion here so the round trip
+     * push → pull is unit-consistent with locally captured values.
+     *
+     * Eccentric peak/avg is harder to derive because the portal stores
+     * `tutMs` and not a separate eccentric force aggregate, so this helper
+     * conservatively keeps eccentric peak/avg as null unless a set DTO
+     * provides them directly. Preservation at LWW merge still protects the
+     * locally captured eccentric values when present.
+     */
+    private fun aggregateSetMetrics(sets: List<PullSetDto>): HydratedMetrics {
+        if (sets.isEmpty()) return HydratedMetrics.EMPTY
+
+        val allReps = sets.flatMap { it.repSummaries }
+        if (allReps.isEmpty()) return HydratedMetrics.EMPTY
+
+        // Cable A force: max of leftForceAvg across all reps (peak proxy)
+        // Cable B force: max of rightForceAvg across all reps
+        // Rep averages: average across all reps that supplied a value.
+        val leftForces = allReps.mapNotNull { it.leftForceAvg }
+        val rightForces = allReps.mapNotNull { it.rightForceAvg }
+        val peakLeft = leftForces.maxOrNull()
+        val peakRight = rightForces.maxOrNull()
+        val avgLeft = leftForces.takeIf { it.isNotEmpty() }?.average()?.toFloat()
+        val avgRight = rightForces.takeIf { it.isNotEmpty() }?.average()?.toFloat()
+
+        return HydratedMetrics(
+            peakForceConcentricA = peakLeft?.let { PortalMappings.newtonsToLoadKg(it) },
+            peakForceConcentricB = peakRight?.let { PortalMappings.newtonsToLoadKg(it) },
+            peakForceEccentricA = null, // Portal does not surface per-cable eccentric peak; preserve local.
+            peakForceEccentricB = null,
+            avgForceConcentricA = avgLeft?.let { PortalMappings.newtonsToLoadKg(it) },
+            avgForceConcentricB = avgRight?.let { PortalMappings.newtonsToLoadKg(it) },
+            avgForceEccentricA = null, // Same — preserved locally if available.
+            avgForceEccentricB = null,
+        )
+    }
+
+    private data class HydratedMetrics(
+        val peakForceConcentricA: Float?,
+        val peakForceConcentricB: Float?,
+        val peakForceEccentricA: Float?,
+        val peakForceEccentricB: Float?,
+        val avgForceConcentricA: Float?,
+        val avgForceConcentricB: Float?,
+        val avgForceEccentricA: Float?,
+        val avgForceEccentricB: Float?,
+    ) {
+        companion object {
+            val EMPTY = HydratedMetrics(null, null, null, null, null, null, null, null)
         }
     }
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalPullAdapter.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalPullAdapter.kt
@@ -97,9 +97,7 @@ object PortalPullAdapter {
                 avgForceConcentricB = metricHydration.avgForceConcentricB,
                 avgForceEccentricA = metricHydration.avgForceEccentricA,
                 avgForceEccentricB = metricHydration.avgForceEccentricB,
-                avgAsymmetryPercent = exercise.sets.flatMap { it.repSummaries }
-                    .mapNotNull { it.asymmetryPct }
-                    .takeIf { it.isNotEmpty() }?.average()?.toFloat(),
+                avgAsymmetryPercent = metricHydration.avgAsymmetryPercent,
                 profileId = profileId,
             )
         }
@@ -133,15 +131,20 @@ object PortalPullAdapter {
         val allReps = sets.flatMap { it.repSummaries }
         if (allReps.isEmpty()) return HydratedMetrics.EMPTY
 
-        // Cable A force: max of leftForceAvg across all reps (peak proxy)
-        // Cable B force: max of rightForceAvg across all reps
-        // Rep averages: average across all reps that supplied a value.
+        // Single pass over allReps — avoid re-flatMapping `sets` again at
+        // the call site to compute avgAsymmetryPercent (gemini-code-assist
+        // medium-priority note). Cable A force: max of leftForceAvg across
+        // all reps (peak proxy). Cable B force: max of rightForceAvg across
+        // all reps. Rep averages: average across all reps that supplied a
+        // value.
         val leftForces = allReps.mapNotNull { it.leftForceAvg }
         val rightForces = allReps.mapNotNull { it.rightForceAvg }
         val peakLeft = leftForces.maxOrNull()
         val peakRight = rightForces.maxOrNull()
         val avgLeft = leftForces.takeIf { it.isNotEmpty() }?.average()?.toFloat()
         val avgRight = rightForces.takeIf { it.isNotEmpty() }?.average()?.toFloat()
+        val asymmetryPcts = allReps.mapNotNull { it.asymmetryPct }
+        val avgAsymmetry = asymmetryPcts.takeIf { it.isNotEmpty() }?.average()?.toFloat()
 
         return HydratedMetrics(
             peakForceConcentricA = peakLeft?.let { PortalMappings.newtonsToLoadKg(it) },
@@ -152,6 +155,7 @@ object PortalPullAdapter {
             avgForceConcentricB = avgRight?.let { PortalMappings.newtonsToLoadKg(it) },
             avgForceEccentricA = null, // Same — preserved locally if available.
             avgForceEccentricB = null,
+            avgAsymmetryPercent = avgAsymmetry,
         )
     }
 
@@ -164,9 +168,10 @@ object PortalPullAdapter {
         val avgForceConcentricB: Float?,
         val avgForceEccentricA: Float?,
         val avgForceEccentricB: Float?,
+        val avgAsymmetryPercent: Float?,
     ) {
         companion object {
-            val EMPTY = HydratedMetrics(null, null, null, null, null, null, null, null)
+            val EMPTY = HydratedMetrics(null, null, null, null, null, null, null, null, null)
         }
     }
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/HistoryManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/HistoryManager.kt
@@ -74,7 +74,29 @@ class HistoryManager(
                 initialValue = emptyList(),
             )
 
-    val groupedWorkoutHistory: StateFlow<List<HistoryItem>> = allWorkoutSessions.map { sessions ->
+    /**
+     * Issue #591: Analytics / History-visible sessions.
+     *
+     * `allWorkoutSessions` powers streak, progress percentage, and
+     * history pagination (still needs every persisted row). For the
+     * `groupedWorkoutHistory` grouping used by `HistoryTab`'s Daily Routine
+     * card and per-set drill-down we instead need to skip zero-rep /
+     * soft-deleted rows so they do not inflate routine set totals or
+     * trip the misleading pre-v0.2.1 placeholder.
+     */
+    val historyVisibleSessions: StateFlow<List<WorkoutSession>> =
+        userProfileRepository.activeProfile
+            .flatMapLatest { profile ->
+                val profileId = profile?.id ?: "default"
+                workoutRepository.getHistoryVisibleSessions(profileId)
+            }
+            .stateIn(
+                scope = scope,
+                started = SharingStarted.WhileSubscribed(5000),
+                initialValue = emptyList(),
+            )
+
+    val groupedWorkoutHistory: StateFlow<List<HistoryItem>> = historyVisibleSessions.map { sessions ->
         val groupedByRoutine = sessions.filter { it.routineSessionId != null }
             .groupBy { it.routineSessionId!! }
             .map { (id, sessionList) ->

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/HistoryManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/HistoryManager.kt
@@ -228,6 +228,16 @@ class HistoryManager(
         scope.launch { workoutRepository.deleteSession(sessionId) }
     }
 
+    /**
+     * Issue #591 follow-up (chatgpt-codex-connector P2): soft-delete
+     * every WorkoutSession row belonging to this routine session so
+     * the zero-rep / ghost rows hidden by `getHistoryVisibleSessions`
+     * do not survive the History "Delete All Sets" affordance.
+     */
+    fun deleteRoutineWorkouts(routineSessionId: String) {
+        scope.launch { workoutRepository.deleteSessionsByRoutineSessionId(routineSessionId) }
+    }
+
     fun deleteAllWorkouts() {
         scope.launch { workoutRepository.deleteAllSessions() }
     }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/AnalyticsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/AnalyticsScreen.kt
@@ -441,6 +441,11 @@ fun AnalyticsScreen(viewModel: MainViewModel, themeMode: com.devil.phoenixprojec
                         formatWeight = viewModel::formatWeight,
                         kgToDisplay = viewModel::kgToDisplay,
                         onDeleteWorkout = { viewModel.deleteWorkout(it) },
+                        // Issue #591 follow-up: route the "Delete All
+                        // Sets" group action through HistoryManager
+                        // so zero-rep ghost rows hidden by the History
+                        // filter are soft-deleted too.
+                        onDeleteRoutineGroup = { viewModel.deleteRoutineWorkouts(it) },
                         exerciseRepository = viewModel.exerciseRepository,
                         onTagJustLiftSessionExercise = { sessionId, exercise, isAmrap ->
                             viewModel.tagJustLiftSessionExercise(sessionId, exercise, isAmrap)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/HistoryTab.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/HistoryTab.kt
@@ -108,6 +108,7 @@ fun HistoryTab(
     formatWeight: (Float, WeightUnit) -> String,
     kgToDisplay: (Float, WeightUnit) -> Float,
     onDeleteWorkout: (String) -> Unit,
+    onDeleteRoutineGroup: (String) -> Unit,
     exerciseRepository: ExerciseRepository,
     onTagJustLiftSessionExercise: suspend (String, Exercise, Boolean) -> Unit = { _, _, _ -> },
     onRefresh: () -> Unit = {},
@@ -210,7 +211,13 @@ fun HistoryTab(
                                 exerciseRepository = exerciseRepository,
                                 repMetricRepository = repMetricRepository,
                                 onTagJustLiftSessionExercise = onTagJustLiftSessionExercise,
-                                onDelete = { sessionId -> onDeleteWorkout(sessionId) },
+                                // Issue #591 follow-up: thread the
+                                // routine-level delete callback so the
+                                // History "Delete All Sets" path also
+                                // cleans up zero-rep ghost rows hidden by
+                                // the History filter. The single-session
+                                // path above still uses onDeleteWorkout.
+                                onDeleteRoutineGroup = onDeleteRoutineGroup,
                             )
                         }
                     }
@@ -773,7 +780,10 @@ fun GroupedRoutineCard(
     exerciseRepository: com.devil.phoenixproject.data.repository.ExerciseRepository,
     repMetricRepository: RepMetricRepository,
     onTagJustLiftSessionExercise: suspend (String, Exercise, Boolean) -> Unit = { _, _, _ -> },
-    onDelete: (String) -> Unit,
+    // Issue #591 follow-up: receives routineSessionId so the caller can
+    // soft-delete every WorkoutSession row for the routine (including
+    // zero-rep ghost rows hidden by `getHistoryVisibleSessions`).
+    onDeleteRoutineGroup: (String) -> Unit,
 ) {
     val scope = rememberCoroutineScope()
     var showDeleteDialog by remember { mutableStateOf(false) }
@@ -1173,10 +1183,12 @@ fun GroupedRoutineCard(
             confirmButton = {
                 TextButton(
                     onClick = {
-                        // Delete all sessions in the routine
-                        groupedItem.sessions.forEach { session ->
-                            onDelete(session.id)
-                        }
+                        // Issue #591 follow-up: delete the whole routine
+                        // session by id so zero-rep ghost rows hidden by
+                        // the History filter are cleaned up too. Looping
+                        // over `groupedItem.sessions` would only delete
+                        // the visible rows.
+                        onDeleteRoutineGroup(groupedItem.routineSessionId)
                         showDeleteDialog = false
                     },
                     modifier = Modifier.height(56.dp), // Material 3 Expressive: Taller button

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/HistoryTab.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/HistoryTab.kt
@@ -476,8 +476,11 @@ fun WorkoutHistoryCard(
                                     tint = MaterialTheme.colorScheme.onSurfaceVariant,
                                 )
                                 Spacer(modifier = Modifier.width(Spacing.small))
+                                // Issue #591: see per-set drill-down note —
+                                // frame this honestly instead of blaming the
+                                // app version.
                                 Text(
-                                    "Detailed metrics available for workouts after v0.2.1",
+                                    "Detailed metrics were not captured for this set",
                                     style = MaterialTheme.typography.bodyMedium,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 )
@@ -1063,8 +1066,18 @@ fun GroupedRoutineCard(
                                 ) {
                                     Icon(Icons.Default.Info, null, tint = MaterialTheme.colorScheme.onSurfaceVariant)
                                     Spacer(modifier = Modifier.width(Spacing.small))
+                                    // Issue #591: The "after v0.2.1" copy is
+                                    // misleading for current sessions whose
+                                    // metric columns were nulled by a sync pull
+                                    // or by a zero-rep save. History now also
+                                    // filters zero-rep rows out of routine
+                                    // grouping so this card only appears for
+                                    // real legacy / unmeasured rows. Frame it
+                                    // honestly: this set's detailed metrics
+                                    // were not captured for this device, not
+                                    // "you need a newer app".
                                     Text(
-                                        "Detailed metrics available for workouts after v0.2.1",
+                                        "Detailed metrics were not captured for this set",
                                         style = MaterialTheme.typography.bodyMedium,
                                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                                     )

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/HistoryTab.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/HistoryTab.kt
@@ -93,6 +93,7 @@ import vitruvianprojectphoenix.shared.generated.resources.Res
 import vitruvianprojectphoenix.shared.generated.resources.cd_delete_routine
 import vitruvianprojectphoenix.shared.generated.resources.cd_delete_workout
 import vitruvianprojectphoenix.shared.generated.resources.cd_workout_session_icon
+import vitruvianprojectphoenix.shared.generated.resources.detailed_metrics_not_captured
 import vitruvianprojectphoenix.shared.generated.resources.empty_no_history_all
 import vitruvianprojectphoenix.shared.generated.resources.empty_no_history_period
 import vitruvianprojectphoenix.shared.generated.resources.empty_no_history_title
@@ -487,7 +488,7 @@ fun WorkoutHistoryCard(
                                 // frame this honestly instead of blaming the
                                 // app version.
                                 Text(
-                                    "Detailed metrics were not captured for this set",
+                                    stringResource(Res.string.detailed_metrics_not_captured),
                                     style = MaterialTheme.typography.bodyMedium,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 )
@@ -1087,7 +1088,7 @@ fun GroupedRoutineCard(
                                     // were not captured for this device, not
                                     // "you need a newer app".
                                     Text(
-                                        "Detailed metrics were not captured for this set",
+                                        stringResource(Res.string.detailed_metrics_not_captured),
                                         style = MaterialTheme.typography.bodyMedium,
                                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                                     )

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
@@ -252,6 +252,15 @@ class MainViewModel constructor(
     val workoutStreak: StateFlow<Int?> get() = historyManager.workoutStreak
     val progressPercentage: StateFlow<Int?> get() = historyManager.progressPercentage
     fun deleteWorkout(sessionId: String) = historyManager.deleteWorkout(sessionId)
+
+    /**
+     * Issue #591 follow-up (chatgpt-codex-connector P2): route the
+     * History "Delete All Sets" group action through the HistoryManager
+     * so zero-rep ghost rows hidden by `getHistoryVisibleSessions` are
+     * soft-deleted along with the visible sets.
+     */
+    fun deleteRoutineWorkouts(routineSessionId: String) = historyManager.deleteRoutineWorkouts(routineSessionId)
+
     fun deleteAllWorkouts() = historyManager.deleteAllWorkouts()
 
     // ===== Settings Delegation =====

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/DataBackupManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/DataBackupManager.kt
@@ -210,7 +210,7 @@ abstract class BaseDataBackupManager(
     // -- Legacy export (kept for backward compatibility) --
 
     override suspend fun exportAllData(): BackupData = withContext(Dispatchers.IO) {
-        val sessions = queries.selectAllSessionsSync().executeAsList()
+        val sessions = queries.selectBackupSessionsSync().executeAsList()
 
         // IMPORTANT: Load metrics per-session to avoid memory exhaustion on iOS.
         // Loading all metrics at once can cause OOM crashes on iOS due to how the
@@ -1790,7 +1790,7 @@ abstract class BaseDataBackupManager(
     ) {
         // Phase 1: Count
         onProgress(BackupProgress(BackupPhase.COUNTING, 0, 0))
-        val sessionCount = queries.countAllWorkoutSessions().executeAsOne()
+        val sessionCount = queries.countBackupWorkoutSessions().executeAsOne()
         val metricCount = runCatching { queries.countAllMetricSamples().executeAsOne() }.getOrElse { 0L }
         val routines = queries.selectAllRoutinesSync().executeAsList()
         val routineExercises = queries.selectAllRoutineExercisesSync().executeAsList()
@@ -1805,7 +1805,7 @@ abstract class BaseDataBackupManager(
         // Phase 2: Sessions
         onProgress(BackupProgress(BackupPhase.SESSIONS, 0, sessionCount))
         writer.write("\"workoutSessions\":[")
-        val sessions = queries.selectAllSessionsSync().executeAsList()
+        val sessions = queries.selectBackupSessionsSync().executeAsList()
         sessions.forEachIndexed { index, session ->
             if (index > 0) writer.write(",")
             writer.write(json.encodeToString(WorkoutSessionBackup.serializer(), mapSessionToBackup(session, routineNameResolutionContext)))

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/DataBackupManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/DataBackupManager.kt
@@ -1791,7 +1791,7 @@ abstract class BaseDataBackupManager(
         // Phase 1: Count
         onProgress(BackupProgress(BackupPhase.COUNTING, 0, 0))
         val sessionCount = queries.countBackupWorkoutSessions().executeAsOne()
-        val metricCount = runCatching { queries.countAllMetricSamples().executeAsOne() }.getOrElse { 0L }
+        val metricCount = runCatching { queries.countBackupMetricSamples().executeAsOne() }.getOrElse { 0L }
         val routines = queries.selectAllRoutinesSync().executeAsList()
         val routineExercises = queries.selectAllRoutineExercisesSync().executeAsList()
         val equipmentRackItems = equipmentRackRepository.getItems()

--- a/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
+++ b/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
@@ -515,11 +515,19 @@ DELETE FROM Exercise WHERE id = ? AND isCustom = 1;
 deleteSession:
 DELETE FROM WorkoutSession WHERE id = ?;
 
--- Issue #591 follow-up: soft-delete every session (including zero-rep
+-- Issue #591 follow-up: hard-delete every session (including zero-rep
 -- ghost rows) that belongs to a given routine session. Used by the
 -- History "Delete All Sets" affordance so ghost rows hidden by the
 -- `selectHistoryVisibleSessions` filter do not survive the user-level
--- deletion (chatgpt-codex-connector P2).
+-- deletion (chatgpt-codex-connector P2). This mirrors deleteSession's
+-- local deletion semantics; workout-session tombstone push is not
+-- currently implemented.
+deleteSessionsByRoutineSessionId:
+DELETE FROM WorkoutSession WHERE routineSessionId = ?;
+
+-- Tombstone helper for code paths that intentionally keep deleted
+-- workout rows locally. Do not use for user-facing History deletes
+-- unless session tombstones are also pushed to the portal.
 softDeleteSessionsByRoutineSessionId:
 UPDATE WorkoutSession
 SET deletedAt = ?, updatedAt = ?
@@ -548,9 +556,8 @@ DELETE FROM ExerciseVideo;
 
 -- Workout Session Queries
 -- Issue #591 follow-up (chatgpt-codex-connector P2): filter soft-
--- deleted rows out of the read path so a History "Delete All Sets"
--- group action (which soft-deletes by routineSessionId) does not
--- leave dangling rows that reappear in streak calc or progress.
+-- deleted rows out of the read path so local tombstones do not leave
+-- dangling rows that reappear in streak calc or progress.
 -- Backup/export uses selectBackupSessionsSync below for the same
 -- user-visible tombstone filter.
 selectAllSessions:
@@ -1411,11 +1418,16 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, :profileId);
 
 -- Analytics helpers for gamification (profile-scoped)
 countTotalWorkouts:
-SELECT COUNT(*) FROM WorkoutSession WHERE profile_id = :profileId AND workingReps > 0;
+SELECT COUNT(*) FROM WorkoutSession WHERE profile_id = :profileId AND deletedAt IS NULL AND workingReps > 0;
 
 -- Count queries for streaming backup progress (global, all profiles)
 countBackupWorkoutSessions:
 SELECT COUNT(*) FROM WorkoutSession WHERE deletedAt IS NULL;
+
+countBackupMetricSamples:
+SELECT COUNT(*)
+FROM MetricSample
+WHERE sessionId IN (SELECT id FROM WorkoutSession WHERE deletedAt IS NULL);
 
 countAllWorkoutSessions:
 SELECT COUNT(*) FROM WorkoutSession;
@@ -1427,19 +1439,19 @@ countAllRoutineExercises:
 SELECT COUNT(*) FROM RoutineExercise;
 
 countTotalReps:
-SELECT SUM(totalReps) FROM WorkoutSession WHERE profile_id = :profileId AND workingReps > 0;
+SELECT SUM(totalReps) FROM WorkoutSession WHERE profile_id = :profileId AND deletedAt IS NULL AND workingReps > 0;
 
 countTotalVolume:
-SELECT SUM(COALESCE(totalVolumeKg, totalReps * weightPerCableKg * COALESCE(cableCount, 1))) FROM WorkoutSession WHERE profile_id = :profileId AND workingReps > 0;
+SELECT SUM(COALESCE(totalVolumeKg, totalReps * weightPerCableKg * COALESCE(cableCount, 1))) FROM WorkoutSession WHERE profile_id = :profileId AND deletedAt IS NULL AND workingReps > 0;
 
 countUniqueExercises:
-SELECT COUNT(DISTINCT exerciseId) FROM WorkoutSession WHERE exerciseId IS NOT NULL AND exerciseId != '' AND profile_id = :profileId AND workingReps > 0;
+SELECT COUNT(DISTINCT exerciseId) FROM WorkoutSession WHERE exerciseId IS NOT NULL AND exerciseId != '' AND profile_id = :profileId AND deletedAt IS NULL AND workingReps > 0;
 
 countPersonalRecords:
 SELECT COUNT(*) FROM PersonalRecord WHERE profile_id = :profileId;
 
 selectWorkoutDates:
-SELECT DISTINCT DATE(timestamp / 1000, 'unixepoch') AS workoutDate FROM WorkoutSession WHERE profile_id = :profileId AND workingReps > 0 ORDER BY timestamp DESC;
+SELECT DISTINCT DATE(timestamp / 1000, 'unixepoch') AS workoutDate FROM WorkoutSession WHERE profile_id = :profileId AND deletedAt IS NULL AND workingReps > 0 ORDER BY timestamp DESC;
 
 -- ==================== RPG ATTRIBUTES QUERIES ====================
 

--- a/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
+++ b/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
@@ -539,6 +539,22 @@ DELETE FROM ExerciseVideo;
 selectAllSessions:
 SELECT * FROM WorkoutSession WHERE profile_id = :profileId ORDER BY timestamp DESC;
 
+-- Issue #591: Analytics / History visible rows.
+-- Filter mirrors selectCompletedHealthExportCandidates and
+-- selectSessionsByRoutineSessionId: a row counts as a "real" completed
+-- set when it has not been soft-deleted and has at least one recorded
+-- rep (working or total). Without this guard the Daily Routine card
+-- counts zero-rep rows as sets, producing
+--   "Incline Fly — 0 reps / 6 sets / 0 lbs"
+-- and per-set drill-downs render the misleading "after v0.2.1"
+-- placeholder for rows that the recorder never captured.
+selectHistoryVisibleSessions:
+SELECT * FROM WorkoutSession
+WHERE profile_id = :profileId
+AND deletedAt IS NULL
+AND (workingReps > 0 OR totalReps > 0)
+ORDER BY timestamp DESC;
+
 selectSessionById:
 SELECT * FROM WorkoutSession WHERE id = ?;
 

--- a/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
+++ b/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
@@ -515,6 +515,17 @@ DELETE FROM Exercise WHERE id = ? AND isCustom = 1;
 deleteSession:
 DELETE FROM WorkoutSession WHERE id = ?;
 
+-- Issue #591 follow-up: soft-delete every session (including zero-rep
+-- ghost rows) that belongs to a given routine session. Used by the
+-- History "Delete All Sets" affordance so ghost rows hidden by the
+-- `selectHistoryVisibleSessions` filter do not survive the user-level
+-- deletion (chatgpt-codex-connector P2).
+softDeleteSessionsByRoutineSessionId:
+UPDATE WorkoutSession
+SET deletedAt = ?, updatedAt = ?
+WHERE routineSessionId = ?
+  AND deletedAt IS NULL;
+
 deleteAllSessions:
 DELETE FROM WorkoutSession;
 

--- a/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
+++ b/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
@@ -565,6 +565,47 @@ SELECT * FROM WorkoutSession WHERE id = ?;
 selectSessionUpdatedAt:
 SELECT updatedAt FROM WorkoutSession WHERE id = ?;
 
+-- Issue #591 follow-up: batch-read the existing updatedAt for a list of
+-- session ids. Used by SqlDelightSyncRepository.mergeSessionsLww so the
+-- LWW gate does not issue one round-trip per incoming pull row. Returns
+-- (id, updatedAt) so the caller can build an in-memory map keyed by id.
+selectSessionsUpdatedAtByIds:
+SELECT id, updatedAt FROM WorkoutSession WHERE id IN ?;
+
+-- Issue #591 follow-up: batch-read the detailed metric / biomechanics
+-- columns used by the LWW preservation guard for a list of session ids.
+-- Mirrors the column list in
+-- SqlDelightSyncRepository.preserveMetrics() so the LWW gate can fall
+-- back to the locally captured values without a per-row full-row read.
+selectSessionsMetricsForPreservationByIds:
+SELECT
+    id,
+    peakForceConcentricA,
+    peakForceConcentricB,
+    peakForceEccentricA,
+    peakForceEccentricB,
+    avgForceConcentricA,
+    avgForceConcentricB,
+    avgForceEccentricA,
+    avgForceEccentricB,
+    heaviestLiftKg,
+    totalVolumeKg,
+    cableCount,
+    display_multiplier,
+    estimatedCalories,
+    warmupAvgWeightKg,
+    workingAvgWeightKg,
+    burnoutAvgWeightKg,
+    peakWeightKg,
+    rpe,
+    avgMcvMmS,
+    avgAsymmetryPercent,
+    totalVelocityLossPercent,
+    dominantSide,
+    strengthProfile,
+    formScore
+FROM WorkoutSession WHERE id IN ?;
+
 -- Sync version for backup
 selectAllSessionsSync:
 SELECT * FROM WorkoutSession;

--- a/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
+++ b/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
@@ -550,10 +550,9 @@ DELETE FROM ExerciseVideo;
 -- Issue #591 follow-up (chatgpt-codex-connector P2): filter soft-
 -- deleted rows out of the read path so a History "Delete All Sets"
 -- group action (which soft-deletes by routineSessionId) does not
--- leave dangling rows that reappear in streak calc, progress, or
--- backup export. The `deletedAt IS NULL` guard mirrors the existing
--- pattern used by selectCompletedHealthExportCandidates and
--- selectHistoryVisibleSessions.
+-- leave dangling rows that reappear in streak calc or progress.
+-- Backup/export uses selectBackupSessionsSync below for the same
+-- user-visible tombstone filter.
 selectAllSessions:
 SELECT * FROM WorkoutSession
 WHERE profile_id = :profileId
@@ -627,7 +626,16 @@ SELECT
     formScore
 FROM WorkoutSession WHERE id IN ?;
 
--- Sync version for backup
+-- Backup/export session rows. Unlike selectAllSessionsSync, this must
+-- not serialize local tombstones: WorkoutSessionBackup has no deletedAt
+-- field, so exporting soft-deleted rows would resurrect deleted sets on
+-- import/restore.
+selectBackupSessionsSync:
+SELECT * FROM WorkoutSession
+WHERE deletedAt IS NULL;
+
+-- Sync/migration version for code paths that need every local row,
+-- including tombstones.
 selectAllSessionsSync:
 SELECT * FROM WorkoutSession;
 
@@ -1406,6 +1414,9 @@ countTotalWorkouts:
 SELECT COUNT(*) FROM WorkoutSession WHERE profile_id = :profileId AND workingReps > 0;
 
 -- Count queries for streaming backup progress (global, all profiles)
+countBackupWorkoutSessions:
+SELECT COUNT(*) FROM WorkoutSession WHERE deletedAt IS NULL;
+
 countAllWorkoutSessions:
 SELECT COUNT(*) FROM WorkoutSession;
 

--- a/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
+++ b/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
@@ -547,8 +547,18 @@ deleteAllVideos:
 DELETE FROM ExerciseVideo;
 
 -- Workout Session Queries
+-- Issue #591 follow-up (chatgpt-codex-connector P2): filter soft-
+-- deleted rows out of the read path so a History "Delete All Sets"
+-- group action (which soft-deletes by routineSessionId) does not
+-- leave dangling rows that reappear in streak calc, progress, or
+-- backup export. The `deletedAt IS NULL` guard mirrors the existing
+-- pattern used by selectCompletedHealthExportCandidates and
+-- selectHistoryVisibleSessions.
 selectAllSessions:
-SELECT * FROM WorkoutSession WHERE profile_id = :profileId ORDER BY timestamp DESC;
+SELECT * FROM WorkoutSession
+WHERE profile_id = :profileId
+AND deletedAt IS NULL
+ORDER BY timestamp DESC;
 
 -- Issue #591: Analytics / History visible rows.
 -- Filter mirrors selectCompletedHealthExportCandidates and

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/Issue591AnalyticsHydrationTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/Issue591AnalyticsHydrationTest.kt
@@ -1,0 +1,262 @@
+package com.devil.phoenixproject.data.sync
+
+import com.devil.phoenixproject.data.sync.PortalPullAdapter
+import com.devil.phoenixproject.data.sync.PullExerciseDto
+import com.devil.phoenixproject.data.sync.PullRepSummaryDto
+import com.devil.phoenixproject.data.sync.PullSetDto
+import com.devil.phoenixproject.data.sync.PullWorkoutSessionDto
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Issue #591: Analytics only records first set of first exercise in
+ * multi-exercise routine; per-set drill-down shows 'after v0.2.1'
+ * placeholder on v0.9.2.
+ *
+ * Regression coverage for the two-part fix:
+ *   1. PortalPullAdapter.toWorkoutSessionsWithLookup must hydrate
+ *      detailed metric columns (peakForceConcentricA/B, etc.) from the
+ *      per-rep telemetry carried in PullSetDto.repSummaries so a freshly
+ *      recorded local row is not overwritten by a null-metric pull row.
+ *   2. When the pull DTO carries no rep summaries at all, the
+ *      hydration helper returns null so the LWW merge preserves the
+ *      locally captured value (covered separately by the sync repo
+ *      test).
+ *
+ * Unit conventions: portal rep-summaries carry force in Newtons.
+ * Mobile WorkoutSession metric columns store kg-load (Newtons / 9.80665).
+ * The hydration helper must convert.
+ */
+class Issue591AnalyticsHydrationTest {
+
+    @Test
+    fun `pull DTO with rep summaries hydrates peakForceConcentric from max left right force per cable`() = kotlinx.coroutines.runBlocking {
+        val repForceLeftN = 50f * 9.80665f   // ≈ 50 kg-load per cable
+        val repForceRightN = 55f * 9.80665f  // ≈ 55 kg-load per cable
+        val dto = PullWorkoutSessionDto(
+            id = "portal-session-1",
+            userId = "user-1",
+            startedAt = "2026-06-23T06:16:00Z",
+            durationSeconds = 60,
+            exerciseCount = 1,
+            routineName = "4.Scaffold.Pull/Press",
+            exercises = listOf(
+                PullExerciseDto(
+                    id = "portal-ex-1",
+                    sessionId = "portal-session-1",
+                    name = "Incline Bench Press",
+                    muscleGroup = "Chest",
+                    orderIndex = 0,
+                    sets = listOf(
+                        PullSetDto(
+                            id = "portal-set-1",
+                            exerciseId = "portal-ex-1",
+                            setNumber = 1,
+                            targetReps = 8,
+                            actualReps = 8,
+                            weightKg = 30f,
+                            repSummaries = listOf(
+                                PullRepSummaryDto(
+                                    id = "rep-1", setId = "portal-set-1", repNumber = 1,
+                                    leftForceAvg = repForceLeftN,
+                                    rightForceAvg = repForceRightN,
+                                ),
+                                PullRepSummaryDto(
+                                    id = "rep-2", setId = "portal-set-1", repNumber = 2,
+                                    leftForceAvg = 48f * 9.80665f,
+                                    rightForceAvg = 52f * 9.80665f,
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val sessions = PortalPullAdapter.toWorkoutSessionsWithLookup(
+            portalSession = dto,
+            profileId = "default",
+        ) { _, _, _ -> "exercise-catalog-id-1" }
+
+        assertEquals(1, sessions.size, "one portal exercise should map to one mobile session")
+        val session = sessions[0]
+
+        // peakForceConcentricA/B is the max per-rep left/right force
+        // converted back from Newtons to kg-load. Allow a small
+        // floating-point tolerance because we round-trip through a
+        // Float multiply/divide by 9.80665.
+        val expectedPeakA = 50f
+        val expectedPeakB = 55f
+        assertNotNull(session.peakForceConcentricA, "peakForceConcentricA must be hydrated")
+        assertNotNull(session.peakForceConcentricB, "peakForceConcentricB must be hydrated")
+        assertTrue(
+            abs(session.peakForceConcentricA!! - expectedPeakA) < 0.01f,
+            "peakForceConcentricA expected ~$expectedPeakA, got ${session.peakForceConcentricA}",
+        )
+        assertTrue(
+            abs(session.peakForceConcentricB!! - expectedPeakB) < 0.01f,
+            "peakForceConcentricB expected ~$expectedPeakB, got ${session.peakForceConcentricB}",
+        )
+    }
+
+    @Test
+    fun `pull DTO with rep summaries hydrates avgForceConcentric from rep-set average`() = kotlinx.coroutines.runBlocking {
+        val dto = PullWorkoutSessionDto(
+            id = "portal-session-2",
+            userId = "user-1",
+            startedAt = "2026-06-23T06:16:00Z",
+            durationSeconds = 60,
+            exerciseCount = 1,
+            exercises = listOf(
+                PullExerciseDto(
+                    id = "portal-ex-2",
+                    sessionId = "portal-session-2",
+                    name = "Squat",
+                    muscleGroup = "Legs",
+                    sets = listOf(
+                        PullSetDto(
+                            id = "portal-set-2",
+                            exerciseId = "portal-ex-2",
+                            setNumber = 1,
+                            actualReps = 3,
+                            weightKg = 80f,
+                            repSummaries = listOf(
+                                PullRepSummaryDto(
+                                    id = "r1", setId = "portal-set-2", repNumber = 1,
+                                    leftForceAvg = 80f * 9.80665f,
+                                    rightForceAvg = 80f * 9.80665f,
+                                ),
+                                PullRepSummaryDto(
+                                    id = "r2", setId = "portal-set-2", repNumber = 2,
+                                    leftForceAvg = 70f * 9.80665f,
+                                    rightForceAvg = 75f * 9.80665f,
+                                ),
+                                PullRepSummaryDto(
+                                    id = "r3", setId = "portal-set-2", repNumber = 3,
+                                    leftForceAvg = 60f * 9.80665f,
+                                    rightForceAvg = 65f * 9.80665f,
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val sessions = PortalPullAdapter.toWorkoutSessionsWithLookup(
+            portalSession = dto,
+            profileId = "default",
+        ) { _, _, _ -> "exercise-catalog-id-2" }
+
+        val session = sessions.single()
+        assertNotNull(session.avgForceConcentricA)
+        assertNotNull(session.avgForceConcentricB)
+        // Average of 80, 70, 60 = 70; average of 80, 75, 65 = 73.33
+        assertTrue(
+            abs(session.avgForceConcentricA!! - 70f) < 0.05f,
+            "avgForceConcentricA expected ~70, got ${session.avgForceConcentricA}",
+        )
+        assertTrue(
+            abs(session.avgForceConcentricB!! - 73.333f) < 0.05f,
+            "avgForceConcentricB expected ~73.33, got ${session.avgForceConcentricB}",
+        )
+    }
+
+    @Test
+    fun `pull DTO with empty rep summaries keeps metric fields null so LWW preserves local values`() = kotlinx.coroutines.runBlocking {
+        val dto = PullWorkoutSessionDto(
+            id = "portal-session-3",
+            userId = "user-1",
+            startedAt = "2026-06-23T06:16:00Z",
+            durationSeconds = 60,
+            exerciseCount = 1,
+            exercises = listOf(
+                PullExerciseDto(
+                    id = "portal-ex-3",
+                    sessionId = "portal-session-3",
+                    name = "Bench Press",
+                    muscleGroup = "Chest",
+                    sets = listOf(
+                        PullSetDto(
+                            id = "portal-set-3",
+                            exerciseId = "portal-ex-3",
+                            setNumber = 1,
+                            actualReps = 5,
+                            weightKg = 60f,
+                            repSummaries = emptyList(),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val sessions = PortalPullAdapter.toWorkoutSessionsWithLookup(
+            portalSession = dto,
+            profileId = "default",
+        ) { _, _, _ -> "exercise-catalog-id-3" }
+
+        val session = sessions.single()
+        // Hydration must NOT fabricate values — they stay null so the
+        // SqlDelightSyncRepository.mergeSessionsLww LWW gate can fall
+        // back to the locally captured row.
+        assertNull(session.peakForceConcentricA)
+        assertNull(session.peakForceConcentricB)
+        assertNull(session.peakForceEccentricA)
+        assertNull(session.peakForceEccentricB)
+        assertNull(session.avgForceConcentricA)
+        assertNull(session.avgForceConcentricB)
+    }
+
+    @Test
+    fun `asymmetry percent aggregates across rep summaries when supplied`() = kotlinx.coroutines.runBlocking {
+        val dto = PullWorkoutSessionDto(
+            id = "portal-session-4",
+            userId = "user-1",
+            startedAt = "2026-06-23T06:16:00Z",
+            durationSeconds = 60,
+            exerciseCount = 1,
+            exercises = listOf(
+                PullExerciseDto(
+                    id = "portal-ex-4",
+                    sessionId = "portal-session-4",
+                    name = "Curl",
+                    muscleGroup = "Arms",
+                    sets = listOf(
+                        PullSetDto(
+                            id = "portal-set-4",
+                            exerciseId = "portal-ex-4",
+                            setNumber = 1,
+                            actualReps = 2,
+                            weightKg = 20f,
+                            repSummaries = listOf(
+                                PullRepSummaryDto(
+                                    id = "r1", setId = "portal-set-4", repNumber = 1,
+                                    leftForceAvg = 10f * 9.80665f, rightForceAvg = 12f * 9.80665f,
+                                    asymmetryPct = 18f,
+                                ),
+                                PullRepSummaryDto(
+                                    id = "r2", setId = "portal-set-4", repNumber = 2,
+                                    leftForceAvg = 9f * 9.80665f, rightForceAvg = 11f * 9.80665f,
+                                    asymmetryPct = 22f,
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val sessions = PortalPullAdapter.toWorkoutSessionsWithLookup(
+            portalSession = dto,
+            profileId = "default",
+        ) { _, _, _ -> "exercise-catalog-id-4" }
+
+        val session = sessions.single()
+        assertNotNull(session.avgAsymmetryPercent)
+        assertEquals(20f, session.avgAsymmetryPercent, 0.01f)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/Issue591SyncLwwTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/Issue591SyncLwwTest.kt
@@ -1,0 +1,313 @@
+package com.devil.phoenixproject.data.sync
+
+import com.devil.phoenixproject.data.repository.SqlDelightSyncRepository
+import com.devil.phoenixproject.domain.model.WorkoutSession
+import com.devil.phoenixproject.testutil.FakeUserProfileRepository
+import com.devil.phoenixproject.testutil.createTestDatabase
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * Issue #591: Analytics only records first set of first exercise in
+ * multi-exercise routine; per-set drill-down shows 'after v0.2.1'
+ * placeholder on v0.9.2.
+ *
+ * Regression coverage for the LWW preservation guard added to
+ * SqlDelightSyncRepository.mergeSessionsLww: when an incoming pull
+ * row has null detailed metric columns but the existing local row
+ * has captured non-null metrics, the local values must be preserved
+ * instead of being overwritten with null. This is the exact
+ * regression that triggered the "after v0.2.1" placeholder in
+ * Analytics for current v0.9.2 sessions.
+ *
+ * Mirrors the test scaffolding from ConflictResolutionTest so the
+ * pattern stays consistent across the sync suite.
+ */
+class Issue591SyncLwwTest {
+
+    private val testProfileId = "test-profile"
+    private val now = 1_700_000_000_000L
+
+    private lateinit var database: com.devil.phoenixproject.database.VitruvianDatabase
+    private lateinit var userProfileRepository: FakeUserProfileRepository
+    private lateinit var repository: SqlDelightSyncRepository
+
+    private fun setUp() {
+        database = createTestDatabase()
+        userProfileRepository = FakeUserProfileRepository()
+        userProfileRepository.setActiveProfileForTest(id = testProfileId)
+        repository = SqlDelightSyncRepository(database, userProfileRepository)
+    }
+
+    @Test
+    fun `mergeSessionsLww preserves local peakForceConcentric when incoming is null`() = runTest {
+        setUp()
+
+        // GIVEN: A locally recorded session with non-null detailed metrics.
+        val sessionId = "issue-591-set-1"
+        insertLocalSession(
+            WorkoutSession(
+                id = sessionId,
+                timestamp = now,
+                mode = "OldSchool",
+                reps = 8,
+                weightPerCableKg = 30f,
+                duration = 90_000L,
+                totalReps = 8,
+                warmupReps = 0,
+                workingReps = 8,
+                exerciseId = "exercise-incline-bench",
+                exerciseName = "Incline Bench Press",
+                routineSessionId = "routine-1",
+                routineName = "4.Scaffold.Pull/Press",
+                peakForceConcentricA = 50f,
+                peakForceConcentricB = 55f,
+                peakForceEccentricA = 60f,
+                peakForceEccentricB = 62f,
+                avgForceConcentricA = 35f,
+                avgForceConcentricB = 38f,
+                avgForceEccentricA = 40f,
+                avgForceEccentricB = 42f,
+                heaviestLiftKg = 32f,
+                totalVolumeKg = 240f,
+                cableCount = 1,
+                profileId = testProfileId,
+            ),
+            updatedAt = now - 60_000L, // older than incoming
+        )
+
+        // WHEN: A pull arrives with the same id, newer updatedAt, and
+        // ALL detailed metric columns null (current pull DTO does not
+        // hydrate them for every session).
+        val incoming = WorkoutSession(
+            id = sessionId,
+            timestamp = now,
+            mode = "OldSchool",
+            reps = 8,
+            weightPerCableKg = 30f,
+            duration = 90_000L,
+            totalReps = 8,
+            warmupReps = 0,
+            workingReps = 8,
+            exerciseId = "exercise-incline-bench",
+            exerciseName = "Incline Bench Press",
+            routineSessionId = "routine-1",
+            routineName = "4.Scaffold.Pull/Press",
+            // All metric fields are null on the incoming pull.
+            profileId = testProfileId,
+        )
+        repository.mergeSessionsLww(
+            sessions = listOf(incoming),
+            updatedAtBySessionId = mapOf(sessionId to now + 60_000L),
+        )
+
+        // THEN: Local detailed metric columns are preserved.
+        val after = database.vitruvianDatabaseQueries
+            .selectSessionById(sessionId)
+            .executeAsOneOrNull()
+        assertNotNull(after, "session must exist after merge")
+        assertEquals(50f, after.peakForceConcentricA?.toFloat())
+        assertEquals(55f, after.peakForceConcentricB?.toFloat())
+        assertEquals(60f, after.peakForceEccentricA?.toFloat())
+        assertEquals(62f, after.peakForceEccentricB?.toFloat())
+        assertEquals(35f, after.avgForceConcentricA?.toFloat())
+        assertEquals(38f, after.avgForceConcentricB?.toFloat())
+        assertEquals(40f, after.avgForceEccentricA?.toFloat())
+        assertEquals(42f, after.avgForceEccentricB?.toFloat())
+        assertEquals(32f, after.heaviestLiftKg?.toFloat())
+        assertEquals(240f, after.totalVolumeKg?.toFloat())
+        // cableCount should also be preserved (LWW guard applies).
+        assertEquals(1L, after.cableCount)
+    }
+
+    @Test
+    fun `mergeSessionsLww applies incoming metrics when both are populated`() = runTest {
+        setUp()
+
+        // GIVEN: A locally recorded session with metric values.
+        val sessionId = "issue-591-set-2"
+        insertLocalSession(
+            WorkoutSession(
+                id = sessionId,
+                timestamp = now,
+                mode = "OldSchool",
+                weightPerCableKg = 25f,
+                duration = 80_000L,
+                totalReps = 6,
+                workingReps = 6,
+                exerciseName = "Squat",
+                peakForceConcentricA = 30f,
+                profileId = testProfileId,
+            ),
+            updatedAt = now - 60_000L,
+        )
+
+        // WHEN: An incoming pull with NEWER metric values arrives.
+        val incoming = WorkoutSession(
+            id = sessionId,
+            timestamp = now,
+            mode = "OldSchool",
+            weightPerCableKg = 25f,
+            duration = 80_000L,
+            totalReps = 6,
+            workingReps = 6,
+            exerciseName = "Squat",
+            peakForceConcentricA = 45f, // Higher / fresher value
+            profileId = testProfileId,
+        )
+        repository.mergeSessionsLww(
+            sessions = listOf(incoming),
+            updatedAtBySessionId = mapOf(sessionId to now + 60_000L),
+        )
+
+        // THEN: Incoming non-null metric value wins (full LWW).
+        val after = database.vitruvianDatabaseQueries
+            .selectSessionById(sessionId)
+            .executeAsOneOrNull()
+        assertNotNull(after)
+        assertEquals(45f, after.peakForceConcentricA?.toFloat())
+    }
+
+    @Test
+    fun `mergeSessionsLww preserves biomechanics fields when incoming is null`() = runTest {
+        setUp()
+
+        val sessionId = "issue-591-set-3"
+        insertLocalSession(
+            WorkoutSession(
+                id = sessionId,
+                timestamp = now,
+                mode = "OldSchool",
+                weightPerCableKg = 25f,
+                duration = 60_000L,
+                totalReps = 10,
+                workingReps = 10,
+                exerciseName = "Bench Press",
+                avgMcvMmS = 0.45f,
+                avgAsymmetryPercent = 2.5f,
+                totalVelocityLossPercent = 15f,
+                dominantSide = "RIGHT",
+                strengthProfile = "BALANCED",
+                profileId = testProfileId,
+            ),
+            updatedAt = now - 60_000L,
+        )
+
+        val incoming = WorkoutSession(
+            id = sessionId,
+            timestamp = now,
+            mode = "OldSchool",
+            weightPerCableKg = 25f,
+            duration = 60_000L,
+            totalReps = 10,
+            workingReps = 10,
+            exerciseName = "Bench Press",
+            profileId = testProfileId,
+        )
+        repository.mergeSessionsLww(
+            sessions = listOf(incoming),
+            updatedAtBySessionId = mapOf(sessionId to now + 60_000L),
+        )
+
+        val after = database.vitruvianDatabaseQueries
+            .selectSessionById(sessionId)
+            .executeAsOneOrNull()
+        assertNotNull(after)
+        assertEquals(0.45f, after.avgMcvMmS?.toFloat())
+        assertEquals(2.5f, after.avgAsymmetryPercent?.toFloat())
+        assertEquals(15f, after.totalVelocityLossPercent?.toFloat())
+        assertEquals("RIGHT", after.dominantSide)
+        assertEquals("BALANCED", after.strengthProfile)
+    }
+
+    @Test
+    fun `mergeSessionsLww first-time pull with null metrics stores nulls - no preservation possible`() = runTest {
+        setUp()
+
+        // No existing local row.
+        val sessionId = "issue-591-set-4"
+        val incoming = WorkoutSession(
+            id = sessionId,
+            timestamp = now,
+            mode = "OldSchool",
+            weightPerCableKg = 25f,
+            duration = 60_000L,
+            totalReps = 5,
+            workingReps = 5,
+            exerciseName = "Press",
+            // No metrics.
+            profileId = testProfileId,
+        )
+        repository.mergeSessionsLww(
+            sessions = listOf(incoming),
+            updatedAtBySessionId = mapOf(sessionId to now),
+        )
+
+        val after = database.vitruvianDatabaseQueries
+            .selectSessionById(sessionId)
+            .executeAsOneOrNull()
+        assertNotNull(after, "first-time pull must insert the row")
+        assertNull(after.peakForceConcentricA)
+        assertEquals(5L, after.workingReps)
+    }
+
+    private fun insertLocalSession(session: WorkoutSession, updatedAt: Long) {
+        database.vitruvianDatabaseQueries.insertSessionIgnore(
+            id = session.id,
+            timestamp = session.timestamp,
+            mode = session.mode,
+            targetReps = session.reps.toLong(),
+            weightPerCableKg = session.weightPerCableKg.toDouble(),
+            progressionKg = session.progressionKg.toDouble(),
+            duration = session.duration,
+            totalReps = session.totalReps.toLong(),
+            warmupReps = session.warmupReps.toLong(),
+            workingReps = session.workingReps.toLong(),
+            isJustLift = if (session.isJustLift) 1L else 0L,
+            stopAtTop = if (session.stopAtTop) 1L else 0L,
+            eccentricLoad = session.eccentricLoad.toLong(),
+            echoLevel = session.echoLevel.toLong(),
+            exerciseId = session.exerciseId,
+            exerciseName = session.exerciseName,
+            routineSessionId = session.routineSessionId,
+            routineName = session.routineName,
+            routineId = session.routineId,
+            safetyFlags = session.safetyFlags.toLong(),
+            deloadWarningCount = session.deloadWarningCount.toLong(),
+            romViolationCount = session.romViolationCount.toLong(),
+            spotterActivations = session.spotterActivations.toLong(),
+            peakForceConcentricA = session.peakForceConcentricA?.toDouble(),
+            peakForceConcentricB = session.peakForceConcentricB?.toDouble(),
+            peakForceEccentricA = session.peakForceEccentricA?.toDouble(),
+            peakForceEccentricB = session.peakForceEccentricB?.toDouble(),
+            avgForceConcentricA = session.avgForceConcentricA?.toDouble(),
+            avgForceConcentricB = session.avgForceConcentricB?.toDouble(),
+            avgForceEccentricA = session.avgForceEccentricA?.toDouble(),
+            avgForceEccentricB = session.avgForceEccentricB?.toDouble(),
+            heaviestLiftKg = session.heaviestLiftKg?.toDouble(),
+            totalVolumeKg = session.totalVolumeKg?.toDouble(),
+            cableCount = session.cableCount?.toLong(),
+            estimatedCalories = session.estimatedCalories?.toDouble(),
+            warmupAvgWeightKg = session.warmupAvgWeightKg?.toDouble(),
+            workingAvgWeightKg = session.workingAvgWeightKg?.toDouble(),
+            burnoutAvgWeightKg = session.burnoutAvgWeightKg?.toDouble(),
+            peakWeightKg = session.peakWeightKg?.toDouble(),
+            rpe = session.rpe?.toLong(),
+            avgMcvMmS = session.avgMcvMmS?.toDouble(),
+            avgAsymmetryPercent = session.avgAsymmetryPercent?.toDouble(),
+            totalVelocityLossPercent = session.totalVelocityLossPercent?.toDouble(),
+            dominantSide = session.dominantSide,
+            strengthProfile = session.strengthProfile,
+            formScore = session.formScore?.toLong(),
+            updatedAt = updatedAt,
+            profile_id = session.profileId,
+            display_multiplier = session.displayMultiplier?.toLong(),
+            externalAddedLoadKg = session.externalAddedLoadKg.toDouble(),
+            counterweightKg = session.counterweightKg.toDouble(),
+            rackItemsJson = session.rackItemsJson,
+        )
+    }
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/Issue591SyncLwwTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/Issue591SyncLwwTest.kt
@@ -124,10 +124,11 @@ class Issue591SyncLwwTest {
     }
 
     @Test
-    fun `mergeSessionsLww applies incoming metrics when both are populated`() = runTest {
+    fun `mergeSessionsLww preserves local true peaks but applies incoming average metrics`() = runTest {
         setUp()
 
-        // GIVEN: A locally recorded session with metric values.
+        // GIVEN: A locally recorded session with true peak values and
+        // average-force values captured by the mobile recorder.
         val sessionId = "issue-591-set-2"
         insertLocalSession(
             WorkoutSession(
@@ -140,12 +141,19 @@ class Issue591SyncLwwTest {
                 workingReps = 6,
                 exerciseName = "Squat",
                 peakForceConcentricA = 30f,
+                peakForceConcentricB = 32f,
+                avgForceConcentricA = 20f,
+                avgForceConcentricB = 21f,
                 profileId = testProfileId,
             ),
             updatedAt = now - 60_000L,
         )
 
-        // WHEN: An incoming pull with NEWER metric values arrives.
+        // WHEN: A newer portal pull arrives. PortalPullAdapter can only
+        // reconstruct peakForceConcentricA/B from leftForceAvg/rightForceAvg,
+        // so those incoming peak fields are proxies and must not overwrite
+        // true local peaks. Average-force fields are real pull-side values and
+        // still follow normal incoming-wins LWW semantics.
         val incoming = WorkoutSession(
             id = sessionId,
             timestamp = now,
@@ -155,7 +163,10 @@ class Issue591SyncLwwTest {
             totalReps = 6,
             workingReps = 6,
             exerciseName = "Squat",
-            peakForceConcentricA = 45f, // Higher / fresher value
+            peakForceConcentricA = 45f, // Pull-side proxy, not a true per-cable peak.
+            peakForceConcentricB = 46f,
+            avgForceConcentricA = 31f,
+            avgForceConcentricB = 33f,
             profileId = testProfileId,
         )
         repository.mergeSessionsLww(
@@ -163,12 +174,16 @@ class Issue591SyncLwwTest {
             updatedAtBySessionId = mapOf(sessionId to now + 60_000L),
         )
 
-        // THEN: Incoming non-null metric value wins (full LWW).
+        // THEN: True local peaks are preserved, while incoming non-peak
+        // metrics still apply.
         val after = database.vitruvianDatabaseQueries
             .selectSessionById(sessionId)
             .executeAsOneOrNull()
         assertNotNull(after)
-        assertEquals(45f, after.peakForceConcentricA?.toFloat())
+        assertEquals(30f, after.peakForceConcentricA?.toFloat())
+        assertEquals(32f, after.peakForceConcentricB?.toFloat())
+        assertEquals(31f, after.avgForceConcentricA?.toFloat())
+        assertEquals(33f, after.avgForceConcentricB?.toFloat())
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/Issue591SyncLwwTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/Issue591SyncLwwTest.kt
@@ -310,4 +310,79 @@ class Issue591SyncLwwTest {
             rackItemsJson = session.rackItemsJson,
         )
     }
+
+    /**
+     * Issue #591 follow-up (chatgpt-codex-connector P2): the
+     * batched preservation SELECTs must chunk when the incoming id
+     * list exceeds SQLite's host-parameter limit (commonly 999 on
+     * Android). Build a payload that spans 3 chunks at
+     * `BATCH_LOOKUP_CHUNK_SIZE = 500` and assert every session still
+     * preserves its locally captured metric column.
+     */
+    @Test
+    fun `mergeSessionsLww chunked batch lookup preserves metrics across all chunks`() = runTest {
+        setUp()
+
+        val chunkSize = 500
+        val totalCount = chunkSize * 3 + 17 // spans 4 chunks
+
+        val sessions = (0 until totalCount).map { i ->
+            val sessionId = "chunked-$i"
+            // GIVEN: each session starts as a local row with a unique
+            // metric value so we can detect cross-chunk contamination
+            // or off-by-one chunking bugs.
+            insertLocalSession(
+                WorkoutSession(
+                    id = sessionId,
+                    timestamp = now + i * 1_000L,
+                    mode = "OldSchool",
+                    reps = 8,
+                    weightPerCableKg = 30f,
+                    duration = 60_000L,
+                    totalReps = 8,
+                    warmupReps = 0,
+                    workingReps = 8,
+                    exerciseName = "Squat",
+                    peakForceConcentricA = 40f + i, // unique per session
+                    profileId = testProfileId,
+                ),
+                updatedAt = now - 60_000L,
+            )
+            // Incoming pull with NEWER updatedAt but null metrics so
+            // the LWW preservation guard must restore the local value.
+            WorkoutSession(
+                id = sessionId,
+                timestamp = now + i * 1_000L,
+                mode = "OldSchool",
+                reps = 8,
+                weightPerCableKg = 30f,
+                duration = 60_000L,
+                totalReps = 8,
+                warmupReps = 0,
+                workingReps = 8,
+                exerciseName = "Squat",
+                profileId = testProfileId,
+            )
+        }
+        repository.mergeSessionsLww(
+            sessions = sessions,
+            updatedAtBySessionId = sessions.associate { it.id to (now + 10_000_000L + it.timestamp) },
+        )
+
+        // Spot-check a session from each chunk boundary plus the
+        // middle of one chunk. If chunking dropped or reordered ids,
+        // one of these will land on the wrong row.
+        val samples = listOf(0, chunkSize - 1, chunkSize, chunkSize * 2 - 1, chunkSize * 2, totalCount - 1)
+        for (i in samples) {
+            val after = database.vitruvianDatabaseQueries
+                .selectSessionById("chunked-$i")
+                .executeAsOneOrNull()
+            assertNotNull(after, "chunked-$i must exist after merge")
+            assertEquals(
+                40f + i,
+                after.peakForceConcentricA?.toFloat(),
+                "chunked-$i local metric must survive chunked preservation lookup",
+            )
+        }
+    }
 }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/Issue591DeleteRoutineGroupTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/Issue591DeleteRoutineGroupTest.kt
@@ -1,0 +1,148 @@
+package com.devil.phoenixproject.presentation.manager
+
+import com.devil.phoenixproject.testutil.FakePersonalRecordRepository
+import com.devil.phoenixproject.testutil.FakeUserProfileRepository
+import com.devil.phoenixproject.testutil.FakeWorkoutRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Issue #591 follow-up (chatgpt-codex-connector P2): When the user
+ * deletes a routine session from the History tab, the group action
+ * must remove every WorkoutSession row that belongs to the routine
+ * session id — including zero-rep / ghost rows that
+ * `getHistoryVisibleSessions` would have filtered out of the visible
+ * list. Without this, the ghost rows persist silently after the
+ * deletion and re-appear in any code path that bypasses the History
+ * filter (e.g. Cloud sync pull, streak calc, DataBackup export).
+ */
+class Issue591DeleteRoutineGroupTest {
+
+    private val testProfileId = "test-profile"
+
+    private fun newScope() = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher())
+
+    @Test
+    fun `deleteRoutineWorkouts removes ghost rows for the same routineSessionId`() = runTest {
+        val scope = newScope()
+        try {
+            val workoutRepo = FakeWorkoutRepository()
+            val prRepo = FakePersonalRecordRepository()
+            val profileRepo = FakeUserProfileRepository()
+            profileRepo.setActiveProfileForTest(id = testProfileId)
+            val manager = HistoryManager(
+                workoutRepository = workoutRepo,
+                personalRecordRepository = prRepo,
+                userProfileRepository = profileRepo,
+                scope = scope,
+            )
+
+            // GIVEN: A routine with valid sets (visible) AND ghost
+            // zero-rep rows (filtered out by `getHistoryVisibleSessions`).
+            val routineSessionId = "routine-1"
+            val baseTimestamp = 1_700_000_000_000L
+            val valid = (0 until 3).map { i ->
+                session(
+                    id = "bench-$i",
+                    timestamp = baseTimestamp + i * 60_000L,
+                    routineSessionId = routineSessionId,
+                    exerciseId = "bench",
+                    exerciseName = "Incline Bench Press",
+                    weightPerCableKg = 30f,
+                    totalReps = 8,
+                    workingReps = 8,
+                )
+            }
+            val ghost = (0 until 4).map { i ->
+                session(
+                    id = "fly-ghost-$i",
+                    timestamp = baseTimestamp + 240_000L + i * 60_000L,
+                    routineSessionId = routineSessionId,
+                    exerciseId = "fly",
+                    exerciseName = "Incline Fly",
+                    weightPerCableKg = 25f,
+                    totalReps = 0,
+                    workingReps = 0,
+                )
+            }
+            // Unrelated session for a different routine that must survive.
+            val other = listOf(
+                session(
+                    id = "curl-other",
+                    timestamp = baseTimestamp + 1_000_000L,
+                    routineSessionId = "routine-2",
+                    exerciseId = "curl",
+                    exerciseName = "Curl",
+                    weightPerCableKg = 20f,
+                    totalReps = 5,
+                    workingReps = 5,
+                ),
+            )
+            workoutRepo.addSessions(valid + ghost + other)
+            assertEquals(8, workoutRepo.allSessions().size, "precondition: all 8 rows present")
+
+            // WHEN: the user deletes the routine group.
+            manager.deleteRoutineWorkouts(routineSessionId)
+
+            // THEN: every row tied to that routineSessionId is gone —
+            // both the visible valid sets and the ghost rows. The
+            // unrelated routine survives.
+            val remaining = workoutRepo.allSessions()
+            assertEquals(1, remaining.size, "only the unrelated routine survives")
+            assertEquals("curl-other", remaining.single().id)
+
+            // HistoryManager should no longer surface the deleted
+            // routine either.
+            val grouped = manager.groupedWorkoutHistory.first()
+            assertTrue(
+                grouped.none { it is GroupedRoutineHistoryItem && it.routineSessionId == routineSessionId },
+                "deleted routine must not appear in groupedWorkoutHistory",
+            )
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    private fun session(
+        id: String,
+        timestamp: Long = 1_700_000_000_000L,
+        routineSessionId: String? = null,
+        exerciseId: String? = null,
+        exerciseName: String? = null,
+        weightPerCableKg: Float = 0f,
+        totalReps: Int = 0,
+        workingReps: Int = 0,
+    ) = com.devil.phoenixproject.domain.model.WorkoutSession(
+        id = id,
+        timestamp = timestamp,
+        mode = "OldSchool",
+        reps = totalReps,
+        weightPerCableKg = weightPerCableKg,
+        progressionKg = 0f,
+        duration = 0L,
+        totalReps = totalReps,
+        warmupReps = 0,
+        workingReps = workingReps,
+        isJustLift = false,
+        stopAtTop = false,
+        eccentricLoad = 100,
+        echoLevel = 1,
+        exerciseId = exerciseId,
+        exerciseName = exerciseName,
+        routineSessionId = routineSessionId,
+        routineName = if (routineSessionId != null) "Test Routine" else null,
+        safetyFlags = 0,
+        deloadWarningCount = 0,
+        romViolationCount = 0,
+        spotterActivations = 0,
+        profileId = testProfileId,
+    )
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/Issue591HistoryGroupingTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/Issue591HistoryGroupingTest.kt
@@ -1,0 +1,179 @@
+package com.devil.phoenixproject.presentation.manager
+
+import com.devil.phoenixproject.domain.model.WorkoutSession
+import com.devil.phoenixproject.testutil.FakePersonalRecordRepository
+import com.devil.phoenixproject.testutil.FakeUserProfileRepository
+import com.devil.phoenixproject.testutil.FakeWorkoutRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Issue #591: Analytics only records first set of first exercise in
+ * multi-exercise routine; per-set drill-down shows 'after v0.2.1'
+ * placeholder on v0.9.2.
+ *
+ * Regression coverage for the HistoryManager / WorkoutRepository
+ * filter that excludes zero-rep / soft-deleted sessions from the
+ * Analytics / History grouping. The reporter saw a Daily Routine card
+ * that counted six zero-rep rows for "Incline Fly" as six sets
+ * ("0 reps / 6 sets / 0 lbs"). After the fix, only sessions with at
+ * least one recorded rep appear in `groupedWorkoutHistory`.
+ */
+class Issue591HistoryGroupingTest {
+
+    private val testProfileId = "test-profile"
+
+    /**
+     * HistoryManager.stateIn starts work eagerly on subscription; the
+     * test must drive the work immediately or the first() call returns
+     * the empty initialValue. UnconfinedTestDispatcher schedules work
+     * inline so the upstream flows have time to publish before we read.
+     */
+    private fun newScope() = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher())
+
+    @Test
+    fun `groupedWorkoutHistory excludes zero-rep sessions from routine set counts`() = runTest {
+        val scope = newScope()
+        try {
+            val workoutRepo = FakeWorkoutRepository()
+            val prRepo = FakePersonalRecordRepository()
+            val profileRepo = FakeUserProfileRepository()
+            profileRepo.setActiveProfileForTest(id = testProfileId)
+            val manager = HistoryManager(
+                workoutRepository = workoutRepo,
+                personalRecordRepository = prRepo,
+                userProfileRepository = profileRepo,
+                scope = scope,
+            )
+
+            // GIVEN: A routine with mixed valid / zero-rep rows.
+            // Mirrors the reporter's screenshot:
+            //   - Incline Bench Press: 3 valid sets (8 reps each, 30 kg)
+            //   - Incline Fly: 6 zero-rep rows (recorder bug, never
+            //     captured rep counts for that exercise).
+            val routineSessionId = "routine-1"
+            val baseTimestamp = 1_700_000_000_000L
+            val bench = (0 until 3).map { i ->
+                session(
+                    id = "bench-$i",
+                    timestamp = baseTimestamp + i * 60_000L,
+                    routineSessionId = routineSessionId,
+                    exerciseId = "bench",
+                    exerciseName = "Incline Bench Press",
+                    weightPerCableKg = 30f,
+                    totalReps = 8,
+                    workingReps = 8,
+                )
+            }
+            val fly = (0 until 6).map { i ->
+                session(
+                    id = "fly-$i",
+                    timestamp = baseTimestamp + 240_000L + i * 60_000L,
+                    routineSessionId = routineSessionId,
+                    exerciseId = "fly",
+                    exerciseName = "Incline Fly",
+                    weightPerCableKg = 25f,
+                    totalReps = 0, // Ghost rows
+                    workingReps = 0,
+                )
+            }
+            workoutRepo.addSessions(bench + fly)
+
+            // WHEN: History is grouped.
+            val grouped = manager.groupedWorkoutHistory.first()
+                .filterIsInstance<GroupedRoutineHistoryItem>()
+                .single()
+
+            // THEN: only valid sets are counted per exercise.
+            // Incline Fly rows were all zero-rep and the History filter
+            // excludes them; the exercise should not appear as a group
+            // because no valid sets exist for it.
+            val exercisesByName = grouped.sessions
+                .groupBy { it.exerciseName ?: "Unknown" }
+            val benchGroup = exercisesByName["Incline Bench Press"]
+                ?: error("Incline Bench Press group should exist")
+            assertEquals(3, benchGroup.size, "Incline Bench Press should show 3 sets")
+            assertEquals(
+                emptyList(),
+                exercisesByName["Incline Fly"] ?: emptyList(),
+                "Incline Fly should not appear in routine set grouping (every row was a zero-rep ghost row)",
+            )
+            assertEquals(24, grouped.totalReps, "totalReps sums only the valid bench rows (8 x 3)")
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `groupedWorkoutHistory includes rows with non-zero totalReps even if workingReps is zero`() = runTest {
+        val scope = newScope()
+        try {
+            val workoutRepo = FakeWorkoutRepository()
+            val prRepo = FakePersonalRecordRepository()
+            val profileRepo = FakeUserProfileRepository()
+            profileRepo.setActiveProfileForTest(id = testProfileId)
+            val manager = HistoryManager(
+                workoutRepository = workoutRepo,
+                personalRecordRepository = prRepo,
+                userProfileRepository = profileRepo,
+                scope = scope,
+            )
+
+            // A legacy / tagged Just Lift session that populated only
+            // totalReps but no warmup/working split is still a real
+            // workout. The SQL filter (workingReps > 0 OR totalReps > 0)
+            // accepts it.
+            workoutRepo.addSession(
+                session(
+                    id = "legacy-1",
+                    routineSessionId = "r-legacy",
+                    exerciseId = "ex-legacy",
+                    exerciseName = "Curl",
+                    totalReps = 5,
+                    workingReps = 0,
+                ),
+            )
+
+            val grouped = manager.groupedWorkoutHistory.first()
+                .filterIsInstance<GroupedRoutineHistoryItem>()
+                .single()
+            assertEquals(1, grouped.sessions.size)
+            assertEquals(5, grouped.totalReps)
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    private fun session(
+        id: String,
+        timestamp: Long = 1_700_000_000_000L,
+        routineSessionId: String? = null,
+        exerciseId: String? = null,
+        exerciseName: String? = null,
+        weightPerCableKg: Float = 0f,
+        totalReps: Int = 0,
+        workingReps: Int = 0,
+    ): WorkoutSession = WorkoutSession(
+        id = id,
+        timestamp = timestamp,
+        mode = "OldSchool",
+        reps = 10,
+        weightPerCableKg = weightPerCableKg,
+        duration = if (totalReps > 0) 60_000L else 0L,
+        totalReps = totalReps,
+        warmupReps = 0,
+        workingReps = workingReps,
+        exerciseId = exerciseId,
+        exerciseName = exerciseName,
+        routineSessionId = routineSessionId,
+        routineName = if (routineSessionId != null) "Test Routine" else null,
+        profileId = testProfileId,
+    )
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeWorkoutRepository.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeWorkoutRepository.kt
@@ -40,6 +40,15 @@ class FakeWorkoutRepository : WorkoutRepository {
         updateSessionsFlow()
     }
 
+    /**
+     * Issue #591 follow-up test helper: snapshot every session the
+     * fake holds, including zero-rep / ghost rows that the production
+     * `getHistoryVisibleSessions` would filter out. Used by
+     * `Issue591DeleteRoutineGroupTest` to assert the routine-group
+     * delete cleans up hidden rows too.
+     */
+    fun allSessions(): List<WorkoutSession> = sessions.values.toList()
+
     fun addRoutine(routine: Routine) {
         routines[routine.id] = routine
         updateRoutinesFlow()
@@ -119,6 +128,23 @@ class FakeWorkoutRepository : WorkoutRepository {
     override suspend fun deleteAllSessions() {
         sessions.clear()
         metrics.clear()
+        updateSessionsFlow()
+    }
+
+    override suspend fun deleteSessionsByRoutineSessionId(routineSessionId: String) {
+        // Issue #591 follow-up: remove every session belonging to the
+        // routine session id, including any zero-rep / ghost rows that
+        // `getHistoryVisibleSessions` would have filtered out. Mirrors
+        // the production soft-delete intent (zero-rep cleanup at the
+        // group level) without the SQL deletedAt bookkeeping the
+        // production repository maintains.
+        val matchingIds = sessions.entries
+            .filter { (_, session) -> session.routineSessionId == routineSessionId }
+            .map { it.key }
+        matchingIds.forEach { id ->
+            sessions.remove(id)
+            metrics.remove(id)
+        }
         updateSessionsFlow()
     }
 

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeWorkoutRepository.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeWorkoutRepository.kt
@@ -35,6 +35,11 @@ class FakeWorkoutRepository : WorkoutRepository {
         updateSessionsFlow()
     }
 
+    fun addSessions(sessionList: List<WorkoutSession>) {
+        sessionList.forEach { sessions[it.id] = it }
+        updateSessionsFlow()
+    }
+
     fun addRoutine(routine: Routine) {
         routines[routine.id] = routine
         updateRoutinesFlow()
@@ -71,6 +76,22 @@ class FakeWorkoutRepository : WorkoutRepository {
     // ========== WorkoutRepository interface implementation ==========
 
     override fun getAllSessions(profileId: String): Flow<List<WorkoutSession>> = _sessionsFlow
+
+    // Issue #591: filter zero-rep / soft-deleted rows from Analytics view.
+    // The Fake mirrors the SQL eligibility guard
+    //   deletedAt IS NULL AND (workingReps > 0 OR totalReps > 0)
+    // so unit tests using this fake exercise the same data the
+    // production SqlDelightWorkoutRepository returns.
+    override fun getHistoryVisibleSessions(profileId: String): Flow<List<WorkoutSession>> =
+        _sessionsFlow.map { all ->
+            all.filter { session ->
+                // No deletedAt field on WorkoutSession today; when soft
+                // delete lands, gate on it here too. For now the in-memory
+                // fake never stores deleted rows, so only the rep guard is
+                // required to match the SQL behavior.
+                session.workingReps > 0 || session.totalReps > 0
+            }
+        }
 
     override suspend fun getSessionCountForExercise(exerciseId: String, profileId: String): Long = sessions.values.count { it.exerciseId == exerciseId }.toLong()
 


### PR DESCRIPTION
Fixes 9thLevelSoftware/Project-Phoenix-MP#591

## Summary

On v0.9.2, completing a multi-exercise routine (e.g. "4.Scaffold.Pull/Press" with Incline Bench Press + Incline Fly, 3 sets each) produced a Daily Routine card whose second exercise showed 0 reps / 6 sets / 0 lbs, and per-set drill-downs rendered the misleading "Detailed metrics available for workouts after v0.2.1" placeholder on a current app version.

Two concrete failure points were identified by the GPT-5.5 RCA:

1. **Cloud-sync pull nulled detailed set metrics.** The pull DTO carries per-rep telemetry but the adapter never hydrated peakForce* / avgForce* / biomechanics fields, and mergeSessionsLww then overwrote locally captured metrics with null on the next sync.
2. **History counted zero-rep WorkoutSession rows as sets.** selectAllSessions does not filter ghost rows; GroupedRoutineCard treats sessions.size as the per-exercise set count.

## Changes

### `SqlDelightSyncRepository.mergeSessionsLww` — preserve non-null local metrics
Before `mergeSessionLww` writes, load existing rows in batched/chunked lookups and copy any non-null metric / biomechanics column onto the incoming pull row when the incoming value is null. Non-metric columns (timestamp, reps, mode, exercise tag, etc.) still follow LWW.

Columns preserved: peakForceConcentricA/B, peakForceEccentricA/B, avgForceConcentricA/B, avgForceEccentricA/B, heaviestLiftKg, totalVolumeKg, cableCount, displayMultiplier, estimatedCalories, warmup/working/burnoutAvgWeightKg, peakWeightKg, rpe, avgMcvMmS, avgAsymmetryPercent, totalVelocityLossPercent, dominantSide, strengthProfile, formScore. Follow-up note: pull-side per-cable concentric peaks are derived from average-force DTO fields, so existing local true peaks win over those proxy values; first-time pulls still keep the proxy because there is no local capture to preserve.

### `PortalPullAdapter.toWorkoutSessionsWithLookup` — hydrate from `PullSetDto.repSummaries`
Aggregate per-rep `leftForceAvg` / `rightForceAvg` (Newtons) into per-cable concentric average force (mean) and a best-effort peak proxy for first-time pulls, converting via `PortalMappings.newtonsToLoadKg`. Eccentric peak/avg stays null because the portal does not surface per-cable eccentric force; the LWW preservation guard protects locally captured eccentric values and true per-cable peaks when present. Also aggregates `avgAsymmetryPercent` from rep-level asymmetryPct.

### `WorkoutRepository.getHistoryVisibleSessions` + `HistoryManager.historyVisibleSessions`
New SQL query `selectHistoryVisibleSessions` (and matching Fake filter) that mirrors the completed-session eligibility already used by `selectCompletedHealthExportCandidates` / `selectSessionsByRoutineSessionId` / `selectSessionsForPhasePRBackfill`:

```sql
WHERE profile_id = :profileId
  AND deletedAt IS NULL
  AND (workingReps > 0 OR totalReps > 0)
```

`groupedWorkoutHistory` now reads from this flow so the Daily Routine card no longer counts ghost zero-rep rows as sets. The unfiltered `allWorkoutSessions` flow is preserved for streak / progress / pagination paths that legitimately need every persisted row.

### `HistoryTab` placeholder copy
"Detailed metrics available for workouts after v0.2.1" → "Detailed metrics were not captured for this set". The v0.2.1 wording blamed the app version for a sync / capture data-loss that is not a version-gate. Combined with the History filter, this card now only renders for genuinely legacy / unmeasured rows.

## Regression tests

- `Issue591AnalyticsHydrationTest`: hydrates average force and first-time-pull peak proxies from rep summaries (Newtons → kg-load), null stays null when no rep data, asymmetry aggregation.
- `Issue591SyncLwwTest`: locally captured metric columns are preserved when the incoming pull is null; local true peak values are preserved over pull-side average-force proxies; incoming average metrics still update; biomechanics fields preserved; first-time pull with null metrics stores nulls (no fabrication).
- `Issue591HistoryGroupingTest`: zero-rep sessions excluded from routine grouping; legacy totalReps-only rows (e.g. Just Lift tagged without working/warmup split) still included.

`./gradlew :shared:testAndroidHostTest` — all green, including the rest of the sync test suite (`PortalPullAdapterTest`, `ConflictResolutionTest`, `PortalMappingsWeightTest`, `PortalPullAdapterSessionTest`, `PortalPullPaginationTest`, `SyncManagerTest`, `PortalTokenRefreshTest`, `PortalPushLimitsTest`).

## Acceptance criteria coverage

- [x] Two-exercise / three-working-set routine shows 3 valid sets per exercise in Analytics (zero-rep rows filtered).
- [x] Zero-rep rows do not inflate routine set counts or drill-down cards.
- [x] Locally recorded non-null peakForceConcentricA/B survive pull/LWW merge.
- [x] Portal-pulled rows either hydrate from repSummaries or preserve existing local metrics; incoming null metrics do not erase captured metrics.
- [x] Misleading "after v0.2.1" copy no longer appears for current sessions with missing capture/sync data.
