### PR TITLE
fix(audio): correct setup-rep sound timing (#531)

### DIFF
--- a/docs/superpowers/plans/2026-06-26-issue-531-setup-rep-audio.md
+++ b/docs/superpowers/plans/2026-06-26-issue-531-setup-rep-audio.md
@@ -1,0 +1,531 @@
+# Issue #531 Setup-Rep Audio Timing Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the three setup-rep audio symptoms reported in Issue #531 — dropped setup-rep chirps, a stray transition tone mid-set, and a best-effort suppression of the phantom chirp on screen entry.
+
+**Architecture:** Surgical edits to `RepCounterFromMachine.processModern()` (per-increment warmup chirp emission + a narrow directional-counter carryover guard) plus a one-line transition-tone de-dupe in `ActiveSessionEngine`. No changes to BLE, sync, or UI contracts. The `WARMUP_TO_WORKING` `HapticEvent` enum and its iOS/Android sound mappings stay (other tests depend on them); only its emission from the rep-event path is removed.
+
+**Tech Stack:** Kotlin Multiplatform (Kotlin 2.3.0), `kotlin.test`, kotlinx-coroutines-test. Shared-module tests run on the JVM host via the `androidHostTest` source set.
+
+## Global Constraints
+
+- **Preserve Issue #210 contract:** the first packet of a set counts immediately — never discard/baseline a fresh first rep. Counts stay absolute-from-machine (no baseline subtraction).
+- **Preserve Issue #553 contract:** when `repsRomCount == 0 && repsSetCount == 0` and the `up` counter advances, warmup must still progress from the `up` counter (Echo dropped-rep escape hatch).
+- **Preserve variable-warmup (#411) contract:** `warmupTarget == 0` sets must not gain warmup gating.
+- **Do not remove** the `HapticEvent.WARMUP_TO_WORKING` enum value or its iOS/Android sound-file mappings — `HapticEventAudioTest`, `WorkoutMetricTest`, and `HapticFeedbackAudioRoutingGuardTest` assert their presence.
+- **Test command (shared module):** `./gradlew :shared:testAndroidHostTest`
+  - Single class filter: `./gradlew :shared:testAndroidHostTest --tests "<fully.qualified.ClassName>"`
+- **Symptom 1 is a best-effort heuristic.** It only catches *large* directional carryover; it introduces no regression if the real phantom is a small slack tick. An on-device Echo + normal-mode warmup smoke test is required before merge.
+- Conventional Commits. Branch: `fix/issue-531-setup-rep-audio`.
+
+---
+
+### Task 1: Per-increment warmup chirp emission (Symptom 2 — dropped setup chirps)
+
+**Files:**
+- Modify: `shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/RepCounterFromMachine.kt` — `processModern()` primary warmup branch (currently lines 453–474) and the up-counter fallback branch (currently lines 484–505)
+- Test: `shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/RepCounterFromMachineTest.kt`
+
+**Interfaces:**
+- Consumes: existing `RepCounterFromMachine.process(...)` and `onRepEvent: ((RepEvent) -> Unit)?` (no signature change).
+- Produces: same `RepEvent` stream, but one `WARMUP_COMPLETED` event per integer warmup-rep step instead of one per `process()` call.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `RepCounterFromMachineTest.kt` (inside `class RepCounterFromMachineTest`, e.g. after the Issue #553 block near line 771):
+
+```kotlin
+    // ========== Issue #531: Per-increment warmup chirp emission ==========
+
+    @Test
+    fun `issue 531 batched warmup ROM jump emits one chirp per rep`() {
+        // A BLE notification can batch/drop so the machine's ROM count jumps by >1 in a
+        // single packet (0 -> 2). Each setup rep must still chirp exactly once.
+        repCounter.configure(warmupTarget = 3, workingTarget = 10, isJustLift = false, stopAtTop = false)
+
+        // Baseline (idle, no movement)
+        repCounter.process(repsRomCount = 0, repsSetCount = 0, up = 0, down = 0)
+
+        // ROM jumps 0 -> 2 in one packet, then -> 3 in the next.
+        repCounter.process(repsRomCount = 2, repsSetCount = 0, up = 2, down = 2)
+        repCounter.process(repsRomCount = 3, repsSetCount = 0, up = 3, down = 3)
+
+        assertEquals(
+            3,
+            capturedEvents.count { it.type == RepType.WARMUP_COMPLETED },
+            "Each setup rep must chirp once even when the ROM count batches",
+        )
+        assertEquals(3, repCounter.getRepCount().warmupReps)
+        assertEquals(
+            1,
+            capturedEvents.count { it.type == RepType.WARMUP_COMPLETE },
+            "WARMUP_COMPLETE fires exactly once when the target is reached",
+        )
+    }
+
+    @Test
+    fun `issue 531 fallback warmup emits one chirp per rep on batched up jump`() {
+        // Firmware that never reports repsRomCount (Echo/unlimited): the up counter can jump
+        // 0 -> 3 in one packet. Per-increment emission must still chirp each setup rep once,
+        // clamped to the warmup target.
+        repCounter.configure(warmupTarget = 3, workingTarget = 10, isJustLift = false, stopAtTop = false)
+
+        repCounter.process(repsRomCount = 0, repsSetCount = 0, up = 0, down = 0)
+        repCounter.process(repsRomCount = 0, repsSetCount = 0, up = 3, down = 0)
+
+        assertEquals(
+            3,
+            capturedEvents.count { it.type == RepType.WARMUP_COMPLETED },
+            "Fallback warmup must chirp once per rep up to the target",
+        )
+        assertEquals(3, repCounter.getRepCount().warmupReps)
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `./gradlew :shared:testAndroidHostTest --tests "com.devil.phoenixproject.domain.usecase.RepCounterFromMachineTest"`
+Expected: FAIL — `issue 531 batched warmup ROM jump...` reports `expected:<3> but was:<2>` (current code emits one `WARMUP_COMPLETED` per packet, so the 0→2 jump yields 1 event), and the fallback test reports `expected:<3> but was:<1>`.
+
+- [ ] **Step 3: Implement per-increment emission in the primary warmup branch**
+
+In `RepCounterFromMachine.kt`, replace the primary warmup branch (currently lines 453–474):
+
+```kotlin
+        // WARMUP TRACKING: Use repsRomCount directly from machine (no pending animation)
+        if (repsRomCount > warmupReps && warmupReps < warmupTarget) {
+            warmupReps = repsRomCount.coerceAtMost(warmupTarget)
+
+            onRepEvent?.invoke(
+                RepEvent(
+                    type = RepType.WARMUP_COMPLETED,
+                    warmupCount = warmupReps,
+                    workingCount = workingReps,
+                ),
+            )
+
+            if (warmupReps >= warmupTarget) {
+                onRepEvent?.invoke(
+                    RepEvent(
+                        type = RepType.WARMUP_COMPLETE,
+                        warmupCount = warmupReps,
+                        workingCount = workingReps,
+                    ),
+                )
+            }
+        }
+```
+
+with:
+
+```kotlin
+        // WARMUP TRACKING: Use repsRomCount directly from machine (no pending animation).
+        // Issue #531: emit one WARMUP_COMPLETED per integer step so a batched/dropped ROM
+        // notification (count jumps 0 -> 2 in a single packet) doesn't drop setup-rep chirps.
+        if (repsRomCount > warmupReps && warmupReps < warmupTarget) {
+            val warmupRepTarget = repsRomCount.coerceAtMost(warmupTarget)
+            while (warmupReps < warmupRepTarget) {
+                warmupReps++
+                onRepEvent?.invoke(
+                    RepEvent(
+                        type = RepType.WARMUP_COMPLETED,
+                        warmupCount = warmupReps,
+                        workingCount = workingReps,
+                    ),
+                )
+            }
+
+            if (warmupReps >= warmupTarget) {
+                onRepEvent?.invoke(
+                    RepEvent(
+                        type = RepType.WARMUP_COMPLETE,
+                        warmupCount = warmupReps,
+                        workingCount = workingReps,
+                    ),
+                )
+            }
+        }
+```
+
+- [ ] **Step 4: Implement per-increment emission in the fallback warmup branch**
+
+Replace the fallback branch (currently lines 484–505):
+
+```kotlin
+        else if (repsSetCount == 0 && repsRomCount == 0 && warmupReps < warmupTarget && upDelta > 0) {
+            warmupReps = (warmupReps + upDelta).coerceAtMost(warmupTarget)
+            logDebug("📈 MODERN FALLBACK: Warmup rep $warmupReps (from up counter, repsRomCount=0)")
+
+            onRepEvent?.invoke(
+                RepEvent(
+                    type = RepType.WARMUP_COMPLETED,
+                    warmupCount = warmupReps,
+                    workingCount = workingReps,
+                ),
+            )
+
+            if (warmupReps >= warmupTarget) {
+                onRepEvent?.invoke(
+                    RepEvent(
+                        type = RepType.WARMUP_COMPLETE,
+                        warmupCount = warmupReps,
+                        workingCount = workingReps,
+                    ),
+                )
+            }
+        }
+```
+
+with:
+
+```kotlin
+        else if (repsSetCount == 0 && repsRomCount == 0 && warmupReps < warmupTarget && upDelta > 0) {
+            // Issue #531: per-increment emission for the up-counter fallback too.
+            val warmupRepTarget = (warmupReps + upDelta).coerceAtMost(warmupTarget)
+            while (warmupReps < warmupRepTarget) {
+                warmupReps++
+                logDebug("📈 MODERN FALLBACK: Warmup rep $warmupReps (from up counter, repsRomCount=0)")
+                onRepEvent?.invoke(
+                    RepEvent(
+                        type = RepType.WARMUP_COMPLETED,
+                        warmupCount = warmupReps,
+                        workingCount = workingReps,
+                    ),
+                )
+            }
+
+            if (warmupReps >= warmupTarget) {
+                onRepEvent?.invoke(
+                    RepEvent(
+                        type = RepType.WARMUP_COMPLETE,
+                        warmupCount = warmupReps,
+                        workingCount = workingReps,
+                    ),
+                )
+            }
+        }
+```
+
+- [ ] **Step 5: Run the full RepCounter test class to verify pass + no regression**
+
+Run: `./gradlew :shared:testAndroidHostTest --tests "com.devil.phoenixproject.domain.usecase.RepCounterFromMachineTest"`
+Expected: PASS — the two new tests pass and all pre-existing tests (including the Issue #210 first-rep, Issue #553 Echo-fallback, and variable-warmup cases) still pass. Existing tests assert only final counts / event presence, not event multiplicity, so per-increment emission is compatible.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/RepCounterFromMachine.kt \
+        shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/RepCounterFromMachineTest.kt
+git commit -m "fix(audio): emit one warmup chirp per setup rep (#531)
+
+Symptom 2: batched/dropped ROM notifications collapsed multi-rep jumps into a
+single WARMUP_COMPLETED, dropping setup-rep chirps (only 2 of 3 registered).
+Emit one event per integer step in both processModern warmup branches.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01T7pTNEeYws971sWpE9V9Bk"
+```
+
+---
+
+### Task 2: Directional-counter carryover guard (Symptom 1 — phantom chirp on entry, heuristic)
+
+**Files:**
+- Modify: `shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/RepCounterFromMachine.kt` — add `carryoverChecked` field (after `isAMRAP`, currently line 36), reset it in `reset()` (currently lines 105–137) and `resetCountsOnly()` (currently lines 146–159), and add the guard at the top of `processModern()` (currently line 385)
+- Test: `shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/RepCounterFromMachineTest.kt`
+
+**Interfaces:**
+- Consumes: existing `process(...)` / `processModern(...)` internals (`lastTopCounter`, `lastCompleteCounter`, `warmupTarget`, `warmupReps`).
+- Produces: on the first modern packet of a set, when directional counters are already past the warmup target while the machine reports zero ROM/set reps, re-baselines `lastTopCounter`/`lastCompleteCounter` once and emits nothing for that packet.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `RepCounterFromMachineTest.kt`:
+
+```kotlin
+    // ========== Issue #531: Carryover guard (phantom-chirp suppression) ==========
+
+    @Test
+    fun `issue 531 large directional carryover does not phantom-fire a warmup rep`() {
+        // Heuristic: the machine's free-running up/down counters can carry over from the prior
+        // set. On the first packet of a fresh set, counters already far past the warmup target
+        // while repsRomCount/repsSetCount are 0 are stale -> must not chirp a phantom warmup rep.
+        repCounter.configure(warmupTarget = 3, workingTarget = 10, isJustLift = false, stopAtTop = false)
+
+        // First packet carries stale up/down = 8 from the previous set.
+        repCounter.process(repsRomCount = 0, repsSetCount = 0, up = 8, down = 8)
+
+        assertEquals(0, repCounter.getRepCount().warmupReps, "Stale carryover must not advance warmup")
+        assertTrue(capturedEvents.isEmpty(), "Carryover packet must emit no rep events")
+
+        // Real warmup reps afterward count normally (delta from the re-baselined counters).
+        repCounter.process(repsRomCount = 1, repsSetCount = 0, up = 9, down = 9)
+        repCounter.process(repsRomCount = 2, repsSetCount = 0, up = 10, down = 10)
+        repCounter.process(repsRomCount = 3, repsSetCount = 0, up = 11, down = 11)
+
+        assertEquals(3, repCounter.getRepCount().warmupReps)
+        assertEquals(3, capturedEvents.count { it.type == RepType.WARMUP_COMPLETED })
+        assertTrue(capturedEvents.any { it.type == RepType.WARMUP_COMPLETE })
+    }
+
+    @Test
+    fun `issue 531 carryover guard ignores a small first up tick`() {
+        // Guard must NOT fire for a plausible fresh-start value (preserves Issue #210): a first
+        // packet with up = 1 is a legitimate first rep, not carryover.
+        repCounter.configure(warmupTarget = 3, workingTarget = 10, isJustLift = false, stopAtTop = false)
+
+        repCounter.process(repsRomCount = 1, repsSetCount = 0, up = 1, down = 1)
+
+        assertEquals(1, repCounter.getRepCount().warmupReps, "Small first up tick is a real rep, not carryover")
+        assertEquals(1, capturedEvents.count { it.type == RepType.WARMUP_COMPLETED })
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `./gradlew :shared:testAndroidHostTest --tests "com.devil.phoenixproject.domain.usecase.RepCounterFromMachineTest"`
+Expected: FAIL — `issue 531 large directional carryover...` fails: without the guard, the first packet (`up=8, repsRomCount=0`) hits the up-counter fallback branch and advances `warmupReps` to the target, so `warmupReps` is `3` (not `0`) and `capturedEvents` is non-empty. (`issue 531 carryover guard ignores a small first up tick` already passes — it is a regression guard.)
+
+- [ ] **Step 3: Add the `carryoverChecked` field**
+
+In `RepCounterFromMachine.kt`, after the `private var isAMRAP = false` line (currently line 36), add:
+
+```kotlin
+
+    // Issue #531: one-shot guard for the directional-counter carryover heuristic. The machine's
+    // up/down counters are free-running and can carry over from the prior set; on the first modern
+    // packet we detect and absorb stale values once so they don't chirp a phantom warmup rep.
+    private var carryoverChecked = false
+```
+
+- [ ] **Step 4: Reset the field in `reset()` and `resetCountsOnly()`**
+
+In `reset()` (currently lines 105–137), add alongside the other resets (e.g. after `shouldStop = false`):
+
+```kotlin
+        carryoverChecked = false
+```
+
+In `resetCountsOnly()` (currently lines 146–159), add alongside the other resets (e.g. after `shouldStop = false`):
+
+```kotlin
+        carryoverChecked = false
+```
+
+- [ ] **Step 5: Add the guard at the top of `processModern()`**
+
+In `processModern()`, immediately after the opening brace (currently line 385, before `val upDelta = calculateDelta(lastTopCounter, up)`), insert:
+
+```kotlin
+        // Issue #531 (symptom 1, heuristic): suppress a phantom warmup chirp caused by the
+        // machine's free-running directional counters carrying over from the prior set. On the
+        // first modern packet of a set, if up/down are already past the warmup target while the
+        // machine reports zero ROM/set reps, treat them as stale and re-baseline once so the
+        // first real movement yields delta ~0. Deliberately narrow to preserve:
+        //   - Issue #210: a real first rep arrives as repsRomCount=1 -> fails repsRomCount==0.
+        //   - Issue #553: sends an explicit up=0/down=0 baseline packet -> fails up>warmupTarget.
+        //   - Issue #411: variable-warmup sets use warmupTarget=0 -> fails warmupTarget>0.
+        if (!carryoverChecked) {
+            carryoverChecked = true
+            if (warmupTarget > 0 && warmupReps == 0 &&
+                repsRomCount == 0 && repsSetCount == 0 &&
+                (up > warmupTarget || down > warmupTarget)
+            ) {
+                logDebug("🩹 Issue #531: directional carryover (up=$up, down=$down) — re-baselining, suppressing phantom warmup")
+                lastTopCounter = up
+                lastCompleteCounter = down
+                return
+            }
+        }
+```
+
+- [ ] **Step 6: Run the full RepCounter test class to verify pass + no regression**
+
+Run: `./gradlew :shared:testAndroidHostTest --tests "com.devil.phoenixproject.domain.usecase.RepCounterFromMachineTest"`
+Expected: PASS — both new tests pass and all pre-existing tests still pass. Note in particular: `Issue 210 - first warmup rep registers immediately in modern mode` (first packet `repsRomCount=1` → guard's `repsRomCount==0` is false → no skip), the Issue #553 tests (explicit `up=0, down=0` baseline first → guard's `up>warmupTarget` is false → no skip), and `variable warmup sets ignore machine repsRomTotal warmup sync` (`warmupTarget=0` → guard's `warmupTarget>0` is false → no skip).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/RepCounterFromMachine.kt \
+        shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/RepCounterFromMachineTest.kt
+git commit -m "fix(audio): suppress phantom warmup chirp from counter carryover (#531)
+
+Symptom 1 (best-effort heuristic): the machine's free-running up/down counters
+can carry over from the prior set, making the first packet's delta fire a phantom
+warmup rep before the user moves. On the first modern packet, re-baseline once when
+counters are already past the warmup target while ROM/set counts are 0. Narrow by
+design to preserve the #210 first-rep, #553 Echo-fallback, and #411 variable-warmup
+contracts. Only catches large carryover; harmless no-op otherwise.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01T7pTNEeYws971sWpE9V9Bk"
+```
+
+---
+
+### Task 3: Single clean transition tone (Symptom 3 — stray double-`beepboop`)
+
+**Files:**
+- Modify: `shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt` — the `RepType.WARMUP_COMPLETE` case in the `repCounter.onRepEvent` handler (currently lines 300–304)
+- Test: `shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/WarmupTransitionToneTest.kt` (create)
+
+**Interfaces:**
+- Consumes: `DWSMTestHarness` (`testutil/DWSMTestHarness.kt`) which exposes `repCounter`, `coordinator`, and `cleanup()`; `coordinator.hapticEvents: SharedFlow<HapticEvent>`; `RepEvent` / `RepType` / `HapticEvent` from `domain.model`.
+- Produces: on a `RepType.WARMUP_COMPLETE` rep event, the engine emits exactly one `HapticEvent.WARMUP_COMPLETE` and no `HapticEvent.WARMUP_TO_WORKING`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/WarmupTransitionToneTest.kt`:
+
+```kotlin
+package com.devil.phoenixproject.presentation.manager
+
+import com.devil.phoenixproject.domain.model.HapticEvent
+import com.devil.phoenixproject.domain.model.RepEvent
+import com.devil.phoenixproject.domain.model.RepType
+import com.devil.phoenixproject.testutil.DWSMTestHarness
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Issue #531: the warmup -> working transition must play a single clean tone. Previously the
+ * rep-event handler emitted both WARMUP_COMPLETE and WARMUP_TO_WORKING, which map to the same
+ * `beepboop` file on both platforms -> a stacked double-tone heard mid-set.
+ */
+class WarmupTransitionToneTest {
+
+    @Test
+    fun `warmup complete emits a single transition tone`() = runTest {
+        val harness = DWSMTestHarness(this)
+        val collected = mutableListOf<HapticEvent>()
+
+        val job = launch(UnconfinedTestDispatcher(testScheduler)) {
+            harness.coordinator.hapticEvents.toList(collected)
+        }
+
+        // Drive the rep-event path exactly as RepCounterFromMachine does on warmup completion.
+        harness.repCounter.onRepEvent?.invoke(
+            RepEvent(type = RepType.WARMUP_COMPLETE, warmupCount = 3, workingCount = 0),
+        )
+        advanceUntilIdle()
+
+        assertEquals(
+            1,
+            collected.count { it is HapticEvent.WARMUP_COMPLETE },
+            "Exactly one WARMUP_COMPLETE should be emitted",
+        )
+        assertEquals(
+            0,
+            collected.count { it is HapticEvent.WARMUP_TO_WORKING },
+            "WARMUP_TO_WORKING must no longer be emitted (single clean transition tone)",
+        )
+
+        job.cancel()
+        harness.cleanup()
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./gradlew :shared:testAndroidHostTest --tests "com.devil.phoenixproject.presentation.manager.WarmupTransitionToneTest"`
+Expected: FAIL — `WARMUP_TO_WORKING must no longer be emitted` reports `expected:<0> but was:<1>` (current handler emits both events).
+
+- [ ] **Step 3: Remove the redundant `WARMUP_TO_WORKING` emission**
+
+In `ActiveSessionEngine.kt`, replace the `RepType.WARMUP_COMPLETE` case (currently lines 300–304):
+
+```kotlin
+                    RepType.WARMUP_COMPLETE -> {
+                        coordinator._hapticEvents.emit(HapticEvent.WARMUP_COMPLETE)
+                        // Issue #100: Distinct transition sound from warmup to working sets
+                        coordinator._hapticEvents.emit(HapticEvent.WARMUP_TO_WORKING)
+                    }
+```
+
+with:
+
+```kotlin
+                    RepType.WARMUP_COMPLETE -> {
+                        // Issue #531: single clean transition tone. Previously also emitted
+                        // WARMUP_TO_WORKING, which maps to the same `beepboop` file on both
+                        // platforms -> a stacked double-tone heard mid-set. The WARMUP_TO_WORKING
+                        // enum + sound mappings remain (used by HapticEventAudioTest and the
+                        // Android routing guard) but are no longer emitted from the rep-event path.
+                        coordinator._hapticEvents.emit(HapticEvent.WARMUP_COMPLETE)
+                    }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `./gradlew :shared:testAndroidHostTest --tests "com.devil.phoenixproject.presentation.manager.WarmupTransitionToneTest"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt \
+        shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/WarmupTransitionToneTest.kt
+git commit -m "fix(audio): single clean warmup-to-working transition tone (#531)
+
+Symptom 3: the rep-event handler emitted both WARMUP_COMPLETE and WARMUP_TO_WORKING,
+which map to the same beepboop file -> a stacked double-tone mid-set. Emit only
+WARMUP_COMPLETE. The WARMUP_TO_WORKING enum + sound maps remain (other tests depend
+on them); only its emission from the rep-event path is removed.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01T7pTNEeYws971sWpE9V9Bk"
+```
+
+---
+
+### Task 4: Full-suite verification + handoff notes
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full shared-module test suite**
+
+Run: `./gradlew :shared:testAndroidHostTest`
+Expected: PASS — entire shared common + androidHostTest suite green, including `RepCounterFromMachineTest`, `WarmupTransitionToneTest`, `HapticEventAudioTest`, `WorkoutMetricTest`, `HapticFeedbackAudioRoutingGuardTest`, and the DWSM/ActiveSessionEngine integration tests.
+
+- [ ] **Step 2: Compile both platforms to catch KMP-specific breakage**
+
+Run: `./gradlew :androidApp:assembleDebug`
+Expected: BUILD SUCCESSFUL. (iOS framework compile `:shared:compileKotlinIosArm64` is optional and only available on macOS.)
+
+- [ ] **Step 3: Record the on-device verification requirement**
+
+Symptom 1's fix is a best-effort heuristic. Before merging, perform an on-device smoke test on iOS:
+- **Normal mode:** start a set; confirm no chirp before the first real setup rep, exactly 3 setup chirps, a single clean transition tone, and no stray tone during working reps.
+- **Echo mode:** confirm warmup still progresses past "Warm Up 1/3" (Issue #553 not regressed).
+
+If the phantom chirp persists in normal mode, capture the `REP_RECEIVED` connection log for the affected set and attach it to Issue #531 — the remaining mechanism (small slack-takeup tick vs. large carryover) can only be resolved with the real packet trace.
+
+- [ ] **Step 4: Update the issue**
+
+Comment on Issue #531 summarizing the three fixes shipped (per-increment setup chirps, carryover guard, single transition tone), and that on-device confirmation of symptom 1 is pending.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Symptom 2 (dropped chirps) → Task 1. ✓
+- Symptom 1 (phantom chirp, heuristic) → Task 2. ✓
+- Symptom 3 (stray transition tone) → Task 1 (timely completion removes late-fire) + Task 3 (de-dupe). ✓
+- Dropped idempotency guard (spec note) → correctly absent from the plan. ✓
+- Preserve #210 / #553 / #411 contracts → covered by Task 2 Step 6 verification and the Global Constraints. ✓
+- On-device verification requirement → Task 4 Step 3. ✓
+
+**Placeholder scan:** No TBD/TODO/"handle edge cases"/"write tests for the above". Every code step shows complete code; every run step shows the command and expected outcome. ✓
+
+**Type/name consistency:** `carryoverChecked` (field) is declared in Task 2 Step 3 and used in Steps 4–5. `warmupRepTarget` is a local in Task 1 (two independent branch scopes — no cross-task reference). `DWSMTestHarness` accessors (`repCounter`, `coordinator`, `cleanup`) match `testutil/DWSMTestHarness.kt`. `HapticEvent.WARMUP_COMPLETE` / `WARMUP_TO_WORKING` and `RepType.WARMUP_COMPLETE` / `WARMUP_COMPLETED` match `domain/model/Models.kt`. ✓
+
+**Note on line numbers:** all "currently line N" references reflect the state of the files at plan-writing time; if earlier tasks shift line numbers, locate the named branch/method instead.

--- a/docs/superpowers/plans/2026-06-26-velocity-based-1rm-foundation.md
+++ b/docs/superpowers/plans/2026-06-26-velocity-based-1rm-foundation.md
@@ -1,0 +1,1384 @@
+# Velocity-Based 1RM — Foundation (Phases 1–2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Automatically estimate a per-exercise velocity-based 1RM from completed workout sets, persist it as a time-series, and display it alongside the existing PR/assessment 1RM on the exercise detail screen.
+
+**Architecture:** Reuse the existing `AssessmentEngine` OLS estimator. A pure-domain `VelocityOneRepMaxEstimator` builds `(load, MCV)` points from a rolling window of completed `WorkoutSession`s (which already carry `avgMcvMmS` and `workingAvgWeightKg`), resolves a Minimum Velocity Threshold (MVT) via a movement-pattern model, and fits the line. A use case orchestrates DB I/O and persists each estimate to a new `VelocityOneRepMaxEstimate` table, triggered from the existing post-save hook. Phase 2 surfaces the latest passing estimate on `ExerciseDetailScreen`.
+
+**Tech Stack:** Kotlin Multiplatform (commonMain), SQLDelight 2.2.1, Koin 4.1.1, Coroutines/Flow, kotlin.test.
+
+Source spec: `docs/superpowers/specs/2026-06-26-velocity-based-1rm-design.md` (issue #517).
+
+## Global Constraints
+
+- All weight values are **per-cable** (0–220 kg). Estimates are stored and computed in per-cable space.
+- MCV is stored in the DB in **mm/s** (`WorkoutSession.avgMcvMmS`); convert to m/s by dividing by `1000f` before fitting.
+- Quality gate: an estimate **passes** iff `distinctLoads >= 2` AND `r2 >= 0.8f` AND the regression slope is negative (the latter is already enforced by `AssessmentEngine`).
+- MVT pattern defaults (m/s): horizontal press `0.15`, vertical press `0.20`, squat `0.30`, hinge/deadlift `0.15`, global fallback `OTHER = 0.20`.
+- Personalized MVT overrides the pattern default only after **≥ 3** captured samples.
+- `Exercise.oneRepMaxKg` remains the authoritative "true/assessment" 1RM and is NOT overwritten by this pipeline.
+- Reuse `AssessmentEngine.estimateOneRepMax()` unchanged — do not reimplement OLS.
+- **No phoenix-portal / sync changes in this plan** (that is Phase 6, a separate plan). New table may include `updatedAt`/`serverId`/`deletedAt` columns for future parity but no sync wiring.
+- Adding a table requires updating **four** places: the `.sq` schema + queries, a new numbered `.sqm` migration, `MigrationStatements.getMigrationStatements()`, and `SchemaManifest` (`SchemaTableOperation`). The `SchemaParityTest`/`SchemaManifestTest` enforce this.
+- Rolling window: **last 28 days** of sessions for the exercise+profile; dedup points by load (most-recent wins); require ≥2 distinct loads.
+
+---
+
+## File Structure
+
+**Create:**
+- `shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/onerepmax/MovementPattern.kt` — pattern enum + classifier (pure).
+- `shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/onerepmax/MvtProvider.kt` — MVT resolution (pure).
+- `shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/onerepmax/VelocityOneRepMaxEstimator.kt` — point construction + fit + quality gate (pure).
+- `shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/ComputeVelocityOneRepMaxUseCase.kt` — orchestration.
+- `shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/RecordPersonalMvtSampleUseCase.kt` — personalized MVT capture.
+- `shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/VelocityOneRepMaxRepository.kt` — interface + entity + impl.
+- `shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/PersonalMvtRepository.kt` — interface + entity + impl.
+- `shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/migrations/36.sqm`
+- `shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/migrations/37.sqm`
+- Test files mirroring each (`commonTest` for pure domain, `androidHostTest` for DB repos).
+
+**Modify:**
+- `shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq` — two CREATE TABLEs, `Exercise.mvtOverrideMs` column, queries.
+- `shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/MigrationStatements.kt` — `36 ->`, `37 ->` branches.
+- `shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/SchemaManifest.kt` — two `SchemaTableOperation`s + `Exercise.mvtOverrideMs` heal op.
+- `shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepository.kt` + `WorkoutRepository.kt` — velocity-points query method.
+- `shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/Exercise.kt` — `mvtOverrideMs` field.
+- `shared/src/commonMain/kotlin/com/devil/phoenixproject/di/DomainModule.kt` + `DataModule.kt` — register new components.
+- `shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/GamificationManager.kt` — invoke compute use case in `processPostSaveEvents`.
+- `shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseDetailScreen.kt` — display latest passing estimate.
+
+---
+
+## Phase 1 — Estimation engine, MVT model, persistence
+
+### Task 1: MovementPattern enum + classifier
+
+**Files:**
+- Create: `shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/onerepmax/MovementPattern.kt`
+- Test: `shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/onerepmax/MovementPatternTest.kt`
+
+**Interfaces:**
+- Produces: `enum class MovementPattern(val defaultMvtMs: Float)` with values `HORIZONTAL_PRESS(0.15f)`, `VERTICAL_PRESS(0.20f)`, `SQUAT(0.30f)`, `HINGE(0.15f)`, `OTHER(0.20f)`; `fun classifyMovementPattern(name: String, muscleGroups: String): MovementPattern`.
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+package com.devil.phoenixproject.domain.onerepmax
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MovementPatternTest {
+    @Test fun `bench press classifies as horizontal press`() =
+        assertEquals(MovementPattern.HORIZONTAL_PRESS, classifyMovementPattern("Barbell Bench Press", "Chest"))
+
+    @Test fun `overhead press classifies as vertical press`() =
+        assertEquals(MovementPattern.VERTICAL_PRESS, classifyMovementPattern("Overhead Press", "Shoulders"))
+
+    @Test fun `back squat classifies as squat`() =
+        assertEquals(MovementPattern.SQUAT, classifyMovementPattern("Back Squat", "Legs"))
+
+    @Test fun `deadlift classifies as hinge`() =
+        assertEquals(MovementPattern.HINGE, classifyMovementPattern("Romanian Deadlift", "Hamstrings"))
+
+    @Test fun `bicep curl falls back to other`() =
+        assertEquals(MovementPattern.OTHER, classifyMovementPattern("Bicep Curl", "Biceps"))
+
+    @Test fun `default mvt values match spec`() {
+        assertEquals(0.15f, MovementPattern.HORIZONTAL_PRESS.defaultMvtMs)
+        assertEquals(0.20f, MovementPattern.VERTICAL_PRESS.defaultMvtMs)
+        assertEquals(0.30f, MovementPattern.SQUAT.defaultMvtMs)
+        assertEquals(0.15f, MovementPattern.HINGE.defaultMvtMs)
+        assertEquals(0.20f, MovementPattern.OTHER.defaultMvtMs)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :shared:testDebugUnitTest --tests "*MovementPatternTest*"`
+Expected: FAIL — `classifyMovementPattern` unresolved.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```kotlin
+package com.devil.phoenixproject.domain.onerepmax
+
+/** Movement patterns with their default Minimum Velocity Threshold (m/s) for 1RM extrapolation. */
+enum class MovementPattern(val defaultMvtMs: Float) {
+    HORIZONTAL_PRESS(0.15f),
+    VERTICAL_PRESS(0.20f),
+    SQUAT(0.30f),
+    HINGE(0.15f),
+    OTHER(0.20f),
+}
+
+/**
+ * Best-effort classification of an exercise into a movement pattern from its name and
+ * muscle groups. Keyword order matters: more specific patterns are checked first.
+ */
+fun classifyMovementPattern(name: String, muscleGroups: String): MovementPattern {
+    val haystack = "$name $muscleGroups".lowercase()
+    return when {
+        listOf("deadlift", "rdl", "hip thrust", "hinge", "good morning", "swing").any { it in haystack } -> MovementPattern.HINGE
+        listOf("squat", "leg press", "lunge", "split squat").any { it in haystack } -> MovementPattern.SQUAT
+        listOf("overhead", "ohp", "shoulder press", "military", "push press").any { it in haystack } -> MovementPattern.VERTICAL_PRESS
+        listOf("bench", "chest press", "horizontal press", "floor press").any { it in haystack } -> MovementPattern.HORIZONTAL_PRESS
+        else -> MovementPattern.OTHER
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :shared:testDebugUnitTest --tests "*MovementPatternTest*"`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/onerepmax/MovementPattern.kt shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/onerepmax/MovementPatternTest.kt
+git commit -m "feat(1rm): add movement-pattern classifier with MVT defaults (#517)"
+```
+
+---
+
+### Task 2: MvtProvider
+
+**Files:**
+- Create: `shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/onerepmax/MvtProvider.kt`
+- Test: `shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/onerepmax/MvtProviderTest.kt`
+
+**Interfaces:**
+- Consumes: `MovementPattern`, `classifyMovementPattern` (Task 1).
+- Produces: `class MvtProvider { fun resolve(exerciseName: String, muscleGroups: String, userOverrideMs: Float?, personalMvtMs: Float?, personalSampleCount: Int): Float }`. Resolution priority: `userOverrideMs` (if > 0) → `personalMvtMs` (if `personalSampleCount >= MIN_PERSONAL_MVT_SAMPLES`) → pattern default. Constant `MvtProvider.MIN_PERSONAL_MVT_SAMPLES = 3`.
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+package com.devil.phoenixproject.domain.onerepmax
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MvtProviderTest {
+    private val provider = MvtProvider()
+
+    @Test fun `falls back to pattern default when no personal or override`() =
+        assertEquals(0.30f, provider.resolve("Back Squat", "Legs", null, null, 0))
+
+    @Test fun `personal mvt overrides pattern once threshold met`() =
+        assertEquals(0.22f, provider.resolve("Back Squat", "Legs", null, 0.22f, 3))
+
+    @Test fun `personal mvt ignored below sample threshold`() =
+        assertEquals(0.30f, provider.resolve("Back Squat", "Legs", null, 0.22f, 2))
+
+    @Test fun `user override beats personal and pattern`() =
+        assertEquals(0.18f, provider.resolve("Back Squat", "Legs", 0.18f, 0.22f, 5))
+
+    @Test fun `non-positive override is ignored`() =
+        assertEquals(0.20f, provider.resolve("Cable Fly", "Chest", 0f, null, 0))
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :shared:testDebugUnitTest --tests "*MvtProviderTest*"`
+Expected: FAIL — `MvtProvider` unresolved.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```kotlin
+package com.devil.phoenixproject.domain.onerepmax
+
+/** Resolves the Minimum Velocity Threshold (m/s) for an exercise. */
+class MvtProvider {
+    fun resolve(
+        exerciseName: String,
+        muscleGroups: String,
+        userOverrideMs: Float?,
+        personalMvtMs: Float?,
+        personalSampleCount: Int,
+    ): Float {
+        if (userOverrideMs != null && userOverrideMs > 0f) return userOverrideMs
+        if (personalMvtMs != null && personalMvtMs > 0f && personalSampleCount >= MIN_PERSONAL_MVT_SAMPLES) {
+            return personalMvtMs
+        }
+        return classifyMovementPattern(exerciseName, muscleGroups).defaultMvtMs
+    }
+
+    companion object {
+        const val MIN_PERSONAL_MVT_SAMPLES = 3
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :shared:testDebugUnitTest --tests "*MvtProviderTest*"`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/onerepmax/MvtProvider.kt shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/onerepmax/MvtProviderTest.kt
+git commit -m "feat(1rm): add MvtProvider with personal-override threshold (#517)"
+```
+
+---
+
+### Task 3: VelocityOneRepMaxEstimator
+
+**Files:**
+- Create: `shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/onerepmax/VelocityOneRepMaxEstimator.kt`
+- Test: `shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/onerepmax/VelocityOneRepMaxEstimatorTest.kt`
+
+**Interfaces:**
+- Consumes: `AssessmentEngine.estimateOneRepMax(points: List<LoadVelocityPoint>, config: AssessmentConfig)` and `LoadVelocityPoint(loadKg, meanVelocityMs)` from `com.devil.phoenixproject.domain.assessment`.
+- Produces:
+  - `data class WorkoutVelocityPoint(val loadPerCableKg: Float, val mcvMmS: Float, val timestampMs: Long, val workingReps: Int)`
+  - `data class VelocityOneRepMaxResult(val estimatedPerCableKg: Float, val mvtUsedMs: Float, val r2: Float, val distinctLoads: Int, val passedQualityGate: Boolean)`
+  - `class VelocityOneRepMaxEstimator(private val assessmentEngine: AssessmentEngine) { fun estimate(points: List<WorkoutVelocityPoint>, mvtMs: Float): VelocityOneRepMaxResult? }`
+  - Returns `null` when no estimate is computable (fewer than 2 distinct loads after dedup, or the regression is degenerate/positive-slope). When non-null, `estimatedPerCableKg` is per-cable.
+  - Constants on companion: `R2_PASS_THRESHOLD = 0.8f`, `MIN_DISTINCT_LOADS = 2`, `LOAD_BUCKET_KG = 0.5f`.
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+package com.devil.phoenixproject.domain.onerepmax
+
+import com.devil.phoenixproject.domain.assessment.AssessmentEngine
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class VelocityOneRepMaxEstimatorTest {
+    private val estimator = VelocityOneRepMaxEstimator(AssessmentEngine())
+
+    private fun point(load: Float, mcvMmS: Float, ts: Long = 0L) =
+        WorkoutVelocityPoint(loadPerCableKg = load, mcvMmS = mcvMmS, timestampMs = ts, workingReps = 5)
+
+    @Test fun `two distinct loads produce a passing estimate`() {
+        // load 40 @ 1.2 m/s (1200 mm/s), load 80 @ 0.6 m/s -> 1RM at 0.30 m/s
+        val result = estimator.estimate(
+            points = listOf(point(40f, 1200f), point(80f, 600f)),
+            mvtMs = 0.30f,
+        )
+        assertNotNull(result)
+        assertTrue(result.passedQualityGate, "2 clean points on a line should pass")
+        assertTrue(result.estimatedPerCableKg in 95f..105f, "expected ~100kg, got ${result.estimatedPerCableKg}")
+    }
+
+    @Test fun `single distinct load returns null`() {
+        assertNull(estimator.estimate(listOf(point(60f, 800f), point(60f, 790f)), mvtMs = 0.30f))
+    }
+
+    @Test fun `positive slope returns null`() {
+        // velocity increasing with load is non-physiological -> AssessmentEngine rejects
+        assertNull(estimator.estimate(listOf(point(40f, 600f), point(80f, 900f)), mvtMs = 0.30f))
+    }
+
+    @Test fun `duplicate loads are deduped keeping most recent`() {
+        // newest 60kg point (ts=100) should win over older (ts=1)
+        val result = estimator.estimate(
+            points = listOf(point(40f, 1200f, ts = 50), point(60f, 900f, ts = 100), point(60f, 100f, ts = 1)),
+            mvtMs = 0.30f,
+        )
+        assertNotNull(result)
+        // distinctLoads counts unique buckets, not raw points
+        assertTrue(result.distinctLoads == 2)
+    }
+
+    @Test fun `warmup-only or zero-rep points excluded by caller contract are not required here`() {
+        // estimator trusts caller to pass working points; verify it still needs 2 loads
+        assertNull(estimator.estimate(listOf(point(50f, 700f)), mvtMs = 0.20f))
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :shared:testDebugUnitTest --tests "*VelocityOneRepMaxEstimatorTest*"`
+Expected: FAIL — estimator unresolved.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```kotlin
+package com.devil.phoenixproject.domain.onerepmax
+
+import com.devil.phoenixproject.domain.assessment.AssessmentConfig
+import com.devil.phoenixproject.domain.assessment.AssessmentEngine
+import com.devil.phoenixproject.domain.assessment.LoadVelocityPoint
+import kotlin.math.roundToInt
+
+/** One completed-set data point fed into velocity-1RM estimation. Load is per-cable; MCV in mm/s. */
+data class WorkoutVelocityPoint(
+    val loadPerCableKg: Float,
+    val mcvMmS: Float,
+    val timestampMs: Long,
+    val workingReps: Int,
+)
+
+/** Result of a velocity-based 1RM estimate. Estimate is per-cable kg. */
+data class VelocityOneRepMaxResult(
+    val estimatedPerCableKg: Float,
+    val mvtUsedMs: Float,
+    val r2: Float,
+    val distinctLoads: Int,
+    val passedQualityGate: Boolean,
+)
+
+/**
+ * Builds load-velocity points from completed sets and fits a 1RM via the existing
+ * [AssessmentEngine]. Pure: no I/O. The caller supplies an already-windowed list of
+ * working-set points and the resolved MVT.
+ */
+class VelocityOneRepMaxEstimator(private val assessmentEngine: AssessmentEngine) {
+
+    fun estimate(points: List<WorkoutVelocityPoint>, mvtMs: Float): VelocityOneRepMaxResult? {
+        // Keep only usable points, then dedup by load bucket keeping the most recent.
+        val deduped = points
+            .filter { it.loadPerCableKg > 0f && it.mcvMmS > 0f && it.workingReps > 0 }
+            .groupBy { bucketOf(it.loadPerCableKg) }
+            .map { (_, group) -> group.maxByOrNull { it.timestampMs }!! }
+
+        val distinctLoads = deduped.size
+        if (distinctLoads < MIN_DISTINCT_LOADS) return null
+
+        val lvPoints = deduped.map {
+            LoadVelocityPoint(loadKg = it.loadPerCableKg, meanVelocityMs = it.mcvMmS / 1000f)
+        }
+
+        // minSets=2 matches our gate; oneRmVelocityMs is the resolved MVT.
+        val config = AssessmentConfig(minSets = MIN_DISTINCT_LOADS, oneRmVelocityMs = mvtMs)
+        val assessment = assessmentEngine.estimateOneRepMax(lvPoints, config) ?: return null
+
+        val passed = distinctLoads >= MIN_DISTINCT_LOADS && assessment.r2 >= R2_PASS_THRESHOLD
+        return VelocityOneRepMaxResult(
+            estimatedPerCableKg = assessment.estimatedOneRepMaxKg,
+            mvtUsedMs = mvtMs,
+            r2 = assessment.r2,
+            distinctLoads = distinctLoads,
+            passedQualityGate = passed,
+        )
+    }
+
+    private fun bucketOf(loadKg: Float): Int = (loadKg / LOAD_BUCKET_KG).roundToInt()
+
+    companion object {
+        const val R2_PASS_THRESHOLD = 0.8f
+        const val MIN_DISTINCT_LOADS = 2
+        const val LOAD_BUCKET_KG = 0.5f
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :shared:testDebugUnitTest --tests "*VelocityOneRepMaxEstimatorTest*"`
+Expected: PASS (5 tests). If the `~100kg` assertion is off, recheck the mm/s→m/s conversion (`/1000f`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/onerepmax/VelocityOneRepMaxEstimator.kt shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/onerepmax/VelocityOneRepMaxEstimatorTest.kt
+git commit -m "feat(1rm): add VelocityOneRepMaxEstimator reusing AssessmentEngine (#517)"
+```
+
+---
+
+### Task 4: `VelocityOneRepMaxEstimate` table (schema + migration + manifest)
+
+**Files:**
+- Modify: `shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq`
+- Create: `shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/migrations/36.sqm`
+- Modify: `shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/MigrationStatements.kt`
+- Modify: `shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/SchemaManifest.kt`
+- Test: `shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/local/SchemaManifestTest.kt` (existing parity test — must still pass).
+
+**Interfaces:**
+- Produces SQLDelight queries: `insertVelocityOneRepMax`, `selectVelocityOneRepMaxByExercise`, `selectLatestPassingVelocityOneRepMax`.
+
+- [ ] **Step 1: Add the table + queries to `VitruvianDatabase.sq`**
+
+Insert after the `AssessmentResult` block (around line 434):
+
+```sql
+-- ==================== VELOCITY-BASED 1RM ESTIMATES ====================
+-- Auto-computed velocity 1RM time-series (issue #517). Separate from
+-- AssessmentResult (wizard) and from Exercise.oneRepMaxKg (authoritative true 1RM).
+
+CREATE TABLE VelocityOneRepMaxEstimate (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    exerciseId TEXT NOT NULL,
+    estimatedPerCableKg REAL NOT NULL,
+    mvtUsedMs REAL NOT NULL,
+    r2 REAL NOT NULL,
+    distinctLoads INTEGER NOT NULL,
+    passedQualityGate INTEGER NOT NULL DEFAULT 0,
+    computedAt INTEGER NOT NULL,
+    profile_id TEXT NOT NULL DEFAULT 'default',
+    -- Sync columns (future parity; unused in this plan)
+    updatedAt INTEGER,
+    serverId TEXT,
+    deletedAt INTEGER,
+    FOREIGN KEY (exerciseId) REFERENCES Exercise(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_velocity_1rm_exercise ON VelocityOneRepMaxEstimate(exerciseId, profile_id);
+
+insertVelocityOneRepMax:
+INSERT INTO VelocityOneRepMaxEstimate (exerciseId, estimatedPerCableKg, mvtUsedMs, r2, distinctLoads, passedQualityGate, computedAt, profile_id)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?);
+
+selectVelocityOneRepMaxByExercise:
+SELECT * FROM VelocityOneRepMaxEstimate
+WHERE exerciseId = :exerciseId AND profile_id = :profileId AND deletedAt IS NULL
+ORDER BY computedAt DESC;
+
+selectLatestPassingVelocityOneRepMax:
+SELECT * FROM VelocityOneRepMaxEstimate
+WHERE exerciseId = :exerciseId AND profile_id = :profileId
+AND passedQualityGate = 1 AND deletedAt IS NULL
+ORDER BY computedAt DESC
+LIMIT 1;
+```
+
+- [ ] **Step 2: Create migration `36.sqm`**
+
+```sql
+-- Migration 36: Velocity-based 1RM estimate time-series (issue #517).
+CREATE TABLE IF NOT EXISTS VelocityOneRepMaxEstimate (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    exerciseId TEXT NOT NULL,
+    estimatedPerCableKg REAL NOT NULL,
+    mvtUsedMs REAL NOT NULL,
+    r2 REAL NOT NULL,
+    distinctLoads INTEGER NOT NULL,
+    passedQualityGate INTEGER NOT NULL DEFAULT 0,
+    computedAt INTEGER NOT NULL,
+    profile_id TEXT NOT NULL DEFAULT 'default',
+    updatedAt INTEGER,
+    serverId TEXT,
+    deletedAt INTEGER,
+    FOREIGN KEY (exerciseId) REFERENCES Exercise(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_velocity_1rm_exercise ON VelocityOneRepMaxEstimate(exerciseId, profile_id);
+```
+
+- [ ] **Step 3: Add the `36 ->` branch to `MigrationStatements.getMigrationStatements()`**
+
+Add a new `when` branch (match the existing `35 ->` style — `CREATE TABLE IF NOT EXISTS` + index as separate list entries):
+
+```kotlin
+36 -> listOf(
+    """CREATE TABLE IF NOT EXISTS VelocityOneRepMaxEstimate (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        exerciseId TEXT NOT NULL,
+        estimatedPerCableKg REAL NOT NULL,
+        mvtUsedMs REAL NOT NULL,
+        r2 REAL NOT NULL,
+        distinctLoads INTEGER NOT NULL,
+        passedQualityGate INTEGER NOT NULL DEFAULT 0,
+        computedAt INTEGER NOT NULL,
+        profile_id TEXT NOT NULL DEFAULT 'default',
+        updatedAt INTEGER,
+        serverId TEXT,
+        deletedAt INTEGER,
+        FOREIGN KEY (exerciseId) REFERENCES Exercise(id) ON DELETE CASCADE
+    )""",
+    """CREATE INDEX IF NOT EXISTS idx_velocity_1rm_exercise ON VelocityOneRepMaxEstimate(exerciseId, profile_id)""",
+)
+```
+
+- [ ] **Step 4: Add a `SchemaTableOperation` to `SchemaManifest.kt`**
+
+Append to the table-operations list (same shape as the existing `SchemaTableOperation(...)` entries near line 1029+), using `CREATE TABLE IF NOT EXISTS` with the identical column list from Step 2.
+
+```kotlin
+SchemaTableOperation(
+    table = "VelocityOneRepMaxEstimate",
+    createSql = """
+        CREATE TABLE IF NOT EXISTS VelocityOneRepMaxEstimate (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            exerciseId TEXT NOT NULL,
+            estimatedPerCableKg REAL NOT NULL,
+            mvtUsedMs REAL NOT NULL,
+            r2 REAL NOT NULL,
+            distinctLoads INTEGER NOT NULL,
+            passedQualityGate INTEGER NOT NULL DEFAULT 0,
+            computedAt INTEGER NOT NULL,
+            profile_id TEXT NOT NULL DEFAULT 'default',
+            updatedAt INTEGER,
+            serverId TEXT,
+            deletedAt INTEGER,
+            FOREIGN KEY (exerciseId) REFERENCES Exercise(id) ON DELETE CASCADE
+        )
+    """.trimIndent(),
+),
+```
+
+- [ ] **Step 5: Run the schema build + parity tests**
+
+Run: `./gradlew :shared:generateCommonMainVitruvianDatabaseInterface :shared:testDebugUnitTest --tests "*SchemaManifestTest*" --tests "*SchemaParityTest*"`
+Expected: SQLDelight generates `insertVelocityOneRepMax` etc.; parity tests PASS. If parity fails, the `.sq` CREATE and the `SchemaManifest` createSql differ — reconcile them character-for-character (ignoring whitespace).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add shared/src/commonMain/sqldelight shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/MigrationStatements.kt shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/SchemaManifest.kt
+git commit -m "feat(1rm): add VelocityOneRepMaxEstimate table + migration 36 (#517)"
+```
+
+---
+
+### Task 5: VelocityOneRepMaxRepository
+
+**Files:**
+- Create: `shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/VelocityOneRepMaxRepository.kt`
+- Test: `shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightVelocityOneRepMaxRepositoryTest.kt`
+
+**Interfaces:**
+- Consumes: generated queries from Task 4; `VitruvianDatabase`.
+- Produces:
+  - `data class VelocityOneRepMaxEntity(val id: Long, val exerciseId: String, val estimatedPerCableKg: Float, val mvtUsedMs: Float, val r2: Float, val distinctLoads: Int, val passedQualityGate: Boolean, val computedAt: Long, val profileId: String)`
+  - `interface VelocityOneRepMaxRepository { suspend fun insert(result: VelocityOneRepMaxResult, exerciseId: String, computedAt: Long, profileId: String); suspend fun getLatestPassing(exerciseId: String, profileId: String): VelocityOneRepMaxEntity?; fun getHistory(exerciseId: String, profileId: String): Flow<List<VelocityOneRepMaxEntity>> }`
+  - `class SqlDelightVelocityOneRepMaxRepository(private val db: VitruvianDatabase) : VelocityOneRepMaxRepository`
+
+- [ ] **Step 1: Write the failing test**
+
+Copy the in-memory DB harness from the existing `SqlDelightAssessmentRepositoryTest.kt` (same package/source set) for driver + schema creation, then:
+
+```kotlin
+package com.devil.phoenixproject.data.repository
+
+import com.devil.phoenixproject.domain.onerepmax.VelocityOneRepMaxResult
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SqlDelightVelocityOneRepMaxRepositoryTest {
+    // val db = createInMemoryTestDatabase()  // harness copied from SqlDelightAssessmentRepositoryTest
+
+    private fun result(estimate: Float, passed: Boolean) =
+        VelocityOneRepMaxResult(estimatedPerCableKg = estimate, mvtUsedMs = 0.3f, r2 = if (passed) 0.95f else 0.4f, distinctLoads = 3, passedQualityGate = passed)
+
+    @Test fun `insert then latest passing returns most recent passing row`() = runTest {
+        val db = createInMemoryTestDatabase()
+        // Seed an Exercise row 'ex1' first (FK). Reuse the exercise-insert helper from the harness.
+        seedExercise(db, id = "ex1")
+        val repo = SqlDelightVelocityOneRepMaxRepository(db)
+
+        repo.insert(result(100f, passed = true), exerciseId = "ex1", computedAt = 1_000L, profileId = "default")
+        repo.insert(result(120f, passed = false), exerciseId = "ex1", computedAt = 2_000L, profileId = "default")
+        repo.insert(result(110f, passed = true), exerciseId = "ex1", computedAt = 3_000L, profileId = "default")
+
+        val latest = repo.getLatestPassing("ex1", "default")
+        assertEquals(110f, latest?.estimatedPerCableKg)
+        assertTrue(latest!!.passedQualityGate)
+    }
+
+    @Test fun `latest passing is null when only failing rows exist`() = runTest {
+        val db = createInMemoryTestDatabase()
+        seedExercise(db, id = "ex2")
+        val repo = SqlDelightVelocityOneRepMaxRepository(db)
+        repo.insert(result(90f, passed = false), exerciseId = "ex2", computedAt = 1_000L, profileId = "default")
+        assertNull(repo.getLatestPassing("ex2", "default"))
+    }
+}
+```
+
+> Note: `createInMemoryTestDatabase()` and `seedExercise(...)` are the harness helpers — copy them verbatim from `SqlDelightAssessmentRepositoryTest.kt`, which already constructs a `VitruvianDatabase` over an in-memory `JdbcSqliteDriver` and inserts Exercise rows for FK satisfaction.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :shared:testDebugUnitTest --tests "*SqlDelightVelocityOneRepMaxRepositoryTest*"`
+Expected: FAIL — repository unresolved.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```kotlin
+package com.devil.phoenixproject.data.repository
+
+import app.cash.sqldelight.coroutines.asFlow
+import app.cash.sqldelight.coroutines.mapToList
+import com.devil.phoenixproject.database.VitruvianDatabase
+import com.devil.phoenixproject.domain.onerepmax.VelocityOneRepMaxResult
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.withContext
+
+data class VelocityOneRepMaxEntity(
+    val id: Long,
+    val exerciseId: String,
+    val estimatedPerCableKg: Float,
+    val mvtUsedMs: Float,
+    val r2: Float,
+    val distinctLoads: Int,
+    val passedQualityGate: Boolean,
+    val computedAt: Long,
+    val profileId: String,
+)
+
+interface VelocityOneRepMaxRepository {
+    suspend fun insert(result: VelocityOneRepMaxResult, exerciseId: String, computedAt: Long, profileId: String)
+    suspend fun getLatestPassing(exerciseId: String, profileId: String): VelocityOneRepMaxEntity?
+    fun getHistory(exerciseId: String, profileId: String): Flow<List<VelocityOneRepMaxEntity>>
+}
+
+class SqlDelightVelocityOneRepMaxRepository(private val db: VitruvianDatabase) : VelocityOneRepMaxRepository {
+    private val queries = db.vitruvianDatabaseQueries
+
+    private fun map(
+        id: Long, exerciseId: String, estimatedPerCableKg: Double, mvtUsedMs: Double, r2: Double,
+        distinctLoads: Long, passedQualityGate: Long, computedAt: Long, profile_id: String,
+        updatedAt: Long?, serverId: String?, deletedAt: Long?,
+    ) = VelocityOneRepMaxEntity(
+        id = id, exerciseId = exerciseId, estimatedPerCableKg = estimatedPerCableKg.toFloat(),
+        mvtUsedMs = mvtUsedMs.toFloat(), r2 = r2.toFloat(), distinctLoads = distinctLoads.toInt(),
+        passedQualityGate = passedQualityGate != 0L, computedAt = computedAt, profileId = profile_id,
+    )
+
+    override suspend fun insert(result: VelocityOneRepMaxResult, exerciseId: String, computedAt: Long, profileId: String) =
+        withContext(Dispatchers.IO) {
+            queries.insertVelocityOneRepMax(
+                exerciseId = exerciseId,
+                estimatedPerCableKg = result.estimatedPerCableKg.toDouble(),
+                mvtUsedMs = result.mvtUsedMs.toDouble(),
+                r2 = result.r2.toDouble(),
+                distinctLoads = result.distinctLoads.toLong(),
+                passedQualityGate = if (result.passedQualityGate) 1L else 0L,
+                computedAt = computedAt,
+                profile_id = profileId,
+            )
+        }
+
+    override suspend fun getLatestPassing(exerciseId: String, profileId: String): VelocityOneRepMaxEntity? =
+        withContext(Dispatchers.IO) {
+            queries.selectLatestPassingVelocityOneRepMax(exerciseId, profileId, ::map).executeAsOneOrNull()
+        }
+
+    override fun getHistory(exerciseId: String, profileId: String): Flow<List<VelocityOneRepMaxEntity>> =
+        queries.selectVelocityOneRepMaxByExercise(exerciseId, profileId, ::map).asFlow().mapToList(Dispatchers.IO)
+}
+```
+
+> If the generated `map` parameter order/types differ (SQLDelight orders by column declaration), align the `::map` signature to the generated query's mapper exactly — the compiler error will name the expected lambda type.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :shared:testDebugUnitTest --tests "*SqlDelightVelocityOneRepMaxRepositoryTest*"`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/VelocityOneRepMaxRepository.kt shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightVelocityOneRepMaxRepositoryTest.kt
+git commit -m "feat(1rm): add VelocityOneRepMaxRepository (#517)"
+```
+
+---
+
+### Task 6: Per-exercise velocity-points query on WorkoutRepository
+
+**Files:**
+- Modify: `shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq` (add query)
+- Modify: `shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/WorkoutRepository.kt` (interface method)
+- Modify: `shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepository.kt` (impl)
+- Test: `shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepositoryVelocityPointsTest.kt`
+
+**Interfaces:**
+- Produces: `suspend fun WorkoutRepository.getVelocityPointsForExercise(exerciseId: String, profileId: String, sinceTimestampMs: Long): List<WorkoutVelocityPoint>` (returns the domain type from Task 3). Load uses `workingAvgWeightKg` when non-null, else `weightPerCableKg`.
+
+- [ ] **Step 1: Add the query to `VitruvianDatabase.sq`**
+
+Place near the other `WorkoutSession` SELECTs (after `selectSessionsByExerciseSince` region ~line 595):
+
+```sql
+selectVelocityPointsByExercise:
+SELECT workingAvgWeightKg, weightPerCableKg, avgMcvMmS, timestamp, workingReps
+FROM WorkoutSession
+WHERE exerciseId = :exerciseId
+  AND profile_id = :profileId
+  AND timestamp >= :sinceTimestamp
+  AND deletedAt IS NULL
+  AND avgMcvMmS IS NOT NULL
+  AND workingReps > 0
+ORDER BY timestamp DESC;
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```kotlin
+package com.devil.phoenixproject.data.repository
+
+import com.devil.phoenixproject.domain.onerepmax.WorkoutVelocityPoint
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SqlDelightWorkoutRepositoryVelocityPointsTest {
+    @Test fun `returns one point per qualifying session using working avg weight`() = runTest {
+        val db = createInMemoryTestDatabase()
+        seedExercise(db, id = "ex1")
+        val repo = SqlDelightWorkoutRepository(db /* + same deps as production ctor */)
+
+        // session A: workingAvgWeightKg=40, mcv=1200, ts=2000, workingReps=5
+        seedSession(db, exerciseId = "ex1", weightPerCableKg = 42f, workingAvgWeightKg = 40f, avgMcvMmS = 1200f, timestamp = 2000L, workingReps = 5, profileId = "default")
+        // session B (older, before window): excluded by sinceTimestamp
+        seedSession(db, exerciseId = "ex1", weightPerCableKg = 80f, workingAvgWeightKg = 80f, avgMcvMmS = 600f, timestamp = 100L, workingReps = 5, profileId = "default")
+
+        val points = repo.getVelocityPointsForExercise("ex1", "default", sinceTimestampMs = 1000L)
+        assertEquals(1, points.size)
+        assertEquals(40f, points.first().loadPerCableKg)
+        assertEquals(1200f, points.first().mcvMmS)
+    }
+}
+```
+
+> `seedSession(...)` is a harness helper inserting a `WorkoutSession` with the given columns — add it next to `seedExercise` in the shared test harness (it wraps `queries.insertSession(...)` with defaults for unrelated columns).
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `./gradlew :shared:testDebugUnitTest --tests "*WorkoutRepositoryVelocityPointsTest*"`
+Expected: FAIL — `getVelocityPointsForExercise` unresolved.
+
+- [ ] **Step 4: Implement the interface method + impl**
+
+In `WorkoutRepository.kt`:
+
+```kotlin
+suspend fun getVelocityPointsForExercise(
+    exerciseId: String,
+    profileId: String,
+    sinceTimestampMs: Long,
+): List<com.devil.phoenixproject.domain.onerepmax.WorkoutVelocityPoint>
+```
+
+In `SqlDelightWorkoutRepository.kt`:
+
+```kotlin
+override suspend fun getVelocityPointsForExercise(
+    exerciseId: String,
+    profileId: String,
+    sinceTimestampMs: Long,
+): List<WorkoutVelocityPoint> = withContext(Dispatchers.IO) {
+    queries.selectVelocityPointsByExercise(exerciseId, profileId, sinceTimestampMs).executeAsList().map { row ->
+        WorkoutVelocityPoint(
+            loadPerCableKg = (row.workingAvgWeightKg ?: row.weightPerCableKg).toFloat(),
+            mcvMmS = (row.avgMcvMmS ?: 0.0).toFloat(),
+            timestampMs = row.timestamp,
+            workingReps = row.workingReps.toInt(),
+        )
+    }
+}
+```
+
+Add imports for `WorkoutVelocityPoint`, `Dispatchers`, `IO`, `withContext` if absent.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `./gradlew :shared:testDebugUnitTest --tests "*WorkoutRepositoryVelocityPointsTest*"`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add shared/src/commonMain/sqldelight shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/WorkoutRepository.kt shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepository.kt shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepositoryVelocityPointsTest.kt
+git commit -m "feat(1rm): add per-exercise velocity-points query (#517)"
+```
+
+---
+
+### Task 7: Personal MVT table + Exercise override column + repository
+
+**Files:**
+- Modify: `VitruvianDatabase.sq` (ExerciseMvt table + `Exercise.mvtOverrideMs` column + queries), `MigrationStatements.kt` (`37 ->`), `SchemaManifest.kt` (table op + Exercise heal op), `Exercise.kt` (field), the Exercise SQL mapper wherever `selectExerciseById`/`insertExercise` are mapped.
+- Create: `shared/src/commonMain/sqldelight/.../migrations/37.sqm`, `data/repository/PersonalMvtRepository.kt`
+- Test: `shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightPersonalMvtRepositoryTest.kt`
+
+**Interfaces:**
+- Produces:
+  - `data class PersonalMvtEntity(val exerciseId: String, val profileId: String, val personalMvtMs: Float, val sampleCount: Int)`
+  - `interface PersonalMvtRepository { suspend fun get(exerciseId: String, profileId: String): PersonalMvtEntity?; suspend fun upsert(exerciseId: String, profileId: String, personalMvtMs: Float, sampleCount: Int) }`
+  - `Exercise.mvtOverrideMs: Float?` (nullable, default null).
+
+- [ ] **Step 1: Schema additions in `VitruvianDatabase.sq`**
+
+```sql
+ALTER TABLE Exercise ADD COLUMN mvtOverrideMs REAL;  -- handled via migration; see note
+
+CREATE TABLE ExerciseMvt (
+    exerciseId TEXT NOT NULL,
+    profile_id TEXT NOT NULL DEFAULT 'default',
+    personalMvtMs REAL NOT NULL,
+    sampleCount INTEGER NOT NULL DEFAULT 0,
+    updatedAt INTEGER NOT NULL,
+    PRIMARY KEY (exerciseId, profile_id),
+    FOREIGN KEY (exerciseId) REFERENCES Exercise(id) ON DELETE CASCADE
+);
+
+selectExerciseMvt:
+SELECT * FROM ExerciseMvt WHERE exerciseId = :exerciseId AND profile_id = :profileId;
+
+upsertExerciseMvt:
+INSERT INTO ExerciseMvt (exerciseId, profile_id, personalMvtMs, sampleCount, updatedAt)
+VALUES (:exerciseId, :profileId, :personalMvtMs, :sampleCount, :updatedAt)
+ON CONFLICT(exerciseId, profile_id) DO UPDATE SET
+    personalMvtMs = excluded.personalMvtMs,
+    sampleCount = excluded.sampleCount,
+    updatedAt = excluded.updatedAt;
+```
+
+> The `mvtOverrideMs` column must be added to the actual `CREATE TABLE Exercise` definition in the `.sq` (so generated code/mapper includes it), AND added via migration 37 for existing DBs. Update the Exercise SQL mapper (`mapToExercise`/`insertExercise` call sites) to read/write the new nullable column (`mvtOverrideMs = null` on insert unless set).
+
+- [ ] **Step 2: Migration `37.sqm`**
+
+```sql
+-- Migration 37: personalized MVT storage + per-exercise MVT override (issue #517).
+ALTER TABLE Exercise ADD COLUMN mvtOverrideMs REAL;
+CREATE TABLE IF NOT EXISTS ExerciseMvt (
+    exerciseId TEXT NOT NULL,
+    profile_id TEXT NOT NULL DEFAULT 'default',
+    personalMvtMs REAL NOT NULL,
+    sampleCount INTEGER NOT NULL DEFAULT 0,
+    updatedAt INTEGER NOT NULL,
+    PRIMARY KEY (exerciseId, profile_id),
+    FOREIGN KEY (exerciseId) REFERENCES Exercise(id) ON DELETE CASCADE
+);
+```
+
+- [ ] **Step 3: `MigrationStatements.kt` `37 ->` branch** — mirror Step 2 as two list entries (`ALTER TABLE ... ADD COLUMN mvtOverrideMs REAL` is recoverable on "duplicate column"; the reconciler already treats duplicate-column as recoverable). **`SchemaManifest.kt`**: add a `SchemaTableOperation` for `ExerciseMvt` and a `SchemaHealOperation(table = "Exercise", column = "mvtOverrideMs", sql = "ALTER TABLE Exercise ADD COLUMN mvtOverrideMs REAL")`.
+
+- [ ] **Step 4: Add `mvtOverrideMs` to `Exercise.kt`**
+
+```kotlin
+val mvtOverrideMs: Float? = null, // User-set Minimum Velocity Threshold override (m/s) for velocity-1RM
+```
+
+Add to the `data class Exercise(...)` parameter list (after `displayName`). Update the Exercise repository mapper to populate it from the row and persist it on insert/update.
+
+- [ ] **Step 5: Write the failing repository test**
+
+```kotlin
+package com.devil.phoenixproject.data.repository
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class SqlDelightPersonalMvtRepositoryTest {
+    @Test fun `upsert then get round-trips and updates`() = runTest {
+        val db = createInMemoryTestDatabase()
+        seedExercise(db, id = "ex1")
+        val repo = SqlDelightPersonalMvtRepository(db)
+        assertNull(repo.get("ex1", "default"))
+
+        repo.upsert("ex1", "default", personalMvtMs = 0.18f, sampleCount = 1)
+        assertEquals(1, repo.get("ex1", "default")?.sampleCount)
+
+        repo.upsert("ex1", "default", personalMvtMs = 0.19f, sampleCount = 2)
+        val updated = repo.get("ex1", "default")
+        assertEquals(2, updated?.sampleCount)
+        assertEquals(0.19f, updated?.personalMvtMs)
+    }
+}
+```
+
+- [ ] **Step 6: Implement `PersonalMvtRepository.kt`**
+
+```kotlin
+package com.devil.phoenixproject.data.repository
+
+import com.devil.phoenixproject.database.VitruvianDatabase
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.withContext
+
+data class PersonalMvtEntity(val exerciseId: String, val profileId: String, val personalMvtMs: Float, val sampleCount: Int)
+
+interface PersonalMvtRepository {
+    suspend fun get(exerciseId: String, profileId: String): PersonalMvtEntity?
+    suspend fun upsert(exerciseId: String, profileId: String, personalMvtMs: Float, sampleCount: Int)
+}
+
+class SqlDelightPersonalMvtRepository(private val db: VitruvianDatabase) : PersonalMvtRepository {
+    private val queries = db.vitruvianDatabaseQueries
+
+    override suspend fun get(exerciseId: String, profileId: String): PersonalMvtEntity? = withContext(Dispatchers.IO) {
+        queries.selectExerciseMvt(exerciseId, profileId).executeAsOneOrNull()?.let {
+            PersonalMvtEntity(it.exerciseId, it.profile_id, it.personalMvtMs.toFloat(), it.sampleCount.toInt())
+        }
+    }
+
+    override suspend fun upsert(exerciseId: String, profileId: String, personalMvtMs: Float, sampleCount: Int) =
+        withContext(Dispatchers.IO) {
+            queries.upsertExerciseMvt(
+                exerciseId = exerciseId,
+                profileId = profileId,
+                personalMvtMs = personalMvtMs.toDouble(),
+                sampleCount = sampleCount.toLong(),
+                updatedAt = com.devil.phoenixproject.util.currentTimeMillis(),
+            )
+        }
+}
+```
+
+- [ ] **Step 7: Run schema + repo tests**
+
+Run: `./gradlew :shared:generateCommonMainVitruvianDatabaseInterface :shared:testDebugUnitTest --tests "*SchemaManifestTest*" --tests "*SchemaParityTest*" --tests "*PersonalMvtRepositoryTest*"`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add shared/src/commonMain/sqldelight shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/Exercise.kt shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/PersonalMvtRepository.kt shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightExerciseRepository.kt shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightPersonalMvtRepositoryTest.kt
+git commit -m "feat(1rm): add personal MVT storage + exercise override column, migration 37 (#517)"
+```
+
+---
+
+### Task 8: ComputeVelocityOneRepMaxUseCase
+
+**Files:**
+- Create: `shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/ComputeVelocityOneRepMaxUseCase.kt`
+- Test: `shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/ComputeVelocityOneRepMaxUseCaseTest.kt`
+
+**Interfaces:**
+- Consumes: `WorkoutRepository.getVelocityPointsForExercise` (Task 6), `ExerciseRepository.getExerciseById`, `PersonalMvtRepository.get` (Task 7), `MvtProvider` (Task 2), `VelocityOneRepMaxEstimator` (Task 3), `VelocityOneRepMaxRepository.insert` (Task 5).
+- Produces: `class ComputeVelocityOneRepMaxUseCase(...) { suspend operator fun invoke(exerciseId: String, profileId: String, nowMs: Long): VelocityOneRepMaxResult? }`. Returns the result (or null) AND persists it when non-null. Window constant `WINDOW_DAYS = 28`.
+
+- [ ] **Step 1: Write the failing test (with fakes)**
+
+```kotlin
+package com.devil.phoenixproject.domain.usecase
+
+import com.devil.phoenixproject.domain.assessment.AssessmentEngine
+import com.devil.phoenixproject.domain.onerepmax.MvtProvider
+import com.devil.phoenixproject.domain.onerepmax.VelocityOneRepMaxEstimator
+import com.devil.phoenixproject.domain.onerepmax.VelocityOneRepMaxResult
+import com.devil.phoenixproject.domain.onerepmax.WorkoutVelocityPoint
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class ComputeVelocityOneRepMaxUseCaseTest {
+    @Test fun `computes and persists an estimate from windowed points`() = runTest {
+        val points = listOf(
+            WorkoutVelocityPoint(40f, 1200f, timestampMs = 5L, workingReps = 5),
+            WorkoutVelocityPoint(80f, 600f, timestampMs = 6L, workingReps = 5),
+        )
+        val inserted = mutableListOf<VelocityOneRepMaxResult>()
+        val useCase = ComputeVelocityOneRepMaxUseCase(
+            workoutPoints = { _, _, _ -> points },
+            exerciseLookup = { _ -> FakeExercise(name = "Back Squat", muscleGroups = "Legs", mvtOverrideMs = null) },
+            personalMvtLookup = { _, _ -> null },
+            mvtProvider = MvtProvider(),
+            estimator = VelocityOneRepMaxEstimator(AssessmentEngine()),
+            persist = { result, _, _, _ -> inserted += result },
+        )
+
+        val result = useCase("ex1", "default", nowMs = 1_000_000L)
+        assertNotNull(result)
+        assertTrue(result.passedQualityGate)
+        assertEquals(1, inserted.size)
+        assertEquals(result.estimatedPerCableKg, inserted.first().estimatedPerCableKg)
+    }
+
+    @Test fun `returns null and persists nothing when fewer than two loads`() = runTest {
+        val inserted = mutableListOf<VelocityOneRepMaxResult>()
+        val useCase = ComputeVelocityOneRepMaxUseCase(
+            workoutPoints = { _, _, _ -> listOf(WorkoutVelocityPoint(50f, 700f, 1L, 5)) },
+            exerciseLookup = { _ -> FakeExercise("Curl", "Biceps", null) },
+            personalMvtLookup = { _, _ -> null },
+            mvtProvider = MvtProvider(),
+            estimator = VelocityOneRepMaxEstimator(AssessmentEngine()),
+            persist = { r, _, _, _ -> inserted += r },
+        )
+        assertEquals(null, useCase("ex1", "default", nowMs = 1L))
+        assertEquals(0, inserted.size)
+    }
+}
+```
+
+> To keep this test pure, the use case takes function-typed collaborators (shown above). `FakeExercise` is a tiny local stub exposing `name`, `muscleGroups`, `mvtOverrideMs`. In production wiring (Task 10) these lambdas delegate to the real repositories.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :shared:testDebugUnitTest --tests "*ComputeVelocityOneRepMaxUseCaseTest*"`
+Expected: FAIL — use case unresolved.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```kotlin
+package com.devil.phoenixproject.domain.usecase
+
+import com.devil.phoenixproject.domain.onerepmax.MvtProvider
+import com.devil.phoenixproject.domain.onerepmax.VelocityOneRepMaxEstimator
+import com.devil.phoenixproject.domain.onerepmax.VelocityOneRepMaxResult
+import com.devil.phoenixproject.domain.onerepmax.WorkoutVelocityPoint
+
+/** Minimal view of an exercise needed for MVT resolution. */
+interface MvtExerciseView { val name: String; val muscleGroups: String; val mvtOverrideMs: Float? }
+
+class ComputeVelocityOneRepMaxUseCase(
+    private val workoutPoints: suspend (exerciseId: String, profileId: String, sinceMs: Long) -> List<WorkoutVelocityPoint>,
+    private val exerciseLookup: suspend (exerciseId: String) -> MvtExerciseView?,
+    private val personalMvtLookup: suspend (exerciseId: String, profileId: String) -> Pair<Float, Int>?, // (mvt, sampleCount)
+    private val mvtProvider: MvtProvider,
+    private val estimator: VelocityOneRepMaxEstimator,
+    private val persist: suspend (result: VelocityOneRepMaxResult, exerciseId: String, computedAt: Long, profileId: String) -> Unit,
+) {
+    suspend operator fun invoke(exerciseId: String, profileId: String, nowMs: Long): VelocityOneRepMaxResult? {
+        val exercise = exerciseLookup(exerciseId) ?: return null
+        val sinceMs = nowMs - WINDOW_DAYS * DAY_MS
+        val points = workoutPoints(exerciseId, profileId, sinceMs)
+        val personal = personalMvtLookup(exerciseId, profileId)
+        val mvt = mvtProvider.resolve(
+            exerciseName = exercise.name,
+            muscleGroups = exercise.muscleGroups,
+            userOverrideMs = exercise.mvtOverrideMs,
+            personalMvtMs = personal?.first,
+            personalSampleCount = personal?.second ?: 0,
+        )
+        val result = estimator.estimate(points, mvt) ?: return null
+        persist(result, exerciseId, nowMs, profileId)
+        return result
+    }
+
+    companion object {
+        const val WINDOW_DAYS = 28
+        private const val DAY_MS = 24L * 60L * 60L * 1000L
+    }
+}
+```
+
+> Note: the `FakeExercise` in the test must implement `MvtExerciseView`. In Task 10 wiring, `exerciseLookup` maps the real `Exercise` to an inline `MvtExerciseView`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :shared:testDebugUnitTest --tests "*ComputeVelocityOneRepMaxUseCaseTest*"`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/ComputeVelocityOneRepMaxUseCase.kt shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/ComputeVelocityOneRepMaxUseCaseTest.kt
+git commit -m "feat(1rm): add ComputeVelocityOneRepMaxUseCase (#517)"
+```
+
+---
+
+### Task 9: RecordPersonalMvtSampleUseCase
+
+**Files:**
+- Create: `shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/RecordPersonalMvtSampleUseCase.kt`
+- Test: `shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/RecordPersonalMvtSampleUseCaseTest.kt`
+
+**Heuristic (documented, tunable):** a completed session is an RIR≈0 proxy when its mean concentric velocity has collapsed to at or below `1.1 ×` the pattern default MVT for that exercise. When so, capture the session's `avgMcvMmS` (in m/s) as a sample; store the rolling mean of the last up-to-5 samples and increment `sampleCount`. This is a deliberately conservative proxy; refining failure detection (true last-rep RIR=0 from rep metrics) is a follow-on.
+
+**Interfaces:**
+- Consumes: `PersonalMvtRepository` (Task 7), `classifyMovementPattern`/`MovementPattern` (Task 1).
+- Produces: `class RecordPersonalMvtSampleUseCase(private val personalMvtRepo: PersonalMvtRepository) { suspend operator fun invoke(exerciseId: String, profileId: String, exerciseName: String, muscleGroups: String, sessionMcvMmS: Float): Boolean }` — returns true when a sample was captured.
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+package com.devil.phoenixproject.domain.usecase
+
+import com.devil.phoenixproject.data.repository.PersonalMvtEntity
+import com.devil.phoenixproject.data.repository.PersonalMvtRepository
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+private class FakePersonalMvtRepo : PersonalMvtRepository {
+    val store = mutableMapOf<String, PersonalMvtEntity>()
+    override suspend fun get(exerciseId: String, profileId: String) = store["$exerciseId/$profileId"]
+    override suspend fun upsert(exerciseId: String, profileId: String, personalMvtMs: Float, sampleCount: Int) {
+        store["$exerciseId/$profileId"] = PersonalMvtEntity(exerciseId, profileId, personalMvtMs, sampleCount)
+    }
+}
+
+class RecordPersonalMvtSampleUseCaseTest {
+    @Test fun `captures sample when velocity collapsed near squat threshold`() = runTest {
+        val repo = FakePersonalMvtRepo()
+        val useCase = RecordPersonalMvtSampleUseCase(repo)
+        // squat default 0.30 m/s; 0.31 m/s (310 mm/s) <= 1.1*0.30 -> capture
+        val captured = useCase("ex1", "default", "Back Squat", "Legs", sessionMcvMmS = 310f)
+        assertTrue(captured)
+        assertEquals(1, repo.get("ex1", "default")?.sampleCount)
+        assertEquals(0.31f, repo.get("ex1", "default")?.personalMvtMs!!, absoluteTolerance = 0.001f)
+    }
+
+    @Test fun `ignores fast non-failure set`() = runTest {
+        val repo = FakePersonalMvtRepo()
+        val useCase = RecordPersonalMvtSampleUseCase(repo)
+        // 0.60 m/s is well above threshold -> not a failure proxy
+        assertFalse(useCase("ex1", "default", "Back Squat", "Legs", sessionMcvMmS = 600f))
+        assertEquals(null, repo.get("ex1", "default"))
+    }
+
+    @Test fun `rolling mean across samples`() = runTest {
+        val repo = FakePersonalMvtRepo()
+        val useCase = RecordPersonalMvtSampleUseCase(repo)
+        useCase("ex1", "default", "Back Squat", "Legs", 300f) // 0.30
+        useCase("ex1", "default", "Back Squat", "Legs", 320f) // 0.32
+        val e = repo.get("ex1", "default")!!
+        assertEquals(2, e.sampleCount)
+        assertEquals(0.31f, e.personalMvtMs, absoluteTolerance = 0.001f)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :shared:testDebugUnitTest --tests "*RecordPersonalMvtSampleUseCaseTest*"`
+Expected: FAIL — use case unresolved.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```kotlin
+package com.devil.phoenixproject.domain.usecase
+
+import com.devil.phoenixproject.data.repository.PersonalMvtRepository
+import com.devil.phoenixproject.domain.onerepmax.classifyMovementPattern
+
+/**
+ * Captures a personalized MVT sample from a completed set whose velocity has collapsed to
+ * an RIR≈0 proxy (<= 1.1 × the pattern default). Maintains a rolling mean of recent samples.
+ */
+class RecordPersonalMvtSampleUseCase(private val personalMvtRepo: PersonalMvtRepository) {
+    suspend operator fun invoke(
+        exerciseId: String,
+        profileId: String,
+        exerciseName: String,
+        muscleGroups: String,
+        sessionMcvMmS: Float,
+    ): Boolean {
+        if (sessionMcvMmS <= 0f) return false
+        val sampleMs = sessionMcvMmS / 1000f
+        val patternDefault = classifyMovementPattern(exerciseName, muscleGroups).defaultMvtMs
+        if (sampleMs > patternDefault * FAILURE_PROXY_FACTOR) return false
+
+        val existing = personalMvtRepo.get(exerciseId, profileId)
+        val prevCount = existing?.sampleCount ?: 0
+        val prevMean = existing?.personalMvtMs ?: 0f
+        // Incremental mean capped at MAX_SAMPLES weighting.
+        val effectiveCount = minOf(prevCount, MAX_SAMPLES - 1)
+        val newCount = prevCount + 1
+        val newMean = (prevMean * effectiveCount + sampleMs) / (effectiveCount + 1)
+        personalMvtRepo.upsert(exerciseId, profileId, newMean, newCount)
+        return true
+    }
+
+    companion object {
+        const val FAILURE_PROXY_FACTOR = 1.1f
+        const val MAX_SAMPLES = 5
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :shared:testDebugUnitTest --tests "*RecordPersonalMvtSampleUseCaseTest*"`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/RecordPersonalMvtSampleUseCase.kt shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/RecordPersonalMvtSampleUseCaseTest.kt
+git commit -m "feat(1rm): add personalized MVT capture use case (#517)"
+```
+
+---
+
+### Task 10: DI wiring + post-save hook
+
+**Files:**
+- Modify: `shared/src/commonMain/kotlin/com/devil/phoenixproject/di/DataModule.kt` (repos), `DomainModule.kt` (providers + use cases).
+- Modify: `shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/GamificationManager.kt` (constructor dep + call in `processPostSaveEvents`).
+- Modify: `shared/src/commonMain/kotlin/com/devil/phoenixproject/di/PresentationModule.kt` (GamificationManager construction — add new arg).
+- Test: `shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/local/KoinGraphSmokeTest.kt` if one exists, else a focused construction test.
+
+**Interfaces:**
+- Consumes everything from Tasks 1–9.
+- Produces: GamificationManager invokes `computeVelocityOneRepMaxUseCase(exerciseId, profileId, currentTimeMillis())` and `recordPersonalMvtSampleUseCase(...)` after PR processing.
+
+- [ ] **Step 1: Register repositories in `DataModule.kt`**
+
+```kotlin
+single<VelocityOneRepMaxRepository> { SqlDelightVelocityOneRepMaxRepository(get()) }
+single<PersonalMvtRepository> { SqlDelightPersonalMvtRepository(get()) }
+```
+
+- [ ] **Step 2: Register providers + use cases in `DomainModule.kt`**
+
+```kotlin
+// Velocity-based 1RM (issue #517)
+single { MvtProvider() }
+single { VelocityOneRepMaxEstimator(get()) } // get() = AssessmentEngine
+
+single {
+    val workoutRepo = get<com.devil.phoenixproject.data.repository.WorkoutRepository>()
+    val exerciseRepo = get<com.devil.phoenixproject.data.repository.ExerciseRepository>()
+    val personalRepo = get<com.devil.phoenixproject.data.repository.PersonalMvtRepository>()
+    val velRepo = get<com.devil.phoenixproject.data.repository.VelocityOneRepMaxRepository>()
+    com.devil.phoenixproject.domain.usecase.ComputeVelocityOneRepMaxUseCase(
+        workoutPoints = { id, profile, since -> workoutRepo.getVelocityPointsForExercise(id, profile, since) },
+        exerciseLookup = { id ->
+            exerciseRepo.getExerciseById(id)?.let { ex ->
+                object : com.devil.phoenixproject.domain.usecase.MvtExerciseView {
+                    override val name = ex.name
+                    override val muscleGroups = ex.muscleGroups
+                    override val mvtOverrideMs = ex.mvtOverrideMs
+                }
+            }
+        },
+        personalMvtLookup = { id, profile -> personalRepo.get(id, profile)?.let { it.personalMvtMs to it.sampleCount } },
+        mvtProvider = get(),
+        estimator = get(),
+        persist = { result, id, computedAt, profile -> velRepo.insert(result, id, computedAt, profile) },
+    )
+}
+
+single { com.devil.phoenixproject.domain.usecase.RecordPersonalMvtSampleUseCase(get()) }
+```
+
+- [ ] **Step 3: Add deps to `GamificationManager` and call them**
+
+In the constructor add:
+```kotlin
+private val computeVelocityOneRepMax: com.devil.phoenixproject.domain.usecase.ComputeVelocityOneRepMaxUseCase,
+private val recordPersonalMvtSample: com.devil.phoenixproject.domain.usecase.RecordPersonalMvtSampleUseCase,
+```
+
+Add a parameter to `processPostSaveEvents` for the session MCV so personal-MVT capture has it:
+```kotlin
+sessionMcvMmS: Float? = null,
+```
+
+After PR processing completes (before `return`), when `exerciseId` is non-null:
+```kotlin
+val exId = exerciseId
+if (exId != null) {
+    try {
+        sessionMcvMmS?.let { mcv ->
+            val ex = exerciseRepository.getExerciseById(exId)
+            if (ex != null) {
+                recordPersonalMvtSample(exId, effectiveProfileId, ex.name, ex.muscleGroups, mcv)
+            }
+        }
+        computeVelocityOneRepMax(exId, effectiveProfileId, com.devil.phoenixproject.util.currentTimeMillis())
+    } catch (e: Exception) {
+        Logger.w(e) { "VELOCITY_1RM: estimate computation failed for $exId" }
+    }
+}
+```
+
+Update the call site in `ActiveSessionEngine.kt` (both `processPostSaveEvents(...)` invocations — manual-stop ~line 3024 and the other save path) to pass `sessionMcvMmS = summary.avgMcvMmS` (or the session's `avgMcvMmS`; use the value persisted on the session). Update `PresentationModule.kt` where `GamificationManager(...)` is constructed to supply the two new `get()` args.
+
+- [ ] **Step 4: Build the shared module**
+
+Run: `./gradlew :shared:assembleDebug`
+Expected: BUILD SUCCESSFUL (Koin graph compiles; constructor args satisfied).
+
+- [ ] **Step 5: Run the full shared test suite**
+
+Run: `./gradlew :shared:testDebugUnitTest`
+Expected: PASS (all prior tasks' tests plus existing suite green).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add shared/src/commonMain/kotlin/com/devil/phoenixproject/di shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/GamificationManager.kt shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+git commit -m "feat(1rm): wire velocity-1RM computation into post-save hook (#517)"
+```
+
+---
+
+## Phase 2 — Display alongside PR
+
+### Task 11: Surface the latest passing estimate on ExerciseDetailScreen
+
+**Files:**
+- Modify: `shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseDetailScreen.kt`
+- Modify: the screen's data source (the composable currently loads PR/1RM data near line 77 "Calculate 1RM progression" and renders the "1RM Hero Card" ~line 125 and "ESTIMATED 1RM" ~line 275). Inject `VelocityOneRepMaxRepository` through the same path the screen already uses for repositories (follow how `PersonalRecordRepository`/assessment data reach this screen — likely a ViewModel or Koin `get()`).
+
+**Interfaces:**
+- Consumes: `VelocityOneRepMaxRepository.getLatestPassing(exerciseId, profileId)` (Task 5).
+- Produces: a visible "VELOCITY 1RM" value (×2 for display via the existing display-multiplier convention used by the hero card) next to the existing assessment/PR 1RM, with the MVT used and timestamp, shown only when a passing estimate exists.
+
+- [ ] **Step 1: Load the estimate**
+
+Following the screen's existing data-loading pattern, fetch the latest passing estimate for the active exercise + profile and hold it in screen state:
+
+```kotlin
+// Pseudocode at the screen's data-load site (mirror the existing PR/assessment load):
+val velocity1Rm by produceState<VelocityOneRepMaxEntity?>(initialValue = null, exerciseId, profileId) {
+    value = velocityOneRepMaxRepository.getLatestPassing(exerciseId, profileId)
+}
+```
+
+- [ ] **Step 2: Render it in the hero card**
+
+Add a labeled value beside the existing "ESTIMATED 1RM" block. Convert per-cable → display using the same multiplier the card already applies to the assessment 1RM (do not hard-code ×2; reuse the card's existing display-weight helper). Show MVT used and the computed date. Render nothing when `velocity1Rm == null`.
+
+```kotlin
+velocity1Rm?.let { v ->
+    StatColumn(
+        label = "VELOCITY 1RM",
+        value = formatDisplayWeight(v.estimatedPerCableKg), // same helper the assessment 1RM uses
+        subtitle = "MVT ${v.mvtUsedMs} m/s",
+    )
+}
+```
+
+- [ ] **Step 3: Verify in the running app (manual — no Compose UI test harness in this module)**
+
+Run: `./gradlew :androidApp:installDebug`
+Then, on a device/emulator with at least two completed sets of one exercise at **different** weights (so a passing estimate exists), open that exercise's detail screen.
+Expected: a "VELOCITY 1RM" value appears next to the existing 1RM, with the MVT and date. For an exercise with only single-weight sets, the value is absent (no passing estimate).
+
+If no real data exists, seed via the existing assessment flow or log a temporary `Logger.d` of `getLatestPassing(...)` to confirm wiring, then remove it.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseDetailScreen.kt
+git commit -m "feat(1rm): display velocity-estimated 1RM on exercise detail (#517)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (Phases 1–2):**
+- Estimate from (load, MCV) via line-of-best-fit mapped to MVT → Tasks 1–3, 8. ✓
+- Rolling-window source (≥2 distinct loads, 28 days) → Tasks 6, 8. ✓
+- Per-movement-pattern MVT defaults + global fallback → Task 1. ✓
+- Personalized MVT (≥3 samples) + user override → Tasks 2, 7, 9. ✓
+- Tiered quality gate (store always; gate display/badges on R²≥0.8 + ≥2 loads) → Task 3 (`passedQualityGate`), Task 5 (`getLatestPassing` filters), Task 11 (display gated). ✓
+- Time-series persistence, `Exercise.oneRepMaxKg` untouched → Tasks 4, 5. ✓
+- Display alongside PR → Task 11. ✓
+- Out of scope here (correctly deferred): badges (Phase 4), `% of 1RM` scaling (Phase 3), backfill (Phase 5), portal parity (Phase 6). The post-save hook (Task 10) is the seam where Phase 4 badges will attach.
+
+**Placeholder scan:** No "TBD"/"handle edge cases"/"similar to Task N". Test code is concrete. Two intentional pointers to existing harness helpers (`createInMemoryTestDatabase`, `seedExercise`/`seedSession`) name the exact source file to copy from — acceptable, not hand-waving.
+
+**Type consistency:** `VelocityOneRepMaxResult`, `WorkoutVelocityPoint`, `MvtExerciseView`, `VelocityOneRepMaxEntity`, `PersonalMvtEntity`, and method names (`getVelocityPointsForExercise`, `getLatestPassing`, `insert`, `upsert`, `resolve`, `estimate`) are used identically across producing and consuming tasks. Quality-gate constants live once on `VelocityOneRepMaxEstimator`. ✓
+
+**Known risks to flag at execution:**
+- SQLDelight generated mapper parameter order may differ from the hand-written `::map`; align to the compiler error (noted in Task 5).
+- `processPostSaveEvents` adds a parameter with a default; both `ActiveSessionEngine` call sites must pass `sessionMcvMmS` (noted in Task 10).
+- The personal-MVT capture heuristic (Task 9) is a deliberate proxy; refining true RIR=0 detection from rep metrics is a follow-on.

--- a/docs/superpowers/specs/2026-06-26-issue-531-setup-rep-audio-design.md
+++ b/docs/superpowers/specs/2026-06-26-issue-531-setup-rep-audio-design.md
@@ -1,0 +1,123 @@
+# Issue #531 — Setup-rep audio timing fix
+
+**Date:** 2026-06-26
+**Issue:** [#531 — Still some odd sound issues](https://github.com/9thLevelSoftware/Project-Phoenix-MP/issues/531)
+**Status:** Design approved, pending implementation plan
+
+## Problem
+
+During the **setup-rep phase** (the 3-rep setup screen shown after the start countdown), audio
+feedback is misaligned. Reported on iOS (build 18252 / v9.2), tester `ikim67`:
+
+1. **Phantom chirp on entry** — a rep chirp plays the moment the 3-rep setup screen appears,
+   before the user moves.
+2. **Dropped setup chirps** — only 2 of the 3 setup reps produce a chirp.
+3. **Stray mid-set transition tone** — around overall rep 4–5 (i.e. a working rep or two in), an
+   "end-of-set–like" sound plays.
+
+A prior adjustment (commit `091c8141`, 2026-06-17) only reworked the **fallback** warmup branch and
+added `REP_RECEIVED` diagnostics; it never touched the **primary** warmup path, so all three
+symptoms persisted.
+
+## Root cause
+
+All three trace to warmup/setup-rep handling in
+`shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/RepCounterFromMachine.kt`
+(`processModern()`), plus one sound-mapping smell in `ActiveSessionEngine`.
+
+| Symptom | Root cause |
+|---------|-----------|
+| 1 — phantom chirp on entry | At set start `reset()` zeroes `lastTopCounter`, but the machine's free-running directional `up`/`down` counters carry over from the prior set. The first packet computes a large `upDelta`; the fallback branch (`repsSetCount==0 && repsRomCount==0 && upDelta>0`) instantly saturates `warmupReps` to target and emits `WARMUP_COMPLETED` + `WARMUP_COMPLETE` with no user movement. |
+| 2 — dropped chirps | The primary warmup branch emits `WARMUP_COMPLETED` **once per packet** but jumps the count straight to the machine value (`warmupReps = repsRomCount.coerceAtMost(warmupTarget)`). A batched/dropped BLE notification (ROM `0→2` in one packet) yields **one** chirp but **+2** reps. The legacy branch correctly does `repeat(delta){ emit }`; the modern branch does not. |
+| 3 — stray transition tone | When dropped chirps leave `warmupReps < warmupTarget`, the first working rep hits the belated path (lines 510–523) and force-fires `WARMUP_COMPLETE`. In `ActiveSessionEngine` that maps to **both** `WARMUP_COMPLETE` **and** `WARMUP_TO_WORKING` — and on iOS both play the same `beepboop` file back-to-back on one shared `AVAudioPlayer`. The stray double-`beepboop` lands a rep or two into the working set. |
+
+## Approach
+
+Surgical fix in `processModern()` + a one-line transition de-dupe in `ActiveSessionEngine`. Keeps the
+parent-repo "trust the machine's `repsRomCount`" model. Rejected alternatives: extracting an explicit
+warmup state machine (larger refactor, more risk to the Echo/Just Lift/AMRAP paths stabilized by
+#553/#538) and moving emission into `ActiveSessionEngine` (changes the event contract, risks
+regressing working-rep/final-rep sounds).
+
+### 1. Baseline reconciliation — "first-packet snapshot"
+
+Fixes symptom 1.
+
+- Add `private var countersBaselined = false`.
+- On the **first `process()` call** of a set, snapshot all four machine counters as the zero
+  reference and return **without emitting**:
+  - `lastTopCounter = up`
+  - `lastCompleteCounter = down`
+  - `romBaseline = repsRomCount`
+  - `setBaseline = repsSetCount`
+- All subsequent counting measures growth beyond the reference:
+  - warmup step target uses `(repsRomCount − romBaseline)`
+  - working count uses `(repsSetCount − setBaseline)`
+- For a normal fresh set the machine starts these at 0, so baselines are 0 → behavior unchanged. For
+  carried-over counters the reference absorbs the stale value → no phantom.
+- Reset `countersBaselined` (and `romBaseline`/`setBaseline`) in **both** `reset()` and
+  `resetCountsOnly()`, so resume/recovery re-baselines to the machine's live position rather than
+  re-counting completed reps.
+
+The baseline early-return is placed at the top of `process()` (before dispatch to
+`processModern`/`processLegacy`) so both packet formats share it.
+
+### 2. Per-increment warmup emission + idempotent completion
+
+Fixes symptoms 2 and 3.
+
+- **Per-increment:** when warmup advances, loop one `WARMUP_COMPLETED` per integer step:
+  ```
+  val target = (repsRomCount - romBaseline).coerceAtMost(warmupTarget)
+  while (warmupReps < target) {
+      warmupReps++
+      emit(WARMUP_COMPLETED, warmupReps, workingReps)
+  }
+  ```
+  Apply the same per-increment loop to the `upDelta` fallback branch. A batched `0→2→3` ROM report
+  now emits exactly 3 chirps.
+- **Idempotent completion:** add `private var warmupCompleteEmitted = false` (reset with the other
+  state). Gate **every** `WARMUP_COMPLETE` emission — primary branch, fallback branch, and the
+  belated working-rep path (lines 510–523) — on this flag so it fires **exactly once** per set and
+  can never re-fire when working reps begin.
+
+### 3. Single clean transition tone
+
+In `ActiveSessionEngine` `onRepEvent`, the `RepType.WARMUP_COMPLETE` case emits both
+`HapticEvent.WARMUP_COMPLETE` and `HapticEvent.WARMUP_TO_WORKING` (both → `beepboop`). Remove the
+`WARMUP_TO_WORKING` emission, keeping the single `WARMUP_COMPLETE` (success haptic + one `beepboop`).
+The now-unused `WARMUP_TO_WORKING` enum value and its iOS/Android sound mappings stay in place
+(removing them would touch the enum + both platform maps for no behavioral gain); flagged as dead.
+
+## Testing (inference-based, no hardware)
+
+New/expanded `RepCounterFromMachineTest` cases asserting the exact emitted-event sequence:
+
+1. Batched ROM `0→2→3` → exactly 3× `WARMUP_COMPLETED` + 1× `WARMUP_COMPLETE`.
+2. Sequential ROM `1→2→3` → 3 + 1 (regression guard for the normal case).
+3. Stale directional counter (`up=8`) on first packet → **zero** events (baseline absorbs it); real
+   reps afterward count correctly.
+4. Working reps begin while `warmupReps < warmupTarget` → exactly one belated `WARMUP_COMPLETE`,
+   never a second.
+5. Working-rep counting + final-rep / `WORKOUT_COMPLETE` sequence unaffected (regression).
+6. Fallback branch (`repsRomCount==0`, `up` advancing) still progresses warmup per-increment.
+
+## Files & risk
+
+| File | Change |
+|------|--------|
+| `RepCounterFromMachine.kt` | Baseline hook in `process()`; per-increment + idempotent-completion in `processModern()`/`processLegacy()` fallback; new fields; resets in `reset()`/`resetCountsOnly()`. **Primary.** |
+| `ActiveSessionEngine.kt` | Remove one `WARMUP_TO_WORKING` emit line. |
+| `RepCounterFromMachineTest.kt` | New/expanded cases above. |
+
+**Risk:** Low–moderate. The baseline early-return touches the shared entry path used by Echo / Just
+Lift / AMRAP; unit tests cover those branches to guard against regressing the #553/#538 fixes. No
+BLE, sync, or UI contract changes.
+
+## Out of scope
+
+- The "what is the 70/58/65 number" question in the issue thread — it's the rep-quality score,
+  already answered by the owner.
+- The "Echo activity not recorded in history" remark — separate issue.
+- Stale-`repsRomCount` carryover on mid-session *resume* (distinct from fresh set start) — the
+  baseline snapshot mitigates it via `romBaseline`, but resume edge cases are not the focus here.

--- a/docs/superpowers/specs/2026-06-26-issue-531-setup-rep-audio-design.md
+++ b/docs/superpowers/specs/2026-06-26-issue-531-setup-rep-audio-design.md
@@ -39,47 +39,73 @@ warmup state machine (larger refactor, more risk to the Echo/Just Lift/AMRAP pat
 #553/#538) and moving emission into `ActiveSessionEngine` (changes the event contract, risks
 regressing working-rep/final-rep sounds).
 
-### 1. Baseline reconciliation — "first-packet snapshot"
+### 1. Carryover guard (heuristic) — best-effort phantom suppression
 
-Fixes symptom 1.
+Fixes symptom 1, **best-effort**. The original "snapshot every first packet and return without
+emitting" idea was **rejected**: four `RepCounterFromMachineTest` cases
+(`Issue 210 - first warmup rep registers immediately in modern mode` line 340, `… in legacy mode`
+line 316, `… after reset` line 378, `… after resetCountsOnly` line 398) hard-assert that the *first*
+packet of a set counts immediately with no baseline — that contract was Issue #210's fix and a blanket
+snapshot reintroduces the bug it closed. Inference alone also cannot distinguish a slack-takeup tick
+(symptom 1) from a genuine firmware-dropped rep (Issue #553), since both appear as `up` advancing
+while `repsRomCount`/`repsSetCount` stay 0.
 
-- Add `private var countersBaselined = false`.
-- On the **first `process()` call** of a set, snapshot all four machine counters as the zero
-  reference and return **without emitting**:
-  - `lastTopCounter = up`
-  - `lastCompleteCounter = down`
-  - `romBaseline = repsRomCount`
-  - `setBaseline = repsSetCount`
-- All subsequent counting measures growth beyond the reference:
-  - warmup step target uses `(repsRomCount − romBaseline)`
-  - working count uses `(repsSetCount − setBaseline)`
-- For a normal fresh set the machine starts these at 0, so baselines are 0 → behavior unchanged. For
-  carried-over counters the reference absorbs the stale value → no phantom.
-- Reset `countersBaselined` (and `romBaseline`/`setBaseline`) in **both** `reset()` and
-  `resetCountsOnly()`, so resume/recovery re-baselines to the machine's live position rather than
-  re-counting completed reps.
+Chosen heuristic — narrow, preserves both the #210 and #553 contracts:
 
-The baseline early-return is placed at the top of `process()` (before dispatch to
-`processModern`/`processLegacy`) so both packet formats share it.
+- Add `private var carryoverChecked = false` (reset in `reset()`/`resetCountsOnly()`).
+- At the **top of `processModern()`** (after the `warmupTarget`/`repsRomTotal` sync), on the first
+  modern packet of a set only, detect the carryover signature and re-baseline once:
+  ```kotlin
+  if (!carryoverChecked) {
+      carryoverChecked = true
+      if (warmupTarget > 0 && warmupReps == 0 &&
+          repsRomCount == 0 && repsSetCount == 0 &&
+          (up > warmupTarget || down > warmupTarget)
+      ) {
+          // Directional counters are free-running and already far above the warmup target
+          // while the machine reports zero ROM/set reps → stale values carried from the prior
+          // set. Re-baseline so the first real movement yields delta ~0, not a phantom warmup rep.
+          lastTopCounter = up
+          lastCompleteCounter = down
+          return
+      }
+  }
+  ```
+- **Why this preserves the contracts:** #210 modern feeds `repsRomCount = 1` (fails the
+  `repsRomCount == 0` test → no skip, counts normally). #210 legacy uses `processLegacy` (untouched).
+  #553 sends an explicit `up = 0, down = 0` baseline packet first (fails the `up > warmupTarget`
+  test → no skip), then advances normally. The variable-warmup case uses `warmupTarget = 0` (fails
+  the `warmupTarget > 0` test → no skip).
+- **Scope limit (documented honestly):** this only catches *large* directional carryover
+  (`up`/`down` already past the warmup target). If symptom 1 is instead a *small* slack-takeup tick
+  (`up: 0 → 1`), this guard does nothing — but it also introduces no regression. If the phantom
+  persists after this ships, the remaining mechanism requires a real `REP_RECEIVED` packet trace to
+  resolve. Applied to `processModern` only (the iOS-reported path); legacy firmware is left untouched.
 
-### 2. Per-increment warmup emission + idempotent completion
+### 2. Per-increment warmup emission
 
-Fixes symptoms 2 and 3.
+Fixes symptom 2, and removes symptom 3's *late-firing* cause (a timely warmup completion means the
+belated working-rep `WARMUP_COMPLETE` path rarely triggers).
 
 - **Per-increment:** when warmup advances, loop one `WARMUP_COMPLETED` per integer step:
   ```
-  val target = (repsRomCount - romBaseline).coerceAtMost(warmupTarget)
+  val target = repsRomCount.coerceAtMost(warmupTarget)
   while (warmupReps < target) {
       warmupReps++
       emit(WARMUP_COMPLETED, warmupReps, workingReps)
   }
   ```
-  Apply the same per-increment loop to the `upDelta` fallback branch. A batched `0→2→3` ROM report
-  now emits exactly 3 chirps.
-- **Idempotent completion:** add `private var warmupCompleteEmitted = false` (reset with the other
-  state). Gate **every** `WARMUP_COMPLETE` emission — primary branch, fallback branch, and the
-  belated working-rep path (lines 510–523) — on this flag so it fires **exactly once** per set and
-  can never re-fire when working reps begin.
+  Apply the same per-increment loop to the `upDelta` fallback branch
+  (`val target = (warmupReps + upDelta).coerceAtMost(warmupTarget)`). A batched `0→2→3` ROM report
+  now emits exactly 3 chirps. Counts stay absolute-from-machine (no baseline subtraction), preserving
+  the Issue #210 first-rep contract.
+
+> **Dropped during planning:** an earlier draft added a `warmupCompleteEmitted` idempotency guard.
+> It was removed — the existing control flow already guarantees `WARMUP_COMPLETE` fires at most once
+> per set (every emission site is gated on `warmupReps < warmupTarget`; the first to fire sets
+> `warmupReps = warmupTarget`, closing all other sites, and the ROM/fallback branches are mutually
+> exclusive `else if`). No double-fire sequence is constructible, so the guard had no failing test
+> (TDD/YAGNI).
 
 ### 3. Single clean transition tone
 
@@ -95,10 +121,14 @@ New/expanded `RepCounterFromMachineTest` cases asserting the exact emitted-event
 
 1. Batched ROM `0→2→3` → exactly 3× `WARMUP_COMPLETED` + 1× `WARMUP_COMPLETE`.
 2. Sequential ROM `1→2→3` → 3 + 1 (regression guard for the normal case).
-3. Stale directional counter (`up=8`) on first packet → **zero** events (baseline absorbs it); real
-   reps afterward count correctly.
-4. Working reps begin while `warmupReps < warmupTarget` → exactly one belated `WARMUP_COMPLETE`,
-   never a second.
+3. Carryover guard: first packet `up=8, down=8, repsRomCount=0, repsSetCount=0` (warmupTarget=3) →
+   **zero** events (guard re-baselines); then `repsRomCount` `1→2→3` produces exactly 3 warmup
+   chirps + 1 `WARMUP_COMPLETE`. Plus a guard-does-not-fire case: first packet `up=1` (small) →
+   normal counting (the existing #210 tests already pin this; add an explicit small-`up` carryover
+   case for clarity).
+4. Single-transition test (engine-level, via `DWSMTestHarness`): invoking the rep-event path with
+   `RepType.WARMUP_COMPLETE` emits exactly one `HapticEvent.WARMUP_COMPLETE` and **zero**
+   `HapticEvent.WARMUP_TO_WORKING` (the de-dupe).
 5. Working-rep counting + final-rep / `WORKOUT_COMPLETE` sequence unaffected (regression).
 6. Fallback branch (`repsRomCount==0`, `up` advancing) still progresses warmup per-increment.
 
@@ -106,13 +136,23 @@ New/expanded `RepCounterFromMachineTest` cases asserting the exact emitted-event
 
 | File | Change |
 |------|--------|
-| `RepCounterFromMachine.kt` | Baseline hook in `process()`; per-increment + idempotent-completion in `processModern()`/`processLegacy()` fallback; new fields; resets in `reset()`/`resetCountsOnly()`. **Primary.** |
+| `RepCounterFromMachine.kt` | Per-increment warmup emission in both `processModern()` branches; carryover guard at top of `processModern()`; one new field (`carryoverChecked`) reset in `reset()`/`resetCountsOnly()`. **Primary.** |
 | `ActiveSessionEngine.kt` | Remove one `WARMUP_TO_WORKING` emit line. |
 | `RepCounterFromMachineTest.kt` | New/expanded cases above. |
 
-**Risk:** Low–moderate. The baseline early-return touches the shared entry path used by Echo / Just
-Lift / AMRAP; unit tests cover those branches to guard against regressing the #553/#538 fixes. No
-BLE, sync, or UI contract changes.
+**Risk:** Low–moderate.
+
+- Symptoms 2 & 3 (per-increment emission, idempotent `WARMUP_COMPLETE`, transition de-dupe) are
+  verified compatible with every existing test — those tests assert final counts and event presence,
+  not event multiplicity. High confidence.
+- Symptom 1 is a **best-effort heuristic** (large-carryover guard) deliberately scoped to NOT touch
+  the #210 first-rep or #553 Echo-fallback contracts. If the real phantom is a small slack-takeup
+  tick rather than large carryover, the guard is a no-op (no regression) and the phantom needs a
+  packet trace to finish. **Recommend an on-device Echo + normal-mode warmup smoke test before
+  merge** to confirm the phantom is gone and Echo warmup still progresses.
+- No BLE, sync, or UI contract changes. The `WARMUP_TO_WORKING` enum + its iOS/Android sound maps
+  stay (asserted by `HapticEventAudioTest` / `HapticFeedbackAudioRoutingGuardTest`); only its
+  emission from `ActiveSessionEngine` is removed.
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-06-26-velocity-based-1rm-design.md
+++ b/docs/superpowers/specs/2026-06-26-velocity-based-1rm-design.md
@@ -1,0 +1,188 @@
+# Velocity-Based 1RM Tracking — Design
+
+**Issue:** [#517](https://github.com/9thLevelSoftware/Project-Phoenix-MP/issues/517)
+**Date:** 2026-06-26
+**Status:** Approved (design), pending implementation plan
+
+## Summary
+
+Use Mean Concentric Velocity (MCV) captured by the Vitruvian machine to estimate a
+per-exercise one-rep max (1RM) automatically from normal workout sets, track that
+estimate over time alongside the existing PR system, fire distinct gamification when it
+increases, and allow `% of estimated-1RM` as a weight-programming basis alongside the
+existing `% of PR`.
+
+**Guiding principle: reuse, don't rebuild.** The core OLS estimator, per-rep MCV
+capture, a 1RM time-series table pattern, PR gamification, and `% of PR` scaling all
+already exist. This feature wires them together, adds an automatic estimation pipeline,
+an MVT (Minimum Velocity Threshold) model, a new scaling basis, and distinct badges.
+
+## Existing infrastructure (reused)
+
+| Capability | Location | Role here |
+| --- | --- | --- |
+| OLS load↔velocity regression → 1RM | `domain/assessment/AssessmentEngine.estimateOneRepMax()` | Reused unchanged as the fitting core |
+| Per-rep MCV + per-sample loads | `domain/model/RepMetrics.kt` (`avgVelocityConcentric`, mm/s), `data/repository/RepMetricRepository.kt` | Source of (load, MCV) points |
+| 1RM estimate persistence pattern | `assessment_results` table, `SqlDelightAssessmentRepository` | Pattern for the new time-series table |
+| Authoritative stored 1RM | `Exercise.oneRepMaxKg` (per-cable) | Stays the "true/assessment" 1RM; PR-scaling fallback |
+| PR + badges | `GamificationManager`, `BadgeDefinitions`, `BadgeCelebrationDialog`, `SqlDelightPersonalRecordRepository` | Distinct velocity-1RM badge added here |
+| `% of PR` scaling | `RoutineExercise.usePercentOfPR/weightPercentOfPR/prTypeForScaling`, `ResolveRoutineWeightsUseCase` | Generalized into a scaling-basis enum |
+| Portal estimate field | `exercise_progress.estimated_1rm_kg` (rep-based hybrid today) | A new separate velocity field is added |
+
+## Decisions (owner + product)
+
+Owner-resolved (issue comment): true 1RM is authoritative; `% of 1RM` is a system-wide
+setting alongside the velocity options; **distinct** badges for velocity-estimated 1RM;
+plot using each completed set; backfill yes.
+
+Product decisions made during brainstorming:
+
+| Decision | Choice |
+| --- | --- |
+| Estimate data source | **Rolling window** across recent sessions per exercise (≥2 distinct loads required) |
+| MVT model | **Per-movement-pattern defaults + global fallback**, personalized override from RIR=0 reps |
+| Scaling integration | **Add `ESTIMATED_1RM` as a third `ScalingBasis`** + system-wide default basis setting |
+| Quality gate | **Tiered** — always store the estimate + R²; gate display and badges on quality |
+| Personalized-MVT trust threshold | ≥3 RIR=0 samples before overriding the default |
+| Badge margin | New passing estimate must beat prior best passing estimate by ≥2.5% |
+| Portal parity | New separate `velocity_estimated_1rm_kg` field (do NOT overwrite rep-based `estimated_1rm_kg`) |
+
+## Architecture
+
+### 1. Estimation pipeline (domain)
+
+New pure component **`VelocityOneRepMaxEstimator`** (no UI/DB deps) that orchestrates
+existing pieces:
+
+- **Point construction.** From a rolling window of completed sets for an
+  `exerciseId + profileId`, build `List<LoadVelocityPoint>`. One point per **distinct
+  working load** observed in the window; its velocity = mean of per-rep
+  `avgVelocityConcentric` over **non-warmup** reps at that load, converted mm/s → m/s.
+  This handles both straight sets at different weights across the window and intra-set
+  drop sets (the issue's worked example).
+- **Window.** Last ~21 days (or last 6 distinct-load sessions), whichever is the tighter
+  practical bound, for that exercise+profile. Dedup by load (most-recent observation
+  wins). Require **≥2 distinct loads** after dedup or return no estimate.
+- **Fit.** Delegate to `AssessmentEngine.estimateOneRepMax(points, config)` unchanged,
+  passing the resolved MVT as `config.oneRmVelocityMs`. It already rejects positive slope
+  and degenerate inputs and returns R².
+- **Weight convention.** Fit in **per-cable** load space (parity with DB / PR /
+  `Exercise.oneRepMaxKg`). Because per-cable = total/2, this is a constant x-axis rescale,
+  so the extrapolated per-cable 1RM is consistent. (Note: the Assessment Wizard fed
+  *total* and divided by 2; the auto pipeline feeds per-cable directly.)
+
+### 2. MVT model
+
+**`MvtProvider`** resolves the MVT in priority order: **personalized → movement-pattern
+default → global fallback.**
+
+- **Pattern defaults** (from the issue): horizontal press 0.15, vertical press/OHP 0.20,
+  squat 0.30, hinge/deadlift 0.15; **global fallback 0.20 m/s**. Exercise→pattern
+  classification is derived from `muscleGroup`/`muscleGroups` and exercise name, leveraging
+  the existing `MovementCategory` enum. An optional user-editable per-exercise MVT override
+  field is exposed in the exercise editor.
+- **Personalized MVT.** Capture the MCV of the last successful rep of sets taken to
+  failure (RIR≈0), detectable via existing stall detection + rep data. Persist a rolling
+  median per exercise+profile. **Override the default only after ≥3 RIR=0 samples.**
+
+### 3. Persistence & time-series
+
+New table **`velocity_1rm_estimate`**:
+
+- Columns: `id`, `profile_id`, `exercise_id`, `estimated_1rm_per_cable_kg`, `mvt_used`,
+  `r2`, `distinct_loads`, `computed_at`, `passed_quality_gate` (bool), plus the standard
+  sync columns (`updated_at`, `server_id`, `deleted_at`) consistent with other synced
+  tables. This is the trend store.
+- **`Exercise.oneRepMaxKg` stays the authoritative "true/assessment 1RM"** and remains
+  the PR-scaling fallback. The auto velocity estimate lives only in the new table — they
+  are separate metrics, both displayable. (This realizes "true 1RM authoritative.")
+- Personalized MVT storage: a small `exercise_mvt` table (`profile_id`, `exercise_id`,
+  `personal_mvt`, `sample_count`, `updated_at`) or equivalent columns; user override lives
+  on `Exercise`.
+
+**Quality gate (tiered).** Always insert the row with its R². Set
+`passed_quality_gate = (distinct_loads ≥ 2) ∧ (r2 ≥ 0.8) ∧ (slope < 0)`. Display
+de-emphasizes or hides failing rows; only passing rows feed badges and `% of 1RM` scaling.
+
+### 4. `% of 1RM` scaling
+
+- Generalize `RoutineExercise.prTypeForScaling: PRType` →
+  **`scalingBasis: ScalingBasis { MAX_WEIGHT_PR, MAX_VOLUME_PR, ESTIMATED_1RM }`**. A
+  migration maps existing `PRType.MAX_WEIGHT → MAX_WEIGHT_PR`,
+  `PRType.MAX_VOLUME → MAX_VOLUME_PR`. The existing `usePercentOfPR` toggle is retained
+  (it remains the on/off for percentage-based scaling).
+- **System-wide `defaultScalingBasis`** setting in `UserPreferences`/`SettingsManager`,
+  applied to newly created routine exercises. Satisfies "system-wide setting alongside the
+  velocity options."
+- `ResolveRoutineWeightsUseCase`: add an `ESTIMATED_1RM` branch resolving to the latest
+  **passing** velocity estimate, falling back `Exercise.oneRepMaxKg` (true 1RM) → PR →
+  absolute weight.
+
+### 5. Gamification
+
+New **distinct** badge type(s) (e.g. `VELOCITY_1RM_PROGRESS`) added to `BadgeDefinitions`
+and `BadgeCategory`, fired through the existing `GamificationManager` when a new **passing**
+estimate beats the prior best passing estimate by **≥2.5%**. Kept separate from PR badges
+so the two progression signals don't conflate.
+
+### 6. Backfill
+
+A one-time background maintenance job replays historical sets that have persisted MCV
+rep-metrics, computes windowed estimates per exercise, and populates the time-series with
+`passed_quality_gate` flags. Runs lazily off the startup path and is idempotent (safe to
+re-run; keyed by exercise + window/computed_at).
+
+### 7. Portal sync parity ⚠️ cross-project
+
+Per the monorepo CLAUDE.md, `exercise_progress.estimated_1rm_kg` currently holds the
+**rep-based hybrid (Brzycki/Epley)** estimate from `OneRepMaxCalculator`. The velocity
+estimate is a *different* metric; overwriting that field would silently change its meaning.
+
+**Add a separate `velocity_estimated_1rm_kg`** across the contract:
+- Mobile: new field in `PortalExerciseDto` / sync DTOs, populated from the latest passing
+  velocity estimate (per-cable).
+- Supabase: new column on `exercise_progress`; update `mobile-sync-push` and
+  `mobile-sync-pull` Edge Functions.
+- Portal: `database.types.ts` regen, `transforms.ts`, and display.
+
+This is a parity-critical change requiring matching work in **phoenix-portal**; it must be
+done as the final phase and reviewed against the portal side.
+
+## Phasing (single spec, sequenced)
+
+1. Estimator + MVT model + persistence (engine, no UI).
+2. Display estimated-1RM alongside PR (exercise history / progress views).
+3. `% of 1RM` scaling basis + system-wide default setting.
+4. Distinct velocity-1RM badges.
+5. Backfill historical estimates.
+6. Portal sync parity (cross-project, separate `velocity_estimated_1rm_kg` field).
+
+## Error handling
+
+- Estimator returns no estimate (not an error) on insufficient/invalid data: <2 distinct
+  loads, non-negative slope, identical loads, no non-warmup reps. No crash, no row gated
+  as passing.
+- Personalized MVT only overrides after the sample threshold; otherwise default applies.
+- Sync tolerates a missing `velocity_estimated_1rm_kg` (legacy payloads) without failing.
+
+## Testing
+
+- **`VelocityOneRepMaxEstimator`** unit tests: insufficient/identical loads, positive-slope
+  rejection, warmup exclusion, mm/s→m/s and per-cable conversions, window dedup,
+  point-per-distinct-load construction, intra-set drop-set case.
+- **`MvtProvider`** tests: pattern classification, global fallback, personalized override
+  threshold (<3 vs ≥3 samples), rolling-median behavior.
+- **`ResolveRoutineWeightsUseCase`** tests: `ESTIMATED_1RM` branch and the full fallback
+  chain (estimate → true 1RM → PR → absolute).
+- **Migration/schema parity**: new tables + `ScalingBasis` mapping, validated by existing
+  `SchemaParityTest` / `SchemaManifestTest`.
+- **Backfill** idempotency test.
+- **Gamification** trigger test: badge fires only on a passing estimate exceeding prior
+  best by ≥2.5%.
+
+## Open items to confirm during planning
+
+- Exact window bound (days vs session count) — pin a single rule in the plan.
+- Movement-pattern classification table (explicit exercise/muscle-group → pattern map).
+- Whether the Assessment Wizard should also write into `velocity_1rm_estimate` for a
+  unified trend (optional, low priority).

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/RepCounterFromMachine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/RepCounterFromMachine.kt
@@ -392,21 +392,22 @@ class RepCounterFromMachine {
     private fun processModern(repsRomCount: Int, repsSetCount: Int, up: Int, down: Int, posA: Float, posB: Float) {
         // Issue #531 (symptom 1, heuristic): suppress a phantom warmup chirp caused by the
         // machine's free-running directional counters carrying over from the prior set. On the
-        // first modern packet of a set, if up/down are already past the warmup target while the
-        // machine reports zero ROM/set reps, treat them as stale and re-baseline once so the
-        // first real movement yields delta ~0. Deliberately narrow to preserve:
+        // first modern packet of a set, if BOTH up and down are already past the warmup target
+        // while the machine reports zero ROM/set reps, treat them as stale and re-baseline once so
+        // the first real movement yields delta ~0. Deliberately narrow to preserve:
         //   - Issue #210: a real first rep arrives as repsRomCount=1 -> fails repsRomCount==0.
-        //   - Issue #553: relies on the up=0/down=0 baseline packet the firmware normally sends
-        //     before warmup -> fails up>warmupTarget. If a fresh Echo set's first packet instead
-        //     arrives with up>warmupTarget and zero ROM/set counts, the warmup reps embedded in
-        //     that jump are dropped here (documented best-effort limit; warmupReps recovers from
-        //     later packets).
+        //   - Issue #553: requires BOTH up AND down past the target. A completed prior set leaves
+        //     both directional counters elevated (up ~= down), so real carryover is caught. But an
+        //     Echo set whose first packet is top-only (up advanced because earlier notifications
+        //     dropped, down still at baseline = genuine setup reps, not carryover) keeps down at 0
+        //     -> fails down>warmupTarget, so the fallback branch counts those reps instead of this
+        //     guard silently dropping them. (Codex PR #596 review.)
         //   - Issue #411: variable-warmup sets use warmupTarget=0 -> fails warmupTarget>0.
         if (!carryoverChecked) {
             carryoverChecked = true
             if (warmupTarget > 0 && warmupReps == 0 &&
                 repsRomCount == 0 && repsSetCount == 0 &&
-                (up > warmupTarget || down > warmupTarget)
+                up > warmupTarget && down > warmupTarget
             ) {
                 logDebug("🩹 Issue #531: directional carryover (up=$up, down=$down) — re-baselining, suppressing phantom warmup")
                 lastTopCounter = up

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/RepCounterFromMachine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/RepCounterFromMachine.kt
@@ -35,6 +35,11 @@ class RepCounterFromMachine {
     private var shouldStop = false
     private var isAMRAP = false
 
+    // Issue #531: one-shot guard for the directional-counter carryover heuristic. The machine's
+    // up/down counters are free-running and can carry over from the prior set; on the first modern
+    // packet we detect and absorb stale values once so they don't chirp a phantom warmup rep.
+    private var carryoverChecked = false
+
     // Pending rep state - true when at TOP, waiting for machine confirm
     private var hasPendingRep = false
     private var pendingRepProgress = 0f // 0.0 at TOP, 1.0 at BOTTOM (legacy, kept for compatibility)
@@ -106,6 +111,7 @@ class RepCounterFromMachine {
         warmupReps = 0
         workingReps = 0
         shouldStop = false
+        carryoverChecked = false
         hasPendingRep = false
         pendingRepProgress = 0f
         // Issue #163: Reset phase tracking
@@ -147,6 +153,7 @@ class RepCounterFromMachine {
         warmupReps = 0
         workingReps = 0
         shouldStop = false
+        carryoverChecked = false
         hasPendingRep = false
         pendingRepProgress = 0f
         // Issue #163: Reset phase tracking (but keep position history for direction detection)
@@ -383,6 +390,27 @@ class RepCounterFromMachine {
      * - Actual rep counting comes from repsRomCount/repsSetCount
      */
     private fun processModern(repsRomCount: Int, repsSetCount: Int, up: Int, down: Int, posA: Float, posB: Float) {
+        // Issue #531 (symptom 1, heuristic): suppress a phantom warmup chirp caused by the
+        // machine's free-running directional counters carrying over from the prior set. On the
+        // first modern packet of a set, if up/down are already past the warmup target while the
+        // machine reports zero ROM/set reps, treat them as stale and re-baseline once so the
+        // first real movement yields delta ~0. Deliberately narrow to preserve:
+        //   - Issue #210: a real first rep arrives as repsRomCount=1 -> fails repsRomCount==0.
+        //   - Issue #553: sends an explicit up=0/down=0 baseline packet -> fails up>warmupTarget.
+        //   - Issue #411: variable-warmup sets use warmupTarget=0 -> fails warmupTarget>0.
+        if (!carryoverChecked) {
+            carryoverChecked = true
+            if (warmupTarget > 0 && warmupReps == 0 &&
+                repsRomCount == 0 && repsSetCount == 0 &&
+                (up > warmupTarget || down > warmupTarget)
+            ) {
+                logDebug("🩹 Issue #531: directional carryover (up=$up, down=$down) — re-baselining, suppressing phantom warmup")
+                lastTopCounter = up
+                lastCompleteCounter = down
+                return
+            }
+        }
+
         // Track UP movement - for working reps, show PENDING (grey) at TOP
         // Issue #210 FIX: No null check needed - lastTopCounter initialized to 0
         val upDelta = calculateDelta(lastTopCounter, up)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/RepCounterFromMachine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/RepCounterFromMachine.kt
@@ -396,7 +396,11 @@ class RepCounterFromMachine {
         // machine reports zero ROM/set reps, treat them as stale and re-baseline once so the
         // first real movement yields delta ~0. Deliberately narrow to preserve:
         //   - Issue #210: a real first rep arrives as repsRomCount=1 -> fails repsRomCount==0.
-        //   - Issue #553: sends an explicit up=0/down=0 baseline packet -> fails up>warmupTarget.
+        //   - Issue #553: relies on the up=0/down=0 baseline packet the firmware normally sends
+        //     before warmup -> fails up>warmupTarget. If a fresh Echo set's first packet instead
+        //     arrives with up>warmupTarget and zero ROM/set counts, the warmup reps embedded in
+        //     that jump are dropped here (documented best-effort limit; warmupReps recovers from
+        //     later packets).
         //   - Issue #411: variable-warmup sets use warmupTarget=0 -> fails warmupTarget>0.
         if (!carryoverChecked) {
             carryoverChecked = true

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/RepCounterFromMachine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/RepCounterFromMachine.kt
@@ -450,17 +450,21 @@ class RepCounterFromMachine {
         lastTopCounter = up
         lastCompleteCounter = down
 
-        // WARMUP TRACKING: Use repsRomCount directly from machine (no pending animation)
+        // WARMUP TRACKING: Use repsRomCount directly from machine (no pending animation).
+        // Issue #531: emit one WARMUP_COMPLETED per integer step so a batched/dropped ROM
+        // notification (count jumps 0 -> 2 in a single packet) doesn't drop setup-rep chirps.
         if (repsRomCount > warmupReps && warmupReps < warmupTarget) {
-            warmupReps = repsRomCount.coerceAtMost(warmupTarget)
-
-            onRepEvent?.invoke(
-                RepEvent(
-                    type = RepType.WARMUP_COMPLETED,
-                    warmupCount = warmupReps,
-                    workingCount = workingReps,
-                ),
-            )
+            val warmupRepTarget = repsRomCount.coerceAtMost(warmupTarget)
+            while (warmupReps < warmupRepTarget) {
+                warmupReps++
+                onRepEvent?.invoke(
+                    RepEvent(
+                        type = RepType.WARMUP_COMPLETED,
+                        warmupCount = warmupReps,
+                        workingCount = workingReps,
+                    ),
+                )
+            }
 
             if (warmupReps >= warmupTarget) {
                 onRepEvent?.invoke(
@@ -482,16 +486,19 @@ class RepCounterFromMachine {
         // unreachable because this branch already fires first when repsRomCount==0
         // and repsSetCount==0 — see PR #554 review (gemini-code-assist) feedback.
         else if (repsSetCount == 0 && repsRomCount == 0 && warmupReps < warmupTarget && upDelta > 0) {
-            warmupReps = (warmupReps + upDelta).coerceAtMost(warmupTarget)
-            logDebug("📈 MODERN FALLBACK: Warmup rep $warmupReps (from up counter, repsRomCount=0)")
-
-            onRepEvent?.invoke(
-                RepEvent(
-                    type = RepType.WARMUP_COMPLETED,
-                    warmupCount = warmupReps,
-                    workingCount = workingReps,
-                ),
-            )
+            // Issue #531: per-increment emission for the up-counter fallback too.
+            val warmupRepTarget = (warmupReps + upDelta).coerceAtMost(warmupTarget)
+            while (warmupReps < warmupRepTarget) {
+                warmupReps++
+                logDebug("📈 MODERN FALLBACK: Warmup rep $warmupReps (from up counter, repsRomCount=0)")
+                onRepEvent?.invoke(
+                    RepEvent(
+                        type = RepType.WARMUP_COMPLETED,
+                        warmupCount = warmupReps,
+                        workingCount = workingReps,
+                    ),
+                )
+            }
 
             if (warmupReps >= warmupTarget) {
                 onRepEvent?.invoke(

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -298,9 +298,12 @@ class ActiveSessionEngine(
                     }
 
                     RepType.WARMUP_COMPLETE -> {
+                        // Issue #531: single clean transition tone. Previously also emitted
+                        // WARMUP_TO_WORKING, which maps to the same `beepboop` file on both
+                        // platforms -> a stacked double-tone heard mid-set. The WARMUP_TO_WORKING
+                        // enum + sound mappings remain (used by HapticEventAudioTest and the
+                        // Android routing guard) but are no longer emitted from the rep-event path.
                         coordinator._hapticEvents.emit(HapticEvent.WARMUP_COMPLETE)
-                        // Issue #100: Distinct transition sound from warmup to working sets
-                        coordinator._hapticEvents.emit(HapticEvent.WARMUP_TO_WORKING)
                     }
 
                     RepType.WORKOUT_COMPLETE -> {

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/RepCounterFromMachineTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/RepCounterFromMachineTest.kt
@@ -862,6 +862,27 @@ class RepCounterFromMachineTest {
         assertEquals(1, capturedEvents.count { it.type == RepType.WARMUP_COMPLETED })
     }
 
+    @Test
+    fun `issue 531 carryover guard does not suppress a top-only first packet`() {
+        // Codex PR #596 review: in Echo/fallback telemetry (repsRomCount/repsSetCount stay 0), a
+        // dropped first notification can arrive with the up counter already past the setup target
+        // while down is still at baseline (e.g. up=4, down=0). Those are REAL setup reps, not
+        // carryover from a completed prior set (which leaves BOTH counters elevated). Requiring
+        // both counters past the target means this packet is counted by the fallback branch, not
+        // silently dropped by the guard.
+        repCounter.configure(warmupTarget = 3, workingTarget = 10, isJustLift = false, stopAtTop = false)
+
+        repCounter.process(repsRomCount = 0, repsSetCount = 0, up = 4, down = 0)
+
+        assertEquals(
+            3,
+            repCounter.getRepCount().warmupReps,
+            "Top-only first packet is real dropped-rep telemetry, not carryover — must be counted",
+        )
+        assertEquals(3, capturedEvents.count { it.type == RepType.WARMUP_COMPLETED })
+        assertEquals(1, capturedEvents.count { it.type == RepType.WARMUP_COMPLETE })
+    }
+
 }
 
 class RepRangesTest {

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/RepCounterFromMachineTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/RepCounterFromMachineTest.kt
@@ -816,6 +816,43 @@ class RepCounterFromMachineTest {
         assertEquals(3, repCounter.getRepCount().warmupReps)
     }
 
+    // ========== Issue #531: Carryover guard (phantom-chirp suppression) ==========
+
+    @Test
+    fun `issue 531 large directional carryover does not phantom-fire a warmup rep`() {
+        // Heuristic: the machine's free-running up/down counters can carry over from the prior
+        // set. On the first packet of a fresh set, counters already far past the warmup target
+        // while repsRomCount/repsSetCount are 0 are stale -> must not chirp a phantom warmup rep.
+        repCounter.configure(warmupTarget = 3, workingTarget = 10, isJustLift = false, stopAtTop = false)
+
+        // First packet carries stale up/down = 8 from the previous set.
+        repCounter.process(repsRomCount = 0, repsSetCount = 0, up = 8, down = 8)
+
+        assertEquals(0, repCounter.getRepCount().warmupReps, "Stale carryover must not advance warmup")
+        assertTrue(capturedEvents.isEmpty(), "Carryover packet must emit no rep events")
+
+        // Real warmup reps afterward count normally (delta from the re-baselined counters).
+        repCounter.process(repsRomCount = 1, repsSetCount = 0, up = 9, down = 9)
+        repCounter.process(repsRomCount = 2, repsSetCount = 0, up = 10, down = 10)
+        repCounter.process(repsRomCount = 3, repsSetCount = 0, up = 11, down = 11)
+
+        assertEquals(3, repCounter.getRepCount().warmupReps)
+        assertEquals(3, capturedEvents.count { it.type == RepType.WARMUP_COMPLETED })
+        assertTrue(capturedEvents.any { it.type == RepType.WARMUP_COMPLETE })
+    }
+
+    @Test
+    fun `issue 531 carryover guard ignores a small first up tick`() {
+        // Guard must NOT fire for a plausible fresh-start value (preserves Issue #210): a first
+        // packet with up = 1 is a legitimate first rep, not carryover.
+        repCounter.configure(warmupTarget = 3, workingTarget = 10, isJustLift = false, stopAtTop = false)
+
+        repCounter.process(repsRomCount = 1, repsSetCount = 0, up = 1, down = 1)
+
+        assertEquals(1, repCounter.getRepCount().warmupReps, "Small first up tick is a real rep, not carryover")
+        assertEquals(1, capturedEvents.count { it.type == RepType.WARMUP_COMPLETED })
+    }
+
 }
 
 class RepRangesTest {

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/RepCounterFromMachineTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/RepCounterFromMachineTest.kt
@@ -770,6 +770,52 @@ class RepCounterFromMachineTest {
         assertTrue(count.isWarmupComplete)
     }
 
+    // ========== Issue #531: Per-increment warmup chirp emission ==========
+
+    @Test
+    fun `issue 531 batched warmup ROM jump emits one chirp per rep`() {
+        // A BLE notification can batch/drop so the machine's ROM count jumps by >1 in a
+        // single packet (0 -> 2). Each setup rep must still chirp exactly once.
+        repCounter.configure(warmupTarget = 3, workingTarget = 10, isJustLift = false, stopAtTop = false)
+
+        // Baseline (idle, no movement)
+        repCounter.process(repsRomCount = 0, repsSetCount = 0, up = 0, down = 0)
+
+        // ROM jumps 0 -> 2 in one packet, then -> 3 in the next.
+        repCounter.process(repsRomCount = 2, repsSetCount = 0, up = 2, down = 2)
+        repCounter.process(repsRomCount = 3, repsSetCount = 0, up = 3, down = 3)
+
+        assertEquals(
+            3,
+            capturedEvents.count { it.type == RepType.WARMUP_COMPLETED },
+            "Each setup rep must chirp once even when the ROM count batches",
+        )
+        assertEquals(3, repCounter.getRepCount().warmupReps)
+        assertEquals(
+            1,
+            capturedEvents.count { it.type == RepType.WARMUP_COMPLETE },
+            "WARMUP_COMPLETE fires exactly once when the target is reached",
+        )
+    }
+
+    @Test
+    fun `issue 531 fallback warmup emits one chirp per rep on batched up jump`() {
+        // Firmware that never reports repsRomCount (Echo/unlimited): the up counter can jump
+        // 0 -> 3 in one packet. Per-increment emission must still chirp each setup rep once,
+        // clamped to the warmup target.
+        repCounter.configure(warmupTarget = 3, workingTarget = 10, isJustLift = false, stopAtTop = false)
+
+        repCounter.process(repsRomCount = 0, repsSetCount = 0, up = 0, down = 0)
+        repCounter.process(repsRomCount = 0, repsSetCount = 0, up = 3, down = 0)
+
+        assertEquals(
+            3,
+            capturedEvents.count { it.type == RepType.WARMUP_COMPLETED },
+            "Fallback warmup must chirp once per rep up to the target",
+        )
+        assertEquals(3, repCounter.getRepCount().warmupReps)
+    }
+
 }
 
 class RepRangesTest {

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/RepCounterFromMachineTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/RepCounterFromMachineTest.kt
@@ -814,6 +814,11 @@ class RepCounterFromMachineTest {
             "Fallback warmup must chirp once per rep up to the target",
         )
         assertEquals(3, repCounter.getRepCount().warmupReps)
+        assertEquals(
+            1,
+            capturedEvents.count { it.type == RepType.WARMUP_COMPLETE },
+            "Fallback warmup must fire WARMUP_COMPLETE exactly once on reaching target",
+        )
     }
 
     // ========== Issue #531: Carryover guard (phantom-chirp suppression) ==========
@@ -838,7 +843,11 @@ class RepCounterFromMachineTest {
 
         assertEquals(3, repCounter.getRepCount().warmupReps)
         assertEquals(3, capturedEvents.count { it.type == RepType.WARMUP_COMPLETED })
-        assertTrue(capturedEvents.any { it.type == RepType.WARMUP_COMPLETE })
+        assertEquals(
+            1,
+            capturedEvents.count { it.type == RepType.WARMUP_COMPLETE },
+            "WARMUP_COMPLETE fires exactly once after the real warmup reps",
+        )
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/WarmupTransitionToneTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/WarmupTransitionToneTest.kt
@@ -1,0 +1,51 @@
+package com.devil.phoenixproject.presentation.manager
+
+import com.devil.phoenixproject.domain.model.HapticEvent
+import com.devil.phoenixproject.domain.model.RepEvent
+import com.devil.phoenixproject.domain.model.RepType
+import com.devil.phoenixproject.testutil.DWSMTestHarness
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Issue #531: the warmup -> working transition must play a single clean tone. Previously the
+ * rep-event handler emitted both WARMUP_COMPLETE and WARMUP_TO_WORKING, which map to the same
+ * `beepboop` file on both platforms -> a stacked double-tone heard mid-set.
+ */
+class WarmupTransitionToneTest {
+
+    @Test
+    fun `warmup complete emits a single transition tone`() = runTest {
+        val harness = DWSMTestHarness(this)
+        val collected = mutableListOf<HapticEvent>()
+
+        val job = launch(UnconfinedTestDispatcher(testScheduler)) {
+            harness.coordinator.hapticEvents.toList(collected)
+        }
+
+        // Drive the rep-event path exactly as RepCounterFromMachine does on warmup completion.
+        harness.repCounter.onRepEvent?.invoke(
+            RepEvent(type = RepType.WARMUP_COMPLETE, warmupCount = 3, workingCount = 0),
+        )
+        advanceUntilIdle()
+
+        assertEquals(
+            1,
+            collected.count { it is HapticEvent.WARMUP_COMPLETE },
+            "Exactly one WARMUP_COMPLETE should be emitted",
+        )
+        assertEquals(
+            0,
+            collected.count { it is HapticEvent.WARMUP_TO_WORKING },
+            "WARMUP_TO_WORKING must no longer be emitted (single clean transition tone)",
+        )
+
+        job.cancel()
+        harness.cleanup()
+    }
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/WarmupTransitionToneTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/WarmupTransitionToneTest.kt
@@ -28,24 +28,26 @@ class WarmupTransitionToneTest {
             harness.coordinator.hapticEvents.toList(collected)
         }
 
-        // Drive the rep-event path exactly as RepCounterFromMachine does on warmup completion.
-        harness.repCounter.onRepEvent?.invoke(
-            RepEvent(type = RepType.WARMUP_COMPLETE, warmupCount = 3, workingCount = 0),
-        )
-        advanceUntilIdle()
+        try {
+            // Drive the rep-event path exactly as RepCounterFromMachine does on warmup completion.
+            harness.repCounter.onRepEvent?.invoke(
+                RepEvent(type = RepType.WARMUP_COMPLETE, warmupCount = 3, workingCount = 0),
+            )
+            advanceUntilIdle()
 
-        assertEquals(
-            1,
-            collected.count { it is HapticEvent.WARMUP_COMPLETE },
-            "Exactly one WARMUP_COMPLETE should be emitted",
-        )
-        assertEquals(
-            0,
-            collected.count { it is HapticEvent.WARMUP_TO_WORKING },
-            "WARMUP_TO_WORKING must no longer be emitted (single clean transition tone)",
-        )
-
-        job.cancel()
-        harness.cleanup()
+            assertEquals(
+                1,
+                collected.count { it is HapticEvent.WARMUP_COMPLETE },
+                "Exactly one WARMUP_COMPLETE should be emitted",
+            )
+            assertEquals(
+                0,
+                collected.count { it is HapticEvent.WARMUP_TO_WORKING },
+                "WARMUP_TO_WORKING must no longer be emitted (single clean transition tone)",
+            )
+        } finally {
+            job.cancel()
+            harness.cleanup()
+        }
     }
 }


### PR DESCRIPTION
Fixes the three setup-rep audio symptoms reported in #531 (iOS, build 18252).

## Symptoms → root cause → fix

All three live in `RepCounterFromMachine.processModern()` (rep counting from BLE notifications), plus one line in `ActiveSessionEngine`.

| Symptom | Root cause | Fix | Commit |
|---|---|---|---|
| Only 2 of 3 setup reps chirp | Primary warmup branch emitted **one** `WARMUP_COMPLETED` per packet but jumped the count straight to the machine value, so batched/dropped BLE ROM counts lost chirps | Emit **one chirp per integer step** in both `processModern` warmup branches (mirrors the legacy `repeat(delta)`) | `80d04a7` |
| Phantom chirp before you move | Machine's free-running `up`/`down` counters carry over from the prior set; the first packet's delta fired a phantom warmup rep | **Narrow one-shot carryover guard** re-baselines once when counters are already past the warmup target while ROM/set counts are 0 | `3924066` |
| Stray "end-of-set"-like tone mid-set | `WARMUP_COMPLETE` + `WARMUP_TO_WORKING` both emitted, both mapping to the same `beepboop` file → stacked double-tone | Emit a **single** transition tone (drop the redundant `WARMUP_TO_WORKING` emission; enum + sound maps retained) | `2bcb15a` |

## Design constraints preserved (verified by existing tests)
- **#210** — first packet of a set still counts immediately; counts stay absolute-from-machine.
- **#553** — Echo/unlimited up-counter warmup fallback still progresses.
- **#411** — variable-warmup (`warmupTarget=0`) sets gain no gating.

## Honesty note — symptom 1 is best-effort
The carryover guard only catches **large** directional carryover. If the real phantom is a small slack-takeup tick, the guard is a harmless no-op and the remaining mechanism needs a real `REP_RECEIVED` packet trace to resolve. Chosen over the original "discard first packet" baseline because that approach regressed #210 (4 existing tests assert the first packet must count).

## Test plan
- [x] `./gradlew :shared:testAndroidHostTest` — full shared suite green (new: `RepCounterFromMachineTest` cases + `WarmupTransitionToneTest`)
- [x] `./gradlew :androidApp:assembleDebug` — green
- [ ] **On-device (required before merge):** iOS — normal mode: no chirp before the first setup rep, exactly 3 setup chirps, single clean transition tone, no stray tone during working reps. Echo mode: warmup still progresses past "Warm Up 1/3" (#553 not regressed).

## Note
Design spec + implementation plan are included under `docs/superpowers/`. This branch also carries one unrelated docs commit, `052e234b` (velocity-1RM foundation plan, #517), which landed mid-session — kept in intentionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)