### PR TITLE
feat(1rm): velocity-based 1RM foundation (Phases 1-2) (#517)

### DIFF
--- a/.github/workflows/android-playstore.yml
+++ b/.github/workflows/android-playstore.yml
@@ -145,6 +145,9 @@ jobs:
           echo "supabase.url=${{ secrets.SUPABASE_URL }}" >> local.properties
           echo "supabase.anon.key=${{ secrets.SUPABASE_ANON_KEY }}" >> local.properties
 
+      - name: Verify Android Supabase runtime config
+        run: ./gradlew :androidApp:verifySupabaseRuntimeConfig
+
       - name: Build Release AAB (signed)
         env:
           KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}

--- a/.github/workflows/android-release-apk.yml
+++ b/.github/workflows/android-release-apk.yml
@@ -156,6 +156,9 @@ jobs:
           echo "supabase.url=${{ secrets.SUPABASE_URL }}" >> local.properties
           echo "supabase.anon.key=${{ secrets.SUPABASE_ANON_KEY }}" >> local.properties
 
+      - name: Verify Android Supabase runtime config
+        run: ./gradlew :androidApp:verifySupabaseRuntimeConfig
+
       - name: Build Release APK (signed)
         env:
           KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,14 +17,10 @@ Keep this managed block so 'openspec update' can refresh the instructions.
 
 <!-- OPENSPEC:END -->
 
-## Agent & Sub-Task Constraints
+## Working Rules
 
-- Spawned agents MUST use ONLY configured MCP tools (Daem0n, Vitruvian) — no freelancing
-- Agents MUST follow project skills in `.claude/skills/` (daem0nmcp-protocol, agent-browser)
-- Agents MUST NOT use tools or skills from other projects (OpenCode, TheBeckoningMU, DaemonChat)
-- Verify agent work against project `.mcp.json` configuration before accepting results
-
-BEFORE ANYTHING ELSE!!!  Look at the parent repo to see how something was implemented in a working fashion before trying to troubleshoot or make changes
+- BEFORE ANYTHING ELSE: check the monorepo parent (`../CLAUDE.md`) and the `phoenix-portal` sibling for how a feature was implemented on the working side before troubleshooting or changing it. Mobile and portal share a parity-critical contract (see Sync Architecture below).
+- Spawned agents must stay within this project's tools and skills (`.claude/skills/agent-browser`); don't pull in tooling from unrelated projects.
 
 # CLAUDE.md
 
@@ -92,9 +88,10 @@ SQLDelight schema at `shared/src/commonMain/sqldelight/.../VitruvianDatabase.sq`
 - **Routine/RoutineExercise** - Custom workout routines
 
 ### Domain Models
-Located in `shared/src/commonMain/kotlin/com/example/vitruvianredux/domain/model/`:
-- **WorkoutModels.kt**: WorkoutMode (6 modes), ConnectionState, WorkoutMetrics, WorkoutSession
-- **ExerciseModels.kt**: MuscleGroup (12 groups), Exercise, Routine
+Located in `shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/`:
+- **Models.kt**: WorkoutMode (6 modes), ConnectionState, WorkoutMetrics, WorkoutSession
+- **Exercise.kt**, **Routine.kt**: Exercise, MuscleGroup, Routine
+- **Gamification.kt**, **RpgModels.kt**, **BiomechanicsModels.kt**, **TrainingCycleModels.kt**: gamification, RPG scoring, velocity zones, cycles
 
 ### Constants
 `util/Constants.kt` contains:
@@ -113,7 +110,6 @@ Located in `shared/src/commonMain/kotlin/com/example/vitruvianredux/domain/model
 ## Hardware Support
 - **Vitruvian V-Form Trainer** (VIT-200): 200kg max, device name `Vee_*`
 - **Vitruvian Trainer+**: 220kg max
-- IMPORTANT: When applicable, prefer using jetbrains-index MCP tools for code navigation and refactoring.
 
 ## Sync Architecture
 
@@ -156,56 +152,3 @@ Uses multiplatform-settings with Keychain backend (`KeychainSettings`) for secur
 - Mobile computes the estimate per exercise-session (per-cable kg) and ships it as `PortalExerciseDto.estimatedOneRepMaxKg`. The portal stores it verbatim in `exercise_progress.estimated_1rm_kg` and recomputes (same hybrid) ONLY when the field is absent (legacy payloads). Mirror any change in the phoenix-portal counterpart.
 - Max-weight PRs (`personal_records`) are a SEPARATE metric from the estimated 1RM — do not relabel one as the other.
 - Stored `Exercise.one_rep_max_kg` (manual 5/3/1 input or VBT assessment) is the fallback scaling baseline for `% of PR` routines when no matching PersonalRecord exists (`ResolveRoutineWeightsUseCase`).
-
-## The Daem0n's Covenant (v6.6.6 - Enforced)
-
-This project is bound to Daem0n for persistent AI memory. **The covenant is ENFORCED at the protocol layer** - mutating tools block with `COMMUNION_REQUIRED` or `COUNSEL_REQUIRED` errors until proper rituals are observed.
-
-**11 MCP tools (8 workflows + 3 cognitive), 63 actions.** The Daem0n speaks through workflow tools with `action` parameters:
-
-| Workflow | Purpose |
-|----------|---------|
-| `commune` | Session start & status (`briefing`, `active_context`, `triggers`, `health`, `covenant`, `updates`) |
-| `consult` | Pre-action intelligence (`preflight`, `recall`, `recall_file`, `recall_entity`, `recall_hierarchical`, `search`, `check_rules`, `compress`) |
-| `inscribe` | Memory writing & linking (`remember`, `remember_batch`, `link`, `unlink`, `pin`, `activate`, `deactivate`, `clear_active`, `ingest`) |
-| `reflect` | Outcomes & verification (`outcome`, `verify`, `execute`) |
-| `understand` | Code comprehension (`index`, `find`, `impact`, `todos`, `refactor`) |
-| `govern` | Rules & triggers (`add_rule`, `update_rule`, `list_rules`, `add_trigger`, `list_triggers`, `remove_trigger`) |
-| `explore` | Graph & discovery (`related`, `chain`, `graph`, `stats`, `communities`, `community_detail`, `rebuild_communities`, `entities`, `backfill_entities`, `evolution`, `versions`, `at_time`) |
-| `maintain` | Housekeeping & federation (`prune`, `archive`, `cleanup`, `compact`, `rebuild_index`, `export`, `import_data`, `link_project`, `unlink_project`, `list_projects`, `consolidate`, `purge_dream_spam`) |
-
-### At Session Dawn (MANDATORY)
-- Commune with `commune(action="briefing", project_path="C:/Users/dasbl/AndroidStudioProjects/Project-Phoenix-MP")` immediately
-- **This is enforced** - other tools will refuse to act until communion is complete
-- Heed any warnings or failed approaches before beginning work
-
-### Before Alterations (MANDATORY for mutations)
-- Cast `consult(action="preflight", description="your intention", project_path="...")` before modifications
-- This grants a **preflight token** valid for 5 minutes proving consultation
-- Cast `consult(action="recall_file", file_path="path", project_path="...")` when touching specific files
-- Acknowledge any warnings about past failures
-
-### After Decisions
-- Cast `inscribe(action="remember", category=..., content=..., rationale=..., file_path=..., project_path="...")` to inscribe decisions
-- Use categories: decision, pattern, warning, learning
-- **Always pass project_path** on every invocation
-
-### After Completion
-- Cast `reflect(action="outcome", memory_id=..., outcome_text=..., worked=..., project_path="...")` to seal the memory
-- ALWAYS record failures (worked=false) - they illuminate future paths
-
-### Cognitive Tools (v6.0.0 - The Three Minds)
-Three standalone reasoning tools for autonomous thought:
-- `simulate_decision(decision_id=..., project_path="...")` - Temporal scrying: replay a past decision with current knowledge
-- `evolve_rule(rule_id=..., project_path="...")` - Rule entropy analysis: detect staleness and suggest evolution
-- `debate_internal(topic=..., advocate_position=..., challenger_position=..., project_path="...")` - Adversarial council: evidence-grounded debate with convergence detection
-
-### MCP Resources (Auto-Injected Context)
-The Daem0n provides subscribable resources for automatic context injection:
-- `daem0n://warnings/{project_path}` - Active warnings
-- `daem0n://failed/{project_path}` - Failed approaches to avoid
-- `daem0n://rules/{project_path}` - All configured rules
-- `daem0n://context/{project_path}` - Combined context (warnings + failed + rules)
-- `daem0n://triggered/{file_path}` - Auto-recalled context for a specific file
-
-See Summon_Daem0n.md for the complete Grimoire (11 tools, 64 actions).

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.net.InetAddress
+import java.net.URI
 import java.util.zip.CRC32
 import java.util.zip.ZipFile
 
@@ -96,6 +98,30 @@ abstract class VerifyReleaseCueResourcesTask : DefaultTask() {
     }
 }
 
+abstract class VerifySupabaseRuntimeConfigTask : DefaultTask() {
+    @get:Input
+    abstract val configuredSupabaseUrl: Property<String>
+
+    @TaskAction
+    fun verifyRuntimeConfig() {
+        val url = configuredSupabaseUrl.get()
+        val uri = runCatching { URI(url) }.getOrNull()
+            ?: throw GradleException("Invalid Supabase URL '$url'. Expected a full https URL.")
+        if (uri.scheme != "https" || uri.host.isNullOrBlank()) {
+            throw GradleException("Invalid Supabase URL '$url'. Expected a full https URL.")
+        }
+
+        val host = uri.host.lowercase()
+
+        val addresses = InetAddress.getAllByName(host)
+        if (addresses.isEmpty()) {
+            throw GradleException("Supabase host '$host' did not resolve.")
+        }
+
+        println("Android Supabase config verified: host=$host, dnsAddresses=${addresses.size}, authPath=/auth/v1")
+    }
+}
+
 // Read Supabase config from local.properties, falling back to environment variables for CI/CD
 val localPropsFile = rootProject.file("local.properties")
 val localPropsMap: Map<String, String> = if (localPropsFile.exists()) {
@@ -117,6 +143,15 @@ val supabaseAnonKey: String = localPropsMap["supabase.anon.key"]?.takeIf { it.is
     ?: System.getenv("SUPABASE_ANON_KEY")
     ?: ""
 
+fun validateSupabaseUrl(url: String) {
+    val uri = runCatching { URI(url) }.getOrNull()
+        ?: throw GradleException("Invalid Supabase URL '$url'. Expected a full https URL.")
+
+    if (uri.scheme != "https" || uri.host.isNullOrBlank()) {
+        throw GradleException("Invalid Supabase URL '$url'. Expected a full https URL.")
+    }
+}
+
 // Validate Supabase credentials unless explicitly skipped (e.g., CI builds that only run tests)
 val skipSupabaseCheck = providers.gradleProperty("skip.supabase.check").orNull?.toBoolean() ?: false
 if (!skipSupabaseCheck && (supabaseUrl.isBlank() || supabaseAnonKey.isBlank())) {
@@ -125,6 +160,15 @@ if (!skipSupabaseCheck && (supabaseUrl.isBlank() || supabaseAnonKey.isBlank())) 
             "or environment variables (SUPABASE_URL, SUPABASE_ANON_KEY), " +
             "or pass -Pskip.supabase.check=true for test-only builds.",
     )
+}
+if (!skipSupabaseCheck && supabaseUrl.isNotBlank()) {
+    validateSupabaseUrl(supabaseUrl)
+}
+
+tasks.register<VerifySupabaseRuntimeConfigTask>("verifySupabaseRuntimeConfig") {
+    group = "verification"
+    description = "Validates the Android runtime Supabase URL and logs a non-secret host summary."
+    configuredSupabaseUrl.set(supabaseUrl)
 }
 
 val injectedVersionCode = providers.gradleProperty("version.code").orNull?.let { raw ->

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/local/SchemaParityTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/local/SchemaParityTest.kt
@@ -334,7 +334,7 @@ class SchemaParityTest {
     // ==================== HELPERS ====================
 
     companion object {
-        private const val CURRENT_VERSION = 37L
+        private const val CURRENT_VERSION = 38L
 
         /**
          * Transient tables are intermediate artifacts of table-rebuild migrations

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/local/SchemaParityTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/local/SchemaParityTest.kt
@@ -334,7 +334,7 @@ class SchemaParityTest {
     // ==================== HELPERS ====================
 
     companion object {
-        private const val CURRENT_VERSION = 36L
+        private const val CURRENT_VERSION = 37L
 
         /**
          * Transient tables are intermediate artifacts of table-rebuild migrations

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/migration/MigrationManagerTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/migration/MigrationManagerTest.kt
@@ -523,6 +523,7 @@ class MigrationManagerTest {
             aliases = null,
             defaultCableConfig = "DOUBLE",
             one_rep_max_kg = oneRepMaxKg,
+            mvtOverrideMs = null,
         )
     }
 

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightAssessmentRepositoryTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightAssessmentRepositoryTest.kt
@@ -82,6 +82,7 @@ class SqlDelightAssessmentRepositoryTest {
             aliases = null,
             defaultCableConfig = "DOUBLE",
             one_rep_max_kg = null,
+            mvtOverrideMs = null,
         )
     }
 }

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightExerciseRepositoryTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightExerciseRepositoryTest.kt
@@ -270,6 +270,7 @@ class SqlDelightExerciseRepositoryTest {
             aliases = null,
             defaultCableConfig = defaultCableConfig,
             one_rep_max_kg = oneRepMaxKg,
+            mvtOverrideMs = null,
         )
     }
 }

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightPersonalMvtRepositoryTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightPersonalMvtRepositoryTest.kt
@@ -1,0 +1,58 @@
+package com.devil.phoenixproject.data.repository
+
+import com.devil.phoenixproject.database.VitruvianDatabase
+import com.devil.phoenixproject.testutil.createTestDatabase
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class SqlDelightPersonalMvtRepositoryTest {
+
+    private fun createInMemoryTestDatabase(): VitruvianDatabase = createTestDatabase()
+
+    private fun seedExercise(db: VitruvianDatabase, id: String) {
+        db.vitruvianDatabaseQueries.insertExercise(
+            id = id,
+            name = id,
+            displayName = null,
+            description = null,
+            created = 0L,
+            muscleGroup = "Chest",
+            muscleGroups = "Chest",
+            muscles = null,
+            equipment = "BAR",
+            movement = null,
+            sidedness = null,
+            grip = null,
+            gripWidth = null,
+            minRepRange = null,
+            popularity = 0.0,
+            archived = 0L,
+            isFavorite = 0L,
+            isCustom = 0L,
+            timesPerformed = 0L,
+            lastPerformed = null,
+            aliases = null,
+            defaultCableConfig = "DOUBLE",
+            one_rep_max_kg = null,
+            mvtOverrideMs = null,
+        )
+    }
+
+    @Test
+    fun `upsert then get round-trips and updates`() = runTest {
+        val db = createInMemoryTestDatabase()
+        seedExercise(db, id = "ex1")
+        val repo = SqlDelightPersonalMvtRepository(db)
+        assertNull(repo.get("ex1", "default"))
+
+        repo.upsert("ex1", "default", personalMvtMs = 0.18f, sampleCount = 1)
+        assertEquals(1, repo.get("ex1", "default")?.sampleCount)
+
+        repo.upsert("ex1", "default", personalMvtMs = 0.19f, sampleCount = 2)
+        val updated = repo.get("ex1", "default")
+        assertEquals(2, updated?.sampleCount)
+        assertEquals(0.19f, updated?.personalMvtMs)
+    }
+}

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightPersonalRecordRepositoryTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightPersonalRecordRepositoryTest.kt
@@ -167,7 +167,7 @@ class SqlDelightPersonalRecordRepositoryTest {
             minRepRange = null, popularity = 0.0, archived = 0L,
             isFavorite = 0L, isCustom = 0L, timesPerformed = 0L,
             lastPerformed = null, aliases = null, defaultCableConfig = "DOUBLE",
-            one_rep_max_kg = null,
+            one_rep_max_kg = null, mvtOverrideMs = null,
         )
 
         // Trigger fires on the 1RM sync (third write in the transaction),
@@ -252,6 +252,7 @@ class SqlDelightPersonalRecordRepositoryTest {
             aliases = null,
             defaultCableConfig = "DOUBLE",
             one_rep_max_kg = null,
+            mvtOverrideMs = null,
         )
     }
 }

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepositoryTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepositoryTest.kt
@@ -173,7 +173,7 @@ class SqlDelightSyncRepositoryTest {
         // column order: id, name, displayName, description, created, muscleGroup,
         // muscleGroups, muscles, equipment, movement, sidedness, grip, gripWidth,
         // minRepRange, popularity, archived, isFavorite, isCustom, timesPerformed,
-        // lastPerformed, aliases, defaultCableConfig, one_rep_max_kg.
+        // lastPerformed, aliases, defaultCableConfig, one_rep_max_kg, mvtOverrideMs.
         database.vitruvianDatabaseQueries.insertExercise(
             "bench-press",
             "Bench Press",
@@ -197,6 +197,7 @@ class SqlDelightSyncRepositoryTest {
             null,
             null,
             "DUAL",
+            null,
             null,
         )
 

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightVelocityOneRepMaxRepositoryTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightVelocityOneRepMaxRepositoryTest.kt
@@ -1,0 +1,77 @@
+package com.devil.phoenixproject.data.repository
+
+import com.devil.phoenixproject.database.VitruvianDatabase
+import com.devil.phoenixproject.domain.onerepmax.VelocityOneRepMaxResult
+import com.devil.phoenixproject.testutil.createTestDatabase
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+
+class SqlDelightVelocityOneRepMaxRepositoryTest {
+
+    private fun createInMemoryTestDatabase(): VitruvianDatabase = createTestDatabase()
+
+    private fun seedExercise(db: VitruvianDatabase, id: String) {
+        db.vitruvianDatabaseQueries.insertExercise(
+            id = id,
+            name = id,
+            displayName = null,
+            description = null,
+            created = 0L,
+            muscleGroup = "Chest",
+            muscleGroups = "Chest",
+            muscles = null,
+            equipment = "BAR",
+            movement = null,
+            sidedness = null,
+            grip = null,
+            gripWidth = null,
+            minRepRange = null,
+            popularity = 0.0,
+            archived = 0L,
+            isFavorite = 0L,
+            isCustom = 0L,
+            timesPerformed = 0L,
+            lastPerformed = null,
+            aliases = null,
+            defaultCableConfig = "DOUBLE",
+            one_rep_max_kg = null,
+        )
+    }
+
+    private fun result(estimate: Float, passed: Boolean) =
+        VelocityOneRepMaxResult(
+            estimatedPerCableKg = estimate,
+            mvtUsedMs = 0.3f,
+            r2 = if (passed) 0.95f else 0.4f,
+            distinctLoads = 3,
+            passedQualityGate = passed,
+        )
+
+    @Test
+    fun `insert then latest passing returns most recent passing row`() = runTest {
+        val db = createInMemoryTestDatabase()
+        seedExercise(db, id = "ex1")
+        val repo = SqlDelightVelocityOneRepMaxRepository(db)
+
+        repo.insert(result(100f, passed = true), exerciseId = "ex1", computedAt = 1_000L, profileId = "default")
+        repo.insert(result(120f, passed = false), exerciseId = "ex1", computedAt = 2_000L, profileId = "default")
+        repo.insert(result(110f, passed = true), exerciseId = "ex1", computedAt = 3_000L, profileId = "default")
+
+        val latest = repo.getLatestPassing("ex1", "default")
+        assertEquals(110f, latest?.estimatedPerCableKg)
+        assertTrue(latest!!.passedQualityGate)
+    }
+
+    @Test
+    fun `latest passing is null when only failing rows exist`() = runTest {
+        val db = createInMemoryTestDatabase()
+        seedExercise(db, id = "ex2")
+        val repo = SqlDelightVelocityOneRepMaxRepository(db)
+        repo.insert(result(90f, passed = false), exerciseId = "ex2", computedAt = 1_000L, profileId = "default")
+        assertNull(repo.getLatestPassing("ex2", "default"))
+    }
+}

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightVelocityOneRepMaxRepositoryTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightVelocityOneRepMaxRepositoryTest.kt
@@ -38,6 +38,7 @@ class SqlDelightVelocityOneRepMaxRepositoryTest {
             aliases = null,
             defaultCableConfig = "DOUBLE",
             one_rep_max_kg = null,
+            mvtOverrideMs = null,
         )
     }
 

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightVelocityOneRepMaxRepositoryTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightVelocityOneRepMaxRepositoryTest.kt
@@ -8,7 +8,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
-import org.junit.Before
 
 class SqlDelightVelocityOneRepMaxRepositoryTest {
 
@@ -63,6 +62,20 @@ class SqlDelightVelocityOneRepMaxRepositoryTest {
 
         val latest = repo.getLatestPassing("ex1", "default")
         assertEquals(110f, latest?.estimatedPerCableKg)
+        assertTrue(latest!!.passedQualityGate)
+    }
+
+    @Test
+    fun `latest passing skips a newer failing row`() = runTest {
+        val db = createInMemoryTestDatabase()
+        seedExercise(db, id = "ex3")
+        val repo = SqlDelightVelocityOneRepMaxRepository(db)
+
+        repo.insert(result(100f, passed = true), exerciseId = "ex3", computedAt = 1_000L, profileId = "default")
+        repo.insert(result(120f, passed = false), exerciseId = "ex3", computedAt = 2_000L, profileId = "default")
+
+        val latest = repo.getLatestPassing("ex3", "default")
+        assertEquals(100f, latest?.estimatedPerCableKg)
         assertTrue(latest!!.passedQualityGate)
     }
 

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepositoryVelocityPointsTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepositoryVelocityPointsTest.kt
@@ -36,6 +36,7 @@ class SqlDelightWorkoutRepositoryVelocityPointsTest {
             aliases = null,
             defaultCableConfig = "DOUBLE",
             one_rep_max_kg = null,
+            mvtOverrideMs = null,
         )
     }
 

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepositoryVelocityPointsTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepositoryVelocityPointsTest.kt
@@ -141,4 +141,51 @@ class SqlDelightWorkoutRepositoryVelocityPointsTest {
         assertEquals(40f, points.first().loadPerCableKg, "workingAvgWeightKg must be preferred over weightPerCableKg")
         assertEquals(1200f, points.first().mcvMmS, "MCV must be preserved as mm/s")
     }
+
+    @Test
+    fun `excludes null-MCV and zero-rep sessions within the window`() = runTest {
+        val db = createInMemoryTestDatabase()
+        seedExercise(db, id = "ex1")
+        val exerciseRepo = SqlDelightExerciseRepository(db, ExerciseImporter(db))
+        val repo = SqlDelightWorkoutRepository(db, exerciseRepo)
+
+        // (a) qualifying in-window session
+        seedSession(
+            db,
+            exerciseId = "ex1",
+            weightPerCableKg = 50f,
+            workingAvgWeightKg = 48f,
+            avgMcvMmS = 900f,
+            timestamp = 3000L,
+            workingReps = 5,
+            profileId = "default",
+        )
+        // (b) in-window but null MCV — excluded by WHERE avgMcvMmS IS NOT NULL
+        seedSession(
+            db,
+            exerciseId = "ex1",
+            weightPerCableKg = 60f,
+            workingAvgWeightKg = 58f,
+            avgMcvMmS = null,
+            timestamp = 3500L,
+            workingReps = 5,
+            profileId = "default",
+        )
+        // (c) in-window but zero working reps — excluded by WHERE workingReps > 0
+        seedSession(
+            db,
+            exerciseId = "ex1",
+            weightPerCableKg = 70f,
+            workingAvgWeightKg = 68f,
+            avgMcvMmS = 800f,
+            timestamp = 4000L,
+            workingReps = 0,
+            profileId = "default",
+        )
+
+        val points = repo.getVelocityPointsForExercise("ex1", "default", sinceTimestampMs = 1000L)
+        assertEquals(1, points.size, "Only the session with non-null MCV and working reps should qualify")
+        assertEquals(48f, points.first().loadPerCableKg)
+        assertEquals(900f, points.first().mcvMmS)
+    }
 }

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepositoryVelocityPointsTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepositoryVelocityPointsTest.kt
@@ -1,0 +1,144 @@
+package com.devil.phoenixproject.data.repository
+
+import com.devil.phoenixproject.data.local.ExerciseImporter
+import com.devil.phoenixproject.database.VitruvianDatabase
+import com.devil.phoenixproject.testutil.createTestDatabase
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+
+class SqlDelightWorkoutRepositoryVelocityPointsTest {
+
+    private fun createInMemoryTestDatabase(): VitruvianDatabase = createTestDatabase()
+
+    private fun seedExercise(db: VitruvianDatabase, id: String) {
+        db.vitruvianDatabaseQueries.insertExercise(
+            id = id,
+            name = id,
+            displayName = null,
+            description = null,
+            created = 0L,
+            muscleGroup = "Chest",
+            muscleGroups = "Chest",
+            muscles = null,
+            equipment = "BAR",
+            movement = null,
+            sidedness = null,
+            grip = null,
+            gripWidth = null,
+            minRepRange = null,
+            popularity = 0.0,
+            archived = 0L,
+            isFavorite = 0L,
+            isCustom = 0L,
+            timesPerformed = 0L,
+            lastPerformed = null,
+            aliases = null,
+            defaultCableConfig = "DOUBLE",
+            one_rep_max_kg = null,
+        )
+    }
+
+    private var sessionCounter = 0
+
+    private fun seedSession(
+        db: VitruvianDatabase,
+        exerciseId: String,
+        weightPerCableKg: Float,
+        workingAvgWeightKg: Float?,
+        avgMcvMmS: Float?,
+        timestamp: Long,
+        workingReps: Int,
+        profileId: String,
+    ) {
+        db.vitruvianDatabaseQueries.insertSession(
+            id = "session-${++sessionCounter}",
+            timestamp = timestamp,
+            mode = "Program:OldSchool",
+            targetReps = 5L,
+            weightPerCableKg = weightPerCableKg.toDouble(),
+            progressionKg = 0.0,
+            duration = 30_000L,
+            totalReps = workingReps.toLong(),
+            warmupReps = 0L,
+            workingReps = workingReps.toLong(),
+            isJustLift = 0L,
+            stopAtTop = 0L,
+            eccentricLoad = 100L,
+            echoLevel = 0L,
+            exerciseId = exerciseId,
+            exerciseName = exerciseId,
+            routineSessionId = null,
+            routineName = null,
+            routineId = null,
+            safetyFlags = 0L,
+            deloadWarningCount = 0L,
+            romViolationCount = 0L,
+            spotterActivations = 0L,
+            peakForceConcentricA = null,
+            peakForceConcentricB = null,
+            peakForceEccentricA = null,
+            peakForceEccentricB = null,
+            avgForceConcentricA = null,
+            avgForceConcentricB = null,
+            avgForceEccentricA = null,
+            avgForceEccentricB = null,
+            heaviestLiftKg = null,
+            totalVolumeKg = null,
+            cableCount = null,
+            estimatedCalories = null,
+            warmupAvgWeightKg = null,
+            workingAvgWeightKg = workingAvgWeightKg?.toDouble(),
+            burnoutAvgWeightKg = null,
+            peakWeightKg = null,
+            rpe = null,
+            avgMcvMmS = avgMcvMmS?.toDouble(),
+            avgAsymmetryPercent = null,
+            totalVelocityLossPercent = null,
+            dominantSide = null,
+            strengthProfile = null,
+            formScore = null,
+            profile_id = profileId,
+            display_multiplier = null,
+            externalAddedLoadKg = 0.0,
+            counterweightKg = 0.0,
+            rackItemsJson = "[]",
+        )
+    }
+
+    @Test
+    fun `returns one point per qualifying session using working avg weight`() = runTest {
+        val db = createInMemoryTestDatabase()
+        seedExercise(db, id = "ex1")
+        val exerciseRepo = SqlDelightExerciseRepository(db, ExerciseImporter(db))
+        val repo = SqlDelightWorkoutRepository(db, exerciseRepo)
+
+        // session A: inside window — workingAvgWeightKg=40 must win over weightPerCableKg=42
+        seedSession(
+            db,
+            exerciseId = "ex1",
+            weightPerCableKg = 42f,
+            workingAvgWeightKg = 40f,
+            avgMcvMmS = 1200f,
+            timestamp = 2000L,
+            workingReps = 5,
+            profileId = "default",
+        )
+        // session B: before sinceTimestamp — must be excluded
+        seedSession(
+            db,
+            exerciseId = "ex1",
+            weightPerCableKg = 80f,
+            workingAvgWeightKg = 80f,
+            avgMcvMmS = 600f,
+            timestamp = 100L,
+            workingReps = 5,
+            profileId = "default",
+        )
+
+        val points = repo.getVelocityPointsForExercise("ex1", "default", sinceTimestampMs = 1000L)
+        assertEquals(1, points.size, "Only the in-window session should be returned")
+        assertEquals(40f, points.first().loadPerCableKg, "workingAvgWeightKg must be preferred over weightPerCableKg")
+        assertEquals(1200f, points.first().mcvMmS, "MCV must be preserved as mm/s")
+    }
+}

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/di/KoinModuleVerifyTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/di/KoinModuleVerifyTest.kt
@@ -40,6 +40,12 @@ class KoinModuleVerifyTest {
                 WorkoutServiceController::class,
                 // Lambda types used in constructor injection (e.g. PortalApiClient tokenProvider)
                 Function0::class,
+                // Function-typed collaborators of ComputeVelocityOneRepMaxUseCase (issue #517):
+                // supplied as lambdas inside the module, not resolved from the graph.
+                Function2::class,
+                Function3::class,
+                Function4::class,
+                Function5::class,
             ),
         )
     }

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/e2e/WorkoutFlowE2ETest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/e2e/WorkoutFlowE2ETest.kt
@@ -87,6 +87,22 @@ class WorkoutFlowE2ETest {
             dataBackupManager = FakeDataBackupManager(),
             userProfileRepository = com.devil.phoenixproject.testutil.FakeUserProfileRepository(),
             workoutServiceController = NoOpWorkoutServiceController,
+            computeVelocityOneRepMaxUseCase = com.devil.phoenixproject.domain.usecase.ComputeVelocityOneRepMaxUseCase(
+                workoutPoints = { _, _, _ -> emptyList() },
+                exerciseLookup = { null },
+                personalMvtLookup = { _, _ -> null },
+                mvtProvider = com.devil.phoenixproject.domain.onerepmax.MvtProvider(),
+                estimator = com.devil.phoenixproject.domain.onerepmax.VelocityOneRepMaxEstimator(
+                    com.devil.phoenixproject.domain.assessment.AssessmentEngine(),
+                ),
+                persist = { _, _, _, _ -> },
+            ),
+            recordPersonalMvtSampleUseCase = com.devil.phoenixproject.domain.usecase.RecordPersonalMvtSampleUseCase(
+                object : com.devil.phoenixproject.data.repository.PersonalMvtRepository {
+                    override suspend fun get(exerciseId: String, profileId: String) = null
+                    override suspend fun upsert(exerciseId: String, profileId: String, personalMvtMs: Float, sampleCount: Int) {}
+                },
+            ),
         )
 
         robot = WorkoutRobot(viewModel, fakeBleRepository)

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/e2e/WorkoutFlowE2ETest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/e2e/WorkoutFlowE2ETest.kt
@@ -103,6 +103,11 @@ class WorkoutFlowE2ETest {
                     override suspend fun upsert(exerciseId: String, profileId: String, personalMvtMs: Float, sampleCount: Int) {}
                 },
             ),
+            velocityOneRepMaxRepository = object : com.devil.phoenixproject.data.repository.VelocityOneRepMaxRepository {
+                override suspend fun insert(result: com.devil.phoenixproject.domain.onerepmax.VelocityOneRepMaxResult, exerciseId: String, computedAt: Long, profileId: String) {}
+                override suspend fun getLatestPassing(exerciseId: String, profileId: String): com.devil.phoenixproject.data.repository.VelocityOneRepMaxEntity? = null
+                override fun getHistory(exerciseId: String, profileId: String): kotlinx.coroutines.flow.Flow<List<com.devil.phoenixproject.data.repository.VelocityOneRepMaxEntity>> = kotlinx.coroutines.flow.flowOf(emptyList())
+            },
         )
 
         robot = WorkoutRobot(viewModel, fakeBleRepository)

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModelTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModelTest.kt
@@ -523,6 +523,7 @@ class ExerciseConfigViewModelTest {
             aliases = null,
             defaultCableConfig = "DOUBLE",
             one_rep_max_kg = null,
+            mvtOverrideMs = null,
         )
     }
 

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModelTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModelTest.kt
@@ -102,6 +102,22 @@ class MainViewModelTest {
             dataBackupManager = FakeDataBackupManager(),
             userProfileRepository = com.devil.phoenixproject.testutil.FakeUserProfileRepository(),
             workoutServiceController = NoOpWorkoutServiceController,
+            computeVelocityOneRepMaxUseCase = com.devil.phoenixproject.domain.usecase.ComputeVelocityOneRepMaxUseCase(
+                workoutPoints = { _, _, _ -> emptyList() },
+                exerciseLookup = { null },
+                personalMvtLookup = { _, _ -> null },
+                mvtProvider = com.devil.phoenixproject.domain.onerepmax.MvtProvider(),
+                estimator = com.devil.phoenixproject.domain.onerepmax.VelocityOneRepMaxEstimator(
+                    com.devil.phoenixproject.domain.assessment.AssessmentEngine(),
+                ),
+                persist = { _, _, _, _ -> },
+            ),
+            recordPersonalMvtSampleUseCase = com.devil.phoenixproject.domain.usecase.RecordPersonalMvtSampleUseCase(
+                object : com.devil.phoenixproject.data.repository.PersonalMvtRepository {
+                    override suspend fun get(exerciseId: String, profileId: String) = null
+                    override suspend fun upsert(exerciseId: String, profileId: String, personalMvtMs: Float, sampleCount: Int) {}
+                },
+            ),
         )
     }
 

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModelTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModelTest.kt
@@ -118,6 +118,11 @@ class MainViewModelTest {
                     override suspend fun upsert(exerciseId: String, profileId: String, personalMvtMs: Float, sampleCount: Int) {}
                 },
             ),
+            velocityOneRepMaxRepository = object : com.devil.phoenixproject.data.repository.VelocityOneRepMaxRepository {
+                override suspend fun insert(result: com.devil.phoenixproject.domain.onerepmax.VelocityOneRepMaxResult, exerciseId: String, computedAt: Long, profileId: String) {}
+                override suspend fun getLatestPassing(exerciseId: String, profileId: String): com.devil.phoenixproject.data.repository.VelocityOneRepMaxEntity? = null
+                override fun getHistory(exerciseId: String, profileId: String): kotlinx.coroutines.flow.Flow<List<com.devil.phoenixproject.data.repository.VelocityOneRepMaxEntity>> = kotlinx.coroutines.flow.flowOf(emptyList())
+            },
         )
     }
 

--- a/shared/src/androidMain/kotlin/com/devil/phoenixproject/di/PlatformModule.android.kt
+++ b/shared/src/androidMain/kotlin/com/devil/phoenixproject/di/PlatformModule.android.kt
@@ -96,6 +96,8 @@ actual val platformModule: Module = module {
             externalActivityRepository = get(),
             workoutServiceController = get(),
             healthExportCursorRepository = get(),
+            computeVelocityOneRepMaxUseCase = get(),
+            recordPersonalMvtSampleUseCase = get(),
         )
     }
 }

--- a/shared/src/androidMain/kotlin/com/devil/phoenixproject/di/PlatformModule.android.kt
+++ b/shared/src/androidMain/kotlin/com/devil/phoenixproject/di/PlatformModule.android.kt
@@ -98,6 +98,7 @@ actual val platformModule: Module = module {
             healthExportCursorRepository = get(),
             computeVelocityOneRepMaxUseCase = get(),
             recordPersonalMvtSampleUseCase = get(),
+            velocityOneRepMaxRepository = get(),
         )
     }
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/ExerciseImporter.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/ExerciseImporter.kt
@@ -204,6 +204,7 @@ class ExerciseImporter(private val database: VitruvianDatabase) {
                             aliases = aliasesStr,
                             defaultCableConfig = cableConfig,
                             one_rep_max_kg = null,
+                            mvtOverrideMs = null,
                         )
                         importedCount++
 
@@ -346,6 +347,7 @@ class ExerciseImporter(private val database: VitruvianDatabase) {
                         aliases = exercise.aliases?.joinToString(","),
                         defaultCableConfig = mapSidednessToCableConfig(exercise.sidedness),
                         one_rep_max_kg = null,
+                        mvtOverrideMs = null,
                     )
 
                     // Insert videos

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/MigrationStatements.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/MigrationStatements.kt
@@ -861,5 +861,25 @@ WHERE gs.rowid = (
         "ALTER TABLE RoutineExercise ADD COLUMN rackBehaviorOverrides TEXT NOT NULL DEFAULT '{}'",
     )
 
+    // Migration 36: Velocity-based 1RM estimate time-series (issue #517).
+    36 -> listOf(
+        """CREATE TABLE IF NOT EXISTS VelocityOneRepMaxEstimate (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        exerciseId TEXT NOT NULL,
+        estimatedPerCableKg REAL NOT NULL,
+        mvtUsedMs REAL NOT NULL,
+        r2 REAL NOT NULL,
+        distinctLoads INTEGER NOT NULL,
+        passedQualityGate INTEGER NOT NULL DEFAULT 0,
+        computedAt INTEGER NOT NULL,
+        profile_id TEXT NOT NULL DEFAULT 'default',
+        updatedAt INTEGER,
+        serverId TEXT,
+        deletedAt INTEGER,
+        FOREIGN KEY (exerciseId) REFERENCES Exercise(id) ON DELETE CASCADE
+    )""",
+        """CREATE INDEX IF NOT EXISTS idx_velocity_1rm_exercise ON VelocityOneRepMaxEstimate(exerciseId, profile_id)""",
+    )
+
     else -> emptyList()
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/MigrationStatements.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/MigrationStatements.kt
@@ -881,5 +881,19 @@ WHERE gs.rowid = (
         """CREATE INDEX IF NOT EXISTS idx_velocity_1rm_exercise ON VelocityOneRepMaxEstimate(exerciseId, profile_id)""",
     )
 
+    // Migration 37: Personalized MVT storage + per-exercise MVT override (issue #517).
+    37 -> listOf(
+        "ALTER TABLE Exercise ADD COLUMN mvtOverrideMs REAL",
+        """CREATE TABLE IF NOT EXISTS ExerciseMvt (
+        exerciseId TEXT NOT NULL,
+        profile_id TEXT NOT NULL DEFAULT 'default',
+        personalMvtMs REAL NOT NULL,
+        sampleCount INTEGER NOT NULL DEFAULT 0,
+        updatedAt INTEGER NOT NULL,
+        PRIMARY KEY (exerciseId, profile_id),
+        FOREIGN KEY (exerciseId) REFERENCES Exercise(id) ON DELETE CASCADE
+    )""",
+    )
+
     else -> emptyList()
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/SchemaManifest.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/SchemaManifest.kt
@@ -685,7 +685,7 @@ internal val manifestTables: List<SchemaTableOperation> = listOf(
     // because applyColumnHeal handles "duplicate column" errors gracefully.
 
     // Exercise -- initial schema, full current shape
-    // Columns added by later migrations: one_rep_max_kg (m1), updatedAt/serverId/deletedAt (m11), displayName (m30)
+    // Columns added by later migrations: one_rep_max_kg (m1), updatedAt/serverId/deletedAt (m11), displayName (m30), mvtOverrideMs (m37)
     SchemaTableOperation(
         table = "Exercise",
         createSql = """
@@ -715,7 +715,8 @@ internal val manifestTables: List<SchemaTableOperation> = listOf(
                 one_rep_max_kg REAL DEFAULT NULL,
                 updatedAt INTEGER,
                 serverId TEXT,
-                deletedAt INTEGER
+                deletedAt INTEGER,
+                mvtOverrideMs REAL
             )
         """.trimIndent(),
     ),
@@ -1137,6 +1138,23 @@ internal val manifestTables: List<SchemaTableOperation> = listOf(
             )
         """.trimIndent(),
     ),
+
+    // ExerciseMvt -- introduced by migration 37.sqm (issue #517).
+    // Personalized Minimum Velocity Threshold per exercise/profile.
+    SchemaTableOperation(
+        table = "ExerciseMvt",
+        createSql = """
+            CREATE TABLE IF NOT EXISTS ExerciseMvt (
+                exerciseId TEXT NOT NULL,
+                profile_id TEXT NOT NULL DEFAULT 'default',
+                personalMvtMs REAL NOT NULL,
+                sampleCount INTEGER NOT NULL DEFAULT 0,
+                updatedAt INTEGER NOT NULL,
+                PRIMARY KEY (exerciseId, profile_id),
+                FOREIGN KEY (exerciseId) REFERENCES Exercise(id) ON DELETE CASCADE
+            )
+        """.trimIndent(),
+    ),
 )
 
 // ============================================================
@@ -1159,6 +1177,8 @@ internal val manifestColumns: List<SchemaHealOperation> = listOf(
     SchemaHealOperation("Exercise", "deletedAt", "ALTER TABLE Exercise ADD COLUMN deletedAt INTEGER"),
     // Migration 30: display name for formatted exercise names
     SchemaHealOperation("Exercise", "displayName", "ALTER TABLE Exercise ADD COLUMN displayName TEXT"),
+    // Migration 37: per-exercise MVT override for velocity 1RM (issue #517)
+    SchemaHealOperation("Exercise", "mvtOverrideMs", "ALTER TABLE Exercise ADD COLUMN mvtOverrideMs REAL"),
 
     // ── WorkoutSession (31 columns) ─────────────────────────────────────
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/SchemaManifest.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/SchemaManifest.kt
@@ -1113,6 +1113,30 @@ internal val manifestTables: List<SchemaTableOperation> = listOf(
             )
         """.trimIndent(),
     ),
+
+    // VelocityOneRepMaxEstimate -- introduced by migration 36.sqm (issue #517).
+    // Auto-computed velocity 1RM time-series. Separate from AssessmentResult (wizard)
+    // and from Exercise.oneRepMaxKg (authoritative true 1RM).
+    SchemaTableOperation(
+        table = "VelocityOneRepMaxEstimate",
+        createSql = """
+            CREATE TABLE IF NOT EXISTS VelocityOneRepMaxEstimate (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                exerciseId TEXT NOT NULL,
+                estimatedPerCableKg REAL NOT NULL,
+                mvtUsedMs REAL NOT NULL,
+                r2 REAL NOT NULL,
+                distinctLoads INTEGER NOT NULL,
+                passedQualityGate INTEGER NOT NULL DEFAULT 0,
+                computedAt INTEGER NOT NULL,
+                profile_id TEXT NOT NULL DEFAULT 'default',
+                updatedAt INTEGER,
+                serverId TEXT,
+                deletedAt INTEGER,
+                FOREIGN KEY (exerciseId) REFERENCES Exercise(id) ON DELETE CASCADE
+            )
+        """.trimIndent(),
+    ),
 )
 
 // ============================================================
@@ -1430,4 +1454,7 @@ internal val manifestIndexes: List<SchemaIndexOperation> = listOf(
 
     // ── RoutineGroup (Phase 39, migration 27.sqm) ──────────────────────
     SchemaIndexOperation("idx_routine_group_profile", "CREATE INDEX IF NOT EXISTS idx_routine_group_profile ON RoutineGroup(profile_id)"),
+
+    // ── VelocityOneRepMaxEstimate (issue #517, migration 36.sqm) ──────
+    SchemaIndexOperation("idx_velocity_1rm_exercise", "CREATE INDEX IF NOT EXISTS idx_velocity_1rm_exercise ON VelocityOneRepMaxEstimate(exerciseId, profile_id)"),
 )

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/PersonalMvtRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/PersonalMvtRepository.kt
@@ -1,0 +1,51 @@
+package com.devil.phoenixproject.data.repository
+
+import com.devil.phoenixproject.database.VitruvianDatabase
+import com.devil.phoenixproject.domain.model.currentTimeMillis
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.withContext
+
+data class PersonalMvtEntity(
+    val exerciseId: String,
+    val profileId: String,
+    val personalMvtMs: Float,
+    val sampleCount: Int,
+)
+
+interface PersonalMvtRepository {
+    suspend fun get(exerciseId: String, profileId: String): PersonalMvtEntity?
+    suspend fun upsert(exerciseId: String, profileId: String, personalMvtMs: Float, sampleCount: Int)
+}
+
+class SqlDelightPersonalMvtRepository(private val db: VitruvianDatabase) : PersonalMvtRepository {
+    private val queries = db.vitruvianDatabaseQueries
+
+    override suspend fun get(exerciseId: String, profileId: String): PersonalMvtEntity? =
+        withContext(Dispatchers.IO) {
+            queries.selectExerciseMvt(exerciseId, profileId).executeAsOneOrNull()?.let {
+                PersonalMvtEntity(
+                    exerciseId = it.exerciseId,
+                    profileId = it.profile_id,
+                    personalMvtMs = it.personalMvtMs.toFloat(),
+                    sampleCount = it.sampleCount.toInt(),
+                )
+            }
+        }
+
+    override suspend fun upsert(
+        exerciseId: String,
+        profileId: String,
+        personalMvtMs: Float,
+        sampleCount: Int,
+    ): Unit = withContext(Dispatchers.IO) {
+        queries.upsertExerciseMvt(
+            exerciseId = exerciseId,
+            profileId = profileId,
+            personalMvtMs = personalMvtMs.toDouble(),
+            sampleCount = sampleCount.toLong(),
+            updatedAt = currentTimeMillis(),
+        )
+        Unit
+    }
+}

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightExerciseRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightExerciseRepository.kt
@@ -43,10 +43,12 @@ class SqlDelightExerciseRepository(db: VitruvianDatabase, private val exerciseIm
         aliases: String?,
         defaultCableConfig: String,
         one_rep_max_kg: Double?,
-        // Sync fields (migration 6)
+        // Sync fields (migration 11)
         updatedAt: Long?,
         serverId: String?,
         deletedAt: Long?,
+        // Per-exercise MVT override (migration 37)
+        mvtOverrideMs: Double?,
     ): Exercise = Exercise(
         id = id,
         name = name,
@@ -63,6 +65,7 @@ class SqlDelightExerciseRepository(db: VitruvianDatabase, private val exerciseIm
             isCustom = isCustom == 1L,
         ),
         displayName = displayName ?: name,
+        mvtOverrideMs = mvtOverrideMs?.toFloat(),
     )
 
     private fun resolveCableIntent(
@@ -217,6 +220,7 @@ class SqlDelightExerciseRepository(db: VitruvianDatabase, private val exerciseIm
                 aliases = null,
                 defaultCableConfig = "DOUBLE", // Legacy field - no longer used
                 one_rep_max_kg = exercise.oneRepMaxKg?.toDouble(),
+                mvtOverrideMs = exercise.mvtOverrideMs?.toDouble(),
             )
 
             Logger.d { "Created custom exercise: ${exercise.name} with ID: $customId" }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt
@@ -437,6 +437,7 @@ class SqlDelightSyncRepository(
                         aliases = null,
                         defaultCableConfig = dto.defaultCableConfig,
                         one_rep_max_kg = null,
+                        mvtOverrideMs = null,
                     )
 
                     if (dto.serverId != null) {

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepository.kt
@@ -1135,6 +1135,21 @@ class SqlDelightWorkoutRepository(private val db: VitruvianDatabase, private val
         }
     }
 
+    override suspend fun getVelocityPointsForExercise(
+        exerciseId: String,
+        profileId: String,
+        sinceTimestampMs: Long,
+    ): List<com.devil.phoenixproject.domain.onerepmax.WorkoutVelocityPoint> = withContext(Dispatchers.IO) {
+        queries.selectVelocityPointsByExercise(exerciseId, profileId, sinceTimestampMs).executeAsList().map { row ->
+            com.devil.phoenixproject.domain.onerepmax.WorkoutVelocityPoint(
+                loadPerCableKg = (row.workingAvgWeightKg ?: row.weightPerCableKg).toFloat(),
+                mcvMmS = (row.avgMcvMmS ?: 0.0).toFloat(),
+                timestampMs = row.timestamp,
+                workingReps = row.workingReps.toInt(),
+            )
+        }
+    }
+
     override fun getAllPhaseStatistics(): Flow<List<PhaseStatisticsData>> = queries.selectAllPhaseStats {
             id,
             sessionId,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepository.kt
@@ -17,6 +17,7 @@ import com.devil.phoenixproject.domain.model.Superset
 import com.devil.phoenixproject.domain.model.WorkoutSession
 import com.devil.phoenixproject.domain.model.currentTimeMillis
 import com.devil.phoenixproject.domain.model.generateUUID
+import com.devil.phoenixproject.domain.onerepmax.WorkoutVelocityPoint
 import com.devil.phoenixproject.util.OneRepMaxCalculator
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
@@ -1139,11 +1140,11 @@ class SqlDelightWorkoutRepository(private val db: VitruvianDatabase, private val
         exerciseId: String,
         profileId: String,
         sinceTimestampMs: Long,
-    ): List<com.devil.phoenixproject.domain.onerepmax.WorkoutVelocityPoint> = withContext(Dispatchers.IO) {
+    ): List<WorkoutVelocityPoint> = withContext(Dispatchers.IO) {
         queries.selectVelocityPointsByExercise(exerciseId, profileId, sinceTimestampMs).executeAsList().map { row ->
-            com.devil.phoenixproject.domain.onerepmax.WorkoutVelocityPoint(
+            WorkoutVelocityPoint(
                 loadPerCableKg = (row.workingAvgWeightKg ?: row.weightPerCableKg).toFloat(),
-                mcvMmS = (row.avgMcvMmS ?: 0.0).toFloat(),
+                mcvMmS = (row.avgMcvMmS ?: 0.0).toFloat(), // non-null guaranteed by WHERE avgMcvMmS IS NOT NULL
                 timestampMs = row.timestamp,
                 workingReps = row.workingReps.toInt(),
             )

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/VelocityOneRepMaxRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/VelocityOneRepMaxRepository.kt
@@ -1,0 +1,65 @@
+package com.devil.phoenixproject.data.repository
+
+import app.cash.sqldelight.coroutines.asFlow
+import app.cash.sqldelight.coroutines.mapToList
+import com.devil.phoenixproject.database.VitruvianDatabase
+import com.devil.phoenixproject.domain.onerepmax.VelocityOneRepMaxResult
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.withContext
+
+data class VelocityOneRepMaxEntity(
+    val id: Long,
+    val exerciseId: String,
+    val estimatedPerCableKg: Float,
+    val mvtUsedMs: Float,
+    val r2: Float,
+    val distinctLoads: Int,
+    val passedQualityGate: Boolean,
+    val computedAt: Long,
+    val profileId: String,
+)
+
+interface VelocityOneRepMaxRepository {
+    suspend fun insert(result: VelocityOneRepMaxResult, exerciseId: String, computedAt: Long, profileId: String)
+    suspend fun getLatestPassing(exerciseId: String, profileId: String): VelocityOneRepMaxEntity?
+    fun getHistory(exerciseId: String, profileId: String): Flow<List<VelocityOneRepMaxEntity>>
+}
+
+class SqlDelightVelocityOneRepMaxRepository(private val db: VitruvianDatabase) : VelocityOneRepMaxRepository {
+    private val queries = db.vitruvianDatabaseQueries
+
+    private fun map(
+        id: Long, exerciseId: String, estimatedPerCableKg: Double, mvtUsedMs: Double, r2: Double,
+        distinctLoads: Long, passedQualityGate: Long, computedAt: Long, profile_id: String,
+        updatedAt: Long?, serverId: String?, deletedAt: Long?,
+    ) = VelocityOneRepMaxEntity(
+        id = id, exerciseId = exerciseId, estimatedPerCableKg = estimatedPerCableKg.toFloat(),
+        mvtUsedMs = mvtUsedMs.toFloat(), r2 = r2.toFloat(), distinctLoads = distinctLoads.toInt(),
+        passedQualityGate = passedQualityGate != 0L, computedAt = computedAt, profileId = profile_id,
+    )
+
+    override suspend fun insert(result: VelocityOneRepMaxResult, exerciseId: String, computedAt: Long, profileId: String) =
+        withContext(Dispatchers.IO) {
+            queries.insertVelocityOneRepMax(
+                exerciseId = exerciseId,
+                estimatedPerCableKg = result.estimatedPerCableKg.toDouble(),
+                mvtUsedMs = result.mvtUsedMs.toDouble(),
+                r2 = result.r2.toDouble(),
+                distinctLoads = result.distinctLoads.toLong(),
+                passedQualityGate = if (result.passedQualityGate) 1L else 0L,
+                computedAt = computedAt,
+                profile_id = profileId,
+            )
+            Unit
+        }
+
+    override suspend fun getLatestPassing(exerciseId: String, profileId: String): VelocityOneRepMaxEntity? =
+        withContext(Dispatchers.IO) {
+            queries.selectLatestPassingVelocityOneRepMax(exerciseId, profileId, ::map).executeAsOneOrNull()
+        }
+
+    override fun getHistory(exerciseId: String, profileId: String): Flow<List<VelocityOneRepMaxEntity>> =
+        queries.selectVelocityOneRepMaxByExercise(exerciseId, profileId, ::map).asFlow().mapToList(Dispatchers.IO)
+}

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/WorkoutRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/WorkoutRepository.kt
@@ -2,6 +2,7 @@ package com.devil.phoenixproject.data.repository
 
 import com.devil.phoenixproject.domain.model.Routine
 import com.devil.phoenixproject.domain.model.WorkoutSession
+import com.devil.phoenixproject.domain.onerepmax.WorkoutVelocityPoint
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -146,7 +147,7 @@ interface WorkoutRepository {
         exerciseId: String,
         profileId: String,
         sinceTimestampMs: Long,
-    ): List<com.devil.phoenixproject.domain.onerepmax.WorkoutVelocityPoint>
+    ): List<WorkoutVelocityPoint>
 }
 
 /**

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/WorkoutRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/WorkoutRepository.kt
@@ -135,6 +135,18 @@ interface WorkoutRepository {
      * Get all phase statistics
      */
     fun getAllPhaseStatistics(): Flow<List<PhaseStatisticsData>>
+
+    /**
+     * Issue #517: Velocity-based 1RM foundation.
+     * Returns per-set [WorkoutVelocityPoint] records for a given exercise within the
+     * time window [sinceTimestampMs, now]. Points with null MCV or zero working reps
+     * are excluded. Load uses [workingAvgWeightKg] when captured, else [weightPerCableKg].
+     */
+    suspend fun getVelocityPointsForExercise(
+        exerciseId: String,
+        profileId: String,
+        sinceTimestampMs: Long,
+    ): List<com.devil.phoenixproject.domain.onerepmax.WorkoutVelocityPoint>
 }
 
 /**

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/di/DataModule.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/di/DataModule.kt
@@ -53,6 +53,10 @@ val dataModule = module {
     // Assessment Repository
     single<AssessmentRepository> { SqlDelightAssessmentRepository(get(), get(), get()) }
 
+    // Velocity-based 1RM Repositories (issue #517)
+    single<VelocityOneRepMaxRepository> { SqlDelightVelocityOneRepMaxRepository(get()) }
+    single<PersonalMvtRepository> { SqlDelightPersonalMvtRepository(get()) }
+
     // External Activity Repository (Task 3 - third-party integrations)
     single<ExternalActivityRepository> { SqlDelightExternalActivityRepository(get()) }
     single<ExternalRoutineRepository> { SqlDelightExternalRoutineRepository(get()) }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/di/DomainModule.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/di/DomainModule.kt
@@ -3,13 +3,22 @@ package com.devil.phoenixproject.di
 import com.devil.phoenixproject.data.migration.MigrationManager
 import com.devil.phoenixproject.data.preferences.PreferencesManager
 import com.devil.phoenixproject.data.preferences.SettingsPreferencesManager
+import com.devil.phoenixproject.data.repository.ExerciseRepository
 import com.devil.phoenixproject.data.repository.GamificationRepository
+import com.devil.phoenixproject.data.repository.PersonalMvtRepository
 import com.devil.phoenixproject.data.repository.UserProfileRepository
+import com.devil.phoenixproject.data.repository.VelocityOneRepMaxRepository
+import com.devil.phoenixproject.data.repository.WorkoutRepository
 import com.devil.phoenixproject.domain.assessment.AssessmentEngine
+import com.devil.phoenixproject.domain.onerepmax.MvtProvider
+import com.devil.phoenixproject.domain.onerepmax.VelocityOneRepMaxEstimator
 import com.devil.phoenixproject.domain.usecase.ApplyEquipmentRackLoadUseCase
 import com.devil.phoenixproject.domain.usecase.ApplyRoutineModifierUseCase
+import com.devil.phoenixproject.domain.usecase.ComputeVelocityOneRepMaxUseCase
+import com.devil.phoenixproject.domain.usecase.MvtExerciseView
 import com.devil.phoenixproject.domain.usecase.ProgressionUseCase
 import com.devil.phoenixproject.domain.usecase.RecommendWeightAdjustmentUseCase
+import com.devil.phoenixproject.domain.usecase.RecordPersonalMvtSampleUseCase
 import com.devil.phoenixproject.domain.usecase.RepCounterFromMachine
 import com.devil.phoenixproject.domain.usecase.ResolveRoutineWeightsUseCase
 import com.devil.phoenixproject.domain.usecase.RoutineTimeEstimator
@@ -35,6 +44,33 @@ val domainModule = module {
 
     // Assessment
     single { AssessmentEngine() }
+
+    // Velocity-based 1RM (issue #517)
+    single { MvtProvider() }
+    single { VelocityOneRepMaxEstimator(get()) } // get() = AssessmentEngine
+    single {
+        val workoutRepo = get<WorkoutRepository>()
+        val exerciseRepo = get<ExerciseRepository>()
+        val personalRepo = get<PersonalMvtRepository>()
+        val velRepo = get<VelocityOneRepMaxRepository>()
+        ComputeVelocityOneRepMaxUseCase(
+            workoutPoints = { id, profile, since -> workoutRepo.getVelocityPointsForExercise(id, profile, since) },
+            exerciseLookup = { id ->
+                exerciseRepo.getExerciseById(id)?.let { ex ->
+                    object : MvtExerciseView {
+                        override val name = ex.name
+                        override val muscleGroups = ex.muscleGroups
+                        override val mvtOverrideMs = ex.mvtOverrideMs
+                    }
+                }
+            },
+            personalMvtLookup = { id, profile -> personalRepo.get(id, profile)?.let { it.personalMvtMs to it.sampleCount } },
+            mvtProvider = get(),
+            estimator = get(),
+            persist = { result, id, computedAt, profile -> velRepo.insert(result, id, computedAt, profile) },
+        )
+    }
+    single { RecordPersonalMvtSampleUseCase(get()) }
 
     // Migration
     single { MigrationManager(get(), get<UserProfileRepository>(), get<GamificationRepository>()) }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/Exercise.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/Exercise.kt
@@ -31,6 +31,7 @@ data class Exercise(
     val oneRepMaxKg: Float? = null, // User's 1RM for percentage-based programming
     val cableIntent: ExerciseCableIntent? = null, // Explicit single/dual cable metadata when known
     val displayName: String = name, // Disambiguated name from catalog; defaults to base name
+    val mvtOverrideMs: Float? = null, // User-set Minimum Velocity Threshold override (m/s) for velocity-1RM
 ) {
     /**
      * Whether this exercise uses any cable accessory (handles, bar, rope, etc.).

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/onerepmax/MovementPattern.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/onerepmax/MovementPattern.kt
@@ -1,0 +1,25 @@
+package com.devil.phoenixproject.domain.onerepmax
+
+/** Movement patterns with their default Minimum Velocity Threshold (m/s) for 1RM extrapolation. */
+enum class MovementPattern(val defaultMvtMs: Float) {
+    HORIZONTAL_PRESS(0.15f),
+    VERTICAL_PRESS(0.20f),
+    SQUAT(0.30f),
+    HINGE(0.15f),
+    OTHER(0.20f),
+}
+
+/**
+ * Best-effort classification of an exercise into a movement pattern from its name and
+ * muscle groups. Keyword order matters: more specific patterns are checked first.
+ */
+fun classifyMovementPattern(name: String, muscleGroups: String): MovementPattern {
+    val haystack = "$name $muscleGroups".lowercase()
+    return when {
+        listOf("deadlift", "rdl", "hip thrust", "hinge", "good morning", "swing").any { it in haystack } -> MovementPattern.HINGE
+        listOf("squat", "leg press", "lunge", "split squat").any { it in haystack } -> MovementPattern.SQUAT
+        listOf("overhead", "ohp", "shoulder press", "military", "push press").any { it in haystack } -> MovementPattern.VERTICAL_PRESS
+        listOf("bench", "chest press", "horizontal press", "floor press").any { it in haystack } -> MovementPattern.HORIZONTAL_PRESS
+        else -> MovementPattern.OTHER
+    }
+}

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/onerepmax/MvtProvider.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/onerepmax/MvtProvider.kt
@@ -1,0 +1,22 @@
+package com.devil.phoenixproject.domain.onerepmax
+
+/** Resolves the Minimum Velocity Threshold (m/s) for an exercise. */
+class MvtProvider {
+    fun resolve(
+        exerciseName: String,
+        muscleGroups: String,
+        userOverrideMs: Float?,
+        personalMvtMs: Float?,
+        personalSampleCount: Int,
+    ): Float {
+        if (userOverrideMs != null && userOverrideMs > 0f) return userOverrideMs
+        if (personalMvtMs != null && personalMvtMs > 0f && personalSampleCount >= MIN_PERSONAL_MVT_SAMPLES) {
+            return personalMvtMs
+        }
+        return classifyMovementPattern(exerciseName, muscleGroups).defaultMvtMs
+    }
+
+    companion object {
+        const val MIN_PERSONAL_MVT_SAMPLES = 3
+    }
+}

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/onerepmax/VelocityOneRepMaxEstimator.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/onerepmax/VelocityOneRepMaxEstimator.kt
@@ -1,0 +1,67 @@
+package com.devil.phoenixproject.domain.onerepmax
+
+import com.devil.phoenixproject.domain.assessment.AssessmentConfig
+import com.devil.phoenixproject.domain.assessment.AssessmentEngine
+import com.devil.phoenixproject.domain.assessment.LoadVelocityPoint
+import kotlin.math.roundToInt
+
+/** One completed-set data point fed into velocity-1RM estimation. Load is per-cable; MCV in mm/s. */
+data class WorkoutVelocityPoint(
+    val loadPerCableKg: Float,
+    val mcvMmS: Float,
+    val timestampMs: Long,
+    val workingReps: Int,
+)
+
+/** Result of a velocity-based 1RM estimate. Estimate is per-cable kg. */
+data class VelocityOneRepMaxResult(
+    val estimatedPerCableKg: Float,
+    val mvtUsedMs: Float,
+    val r2: Float,
+    val distinctLoads: Int,
+    val passedQualityGate: Boolean,
+)
+
+/**
+ * Builds load-velocity points from completed sets and fits a 1RM via the existing
+ * [AssessmentEngine]. Pure: no I/O. The caller supplies an already-windowed list of
+ * working-set points and the resolved MVT.
+ */
+class VelocityOneRepMaxEstimator(private val assessmentEngine: AssessmentEngine) {
+
+    fun estimate(points: List<WorkoutVelocityPoint>, mvtMs: Float): VelocityOneRepMaxResult? {
+        // Keep only usable points, then dedup by load bucket keeping the most recent.
+        val deduped = points
+            .filter { it.loadPerCableKg > 0f && it.mcvMmS > 0f && it.workingReps > 0 }
+            .groupBy { bucketOf(it.loadPerCableKg) }
+            .map { (_, group) -> group.maxByOrNull { it.timestampMs }!! }
+
+        val distinctLoads = deduped.size
+        if (distinctLoads < MIN_DISTINCT_LOADS) return null
+
+        val lvPoints = deduped.map {
+            LoadVelocityPoint(loadKg = it.loadPerCableKg, meanVelocityMs = it.mcvMmS / 1000f)
+        }
+
+        // minSets=2 matches our gate; oneRmVelocityMs is the resolved MVT.
+        val config = AssessmentConfig(minSets = MIN_DISTINCT_LOADS, oneRmVelocityMs = mvtMs)
+        val assessment = assessmentEngine.estimateOneRepMax(lvPoints, config) ?: return null
+
+        val passed = distinctLoads >= MIN_DISTINCT_LOADS && assessment.r2 >= R2_PASS_THRESHOLD
+        return VelocityOneRepMaxResult(
+            estimatedPerCableKg = assessment.estimatedOneRepMaxKg,
+            mvtUsedMs = mvtMs,
+            r2 = assessment.r2,
+            distinctLoads = distinctLoads,
+            passedQualityGate = passed,
+        )
+    }
+
+    private fun bucketOf(loadKg: Float): Int = (loadKg / LOAD_BUCKET_KG).roundToInt()
+
+    companion object {
+        const val R2_PASS_THRESHOLD = 0.8f
+        const val MIN_DISTINCT_LOADS = 2
+        const val LOAD_BUCKET_KG = 0.5f
+    }
+}

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/ComputeVelocityOneRepMaxUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/ComputeVelocityOneRepMaxUseCase.kt
@@ -1,0 +1,40 @@
+package com.devil.phoenixproject.domain.usecase
+
+import com.devil.phoenixproject.domain.onerepmax.MvtProvider
+import com.devil.phoenixproject.domain.onerepmax.VelocityOneRepMaxEstimator
+import com.devil.phoenixproject.domain.onerepmax.VelocityOneRepMaxResult
+import com.devil.phoenixproject.domain.onerepmax.WorkoutVelocityPoint
+
+/** Minimal view of an exercise needed for MVT resolution. */
+interface MvtExerciseView { val name: String; val muscleGroups: String; val mvtOverrideMs: Float? }
+
+class ComputeVelocityOneRepMaxUseCase(
+    private val workoutPoints: suspend (exerciseId: String, profileId: String, sinceMs: Long) -> List<WorkoutVelocityPoint>,
+    private val exerciseLookup: suspend (exerciseId: String) -> MvtExerciseView?,
+    private val personalMvtLookup: suspend (exerciseId: String, profileId: String) -> Pair<Float, Int>?, // (mvt, sampleCount)
+    private val mvtProvider: MvtProvider,
+    private val estimator: VelocityOneRepMaxEstimator,
+    private val persist: suspend (result: VelocityOneRepMaxResult, exerciseId: String, computedAt: Long, profileId: String) -> Unit,
+) {
+    suspend operator fun invoke(exerciseId: String, profileId: String, nowMs: Long): VelocityOneRepMaxResult? {
+        val exercise = exerciseLookup(exerciseId) ?: return null
+        val sinceMs = nowMs - WINDOW_DAYS * DAY_MS
+        val points = workoutPoints(exerciseId, profileId, sinceMs)
+        val personal = personalMvtLookup(exerciseId, profileId)
+        val mvt = mvtProvider.resolve(
+            exerciseName = exercise.name,
+            muscleGroups = exercise.muscleGroups,
+            userOverrideMs = exercise.mvtOverrideMs,
+            personalMvtMs = personal?.first,
+            personalSampleCount = personal?.second ?: 0,
+        )
+        val result = estimator.estimate(points, mvt) ?: return null
+        persist(result, exerciseId, nowMs, profileId)
+        return result
+    }
+
+    companion object {
+        const val WINDOW_DAYS = 28
+        private const val DAY_MS = 24L * 60L * 60L * 1000L
+    }
+}

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/RecordPersonalMvtSampleUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/RecordPersonalMvtSampleUseCase.kt
@@ -1,0 +1,38 @@
+package com.devil.phoenixproject.domain.usecase
+
+import com.devil.phoenixproject.data.repository.PersonalMvtRepository
+import com.devil.phoenixproject.domain.onerepmax.classifyMovementPattern
+
+/**
+ * Captures a personalized MVT sample from a completed set whose velocity has collapsed to
+ * an RIR≈0 proxy (<= 1.1 × the pattern default). Maintains a rolling mean of recent samples.
+ */
+class RecordPersonalMvtSampleUseCase(private val personalMvtRepo: PersonalMvtRepository) {
+    suspend operator fun invoke(
+        exerciseId: String,
+        profileId: String,
+        exerciseName: String,
+        muscleGroups: String,
+        sessionMcvMmS: Float,
+    ): Boolean {
+        if (sessionMcvMmS <= 0f) return false
+        val sampleMs = sessionMcvMmS / 1000f
+        val patternDefault = classifyMovementPattern(exerciseName, muscleGroups).defaultMvtMs
+        if (sampleMs > patternDefault * FAILURE_PROXY_FACTOR) return false
+
+        val existing = personalMvtRepo.get(exerciseId, profileId)
+        val prevCount = existing?.sampleCount ?: 0
+        val prevMean = existing?.personalMvtMs ?: 0f
+        // Incremental mean capped at MAX_SAMPLES weighting.
+        val effectiveCount = minOf(prevCount, MAX_SAMPLES - 1)
+        val newCount = prevCount + 1
+        val newMean = (prevMean * effectiveCount + sampleMs) / (effectiveCount + 1)
+        personalMvtRepo.upsert(exerciseId, profileId, newMean, newCount)
+        return true
+    }
+
+    companion object {
+        const val FAILURE_PROXY_FACTOR = 1.1f
+        const val MAX_SAMPLES = 5
+    }
+}

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -3035,6 +3035,7 @@ class ActiveSessionEngine(
                 peakConcentricForceKg = maxOf(summary.peakForceConcentricA, summary.peakForceConcentricB),
                 peakEccentricForceKg = maxOf(summary.peakForceEccentricA, summary.peakForceEccentricB),
                 profileId = userProfileRepository.activeProfile.value?.id ?: "default",
+                sessionMcvMmS = session.avgMcvMmS,
             )
 
             if (hasPR && completedSetId != null) {
@@ -3593,6 +3594,7 @@ class ActiveSessionEngine(
             peakConcentricForceKg = maxOf(summary.peakForceConcentricA, summary.peakForceConcentricB),
             peakEccentricForceKg = maxOf(summary.peakForceEccentricA, summary.peakForceEccentricB),
             profileId = userProfileRepository.activeProfile.value?.id ?: "default",
+            sessionMcvMmS = session.avgMcvMmS,
         )
 
         if (hasPR && completedSetId != null) {

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/GamificationManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/GamificationManager.kt
@@ -35,6 +35,12 @@ class GamificationManager(
     private val hapticEvents: MutableSharedFlow<HapticEvent>,
     private val scope: CoroutineScope,
     private val gamificationEnabled: StateFlow<Boolean>,
+    /**
+     * Optional post-save hook (issue #517). Invoked after PR/badge processing with the resolved
+     * exercise id, profile id, and the session's average MCV (mm/s, nullable). Defaults to a no-op
+     * so existing construction sites (production wiring supplies the real lambda) need no changes.
+     */
+    private val onPostSaveComputed: suspend (exerciseId: String, profileId: String, sessionMcvMmS: Float?) -> Unit = { _, _, _ -> },
 ) {
     private val _prCelebrationEvent = MutableSharedFlow<PRCelebrationEvent>()
     val prCelebrationEvent: SharedFlow<PRCelebrationEvent> = _prCelebrationEvent.asSharedFlow()
@@ -69,6 +75,7 @@ class GamificationManager(
         peakConcentricForceKg: Float = 0f,
         peakEccentricForceKg: Float = 0f,
         profileId: String = "default",
+        sessionMcvMmS: Float? = null,
     ): Boolean {
         var hasCelebrationSound = false
 
@@ -216,6 +223,17 @@ class GamificationManager(
                     // Issue #319: Emit to UI-visible error flow (direct emit in suspend function)
                     _prTrackingErrorEvents.emit(errorMsg)
                 }
+            }
+        }
+
+        // Velocity-based 1RM (issue #517): compute estimate + capture personalized-MVT sample.
+        // Runs regardless of the gamification toggle; isolated in try/catch so a failure here
+        // never breaks PR/badge flow.
+        exerciseId?.takeIf { it.isNotBlank() }?.let { id ->
+            try {
+                onPostSaveComputed(id, effectiveProfileId, sessionMcvMmS)
+            } catch (e: Exception) {
+                Logger.w(e) { "VELOCITY_1RM: post-save hook failed for $id" }
             }
         }
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseDetailScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseDetailScreen.kt
@@ -68,16 +68,20 @@ fun ExerciseDetailScreen(exerciseId: String, navController: NavController, viewM
 
     // Get exercise name
     var exerciseName by remember { mutableStateOf("Loading...") }
-    // Velocity-based 1RM estimate (issue #517): latest estimate that passed the quality gate.
-    var velocity1Rm by remember { mutableStateOf<VelocityOneRepMaxEntity?>(null) }
     LaunchedEffect(exerciseId) {
         val exercise = viewModel.exerciseRepository.getExerciseById(exerciseId)
         exerciseName = exercise?.name ?: "Unknown Exercise"
         // Clear topbar title to allow dynamic title from EnhancedMainScreen
         viewModel.updateTopBarTitle("")
-        // Load latest passing velocity-1RM estimate for this exercise.
-        // TODO: use active profile id when exposed as a public property on MainViewModel
-        velocity1Rm = viewModel.velocityOneRepMaxRepository.getLatestPassing(exerciseId, "default")
+    }
+
+    // Velocity-based 1RM estimate (issue #517): latest estimate that passed the quality gate,
+    // scoped to the active profile. Keyed on exerciseId + profileId so the value resets (no
+    // stale flash) when either changes.
+    val profileId by viewModel.activeProfileId.collectAsState()
+    var velocity1Rm by remember(exerciseId, profileId) { mutableStateOf<VelocityOneRepMaxEntity?>(null) }
+    LaunchedEffect(exerciseId, profileId) {
+        velocity1Rm = viewModel.velocityOneRepMaxRepository.getLatestPassing(exerciseId, profileId)
     }
 
     // Calculate 1RM progression using saved per-cable load.

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseDetailScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseDetailScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.devil.phoenixproject.data.repository.ExerciseRepository
+import com.devil.phoenixproject.data.repository.VelocityOneRepMaxEntity
 import com.devil.phoenixproject.domain.model.ConnectionState
 import com.devil.phoenixproject.domain.model.WeightUnit
 import com.devil.phoenixproject.domain.model.WorkoutSession
@@ -67,11 +68,16 @@ fun ExerciseDetailScreen(exerciseId: String, navController: NavController, viewM
 
     // Get exercise name
     var exerciseName by remember { mutableStateOf("Loading...") }
+    // Velocity-based 1RM estimate (issue #517): latest estimate that passed the quality gate.
+    var velocity1Rm by remember { mutableStateOf<VelocityOneRepMaxEntity?>(null) }
     LaunchedEffect(exerciseId) {
         val exercise = viewModel.exerciseRepository.getExerciseById(exerciseId)
         exerciseName = exercise?.name ?: "Unknown Exercise"
         // Clear topbar title to allow dynamic title from EnhancedMainScreen
         viewModel.updateTopBarTitle("")
+        // Load latest passing velocity-1RM estimate for this exercise.
+        // TODO: use active profile id when exposed as a public property on MainViewModel
+        velocity1Rm = viewModel.velocityOneRepMaxRepository.getLatestPassing(exerciseId, "default")
     }
 
     // Calculate 1RM progression using saved per-cable load.
@@ -129,6 +135,7 @@ fun ExerciseDetailScreen(exerciseId: String, navController: NavController, viewM
                         previousOneRepMax = previousOneRepMax,
                         weightUnit = weightUnit,
                         formatWeight = viewModel::formatWeight,
+                        velocity1Rm = velocity1Rm,
                     )
                 }
 
@@ -249,6 +256,7 @@ private fun OneRepMaxCard(
     previousOneRepMax: Float?,
     weightUnit: WeightUnit,
     formatWeight: (Float, WeightUnit) -> String,
+    velocity1Rm: VelocityOneRepMaxEntity? = null,
 ) {
     val delta = if (currentOneRepMax != null && previousOneRepMax != null) {
         currentOneRepMax - previousOneRepMax
@@ -316,6 +324,30 @@ private fun OneRepMaxCard(
                     "No data",
                     style = MaterialTheme.typography.titleLarge,
                     color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.5f),
+                )
+            }
+
+            // Velocity-based 1RM (issue #517): show only when a passing estimate exists.
+            velocity1Rm?.let { v ->
+                Spacer(Modifier.height(16.dp))
+                HorizontalDivider(color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.2f))
+                Spacer(Modifier.height(12.dp))
+                Text(
+                    "VELOCITY 1RM",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f),
+                )
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    formatWeight(v.estimatedPerCableKg, weightUnit),
+                    style = MaterialTheme.typography.headlineMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                )
+                Text(
+                    "MVT ${KmpUtils.formatFloat(v.mvtUsedMs, 2)} m/s",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.6f),
                 )
             }
         }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
@@ -70,8 +70,11 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -125,6 +128,13 @@ class MainViewModel constructor(
 
     // === Phase 1a: HistoryManager (extracted from this class) ===
     val historyManager = HistoryManager(workoutRepository, personalRecordRepository, userProfileRepository, viewModelScope)
+
+    // Active profile id, exposed publicly so profile-scoped reads (e.g. velocity-1RM on
+    // ExerciseDetailScreen) query the correct profile instead of a hardcoded "default".
+    val activeProfileId: StateFlow<String> =
+        userProfileRepository.activeProfile
+            .map { it?.id ?: "default" }
+            .stateIn(viewModelScope, SharingStarted.Eagerly, "default")
 
     // === Phase 2b: GamificationManager (extracted from this class) ===
     val gamificationManager = GamificationManager(

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
@@ -49,7 +49,9 @@ import com.devil.phoenixproject.domain.model.WorkoutSession
 import com.devil.phoenixproject.domain.model.WorkoutState
 import com.devil.phoenixproject.domain.usecase.ApplyEquipmentRackLoadUseCase
 import com.devil.phoenixproject.domain.usecase.ApplyRoutineModifierUseCase
+import com.devil.phoenixproject.domain.usecase.ComputeVelocityOneRepMaxUseCase
 import com.devil.phoenixproject.domain.usecase.RecommendWeightAdjustmentUseCase
+import com.devil.phoenixproject.domain.usecase.RecordPersonalMvtSampleUseCase
 import com.devil.phoenixproject.domain.usecase.RepCounterFromMachine
 import com.devil.phoenixproject.domain.usecase.ResolveRoutineWeightsUseCase
 import com.devil.phoenixproject.presentation.manager.BleConnectionManager
@@ -104,6 +106,9 @@ class MainViewModel constructor(
     private val externalActivityRepository: ExternalActivityRepository? = null,
     private val workoutServiceController: WorkoutServiceController,
     private val healthExportCursorRepository: IntegrationSyncCursorRepository? = null,
+    // Velocity-based 1RM (issue #517): computed via GamificationManager's post-save hook.
+    private val computeVelocityOneRepMaxUseCase: ComputeVelocityOneRepMaxUseCase,
+    private val recordPersonalMvtSampleUseCase: RecordPersonalMvtSampleUseCase,
 ) : ViewModel() {
 
     // Shared haptic events flow - created here, passed to both GamificationManager and WorkoutSessionManager
@@ -126,6 +131,16 @@ class MainViewModel constructor(
         _hapticEvents,
         viewModelScope,
         settingsManager.gamificationEnabled,
+        // Velocity-based 1RM post-save hook (issue #517): capture personalized-MVT sample then
+        // recompute the velocity-1RM estimate for the just-saved exercise.
+        onPostSaveComputed = { exId, profile, mcv ->
+            mcv?.let { v ->
+                exerciseRepository.getExerciseById(exId)?.let { ex ->
+                    recordPersonalMvtSampleUseCase(exId, profile, ex.name, ex.muscleGroups, v)
+                }
+            }
+            computeVelocityOneRepMaxUseCase(exId, profile, com.devil.phoenixproject.domain.model.currentTimeMillis())
+        },
     )
 
     // === Phase 3: WorkoutSessionManager (extracted from this class) ===

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
@@ -20,6 +20,7 @@ import com.devil.phoenixproject.data.repository.RepMetricRepository
 import com.devil.phoenixproject.data.repository.ScannedDevice
 import com.devil.phoenixproject.data.repository.TrainingCycleRepository
 import com.devil.phoenixproject.data.repository.UserProfileRepository
+import com.devil.phoenixproject.data.repository.VelocityOneRepMaxRepository
 import com.devil.phoenixproject.data.repository.WorkoutRepository
 import com.devil.phoenixproject.data.sync.SyncTriggerManager
 import com.devil.phoenixproject.domain.model.AppliedRoutineModifier
@@ -109,6 +110,8 @@ class MainViewModel constructor(
     // Velocity-based 1RM (issue #517): computed via GamificationManager's post-save hook.
     private val computeVelocityOneRepMaxUseCase: ComputeVelocityOneRepMaxUseCase,
     private val recordPersonalMvtSampleUseCase: RecordPersonalMvtSampleUseCase,
+    // Exposed as a public val so ExerciseDetailScreen can query the latest passing estimate.
+    val velocityOneRepMaxRepository: VelocityOneRepMaxRepository,
 ) : ViewModel() {
 
     // Shared haptic events flow - created here, passed to both GamificationManager and WorkoutSessionManager

--- a/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
+++ b/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
@@ -433,6 +433,45 @@ CREATE TABLE AssessmentResult (
 CREATE INDEX idx_assessment_result_exercise ON AssessmentResult(exerciseId);
 CREATE INDEX idx_assessment_profile ON AssessmentResult(profile_id);
 
+-- ==================== VELOCITY-BASED 1RM ESTIMATES ====================
+-- Auto-computed velocity 1RM time-series (issue #517). Separate from
+-- AssessmentResult (wizard) and from Exercise.oneRepMaxKg (authoritative true 1RM).
+
+CREATE TABLE VelocityOneRepMaxEstimate (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    exerciseId TEXT NOT NULL,
+    estimatedPerCableKg REAL NOT NULL,
+    mvtUsedMs REAL NOT NULL,
+    r2 REAL NOT NULL,
+    distinctLoads INTEGER NOT NULL,
+    passedQualityGate INTEGER NOT NULL DEFAULT 0,
+    computedAt INTEGER NOT NULL,
+    profile_id TEXT NOT NULL DEFAULT 'default',
+    -- Sync columns (future parity; unused in this plan)
+    updatedAt INTEGER,
+    serverId TEXT,
+    deletedAt INTEGER,
+    FOREIGN KEY (exerciseId) REFERENCES Exercise(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_velocity_1rm_exercise ON VelocityOneRepMaxEstimate(exerciseId, profile_id);
+
+insertVelocityOneRepMax:
+INSERT INTO VelocityOneRepMaxEstimate (exerciseId, estimatedPerCableKg, mvtUsedMs, r2, distinctLoads, passedQualityGate, computedAt, profile_id)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?);
+
+selectVelocityOneRepMaxByExercise:
+SELECT * FROM VelocityOneRepMaxEstimate
+WHERE exerciseId = :exerciseId AND profile_id = :profileId AND deletedAt IS NULL
+ORDER BY computedAt DESC;
+
+selectLatestPassingVelocityOneRepMax:
+SELECT * FROM VelocityOneRepMaxEstimate
+WHERE exerciseId = :exerciseId AND profile_id = :profileId
+AND passedQualityGate = 1 AND deletedAt IS NULL
+ORDER BY computedAt DESC
+LIMIT 1;
+
 -- Queries
 
 -- Exercise Queries

--- a/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
+++ b/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
@@ -29,7 +29,9 @@ CREATE TABLE Exercise (
     -- Sync fields (added in migration 6)
     updatedAt INTEGER,
     serverId TEXT,
-    deletedAt INTEGER
+    deletedAt INTEGER,
+    -- Per-exercise MVT override (added in migration 37, issue #517)
+    mvtOverrideMs REAL
 );
 
 CREATE INDEX idx_exercise_popularity ON Exercise(popularity DESC, name ASC);
@@ -472,6 +474,28 @@ AND passedQualityGate = 1 AND deletedAt IS NULL
 ORDER BY computedAt DESC
 LIMIT 1;
 
+-- ==================== PERSONAL MVT TABLE ====================
+-- Personalized Minimum Velocity Threshold per exercise/profile (issue #517).
+-- Stored alongside the exercise; used by VelocityOneRepMaxEstimator to override
+-- the default MVT when the user has enough personal data.
+
+CREATE TABLE ExerciseMvt (
+    exerciseId TEXT NOT NULL,
+    profile_id TEXT NOT NULL DEFAULT 'default',
+    personalMvtMs REAL NOT NULL,
+    sampleCount INTEGER NOT NULL DEFAULT 0,
+    updatedAt INTEGER NOT NULL,
+    PRIMARY KEY (exerciseId, profile_id),
+    FOREIGN KEY (exerciseId) REFERENCES Exercise(id) ON DELETE CASCADE
+);
+
+selectExerciseMvt:
+SELECT * FROM ExerciseMvt WHERE exerciseId = :exerciseId AND profile_id = :profileId;
+
+upsertExerciseMvt:
+INSERT OR REPLACE INTO ExerciseMvt (exerciseId, profile_id, personalMvtMs, sampleCount, updatedAt)
+VALUES (:exerciseId, :profileId, :personalMvtMs, :sampleCount, :updatedAt);
+
 -- Queries
 
 -- Exercise Queries
@@ -506,9 +530,9 @@ INSERT OR REPLACE INTO Exercise (
     id, name, displayName, description, created, muscleGroup, muscleGroups, muscles,
     equipment, movement, sidedness, grip, gripWidth, minRepRange,
     popularity, archived, isFavorite, isCustom, timesPerformed, lastPerformed,
-    aliases, defaultCableConfig, one_rep_max_kg
+    aliases, defaultCableConfig, one_rep_max_kg, mvtOverrideMs
 )
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 countExercises:
 SELECT COUNT(*) FROM Exercise;

--- a/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
+++ b/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
@@ -471,7 +471,7 @@ selectLatestPassingVelocityOneRepMax:
 SELECT * FROM VelocityOneRepMaxEstimate
 WHERE exerciseId = :exerciseId AND profile_id = :profileId
 AND passedQualityGate = 1 AND deletedAt IS NULL
-ORDER BY computedAt DESC
+ORDER BY computedAt DESC, id DESC
 LIMIT 1;
 
 -- ==================== PERSONAL MVT TABLE ====================

--- a/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
+++ b/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
@@ -638,6 +638,23 @@ SELECT updatedAt FROM WorkoutSession WHERE id = ?;
 selectSessionsUpdatedAtByIds:
 SELECT id, updatedAt FROM WorkoutSession WHERE id IN ?;
 
+-- Issue #517: Velocity-based 1RM foundation. Returns per-set load + MCV
+-- points for a specific exercise, used by VelocityOneRepMaxEstimator.
+-- Load uses workingAvgWeightKg when available (more accurate than the
+-- target weight), else falls back to weightPerCableKg. Null MCV and
+-- zero-rep rows are excluded; the estimator requires actual captured
+-- biomechanics data.
+selectVelocityPointsByExercise:
+SELECT workingAvgWeightKg, weightPerCableKg, avgMcvMmS, timestamp, workingReps
+FROM WorkoutSession
+WHERE exerciseId = :exerciseId
+  AND profile_id = :profileId
+  AND timestamp >= :sinceTimestamp
+  AND deletedAt IS NULL
+  AND avgMcvMmS IS NOT NULL
+  AND workingReps > 0
+ORDER BY timestamp DESC;
+
 -- Issue #591 follow-up: batch-read the detailed metric / biomechanics
 -- columns used by the LWW preservation guard for a list of session ids.
 -- Mirrors the column list in

--- a/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/migrations/36.sqm
+++ b/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/migrations/36.sqm
@@ -1,0 +1,17 @@
+-- Migration 36: Velocity-based 1RM estimate time-series (issue #517).
+CREATE TABLE IF NOT EXISTS VelocityOneRepMaxEstimate (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    exerciseId TEXT NOT NULL,
+    estimatedPerCableKg REAL NOT NULL,
+    mvtUsedMs REAL NOT NULL,
+    r2 REAL NOT NULL,
+    distinctLoads INTEGER NOT NULL,
+    passedQualityGate INTEGER NOT NULL DEFAULT 0,
+    computedAt INTEGER NOT NULL,
+    profile_id TEXT NOT NULL DEFAULT 'default',
+    updatedAt INTEGER,
+    serverId TEXT,
+    deletedAt INTEGER,
+    FOREIGN KEY (exerciseId) REFERENCES Exercise(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_velocity_1rm_exercise ON VelocityOneRepMaxEstimate(exerciseId, profile_id);

--- a/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/migrations/37.sqm
+++ b/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/migrations/37.sqm
@@ -1,0 +1,11 @@
+-- Migration 37: personalized MVT storage + per-exercise MVT override (issue #517).
+ALTER TABLE Exercise ADD COLUMN mvtOverrideMs REAL;
+CREATE TABLE IF NOT EXISTS ExerciseMvt (
+    exerciseId TEXT NOT NULL,
+    profile_id TEXT NOT NULL DEFAULT 'default',
+    personalMvtMs REAL NOT NULL,
+    sampleCount INTEGER NOT NULL DEFAULT 0,
+    updatedAt INTEGER NOT NULL,
+    PRIMARY KEY (exerciseId, profile_id),
+    FOREIGN KEY (exerciseId) REFERENCES Exercise(id) ON DELETE CASCADE
+);

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/onerepmax/MovementPatternTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/onerepmax/MovementPatternTest.kt
@@ -1,0 +1,29 @@
+package com.devil.phoenixproject.domain.onerepmax
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MovementPatternTest {
+    @Test fun `bench press classifies as horizontal press`() =
+        assertEquals(MovementPattern.HORIZONTAL_PRESS, classifyMovementPattern("Barbell Bench Press", "Chest"))
+
+    @Test fun `overhead press classifies as vertical press`() =
+        assertEquals(MovementPattern.VERTICAL_PRESS, classifyMovementPattern("Overhead Press", "Shoulders"))
+
+    @Test fun `back squat classifies as squat`() =
+        assertEquals(MovementPattern.SQUAT, classifyMovementPattern("Back Squat", "Legs"))
+
+    @Test fun `deadlift classifies as hinge`() =
+        assertEquals(MovementPattern.HINGE, classifyMovementPattern("Romanian Deadlift", "Hamstrings"))
+
+    @Test fun `bicep curl falls back to other`() =
+        assertEquals(MovementPattern.OTHER, classifyMovementPattern("Bicep Curl", "Biceps"))
+
+    @Test fun `default mvt values match spec`() {
+        assertEquals(0.15f, MovementPattern.HORIZONTAL_PRESS.defaultMvtMs)
+        assertEquals(0.20f, MovementPattern.VERTICAL_PRESS.defaultMvtMs)
+        assertEquals(0.30f, MovementPattern.SQUAT.defaultMvtMs)
+        assertEquals(0.15f, MovementPattern.HINGE.defaultMvtMs)
+        assertEquals(0.20f, MovementPattern.OTHER.defaultMvtMs)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/onerepmax/MvtProviderTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/onerepmax/MvtProviderTest.kt
@@ -1,0 +1,23 @@
+package com.devil.phoenixproject.domain.onerepmax
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MvtProviderTest {
+    private val provider = MvtProvider()
+
+    @Test fun `falls back to pattern default when no personal or override`() =
+        assertEquals(0.30f, provider.resolve("Back Squat", "Legs", null, null, 0))
+
+    @Test fun `personal mvt overrides pattern once threshold met`() =
+        assertEquals(0.22f, provider.resolve("Back Squat", "Legs", null, 0.22f, 3))
+
+    @Test fun `personal mvt ignored below sample threshold`() =
+        assertEquals(0.30f, provider.resolve("Back Squat", "Legs", null, 0.22f, 2))
+
+    @Test fun `user override beats personal and pattern`() =
+        assertEquals(0.18f, provider.resolve("Back Squat", "Legs", 0.18f, 0.22f, 5))
+
+    @Test fun `non-positive override is ignored`() =
+        assertEquals(0.20f, provider.resolve("Cable Fly", "Chest", 0f, null, 0))
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/onerepmax/VelocityOneRepMaxEstimatorTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/onerepmax/VelocityOneRepMaxEstimatorTest.kt
@@ -1,0 +1,50 @@
+package com.devil.phoenixproject.domain.onerepmax
+
+import com.devil.phoenixproject.domain.assessment.AssessmentEngine
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class VelocityOneRepMaxEstimatorTest {
+    private val estimator = VelocityOneRepMaxEstimator(AssessmentEngine())
+
+    private fun point(load: Float, mcvMmS: Float, ts: Long = 0L) =
+        WorkoutVelocityPoint(loadPerCableKg = load, mcvMmS = mcvMmS, timestampMs = ts, workingReps = 5)
+
+    @Test fun `two distinct loads produce a passing estimate`() {
+        // load 40 @ 1.2 m/s (1200 mm/s), load 80 @ 0.6 m/s -> 1RM at 0.30 m/s
+        val result = estimator.estimate(
+            points = listOf(point(40f, 1200f), point(80f, 600f)),
+            mvtMs = 0.30f,
+        )
+        assertNotNull(result)
+        assertTrue(result.passedQualityGate, "2 clean points on a line should pass")
+        assertTrue(result.estimatedPerCableKg in 95f..105f, "expected ~100kg, got ${result.estimatedPerCableKg}")
+    }
+
+    @Test fun `single distinct load returns null`() {
+        assertNull(estimator.estimate(listOf(point(60f, 800f), point(60f, 790f)), mvtMs = 0.30f))
+    }
+
+    @Test fun `positive slope returns null`() {
+        // velocity increasing with load is non-physiological -> AssessmentEngine rejects
+        assertNull(estimator.estimate(listOf(point(40f, 600f), point(80f, 900f)), mvtMs = 0.30f))
+    }
+
+    @Test fun `duplicate loads are deduped keeping most recent`() {
+        // newest 60kg point (ts=100) should win over older (ts=1)
+        val result = estimator.estimate(
+            points = listOf(point(40f, 1200f, ts = 50), point(60f, 900f, ts = 100), point(60f, 100f, ts = 1)),
+            mvtMs = 0.30f,
+        )
+        assertNotNull(result)
+        // distinctLoads counts unique buckets, not raw points
+        assertTrue(result.distinctLoads == 2)
+    }
+
+    @Test fun `warmup-only or zero-rep points excluded by caller contract are not required here`() {
+        // estimator trusts caller to pass working points; verify it still needs 2 loads
+        assertNull(estimator.estimate(listOf(point(50f, 700f)), mvtMs = 0.20f))
+    }
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/ComputeVelocityOneRepMaxUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/ComputeVelocityOneRepMaxUseCaseTest.kt
@@ -24,8 +24,9 @@ class ComputeVelocityOneRepMaxUseCaseTest {
             WorkoutVelocityPoint(80f, 600f, timestampMs = 6L, workingReps = 5),
         )
         val inserted = mutableListOf<VelocityOneRepMaxResult>()
+        var capturedSinceMs = -1L
         val useCase = ComputeVelocityOneRepMaxUseCase(
-            workoutPoints = { _, _, _ -> points },
+            workoutPoints = { _, _, since -> capturedSinceMs = since; points },
             exerciseLookup = { _ -> FakeExercise(name = "Back Squat", muscleGroups = "Legs", mvtOverrideMs = null) },
             personalMvtLookup = { _, _ -> null },
             mvtProvider = MvtProvider(),
@@ -38,6 +39,22 @@ class ComputeVelocityOneRepMaxUseCaseTest {
         assertTrue(result.passedQualityGate)
         assertEquals(1, inserted.size)
         assertEquals(result.estimatedPerCableKg, inserted.first().estimatedPerCableKg)
+        // 28-day window: sinceMs = nowMs - 28 days
+        assertEquals(1_000_000L - 28L * 86_400_000L, capturedSinceMs)
+    }
+
+    @Test fun `returns null and persists nothing when exercise not found`() = runTest {
+        val inserted = mutableListOf<VelocityOneRepMaxResult>()
+        val useCase = ComputeVelocityOneRepMaxUseCase(
+            workoutPoints = { _, _, _ -> error("workoutPoints should not be called when exercise is missing") },
+            exerciseLookup = { _ -> null },
+            personalMvtLookup = { _, _ -> null },
+            mvtProvider = MvtProvider(),
+            estimator = VelocityOneRepMaxEstimator(AssessmentEngine()),
+            persist = { r, _, _, _ -> inserted += r },
+        )
+        assertEquals(null, useCase("ex1", "default", nowMs = 1_000_000L))
+        assertEquals(0, inserted.size)
     }
 
     @Test fun `returns null and persists nothing when fewer than two loads`() = runTest {

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/ComputeVelocityOneRepMaxUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/ComputeVelocityOneRepMaxUseCaseTest.kt
@@ -1,0 +1,56 @@
+package com.devil.phoenixproject.domain.usecase
+
+import com.devil.phoenixproject.domain.assessment.AssessmentEngine
+import com.devil.phoenixproject.domain.onerepmax.MvtProvider
+import com.devil.phoenixproject.domain.onerepmax.VelocityOneRepMaxEstimator
+import com.devil.phoenixproject.domain.onerepmax.VelocityOneRepMaxResult
+import com.devil.phoenixproject.domain.onerepmax.WorkoutVelocityPoint
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+private data class FakeExercise(
+    override val name: String,
+    override val muscleGroups: String,
+    override val mvtOverrideMs: Float?,
+) : MvtExerciseView
+
+class ComputeVelocityOneRepMaxUseCaseTest {
+    @Test fun `computes and persists an estimate from windowed points`() = runTest {
+        val points = listOf(
+            WorkoutVelocityPoint(40f, 1200f, timestampMs = 5L, workingReps = 5),
+            WorkoutVelocityPoint(80f, 600f, timestampMs = 6L, workingReps = 5),
+        )
+        val inserted = mutableListOf<VelocityOneRepMaxResult>()
+        val useCase = ComputeVelocityOneRepMaxUseCase(
+            workoutPoints = { _, _, _ -> points },
+            exerciseLookup = { _ -> FakeExercise(name = "Back Squat", muscleGroups = "Legs", mvtOverrideMs = null) },
+            personalMvtLookup = { _, _ -> null },
+            mvtProvider = MvtProvider(),
+            estimator = VelocityOneRepMaxEstimator(AssessmentEngine()),
+            persist = { result, _, _, _ -> inserted += result },
+        )
+
+        val result = useCase("ex1", "default", nowMs = 1_000_000L)
+        assertNotNull(result)
+        assertTrue(result.passedQualityGate)
+        assertEquals(1, inserted.size)
+        assertEquals(result.estimatedPerCableKg, inserted.first().estimatedPerCableKg)
+    }
+
+    @Test fun `returns null and persists nothing when fewer than two loads`() = runTest {
+        val inserted = mutableListOf<VelocityOneRepMaxResult>()
+        val useCase = ComputeVelocityOneRepMaxUseCase(
+            workoutPoints = { _, _, _ -> listOf(WorkoutVelocityPoint(50f, 700f, 1L, 5)) },
+            exerciseLookup = { _ -> FakeExercise("Curl", "Biceps", null) },
+            personalMvtLookup = { _, _ -> null },
+            mvtProvider = MvtProvider(),
+            estimator = VelocityOneRepMaxEstimator(AssessmentEngine()),
+            persist = { r, _, _, _ -> inserted += r },
+        )
+        assertEquals(null, useCase("ex1", "default", nowMs = 1L))
+        assertEquals(0, inserted.size)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/RecordPersonalMvtSampleUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/RecordPersonalMvtSampleUseCaseTest.kt
@@ -1,0 +1,47 @@
+package com.devil.phoenixproject.domain.usecase
+
+import com.devil.phoenixproject.data.repository.PersonalMvtEntity
+import com.devil.phoenixproject.data.repository.PersonalMvtRepository
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+private class FakePersonalMvtRepo : PersonalMvtRepository {
+    val store = mutableMapOf<String, PersonalMvtEntity>()
+    override suspend fun get(exerciseId: String, profileId: String) = store["$exerciseId/$profileId"]
+    override suspend fun upsert(exerciseId: String, profileId: String, personalMvtMs: Float, sampleCount: Int) {
+        store["$exerciseId/$profileId"] = PersonalMvtEntity(exerciseId, profileId, personalMvtMs, sampleCount)
+    }
+}
+
+class RecordPersonalMvtSampleUseCaseTest {
+    @Test fun `captures sample when velocity collapsed near squat threshold`() = runTest {
+        val repo = FakePersonalMvtRepo()
+        val useCase = RecordPersonalMvtSampleUseCase(repo)
+        // squat default 0.30 m/s; 0.31 m/s (310 mm/s) <= 1.1*0.30 -> capture
+        val captured = useCase("ex1", "default", "Back Squat", "Legs", sessionMcvMmS = 310f)
+        assertTrue(captured)
+        assertEquals(1, repo.get("ex1", "default")?.sampleCount)
+        assertEquals(0.31f, repo.get("ex1", "default")?.personalMvtMs!!, absoluteTolerance = 0.001f)
+    }
+
+    @Test fun `ignores fast non-failure set`() = runTest {
+        val repo = FakePersonalMvtRepo()
+        val useCase = RecordPersonalMvtSampleUseCase(repo)
+        // 0.60 m/s is well above threshold -> not a failure proxy
+        assertFalse(useCase("ex1", "default", "Back Squat", "Legs", sessionMcvMmS = 600f))
+        assertEquals(null, repo.get("ex1", "default"))
+    }
+
+    @Test fun `rolling mean across samples`() = runTest {
+        val repo = FakePersonalMvtRepo()
+        val useCase = RecordPersonalMvtSampleUseCase(repo)
+        useCase("ex1", "default", "Back Squat", "Legs", 300f) // 0.30
+        useCase("ex1", "default", "Back Squat", "Legs", 320f) // 0.32
+        val e = repo.get("ex1", "default")!!
+        assertEquals(2, e.sampleCount)
+        assertEquals(0.31f, e.personalMvtMs, absoluteTolerance = 0.001f)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeWorkoutRepository.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeWorkoutRepository.kt
@@ -259,4 +259,26 @@ class FakeWorkoutRepository : WorkoutRepository {
     }
 
     override fun getAllPhaseStatistics(): Flow<List<PhaseStatisticsData>> = _phaseStatisticsFlow
+
+    override suspend fun getVelocityPointsForExercise(
+        exerciseId: String,
+        profileId: String,
+        sinceTimestampMs: Long,
+    ): List<com.devil.phoenixproject.domain.onerepmax.WorkoutVelocityPoint> = sessions.values
+        .filter { s ->
+            s.exerciseId == exerciseId &&
+                s.profileId == profileId &&
+                s.timestamp >= sinceTimestampMs &&
+                s.avgMcvMmS != null &&
+                s.workingReps > 0
+        }
+        .sortedByDescending { it.timestamp }
+        .map { s ->
+            com.devil.phoenixproject.domain.onerepmax.WorkoutVelocityPoint(
+                loadPerCableKg = s.workingAvgWeightKg ?: s.weightPerCableKg,
+                mcvMmS = s.avgMcvMmS ?: 0f,
+                timestampMs = s.timestamp,
+                workingReps = s.workingReps,
+            )
+        }
 }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeWorkoutRepository.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeWorkoutRepository.kt
@@ -8,6 +8,7 @@ import com.devil.phoenixproject.domain.model.Routine
 import com.devil.phoenixproject.domain.model.WorkoutMetric
 import com.devil.phoenixproject.domain.model.WorkoutSession
 import com.devil.phoenixproject.domain.model.currentTimeMillis
+import com.devil.phoenixproject.domain.onerepmax.WorkoutVelocityPoint
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
@@ -264,7 +265,7 @@ class FakeWorkoutRepository : WorkoutRepository {
         exerciseId: String,
         profileId: String,
         sinceTimestampMs: Long,
-    ): List<com.devil.phoenixproject.domain.onerepmax.WorkoutVelocityPoint> = sessions.values
+    ): List<WorkoutVelocityPoint> = sessions.values
         .filter { s ->
             s.exerciseId == exerciseId &&
                 s.profileId == profileId &&
@@ -274,9 +275,9 @@ class FakeWorkoutRepository : WorkoutRepository {
         }
         .sortedByDescending { it.timestamp }
         .map { s ->
-            com.devil.phoenixproject.domain.onerepmax.WorkoutVelocityPoint(
+            WorkoutVelocityPoint(
                 loadPerCableKg = s.workingAvgWeightKg ?: s.weightPerCableKg,
-                mcvMmS = s.avgMcvMmS ?: 0f,
+                mcvMmS = s.avgMcvMmS ?: 0f, // non-null guaranteed by the avgMcvMmS != null filter above
                 timestampMs = s.timestamp,
                 workingReps = s.workingReps,
             )

--- a/shared/src/iosMain/kotlin/com/devil/phoenixproject/di/PlatformModule.ios.kt
+++ b/shared/src/iosMain/kotlin/com/devil/phoenixproject/di/PlatformModule.ios.kt
@@ -122,6 +122,7 @@ actual val platformModule: Module = module {
             healthExportCursorRepository = get(),
             computeVelocityOneRepMaxUseCase = get(),
             recordPersonalMvtSampleUseCase = get(),
+            velocityOneRepMaxRepository = get(),
         )
     }
 }

--- a/shared/src/iosMain/kotlin/com/devil/phoenixproject/di/PlatformModule.ios.kt
+++ b/shared/src/iosMain/kotlin/com/devil/phoenixproject/di/PlatformModule.ios.kt
@@ -120,6 +120,8 @@ actual val platformModule: Module = module {
             externalActivityRepository = get(),
             workoutServiceController = get(),
             healthExportCursorRepository = get(),
+            computeVelocityOneRepMaxUseCase = get(),
+            recordPersonalMvtSampleUseCase = get(),
         )
     }
 }


### PR DESCRIPTION
## Velocity-Based 1RM — Foundation (Phases 1–2) · #517

Implements the foundation for estimating a per-exercise 1RM from Mean Concentric Velocity (MCV) and surfacing it alongside PRs. Reuses the existing VBT `AssessmentEngine` (OLS load↔velocity regression) rather than rebuilding the math.

Closes part of #517 (Phases 1–2; later phases tracked separately — see Follow-ups).

### What's included
- **Estimation** — `VelocityOneRepMaxEstimator` builds `(load, MCV)` points from a rolling **28-day** window of completed sets per exercise (≥2 distinct loads), fits via `AssessmentEngine`, and applies a **quality gate** (distinctLoads ≥ 2 ∧ R² ≥ 0.8 ∧ negative slope). MCV only, never Peak Velocity. Per-cable throughout.
- **MVT model** — movement-pattern defaults (bench 0.15, OHP 0.20, squat 0.30, deadlift/hinge 0.15, fallback 0.20 m/s) + a personalized MVT that overrides the default after ≥3 captured samples; plus a per-exercise `mvtOverrideMs` column.
- **Persistence** — new `VelocityOneRepMaxEstimate` time-series table (migration 36) and `ExerciseMvt` table + `Exercise.mvtOverrideMs` (migration 37), with repositories. `Exercise.oneRepMaxKg` (the authoritative "true" 1RM) is **not** touched.
- **Pipeline** — `ComputeVelocityOneRepMaxUseCase` + `RecordPersonalMvtSampleUseCase`, wired into the post-save flow via a defaulted hook on `GamificationManager` (invoked from `ActiveSessionEngine`), with DI registrations.
- **Display** — latest passing estimate shown as "VELOCITY 1RM" on `ExerciseDetailScreen`, profile-scoped, formatted via the existing weight formatter.

### Testing
- Full `:shared:testAndroidHostTest` suite **GREEN (2167 tests)**; `:androidApp:assembleDebug` builds; schema manifest validated (382 columns / 43 tables).
- TDD per unit: estimator, MVT model, both use cases, both new repositories, the per-exercise velocity-points query, and schema parity/migration tests.
- Built task-by-task with a per-task spec+quality review and a final whole-branch review (**verdict: ready to merge**).

### Not in this PR (deferred to later phases, per the design spec)
`% of 1RM` scaling basis, distinct gamification badges, historical backfill, and phoenix-portal parity (`velocity_estimated_1rm_kg`).

### Follow-ups / handoff
- **Manual device check** (not automatable here): complete ≥2 sets of one exercise at different weights, open its detail screen, confirm "VELOCITY 1RM" appears.
- **Personalized-MVT capture** currently feeds the set-average MCV (`session.avgMcvMmS`); the design intends the last-rep RIR≈0 velocity. The path is gated (≥3 samples) and defaults dominate until refined — to be addressed when personalized MVT is activated.
- The manual-stop save path passes a null session MCV, so personalized-MVT sampling only fires on the standard save path (velocity-1RM compute runs on both).

### Note
This branch also contains 2 incidental commits unrelated to #517: `build(android): verify Supabase runtime config` and `docs: remove Daem0n MCP covenant`.

Design spec: `docs/superpowers/specs/2026-06-26-velocity-based-1rm-design.md` · Plan: `docs/superpowers/plans/2026-06-26-velocity-based-1rm-foundation.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
