### PR TITLE
feat(1rm): % of 1RM scaling, badges, backfill + review fixes (Phases 3-5) (#517)

### DIFF
--- a/docs/superpowers/plans/2026-06-26-velocity-1rm-phase3-percent-of-1rm.md
+++ b/docs/superpowers/plans/2026-06-26-velocity-1rm-phase3-percent-of-1rm.md
@@ -1,0 +1,334 @@
+# Velocity-1RM Phase 3 — `% of 1RM` Scaling Basis — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Let users program routine-set weights as a percentage of their velocity-estimated 1RM (in addition to the existing `% of PR`), selectable per routine-exercise and via a system-wide default.
+
+**Architecture:** Additive — introduce a `ScalingBasis { MAX_WEIGHT_PR, MAX_VOLUME_PR, ESTIMATED_1RM }` enum and a new nullable `scalingBasis` column on `RoutineExercise`. The existing **synced** `prTypeForScaling` field is left untouched; when `scalingBasis` is null (legacy rows) it is derived from `prTypeForScaling`, so nothing about the portal sync contract changes. `ResolveRoutineWeightsUseCase` resolves `ESTIMATED_1RM` from the latest passing velocity estimate, falling back to the stored true 1RM → PR → absolute. A system-wide `defaultScalingBasis` preference seeds new routine exercises.
+
+**Tech Stack:** Kotlin Multiplatform, SQLDelight 2.2.1, Koin, Compose, kotlin.test.
+
+Builds on the merged foundation (Phases 1–2): `VelocityOneRepMaxRepository.getLatestPassing(exerciseId, profileId)` and `Exercise.oneRepMaxKg` already exist.
+
+## Global Constraints
+
+- **Do NOT touch the synced `prTypeForScaling` field** (it ships to the portal via `SqlDelightSyncRepository`). `scalingBasis` is a new, mobile-local, nullable column.
+- `scalingBasis` is nullable; when null, derive via: `MAX_WEIGHT → MAX_WEIGHT_PR`, `MAX_VOLUME → MAX_VOLUME_PR`. Expose this as `RoutineExercise.effectiveScalingBasis: ScalingBasis`.
+- `usePercentOfPR` remains the on/off gate for percentage scaling; `effectiveScalingBasis` only chooses the baseline.
+- Weights are per-cable throughout. Resolution order for `ESTIMATED_1RM`: latest **passing** velocity estimate (per-cable) → `Exercise.oneRepMaxKg` → matching PR → absolute weight.
+- Adding a column requires the project's coordinated update: `.sq` CREATE + both `insertRoutineExercise`/`insertRoutineExerciseIgnore` + the RoutineExercise select mapper, a new `38.sqm`, `MigrationStatements` `38 ->`, `SchemaManifest` (heal op), **`shared/build.gradle.kts` `version = 38 → 39`**, and **`SchemaParityTest.CURRENT_VERSION 38L → 39L`**. The build's schema-manifest validator + `SchemaParityTest`/`SchemaManifestTest` enforce consistency.
+- Module test task is `:shared:testAndroidHostTest` (NOT `testDebugUnitTest`). SQLDelight regen: `./gradlew :shared:generateCommonMainVitruvianDatabaseInterface`.
+- Branch: `fix/issue-517-review-followups` (this work lands on PR #598). Only `git add` files you change.
+
+---
+
+## File Structure
+
+**Create:**
+- `shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/ScalingBasis.kt` — enum + derivation helper.
+- `shared/src/commonMain/sqldelight/.../migrations/38.sqm`.
+
+**Modify:**
+- `domain/model/Routine.kt` — `RoutineExercise.scalingBasis` field + `effectiveScalingBasis`.
+- `sqldelight/.../VitruvianDatabase.sq` — RoutineExercise CREATE + both inserts + select.
+- `data/local/MigrationStatements.kt`, `data/local/SchemaManifest.kt`, `shared/build.gradle.kts`, the `SchemaParityTest` version constant.
+- `data/repository/SqlDelightWorkoutRepository.kt` — RoutineExercise read/write mapper for the new column.
+- `domain/usecase/ResolveRoutineWeightsUseCase.kt` — `ESTIMATED_1RM` branch (+ inject `VelocityOneRepMaxRepository`).
+- `domain/model/UserPreferences.kt`, `data/preferences/PreferencesManager.kt`, `presentation/manager/SettingsManager.kt` — `defaultScalingBasis` preference.
+- `presentation/viewmodel/ExerciseConfigViewModel.kt` + the routine-exercise editor screen + a settings screen — UI for the basis choice and the global default.
+- `di/DomainModule.kt` — `ResolveRoutineWeightsUseCase` constructor arg.
+
+---
+
+### Task 1: `ScalingBasis` enum + `RoutineExercise.scalingBasis` / `effectiveScalingBasis`
+
+**Files:**
+- Create: `shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/ScalingBasis.kt`
+- Modify: `shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/Routine.kt`
+- Test: `shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/ScalingBasisTest.kt`
+
+**Interfaces:**
+- Produces: `enum class ScalingBasis { MAX_WEIGHT_PR, MAX_VOLUME_PR, ESTIMATED_1RM }`; `fun ScalingBasis.Companion.fromPrType(prType: PRType): ScalingBasis`; `RoutineExercise.scalingBasis: ScalingBasis? = null`; `val RoutineExercise.effectiveScalingBasis: ScalingBasis`.
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+package com.devil.phoenixproject.domain.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ScalingBasisTest {
+    @Test fun `fromPrType maps PR types`() {
+        assertEquals(ScalingBasis.MAX_WEIGHT_PR, ScalingBasis.fromPrType(PRType.MAX_WEIGHT))
+        assertEquals(ScalingBasis.MAX_VOLUME_PR, ScalingBasis.fromPrType(PRType.MAX_VOLUME))
+    }
+
+    @Test fun `effectiveScalingBasis uses explicit value when set`() {
+        val ex = sampleRoutineExercise().copy(scalingBasis = ScalingBasis.ESTIMATED_1RM)
+        assertEquals(ScalingBasis.ESTIMATED_1RM, ex.effectiveScalingBasis)
+    }
+
+    @Test fun `effectiveScalingBasis derives from prTypeForScaling when null`() {
+        val ex = sampleRoutineExercise().copy(scalingBasis = null, prTypeForScaling = PRType.MAX_VOLUME)
+        assertEquals(ScalingBasis.MAX_VOLUME_PR, ex.effectiveScalingBasis)
+    }
+}
+```
+
+`sampleRoutineExercise()` — a minimal `RoutineExercise(...)` factory; if no shared test helper exists, build one inline with the required non-default fields (read `RoutineExercise`'s constructor for required params).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :shared:testAndroidHostTest --tests "*ScalingBasisTest*"`
+Expected: FAIL — `ScalingBasis` unresolved.
+
+- [ ] **Step 3: Implement**
+
+`ScalingBasis.kt`:
+```kotlin
+package com.devil.phoenixproject.domain.model
+
+/** Baseline a routine exercise's percentage weight scales from. */
+enum class ScalingBasis {
+    MAX_WEIGHT_PR,
+    MAX_VOLUME_PR,
+    ESTIMATED_1RM,
+    ;
+
+    companion object {
+        fun fromPrType(prType: PRType): ScalingBasis = when (prType) {
+            PRType.MAX_WEIGHT -> MAX_WEIGHT_PR
+            PRType.MAX_VOLUME -> MAX_VOLUME_PR
+        }
+    }
+}
+```
+
+In `Routine.kt`, add to the `RoutineExercise` data class (after `prTypeForScaling`/`setWeightsPercentOfPR`):
+```kotlin
+val scalingBasis: ScalingBasis? = null, // null = derive from prTypeForScaling (legacy/back-compat)
+```
+And a computed property in the class body:
+```kotlin
+/** The resolved scaling baseline; derives from prTypeForScaling for legacy rows. */
+val effectiveScalingBasis: ScalingBasis
+    get() = scalingBasis ?: ScalingBasis.fromPrType(prTypeForScaling)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :shared:testAndroidHostTest --tests "*ScalingBasisTest*"`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/ScalingBasis.kt shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/Routine.kt shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/ScalingBasisTest.kt
+git commit -m "feat(1rm): add ScalingBasis enum + RoutineExercise.scalingBasis (#517)"
+```
+
+---
+
+### Task 2: Persist `scalingBasis` on RoutineExercise (schema + migration + mapper)
+
+**Files:**
+- Modify: `VitruvianDatabase.sq` (RoutineExercise CREATE + `insertRoutineExercise` + `insertRoutineExerciseIgnore` + the RoutineExercise SELECT mapper), `MigrationStatements.kt`, `SchemaManifest.kt`, `shared/build.gradle.kts`, the `SchemaParityTest` version file, `SqlDelightWorkoutRepository.kt` (RoutineExercise read/write).
+- Create: `migrations/38.sqm`
+- Test: existing `SchemaParityTest`/`SchemaManifestTest`, plus a round-trip test in `androidHostTest` (`SqlDelightWorkoutRepositoryRoutineScalingTest.kt`).
+
+**Interfaces:**
+- The RoutineExercise persisted/read includes `scalingBasis` (stored as nullable TEXT enum name).
+
+- [ ] **Step 1: Schema — add the column**
+
+In `VitruvianDatabase.sq` `CREATE TABLE RoutineExercise (...)`, add a nullable column (near `prTypeForScaling`):
+```sql
+scalingBasis TEXT,
+```
+Add `scalingBasis` to the column lists AND the `VALUES (?, …)` of **both** `insertRoutineExercise` and `insertRoutineExerciseIgnore` (one more `?`). Add it to the RoutineExercise SELECT used by the mapper (if it's `SELECT *`, no query change needed, but the generated row gains the column).
+
+- [ ] **Step 2: Migration `38.sqm`**
+
+```sql
+-- Migration 38: per-routine-exercise scaling basis (% of estimated 1RM) — issue #517 Phase 3.
+ALTER TABLE RoutineExercise ADD COLUMN scalingBasis TEXT;
+```
+
+- [ ] **Step 3: MigrationStatements + SchemaManifest + version bumps**
+
+- `MigrationStatements.kt`: add `38 -> listOf("""ALTER TABLE RoutineExercise ADD COLUMN scalingBasis TEXT""")`.
+- `SchemaManifest.kt`: add `SchemaHealOperation(table = "RoutineExercise", column = "scalingBasis", sql = "ALTER TABLE RoutineExercise ADD COLUMN scalingBasis TEXT")`.
+- `shared/build.gradle.kts`: `version = 38` → `version = 39`; update the comment to `// Version 39 = initial schema (1) + 38 migrations (1.sqm through 38.sqm).`
+- `SchemaParityTest`: `CURRENT_VERSION = 38L` → `39L` (grep `CURRENT_VERSION` to locate).
+
+- [ ] **Step 4: Mapper — read/write the column** in `SqlDelightWorkoutRepository.kt`
+
+In the RoutineExercise row→domain mapper, add:
+```kotlin
+scalingBasis = row.scalingBasis?.let { runCatching { ScalingBasis.valueOf(it) }.getOrNull() },
+```
+In both `insertRoutineExercise`/`insertRoutineExerciseIgnore` calls, pass:
+```kotlin
+scalingBasis = routineExercise.scalingBasis?.name,
+```
+Update any other RoutineExercise insert call sites the compiler flags (grep `insertRoutineExercise(`).
+
+- [ ] **Step 5: Round-trip test (TDD)**
+
+```kotlin
+// androidHostTest — SqlDelightWorkoutRepositoryRoutineScalingTest.kt
+@Test fun `routine exercise persists and reads back scalingBasis`() = runTest {
+    val db = createInMemoryTestDatabase()
+    val repo = SqlDelightWorkoutRepository(db /* + prod deps */)
+    val routineId = seedRoutine(db) // create a Routine FK row via existing helper/insert
+    val ex = sampleRoutineExercise().copy(routineId = routineId, scalingBasis = ScalingBasis.ESTIMATED_1RM)
+    repo.saveRoutineExercise(ex) // use the repo's actual save API (read the interface)
+    val read = repo.getRoutineExercises(routineId).first { it.id == ex.id }
+    assertEquals(ScalingBasis.ESTIMATED_1RM, read.scalingBasis)
+}
+```
+Adapt to the repository's real save/read method names and the in-memory harness (mirror an existing `SqlDelightWorkoutRepository`/routine test). If no routine-save test harness exists, build the minimal one following existing patterns.
+
+- [ ] **Step 6: Regen + run parity + round-trip tests**
+
+Run: `./gradlew :shared:generateCommonMainVitruvianDatabaseInterface :shared:testAndroidHostTest --tests "*SchemaManifestTest*" --tests "*SchemaParityTest*" --tests "*RoutineScalingTest*"`
+Expected: PASS. Reconcile `.sq` vs `SchemaManifest` if parity fails.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add shared/src/commonMain/sqldelight shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local shared/build.gradle.kts shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepository.kt shared/src/androidHostTest
+# also the SchemaParityTest version file
+git commit -m "feat(1rm): persist RoutineExercise.scalingBasis, migration 38 (#517)"
+```
+
+---
+
+### Task 3: `ResolveRoutineWeightsUseCase` — `ESTIMATED_1RM` branch
+
+**Files:**
+- Modify: `domain/usecase/ResolveRoutineWeightsUseCase.kt`, `di/DomainModule.kt`
+- Test: `shared/src/commonTest/.../usecase/ResolveRoutineWeightsUseCaseTest.kt`
+
+**Interfaces:**
+- Consumes: `VelocityOneRepMaxRepository.getLatestPassing(exerciseId, profileId): VelocityOneRepMaxEntity?`.
+- The use case constructor gains a `velocityOneRepMaxRepository: VelocityOneRepMaxRepository` param.
+
+- [ ] **Step 1: Write failing tests**
+
+Add cases to the existing test:
+```kotlin
+@Test fun `ESTIMATED_1RM uses latest passing velocity estimate`() = runTest {
+    // fake velocityRepo returns estimate 100f (per-cable) for ex1/default
+    val ex = routineExercise(exerciseId = "ex1", usePercentOfPR = true, weightPercentOfPR = 80,
+        scalingBasis = ScalingBasis.ESTIMATED_1RM)
+    val resolved = useCase(ex, profileId = "default")
+    assertEquals(80f, resolved.baseWeight) // 80% of 100
+}
+
+@Test fun `ESTIMATED_1RM falls back to stored 1RM then PR when no estimate`() = runTest {
+    // velocityRepo returns null; exercise.oneRepMaxKg = 120f -> 80% = 96f
+    ...
+    assertEquals(96f, resolved.baseWeight)
+}
+```
+Use the existing fakes in this test file; add a `FakeVelocityOneRepMaxRepository` returning a configurable `getLatestPassing`.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `./gradlew :shared:testAndroidHostTest --tests "*ResolveRoutineWeightsUseCaseTest*"`
+Expected: FAIL (constructor arity / ESTIMATED_1RM not handled).
+
+- [ ] **Step 3: Implement**
+
+Add the constructor param and branch on `exercise.effectiveScalingBasis`:
+```kotlin
+val scalingWeight: Float? = when (exercise.effectiveScalingBasis) {
+    ScalingBasis.MAX_WEIGHT_PR -> prRepository.getBestWeightPRForWorkoutMode(exerciseId, mode.displayName, profileId)?.weightPerCableKg?.takeIf { it > 0 }
+    ScalingBasis.MAX_VOLUME_PR -> prRepository.getBestVolumePRForWorkoutMode(exerciseId, mode.displayName, profileId)?.weightPerCableKg?.takeIf { it > 0 }
+    ScalingBasis.ESTIMATED_1RM -> velocityOneRepMaxRepository.getLatestPassing(exerciseId, profileId)?.estimatedPerCableKg?.takeIf { it > 0 }
+} ?: exerciseRepository.getExerciseById(exerciseId)?.oneRepMaxKg?.takeIf { it > 0 }
+```
+Keep the existing fallback-to-absolute behavior when `scalingWeight` is null. (Refactor the current `when (exercise.prTypeForScaling)` block to this `effectiveScalingBasis` form — behavior for the two PR bases is unchanged.)
+
+`DomainModule.kt`: `factory { ResolveRoutineWeightsUseCase(get(), get(), get()) }` (add the velocity repo).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `./gradlew :shared:testAndroidHostTest --tests "*ResolveRoutineWeightsUseCaseTest*"`
+Expected: PASS (existing + new cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/ResolveRoutineWeightsUseCase.kt shared/src/commonMain/kotlin/com/devil/phoenixproject/di/DomainModule.kt shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/ResolveRoutineWeightsUseCaseTest.kt
+git commit -m "feat(1rm): resolve % of estimated-1RM in routine weights (#517)"
+```
+
+---
+
+### Task 4: System-wide `defaultScalingBasis` preference
+
+**Files:**
+- Modify: `domain/model/UserPreferences.kt`, `data/preferences/PreferencesManager.kt` (serialize/restore the new field), `presentation/manager/SettingsManager.kt` (StateFlow + setter).
+- Test: `androidHostTest`/`commonTest` for the preference round-trip (mirror an existing PreferencesManager test).
+
+**Interfaces:**
+- Produces: `UserPreferences.defaultScalingBasis: ScalingBasis = ScalingBasis.MAX_WEIGHT_PR`; `SettingsManager.defaultScalingBasis: StateFlow<ScalingBasis>` + `setDefaultScalingBasis(basis: ScalingBasis)`.
+
+- [ ] **Step 1: Write failing test** — assert a set value persists through `PreferencesManager` round-trip (follow the existing preferences test pattern; if persistence is JSON/Settings-backed, assert via the flow after `setDefaultScalingBasis`).
+
+- [ ] **Step 2: Run to verify failure.** `./gradlew :shared:testAndroidHostTest --tests "*Preferences*"` (or the relevant settings test) — FAIL.
+
+- [ ] **Step 3: Implement**
+- `UserPreferences`: add `val defaultScalingBasis: ScalingBasis = ScalingBasis.MAX_WEIGHT_PR,`.
+- `PreferencesManager`: add the field to whatever (de)serializes `UserPreferences` (store `.name`, restore via `runCatching { ScalingBasis.valueOf(it) }.getOrDefault(MAX_WEIGHT_PR)`); follow the exact pattern used for `repCountTiming` (also an enum-valued pref).
+- `SettingsManager`: add the StateFlow + `fun setDefaultScalingBasis(basis: ScalingBasis) { preferencesManager.update { it.copy(defaultScalingBasis = basis) } }` (match the existing setter style, e.g. `setRepCountTiming`).
+
+- [ ] **Step 4: Run to verify pass.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(1rm): add system-wide defaultScalingBasis preference (#517)"
+```
+
+---
+
+### Task 5: UI — per-exercise basis choice + global default toggle
+
+**Files:**
+- Modify: `presentation/viewmodel/ExerciseConfigViewModel.kt` (expose/set `scalingBasis`; seed new exercises from `settingsManager.defaultScalingBasis`), the routine-exercise editor screen (the existing `% of PR` control — add a basis selector incl. "Estimated 1RM"), and the settings screen (a control bound to `setDefaultScalingBasis`).
+
+**Interfaces:**
+- Consumes: Tasks 1, 4. The editor writes `RoutineExercise.scalingBasis`; new exercises default to the system `defaultScalingBasis`.
+
+- [ ] **Step 1: ViewModel** — read the current `% of PR` config flow in `ExerciseConfigViewModel` (grep `prTypeForScaling`), add `scalingBasis` to the editable config state with a setter, and when creating a new routine exercise, initialise `scalingBasis = settingsManager.defaultScalingBasis.value`. Add a unit test if the ViewModel has a testable surface (mirror `ExerciseConfigViewModelTest`).
+
+- [ ] **Step 2: Editor UI** — in the routine-exercise editor where `usePercentOfPR` / `prTypeForScaling` are surfaced, add a basis selector with three options: "Max-weight PR", "Max-volume PR", "Estimated 1RM (velocity)". Bind to the ViewModel. Reuse the screen's existing selector/segmented-control component; do not invent new styling.
+
+- [ ] **Step 3: Settings UI** — add a control (segmented/dropdown) for the system-wide default, bound to `settingsManager.defaultScalingBasis` / `setDefaultScalingBasis`, near the other workout-programming settings.
+
+- [ ] **Step 4: Verify (compile + manual handoff)**
+
+Run: `./gradlew :androidApp:assembleDebug` → BUILD SUCCESSFUL; `./gradlew :shared:testAndroidHostTest` → GREEN.
+Manual handoff (no Compose UI test harness): set a routine exercise to "Estimated 1RM", confirm at workout start the weight resolves from the velocity estimate; toggle the global default and confirm new exercises pick it up.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(1rm): UI for % of 1RM scaling basis + global default (#517)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (design §4):** third scaling basis (`ESTIMATED_1RM`) — Tasks 1–3 ✓; system-wide default — Task 4 ✓; resolution falls back true-1RM → PR → absolute — Task 3 ✓; per-exercise + global UI — Task 5 ✓; synced `prTypeForScaling` untouched (additive `scalingBasis`) — Tasks 1–2 ✓.
+
+**Placeholder scan:** Tasks 4–5 give exact patterns to mirror (`repCountTiming` pref, existing selector components) rather than literal code because they hook into screens whose structure must be read first — each names the concrete file and the existing pattern to copy. No "TBD"/"add validation".
+
+**Type consistency:** `ScalingBasis` (3 values), `effectiveScalingBasis`, `getLatestPassing(...).estimatedPerCableKg`, `defaultScalingBasis`, `setDefaultScalingBasis` used consistently across tasks.
+
+**Deferred (later plans):** distinct badges (Phase 4), backfill (Phase 5), portal parity (Phase 6 — phoenix-portal repo, cannot ride this mobile PR).

--- a/docs/superpowers/plans/2026-06-26-velocity-1rm-phase4-badges.md
+++ b/docs/superpowers/plans/2026-06-26-velocity-1rm-phase4-badges.md
@@ -1,0 +1,382 @@
+# Velocity-1RM Phase 4 — Distinct Velocity-1RM Badges — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Award distinct, tiered badges as a user's velocity-estimated 1RM improves over time — separate from the existing PR badges.
+
+**Architecture:** A "velocity-1RM improvement" = a new passing estimate that beats that exercise's prior best passing estimate by ≥ 2.5%. Improvements are counted statelessly from the persisted `VelocityOneRepMaxEstimate` history (no new schema). Three tiered `STRENGTH` badges (1 / 5 / 15 cumulative improvements across all exercises) fire through the existing `GamificationManager` badge-emit flow, checked from the post-save hook after each new estimate is computed.
+
+**Tech Stack:** Kotlin Multiplatform, SQLDelight, Koin, kotlin.test.
+
+Builds on the merged foundation + Phase 3 (this branch). Reuses `VelocityOneRepMaxRepository`, `VelocityOneRepMaxEntity`, the `GamificationManager` badge pattern (`processSetQualityEvent` is the template), and `BadgeDefinitions`.
+
+## Global Constraints
+
+- Improvement threshold: **`IMPROVEMENT_FACTOR = 1.025f`** (new passing estimate ≥ prior best × 1.025 for that exercise).
+- Improvements are **cumulative across all exercises** for a profile, counted from passing estimates only.
+- Tiers: **1 / 5 / 15** improvements → BRONZE / SILVER / GOLD, `BadgeCategory.STRENGTH`.
+- Badges are **distinct** from PR badges — new `BadgeRequirement.VelocityOneRepMaxImprovements(count)` subtype.
+- The `BadgeRequirement` sealed class drives an **exhaustive** `when` in `Badge.getProgressDescription` — adding a subtype REQUIRES adding a branch there (compiler-enforced).
+- Per-cable weights; estimates already per-cable. No schema migration in this phase (query-only repo addition).
+- Module test task: `:shared:testAndroidHostTest`. Branch: `fix/issue-517-review-followups` (PR #598). Only `git add` files you change.
+
+---
+
+## File Structure
+
+**Modify:**
+- `domain/model/Gamification.kt` — new `BadgeRequirement.VelocityOneRepMaxImprovements` + `getProgressDescription` branch.
+- `data/local/BadgeDefinitions.kt` — 3 tiered badge definitions.
+- `sqldelight/.../VitruvianDatabase.sq` — `selectAllPassingVelocityOneRepMaxByProfile` query.
+- `data/repository/VelocityOneRepMaxRepository.kt` — `getAllPassing(profileId)`.
+- `presentation/manager/GamificationManager.kt` — `checkVelocityOneRepMaxBadges(...)`.
+- `presentation/viewmodel/MainViewModel.kt` — invoke the count + badge check from `onPostSaveComputed`.
+- `di/DomainModule.kt` — register the count use case.
+
+**Create:**
+- `domain/usecase/CountVelocityOneRepMaxImprovementsUseCase.kt`
+
+---
+
+### Task 1: `VelocityOneRepMaxImprovements` requirement + tiered badge definitions
+
+**Files:**
+- Modify: `domain/model/Gamification.kt`, `data/local/BadgeDefinitions.kt`
+- Test: `shared/src/commonTest/.../data/local/VelocityOneRepMaxBadgeDefinitionsTest.kt`
+
+**Interfaces:**
+- Produces: `BadgeRequirement.VelocityOneRepMaxImprovements(val count: Int)`; 3 badges with ids `velocity_1rm_1`, `velocity_1rm_5`, `velocity_1rm_15`.
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+package com.devil.phoenixproject.data.local
+
+import com.devil.phoenixproject.domain.model.BadgeCategory
+import com.devil.phoenixproject.domain.model.BadgeRequirement
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class VelocityOneRepMaxBadgeDefinitionsTest {
+    @Test fun `three tiered velocity 1RM badges exist with STRENGTH category`() {
+        val ids = listOf("velocity_1rm_1", "velocity_1rm_5", "velocity_1rm_15")
+        val badges = ids.map { id -> assertNotNull(BadgeDefinitions.getBadgeById(id), "missing $id") }
+        badges.forEach { assertEquals(BadgeCategory.STRENGTH, it.category) }
+        assertEquals(
+            listOf(1, 5, 15),
+            badges.map { (it.requirement as BadgeRequirement.VelocityOneRepMaxImprovements).count },
+        )
+    }
+
+    @Test fun `velocity 1RM badges are distinct from PR badges`() {
+        val velocity = BadgeDefinitions.allBadges.filter { it.requirement is BadgeRequirement.VelocityOneRepMaxImprovements }
+        val pr = BadgeDefinitions.allBadges.filter { it.requirement is BadgeRequirement.PRsAchieved }
+        assertTrue(velocity.isNotEmpty() && pr.isNotEmpty())
+        assertTrue(velocity.none { v -> pr.any { it.id == v.id } })
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `./gradlew :shared:testAndroidHostTest --tests "*VelocityOneRepMaxBadgeDefinitionsTest*"`
+Expected: FAIL — requirement/badges absent.
+
+- [ ] **Step 3: Implement**
+
+In `Gamification.kt`, add to the `BadgeRequirement` sealed class (with the others):
+```kotlin
+/** Cumulative velocity-estimated 1RM improvements (>=2.5% over prior best) across all exercises. */
+data class VelocityOneRepMaxImprovements(val count: Int) : BadgeRequirement()
+```
+Add the exhaustive-`when` branch in `Badge.getProgressDescription`:
+```kotlin
+is BadgeRequirement.VelocityOneRepMaxImprovements -> "$currentValue/${req.count} velocity 1RMs"
+```
+
+In `BadgeDefinitions.kt`, add to `allBadges` (use the existing `Badge(...)` field shape; pick an `iconResource` consistent with other STRENGTH badges — reuse an existing icon string from a nearby STRENGTH badge):
+```kotlin
+Badge(
+    id = "velocity_1rm_1",
+    name = "Velocity Breakthrough",
+    description = "Improved your velocity-estimated 1RM on any lift",
+    category = BadgeCategory.STRENGTH,
+    iconResource = "trophy", // match an existing STRENGTH badge's iconResource
+    tier = BadgeTier.BRONZE,
+    requirement = BadgeRequirement.VelocityOneRepMaxImprovements(1),
+),
+Badge(
+    id = "velocity_1rm_5",
+    name = "Velocity Climber",
+    description = "5 velocity-estimated 1RM improvements",
+    category = BadgeCategory.STRENGTH,
+    iconResource = "trophy",
+    tier = BadgeTier.SILVER,
+    requirement = BadgeRequirement.VelocityOneRepMaxImprovements(5),
+),
+Badge(
+    id = "velocity_1rm_15",
+    name = "Velocity Master",
+    description = "15 velocity-estimated 1RM improvements",
+    category = BadgeCategory.STRENGTH,
+    iconResource = "trophy",
+    tier = BadgeTier.GOLD,
+    requirement = BadgeRequirement.VelocityOneRepMaxImprovements(15),
+),
+```
+Read an existing STRENGTH `Badge(...)` entry first and match its exact field set/`iconResource` convention.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `./gradlew :shared:testAndroidHostTest --tests "*VelocityOneRepMaxBadgeDefinitionsTest*"`
+Expected: PASS. (Also confirms the exhaustive `when` compiles.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/Gamification.kt shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/BadgeDefinitions.kt shared/src/commonTest/kotlin/com/devil/phoenixproject/data/local/VelocityOneRepMaxBadgeDefinitionsTest.kt
+git commit -m "feat(1rm): add tiered velocity-1RM improvement badges (#517)"
+```
+
+---
+
+### Task 2: `getAllPassing(profileId)` repository query
+
+**Files:**
+- Modify: `sqldelight/.../VitruvianDatabase.sq`, `data/repository/VelocityOneRepMaxRepository.kt`
+- Test: `shared/src/androidHostTest/.../repository/SqlDelightVelocityOneRepMaxRepositoryTest.kt` (extend)
+
+**Interfaces:**
+- Produces: `suspend fun VelocityOneRepMaxRepository.getAllPassing(profileId: String): List<VelocityOneRepMaxEntity>` ordered by `exerciseId, computedAt ASC`.
+
+- [ ] **Step 1: Add the query** to `VitruvianDatabase.sq` (near the other VelocityOneRepMax queries):
+
+```sql
+selectAllPassingVelocityOneRepMaxByProfile:
+SELECT * FROM VelocityOneRepMaxEstimate
+WHERE profile_id = :profileId AND passedQualityGate = 1 AND deletedAt IS NULL
+ORDER BY exerciseId ASC, computedAt ASC;
+```
+
+- [ ] **Step 2: Write the failing test** (extend the existing repo test)
+
+```kotlin
+@Test fun `getAllPassing returns only passing rows for the profile ordered by exercise then time`() = runTest {
+    val db = createInMemoryTestDatabase()
+    seedExercise(db, id = "exA"); seedExercise(db, id = "exB")
+    val repo = SqlDelightVelocityOneRepMaxRepository(db)
+    repo.insert(result(100f, passed = true), "exA", computedAt = 1L, profileId = "default")
+    repo.insert(result(110f, passed = true), "exA", computedAt = 2L, profileId = "default")
+    repo.insert(result(90f, passed = false), "exA", computedAt = 3L, profileId = "default") // excluded
+    repo.insert(result(80f, passed = true), "exB", computedAt = 1L, profileId = "default")
+    repo.insert(result(200f, passed = true), "exA", computedAt = 1L, profileId = "other") // other profile
+
+    val all = repo.getAllPassing("default")
+    assertEquals(3, all.size)
+    assertEquals(listOf("exA", "exA", "exB"), all.map { it.exerciseId })
+    assertEquals(listOf(100f, 110f, 80f), all.map { it.estimatedPerCableKg })
+}
+```
+(`result(...)`/`seedExercise`/`createInMemoryTestDatabase` already exist in this test file from the foundation.)
+
+- [ ] **Step 3: Run to verify failure.** `./gradlew :shared:testAndroidHostTest --tests "*SqlDelightVelocityOneRepMaxRepositoryTest*"` — FAIL (method missing).
+
+- [ ] **Step 4: Implement** in `VelocityOneRepMaxRepository.kt`:
+- Interface: `suspend fun getAllPassing(profileId: String): List<VelocityOneRepMaxEntity>`
+- Impl:
+```kotlin
+override suspend fun getAllPassing(profileId: String): List<VelocityOneRepMaxEntity> =
+    withContext(Dispatchers.IO) {
+        queries.selectAllPassingVelocityOneRepMaxByProfile(profileId, ::map).executeAsList()
+    }
+```
+(Use the same `::map` mapper already defined in this class.)
+
+- [ ] **Step 5: Run to verify pass.** Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add shared/src/commonMain/sqldelight shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/VelocityOneRepMaxRepository.kt shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightVelocityOneRepMaxRepositoryTest.kt
+git commit -m "feat(1rm): add getAllPassing velocity-1RM query (#517)"
+```
+
+---
+
+### Task 3: `CountVelocityOneRepMaxImprovementsUseCase` (pure)
+
+**Files:**
+- Create: `domain/usecase/CountVelocityOneRepMaxImprovementsUseCase.kt`
+- Test: `shared/src/commonTest/.../usecase/CountVelocityOneRepMaxImprovementsUseCaseTest.kt`
+
+**Interfaces:**
+- Produces: `class CountVelocityOneRepMaxImprovementsUseCase { operator fun invoke(passingEstimates: List<VelocityOneRepMaxEntity>): Int }`. Groups by `exerciseId`, orders each by `computedAt` asc, walks maintaining a running best, counts each estimate that is ≥ runningBest × 1.025 (and updates runningBest), sums across exercises. The first estimate per exercise is the baseline (not an improvement).
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+package com.devil.phoenixproject.domain.usecase
+
+import com.devil.phoenixproject.data.repository.VelocityOneRepMaxEntity
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CountVelocityOneRepMaxImprovementsUseCaseTest {
+    private val useCase = CountVelocityOneRepMaxImprovementsUseCase()
+    private fun e(ex: String, kg: Float, t: Long) =
+        VelocityOneRepMaxEntity(0, ex, kg, 0.3f, 0.95f, 3, true, t, "default")
+
+    @Test fun `counts improvements above 2_5 percent per exercise`() {
+        // exA: 100 (base) -> 103 (+3% improvement) -> 104 (<2.5% over 103, no) -> 110 (improvement over 104)
+        val points = listOf(
+            e("exA", 100f, 1), e("exA", 103f, 2), e("exA", 104f, 3), e("exA", 110f, 4),
+            e("exB", 50f, 1), e("exB", 60f, 2), // exB: base -> +20% improvement
+        )
+        assertEquals(3, useCase(points)) // exA:2 + exB:1
+    }
+
+    @Test fun `single estimate per exercise is not an improvement`() {
+        assertEquals(0, useCase(listOf(e("exA", 100f, 1), e("exB", 80f, 1))))
+    }
+
+    @Test fun `empty input is zero`() = assertEquals(0, useCase(emptyList()))
+}
+```
+
+- [ ] **Step 2: Run to verify failure.** FAIL — use case unresolved.
+
+- [ ] **Step 3: Implement**
+
+```kotlin
+package com.devil.phoenixproject.domain.usecase
+
+import com.devil.phoenixproject.data.repository.VelocityOneRepMaxEntity
+
+/** Counts cumulative velocity-1RM improvements (>= prior best x 1.025) across all exercises. */
+class CountVelocityOneRepMaxImprovementsUseCase {
+    operator fun invoke(passingEstimates: List<VelocityOneRepMaxEntity>): Int {
+        var improvements = 0
+        passingEstimates.groupBy { it.exerciseId }.forEach { (_, rows) ->
+            var best: Float? = null
+            rows.sortedBy { it.computedAt }.forEach { row ->
+                val prior = best
+                if (prior != null && row.estimatedPerCableKg >= prior * IMPROVEMENT_FACTOR) {
+                    improvements++
+                    best = row.estimatedPerCableKg
+                } else if (prior == null || row.estimatedPerCableKg > prior) {
+                    best = row.estimatedPerCableKg
+                }
+            }
+        }
+        return improvements
+    }
+
+    companion object {
+        const val IMPROVEMENT_FACTOR = 1.025f
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify pass.** Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/CountVelocityOneRepMaxImprovementsUseCase.kt shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/CountVelocityOneRepMaxImprovementsUseCaseTest.kt
+git commit -m "feat(1rm): count velocity-1RM improvements (#517)"
+```
+
+---
+
+### Task 4: Award the badges — `GamificationManager` + post-save wiring
+
+**Files:**
+- Modify: `presentation/manager/GamificationManager.kt`, `presentation/viewmodel/MainViewModel.kt`, `di/DomainModule.kt`
+- Test: `shared/src/androidHostTest/.../manager/GamificationManagerTest.kt` (extend)
+
+**Interfaces:**
+- Produces: `suspend fun GamificationManager.checkVelocityOneRepMaxBadges(improvementCount: Int, profileId: String): List<Badge>` — awards unearned `VelocityOneRepMaxImprovements` badges whose `count <= improvementCount`, emits `HapticEvent.BADGE_EARNED` + `_badgeEarnedEvents`, returns newly earned. No new constructor params (uses the existing `gamificationRepository` + emit flows).
+
+- [ ] **Step 1: Write the failing test** (extend `GamificationManagerTest`, mirroring the `processSetQualityEvent` tests)
+
+```kotlin
+@Test fun `checkVelocityOneRepMaxBadges awards bronze at one improvement`() = runTest {
+    // construct GamificationManager via the existing test harness in this file
+    val earned = manager.checkVelocityOneRepMaxBadges(improvementCount = 1, profileId = "default")
+    assertTrue(earned.any { it.id == "velocity_1rm_1" })
+    assertFalse(earned.any { it.id == "velocity_1rm_5" })
+}
+
+@Test fun `checkVelocityOneRepMaxBadges does not re-award already earned`() = runTest {
+    manager.checkVelocityOneRepMaxBadges(1, "default")
+    val again = manager.checkVelocityOneRepMaxBadges(1, "default")
+    assertTrue(again.isEmpty())
+}
+```
+Use the same `GamificationManager(...)` construction the existing tests use (the gamification repo there must support `awardBadge`/`isBadgeEarned`).
+
+- [ ] **Step 2: Run to verify failure.** FAIL — method missing.
+
+- [ ] **Step 3: Implement** `checkVelocityOneRepMaxBadges` in `GamificationManager` (mirror `processSetQualityEvent`, lines ~292–316):
+
+```kotlin
+suspend fun checkVelocityOneRepMaxBadges(improvementCount: Int, profileId: String = "default"): List<Badge> {
+    if (!gamificationEnabled.value) return emptyList()
+    val candidates = BadgeDefinitions.allBadges.filter {
+        it.requirement is BadgeRequirement.VelocityOneRepMaxImprovements
+    }
+    val newlyEarned = mutableListOf<Badge>()
+    for (badge in candidates) {
+        val req = badge.requirement as BadgeRequirement.VelocityOneRepMaxImprovements
+        if (improvementCount >= req.count && !gamificationRepository.isBadgeEarned(badge.id, profileId)) {
+            if (gamificationRepository.awardBadge(badge.id, profileId)) newlyEarned.add(badge)
+        }
+    }
+    if (newlyEarned.isNotEmpty()) {
+        hapticEvents.emit(HapticEvent.BADGE_EARNED)
+        _badgeEarnedEvents.emit(newlyEarned)
+    }
+    return newlyEarned
+}
+```
+
+- [ ] **Step 4: Wire into the post-save hook**
+
+In `MainViewModel`, register the count use case (constructor param + DI) and extend the `onPostSaveComputed` lambda so AFTER `computeVelocityOneRepMaxUseCase(...)` completes (the new estimate is now persisted), it counts improvements and checks badges:
+```kotlin
+computeVelocityOneRepMaxUseCase(exId, profile, currentTimeMillis())
+val improvements = countVelocityOneRepMaxImprovementsUseCase(
+    velocityOneRepMaxRepository.getAllPassing(profile),
+)
+gamificationManager.checkVelocityOneRepMaxBadges(improvements, profile)
+```
+`DomainModule.kt`: `single { CountVelocityOneRepMaxImprovementsUseCase() }`; add it to `MainViewModel`'s constructor + every MainViewModel registration site (PlatformModule.android/ios, MainViewModelTest, WorkoutFlowE2ETest — grep `MainViewModel(`). (MainViewModel already holds `velocityOneRepMaxRepository` and `gamificationManager`.)
+
+- [ ] **Step 5: Run tests + build**
+
+Run: `./gradlew :shared:testAndroidHostTest` (full) and `./gradlew :androidApp:assembleDebug`.
+Expected: GREEN / BUILD SUCCESSFUL.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/GamificationManager.kt shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt shared/src/commonMain/kotlin/com/devil/phoenixproject/di/DomainModule.kt shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/manager/GamificationManagerTest.kt
+# + any MainViewModel registration sites touched
+git commit -m "feat(1rm): award velocity-1RM badges from post-save hook (#517)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (design §5):** distinct badge(s) — Task 1 (new `BadgeRequirement` subtype, separate from `PRsAchieved`) ✓; fired when a new passing estimate beats prior best by ≥2.5% — Task 3 (`IMPROVEMENT_FACTOR = 1.025`) ✓; via existing gamification flow — Task 4 (mirrors `processSetQualityEvent`) ✓; tiered improvement count (user decision) — Tasks 1+3 ✓.
+
+**Placeholder scan:** Task 1 says "match an existing STRENGTH badge's `iconResource`" rather than guessing an icon string — read-then-match, not a placeholder. No "TBD".
+
+**Type consistency:** `VelocityOneRepMaxImprovements(count)`, `getAllPassing(profileId)`, `CountVelocityOneRepMaxImprovementsUseCase` (takes `List<VelocityOneRepMaxEntity>` → Int), `checkVelocityOneRepMaxBadges(improvementCount, profileId)`, `IMPROVEMENT_FACTOR = 1.025f` consistent across tasks.
+
+**No schema migration** in this phase (query-only). Badges surface automatically via the existing Badges screen (driven by `BadgeDefinitions.allBadges`) — no UI task needed.
+
+**Deferred:** backfill (Phase 5), portal parity (Phase 6, separate repo).

--- a/docs/superpowers/plans/2026-06-26-velocity-1rm-phase5-backfill.md
+++ b/docs/superpowers/plans/2026-06-26-velocity-1rm-phase5-backfill.md
@@ -1,0 +1,252 @@
+# Velocity-1RM Phase 5 — Historical Backfill — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** On a one-time, idempotent, off-startup pass, compute a current velocity-1RM estimate for every exercise the user has already trained (using all available MCV history), so existing users immediately see estimates without waiting for new workouts.
+
+**Architecture:** A `BackfillVelocityOneRepMaxUseCase` enumerates exercises that have MCV-bearing sessions, and for each eligible one (≥2 distinct loads across **all** history) computes a single current estimate via the existing estimator + MVT model and persists it — skipping exercises that already have an estimate. The whole job runs once, gated by a `velocityOneRepMaxBackfillDone` preference, launched from `MainViewModel` init on a background coroutine. No schema migration.
+
+**Tech Stack:** Kotlin Multiplatform, SQLDelight, Koin, kotlin.test.
+
+Builds on the foundation + Phases 3–4 (this branch). Reuses `ComputeVelocityOneRepMaxUseCase`, `VelocityOneRepMaxRepository`, the preferences pattern.
+
+## Global Constraints
+
+- Backfill computes **one current estimate per exercise** from **all-time** MCV history (not the 28-day live window). Decision: current-estimate-only (no trend reconstruction).
+- Eligibility is the estimator's own gate (≥2 distinct loads; quality flag stored as usual). Per-cable weights.
+- **Idempotent:** gated by a run-once `velocityOneRepMaxBackfillDone` boolean preference AND per-exercise skip when an estimate already exists (handles partial runs / flag resets).
+- Runs **off the startup critical path** (background coroutine), must not block UI or crash the app on failure (wrap in try/catch).
+- No schema migration (query-only additions). Module test task: `:shared:testAndroidHostTest`. Branch: `fix/issue-517-review-followups` (PR #598). Only `git add` files you change.
+
+---
+
+## File Structure
+
+**Modify:**
+- `sqldelight/.../VitruvianDatabase.sq` — `selectExerciseIdsWithVelocityData` + `countVelocityOneRepMaxByExercise` queries.
+- `data/repository/VelocityOneRepMaxRepository.kt` — `hasEstimates(exerciseId, profileId)`.
+- `data/repository/WorkoutRepository.kt` + `SqlDelightWorkoutRepository.kt` — `getExerciseIdsWithVelocityData(profileId)`.
+- `domain/usecase/ComputeVelocityOneRepMaxUseCase.kt` — optional `windowDays` param (default unchanged).
+- `domain/model/UserPreferences.kt`, `data/preferences/PreferencesManager.kt`, `presentation/manager/SettingsManager.kt` — `velocityOneRepMaxBackfillDone` flag.
+- `presentation/viewmodel/MainViewModel.kt` — one-time backfill trigger; `di/DomainModule.kt` — register the backfill use case + MainViewModel param.
+
+**Create:**
+- `domain/usecase/BackfillVelocityOneRepMaxUseCase.kt`
+
+---
+
+### Task 1: Enumerate exercises with MCV data + `hasEstimates`
+
+**Files:**
+- Modify: `VitruvianDatabase.sq`, `WorkoutRepository.kt` + `SqlDelightWorkoutRepository.kt`, `VelocityOneRepMaxRepository.kt`
+- Test: extend `SqlDelightVelocityOneRepMaxRepositoryTest.kt` + a workout-repo test.
+
+**Interfaces:**
+- `suspend fun WorkoutRepository.getExerciseIdsWithVelocityData(profileId: String): List<String>`
+- `suspend fun VelocityOneRepMaxRepository.hasEstimates(exerciseId: String, profileId: String): Boolean`
+
+- [ ] **Step 1: Add queries to `VitruvianDatabase.sq`**
+
+```sql
+selectExerciseIdsWithVelocityData:
+SELECT DISTINCT exerciseId FROM WorkoutSession
+WHERE profile_id = :profileId AND exerciseId IS NOT NULL
+  AND deletedAt IS NULL AND avgMcvMmS IS NOT NULL AND workingReps > 0;
+
+countVelocityOneRepMaxByExercise:
+SELECT COUNT(*) FROM VelocityOneRepMaxEstimate
+WHERE exerciseId = :exerciseId AND profile_id = :profileId AND deletedAt IS NULL;
+```
+
+- [ ] **Step 2: Write failing tests**
+
+In the velocity repo test:
+```kotlin
+@Test fun `hasEstimates reflects presence of rows`() = runTest {
+    val db = createInMemoryTestDatabase(); seedExercise(db, id = "ex1")
+    val repo = SqlDelightVelocityOneRepMaxRepository(db)
+    assertFalse(repo.hasEstimates("ex1", "default"))
+    repo.insert(result(100f, passed = true), "ex1", computedAt = 1L, profileId = "default")
+    assertTrue(repo.hasEstimates("ex1", "default"))
+}
+```
+In a workout-repo test (mirror the existing velocity-points test harness with `seedSession`):
+```kotlin
+@Test fun `getExerciseIdsWithVelocityData returns distinct mcv-bearing exercises`() = runTest {
+    val db = createInMemoryTestDatabase(); seedExercise(db, id = "exA"); seedExercise(db, id = "exB")
+    val repo = SqlDelightWorkoutRepository(db /* + deps */)
+    seedSession(db, exerciseId = "exA", weightPerCableKg = 40f, workingAvgWeightKg = 40f, avgMcvMmS = 800f, timestamp = 1L, workingReps = 5, profileId = "default")
+    seedSession(db, exerciseId = "exA", weightPerCableKg = 60f, workingAvgWeightKg = 60f, avgMcvMmS = 500f, timestamp = 2L, workingReps = 5, profileId = "default")
+    seedSession(db, exerciseId = "exB", weightPerCableKg = 50f, workingAvgWeightKg = 50f, avgMcvMmS = null, timestamp = 1L, workingReps = 5, profileId = "default") // no MCV -> excluded
+    val ids = repo.getExerciseIdsWithVelocityData("default")
+    assertEquals(listOf("exA"), ids)
+}
+```
+
+- [ ] **Step 3: Run to verify failure.** `./gradlew :shared:testAndroidHostTest --tests "*VelocityOneRepMaxRepositoryTest*" --tests "*WorkoutRepositoryVelocityPointsTest*"` — FAIL.
+
+- [ ] **Step 4: Implement**
+
+`VelocityOneRepMaxRepository.kt`:
+```kotlin
+// interface
+suspend fun hasEstimates(exerciseId: String, profileId: String): Boolean
+// impl
+override suspend fun hasEstimates(exerciseId: String, profileId: String): Boolean =
+    withContext(Dispatchers.IO) {
+        queries.countVelocityOneRepMaxByExercise(exerciseId, profileId).executeAsOne() > 0L
+    }
+```
+`WorkoutRepository.kt` + impl:
+```kotlin
+suspend fun getExerciseIdsWithVelocityData(profileId: String): List<String>
+// impl
+override suspend fun getExerciseIdsWithVelocityData(profileId: String): List<String> =
+    withContext(Dispatchers.IO) {
+        queries.selectExerciseIdsWithVelocityData(profileId).executeAsList()
+    }
+```
+Add the new methods to any `FakeWorkoutRepository`/`FakeVelocityOneRepMaxRepository` (commonTest/testutil) + inline test stubs the compiler flags.
+
+- [ ] **Step 5: Run to verify pass; Step 6: Commit**
+
+```bash
+git commit -m "feat(1rm): enumerate MCV-bearing exercises + hasEstimates (#517)"
+```
+
+---
+
+### Task 2: `windowDays` param on `ComputeVelocityOneRepMaxUseCase`
+
+**Files:**
+- Modify: `domain/usecase/ComputeVelocityOneRepMaxUseCase.kt`
+- Test: `ComputeVelocityOneRepMaxUseCaseTest.kt`
+
+**Interfaces:**
+- `suspend operator fun invoke(exerciseId, profileId, nowMs, windowDays: Int = WINDOW_DAYS): VelocityOneRepMaxResult?` — `sinceMs = nowMs - windowDays * DAY_MS`. Existing callers unaffected (default).
+
+- [ ] **Step 1: Failing test** — add a case asserting a large `windowDays` includes an old point that the default 28-day window excludes (capture `sinceMs` via the `workoutPoints` lambda and assert it equals `nowMs - windowDays*DAY_MS`).
+
+- [ ] **Step 2: Run → FAIL** (signature/behavior).
+
+- [ ] **Step 3: Implement** — add the `windowDays: Int = WINDOW_DAYS` param; compute `sinceMs = nowMs - windowDays.toLong() * DAY_MS`. Keep `WINDOW_DAYS = 28`.
+
+- [ ] **Step 4: Run → PASS** (existing tests still green since default is unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(1rm): parameterize compute window for backfill (#517)"
+```
+
+---
+
+### Task 3: `BackfillVelocityOneRepMaxUseCase` + run-once preference
+
+**Files:**
+- Create: `domain/usecase/BackfillVelocityOneRepMaxUseCase.kt`
+- Modify: `domain/model/UserPreferences.kt`, `data/preferences/PreferencesManager.kt`, `presentation/manager/SettingsManager.kt`
+- Test: `shared/src/commonTest/.../usecase/BackfillVelocityOneRepMaxUseCaseTest.kt`
+
+**Interfaces:**
+- `UserPreferences.velocityOneRepMaxBackfillDone: Boolean = false`; `PreferencesManager.setVelocityOneRepMaxBackfillDone(done: Boolean)` (mirror the existing `gamificationEnabled` boolean-pref pattern: `KEY_VELOCITY_1RM_BACKFILL_DONE`, `settings.getBoolean(KEY, false)` on load, setter persists + `updateAndEmit`). `SettingsManager.velocityOneRepMaxBackfillDone: StateFlow<Boolean>`.
+- `class BackfillVelocityOneRepMaxUseCase(private val exerciseIds: suspend (profileId: String) -> List<String>, private val hasEstimates: suspend (exerciseId: String, profileId: String) -> Boolean, private val computeAllTime: suspend (exerciseId: String, profileId: String, nowMs: Long) -> VelocityOneRepMaxResult?) { suspend operator fun invoke(profileId: String, nowMs: Long): Int }` — returns the number of estimates created. For each exercise id: skip if `hasEstimates`; else call `computeAllTime` (which persists). Returns count of non-null results.
+
+- [ ] **Step 1: Failing test (fakes)**
+
+```kotlin
+@Test fun `backfills only exercises without an existing estimate`() = runTest {
+    val computed = mutableListOf<String>()
+    val useCase = BackfillVelocityOneRepMaxUseCase(
+        exerciseIds = { _ -> listOf("exA", "exB", "exC") },
+        hasEstimates = { id, _ -> id == "exB" }, // exB already has one
+        computeAllTime = { id, _, _ -> computed += id; if (id == "exC") null else dummyResult() }, // exC ineligible
+    )
+    val created = useCase("default", nowMs = 1_000L)
+    assertEquals(listOf("exA", "exC"), computed) // exB skipped
+    assertEquals(1, created)                      // only exA produced an estimate
+}
+```
+`dummyResult()` builds a `VelocityOneRepMaxResult(...)`.
+
+- [ ] **Step 2: Run → FAIL.**
+
+- [ ] **Step 3: Implement** the use case (loop, skip-if-hasEstimates, count non-null `computeAllTime`), and the boolean preference across UserPreferences/PreferencesManager/SettingsManager (mirror `gamificationEnabled`).
+
+- [ ] **Step 4: Run → PASS.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(1rm): add BackfillVelocityOneRepMaxUseCase + run-once flag (#517)"
+```
+
+---
+
+### Task 4: One-time startup trigger (idempotent) + DI
+
+**Files:**
+- Modify: `presentation/viewmodel/MainViewModel.kt`, `di/DomainModule.kt`
+- Test: extend an appropriate integration/`MainViewModel` test if one covers init; otherwise verify by build + the use-case test.
+
+**Interfaces:**
+- `DomainModule`: register `BackfillVelocityOneRepMaxUseCase` wiring `exerciseIds → WorkoutRepository.getExerciseIdsWithVelocityData`, `hasEstimates → VelocityOneRepMaxRepository.hasEstimates`, `computeAllTime → { id, profile, now -> computeVelocityOneRepMaxUseCase(id, profile, now, windowDays = BACKFILL_WINDOW_DAYS) }` where `BACKFILL_WINDOW_DAYS = 3650` (10 years ≈ all history).
+- `MainViewModel` gains the backfill use case + reads/sets the `velocityOneRepMaxBackfillDone` flag.
+
+- [ ] **Step 1: Register DI + MainViewModel param**
+
+`DomainModule.kt`:
+```kotlin
+single {
+    val workoutRepo = get<WorkoutRepository>()
+    val velRepo = get<VelocityOneRepMaxRepository>()
+    val compute = get<ComputeVelocityOneRepMaxUseCase>()
+    BackfillVelocityOneRepMaxUseCase(
+        exerciseIds = { profile -> workoutRepo.getExerciseIdsWithVelocityData(profile) },
+        hasEstimates = { id, profile -> velRepo.hasEstimates(id, profile) },
+        computeAllTime = { id, profile, now -> compute(id, profile, now, windowDays = 3650) },
+    )
+}
+```
+Add `backfillVelocityOneRepMaxUseCase` to `MainViewModel`'s constructor; update all MainViewModel construction sites (grep `MainViewModel(` across source sets — production passes `get()`, tests pass a `BackfillVelocityOneRepMaxUseCase(...)` with trivial lambdas or a fake).
+
+- [ ] **Step 2: One-time trigger in `MainViewModel` init**
+
+Add a background launch (mirror the existing `viewModelScope.launch(NonCancellable)` pattern at ~line 663), gated by the run-once flag and wrapped in try/catch:
+```kotlin
+viewModelScope.launch(kotlinx.coroutines.NonCancellable) {
+    try {
+        if (!settingsManager.velocityOneRepMaxBackfillDone.value) {
+            val profile = activeProfileId.value
+            backfillVelocityOneRepMaxUseCase(profile, com.devil.phoenixproject.domain.model.currentTimeMillis())
+            preferencesManager.setVelocityOneRepMaxBackfillDone(true)
+        }
+    } catch (e: Exception) {
+        Logger.w(e) { "VELOCITY_1RM: backfill failed" }
+    }
+}
+```
+(Use the real `preferencesManager`/`settingsManager` references already on MainViewModel; match the profile-id accessor used elsewhere — `activeProfileId`.)
+
+- [ ] **Step 3: Build + full suite**
+
+Run: `./gradlew :androidApp:assembleDebug` and `./gradlew :shared:testAndroidHostTest`.
+Expected: BUILD SUCCESSFUL / GREEN.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat(1rm): run velocity-1RM backfill once on startup (#517)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (design §6):** replays historical sets with MCV — Task 1 (enumerate) + Task 3 (compute all-time) ✓; per-exercise windowed estimate — Task 2 (windowDays) + Task 3 ✓; populates the time-series with quality flags — reuses the foundation's persist (Task 3 via computeAllTime) ✓; lazily off startup — Task 4 (background launch) ✓; idempotent — run-once flag (Task 3/4) + per-exercise `hasEstimates` skip (Task 1/3) ✓.
+
+**Placeholder scan:** Tasks 3–4 reference the `gamificationEnabled` boolean-pref pattern and the `NonCancellable` init pattern by exact location to mirror — read-then-match, not placeholders. `dummyResult()`/`BACKFILL_WINDOW_DAYS = 3650` are concrete.
+
+**Type consistency:** `getExerciseIdsWithVelocityData`, `hasEstimates`, `windowDays`, `velocityOneRepMaxBackfillDone`, `BackfillVelocityOneRepMaxUseCase(exerciseIds, hasEstimates, computeAllTime)` consistent across tasks.
+
+**No schema migration** (query-only). **Deferred:** portal parity (Phase 6, separate phoenix-portal repo) — the only remaining piece after this.

--- a/docs/superpowers/plans/2026-06-26-velocity-1rm-phase6-portal-display.md
+++ b/docs/superpowers/plans/2026-06-26-velocity-1rm-phase6-portal-display.md
@@ -1,0 +1,251 @@
+# Velocity-1RM Phase 6 (Display) — Cross-Repo Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax. **This plan spans TWO repos** — tasks are tagged `[MOBILE]` (`Project-Phoenix-MP`, Kotlin/Gradle) or `[PORTAL]` (`phoenix-portal`, TS/Deno/Supabase/npm). Run each repo's own toolchain from its own directory.
+
+**Goal:** Sync the mobile-computed velocity-estimated 1RM to the portal and display it as a metric clearly distinct from the existing rep-based (formula) estimate.
+
+**Architecture:** Mobile adds a `velocityEstimatedOneRepMaxKg` field to the per-session exercise sync DTO, populated from the latest passing velocity estimate. The portal stores it in a new nullable `exercise_progress.velocity_estimated_1rm_kg` column (separate from the rep-based `estimated_1rm_kg`), echoes it on pull, and surfaces it in analytics as a distinct, labeled current-value stat. Display-only; no weight-programming changes.
+
+**Tech Stack:** Kotlin Multiplatform (mobile), TypeScript + Deno Edge Functions + Supabase Postgres + React/Vite/Vitest (portal).
+
+Spec: `docs/superpowers/specs/2026-06-26-velocity-1rm-phase6-portal-display-design.md`.
+
+## Global Constraints
+
+- **Never clobber `estimated_1rm_kg`** (rep-based hybrid). `velocity_estimated_1rm_kg` is a brand-new, nullable, additive field/column.
+- **Mobile authoritative**: the portal stores/displays verbatim, never recomputes the velocity estimate.
+- **Per-cable** in DB/DTO; portal multiplies by `WEIGHT_MULTIPLIER` (2) for display, identical to `estimated_1rm_kg`.
+- **Backward compatible**: nullable everywhere; legacy payloads/rows without it show no velocity metric and are unaffected.
+- **Per-session model**: `exercise_progress` is keyed `session_id + exercise`. The velocity estimate is a rolling *current* value, so the mobile attaches the **current latest-passing estimate** per exercise to each pushed session-exercise; the portal UI shows the **most-recent non-null** value as the current "Velocity 1RM" stat. **No velocity trend series in this plan** (deferred — the per-session values are not as-of-session).
+- **Out of scope** (separate spec): scaling-basis weight-resolution parity in the portal routine builder.
+- Mobile tests: `cd Project-Phoenix-MP && ./gradlew :shared:testAndroidHostTest`. Portal tests: `cd phoenix-portal && npm test` (Vitest); types: `npm run typecheck`; edge-fn deploy is the user's call (not in CI here).
+
+---
+
+## File Structure
+
+**[MOBILE] Modify:**
+- `shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncDtos.kt` — DTO field.
+- `shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapter.kt` — populate it.
+- `shared/src/commonMain/kotlin/com/devil/phoenixproject/di/SyncModule.kt` (or wherever `PortalSyncAdapter` is constructed) — inject the velocity repo.
+- Tests: `shared/src/commonTest/.../data/sync/PortalSyncAdapterTest.kt`.
+
+**[PORTAL] Modify/Create:**
+- `supabase/migrations/<ts>_add_velocity_estimated_1rm_kg.sql` (create).
+- `supabase/functions/_shared/exerciseProgressRows.ts` — builder field.
+- `supabase/functions/mobile-sync-push/index.ts` — DTO type (pass-through to the builder).
+- `supabase/functions/mobile-sync-pull/index.ts` — echo on pull (if it returns exercise_progress).
+- `src/lib/database.types.ts` (regen), `src/schemas/transforms.ts` + the exercise-progress schema.
+- `src/app/components/ExerciseProgress.tsx`, `src/app/components/analytics/ExerciseDeepDive.tsx`.
+- Tests: `supabase/functions/_shared/__tests__/...` (builder), `src/lib/__tests__/sync-exercise-progress.test.ts`, `src/schemas/__tests__/...` (transform).
+
+---
+
+### Task 1 [MOBILE]: Add `velocityEstimatedOneRepMaxKg` to the exercise DTO + populate it
+
+**Files:**
+- Modify: `data/sync/PortalSyncDtos.kt` (`PortalExerciseDto`, ~`:79`/`:92`), `data/sync/PortalSyncAdapter.kt` (~`:291`), the DI module constructing `PortalSyncAdapter`.
+- Test: `shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapterTest.kt`
+
+**Interfaces:**
+- Produces: `PortalExerciseDto.velocityEstimatedOneRepMaxKg: Float? = null`. The adapter sets it from `VelocityOneRepMaxRepository.getLatestPassing(exerciseId, profileId)?.estimatedPerCableKg` (per-cable), null when no exerciseId or no passing estimate.
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+@Test fun `adapter populates velocityEstimatedOneRepMaxKg from latest passing estimate`() = runTest {
+    // Arrange a session with one exercise (exerciseId = "ex1") and a fake VelocityOneRepMaxRepository
+    // whose getLatestPassing("ex1", profile) returns an entity with estimatedPerCableKg = 92f.
+    val dto = adapter.buildExerciseDto(/* the session/exercise inputs the adapter uses */)
+    assertEquals(92f, dto.velocityEstimatedOneRepMaxKg)
+}
+
+@Test fun `velocityEstimatedOneRepMaxKg is null when no passing estimate`() = runTest {
+    // fake getLatestPassing returns null -> field is null, estimatedOneRepMaxKg (rep-based) still set
+    val dto = adapter.buildExerciseDto(/* ... */)
+    assertEquals(null, dto.velocityEstimatedOneRepMaxKg)
+}
+```
+READ `PortalSyncAdapter` first to find the actual method that builds a `PortalExerciseDto` (the one setting `estimatedOneRepMaxKg = OneRepMaxCalculator.estimate(...)`), the exact inputs it takes (session, exercise, sets, profileId), and how `PortalSyncAdapterTest` constructs the adapter + fakes. Mirror that exactly; add a `FakeVelocityOneRepMaxRepository` (reuse the one in `commonTest/testutil/` if present).
+
+- [ ] **Step 2: Run to verify failure** — `cd Project-Phoenix-MP && ./gradlew :shared:testAndroidHostTest --tests "*PortalSyncAdapterTest*"` → FAIL (field/param missing).
+
+- [ ] **Step 3: Implement**
+- `PortalExerciseDto`: add `val velocityEstimatedOneRepMaxKg: Float? = null,` after `estimatedOneRepMaxKg`.
+- `PortalSyncAdapter`: add a `velocityOneRepMaxRepository: VelocityOneRepMaxRepository` constructor param; where it builds the exercise DTO, set `velocityEstimatedOneRepMaxKg = exercise.id?.let { velocityOneRepMaxRepository.getLatestPassing(it, profileId)?.estimatedPerCableKg }`. (The adapter method is `suspend`; if it isn't, make the velocity lookup happen in the suspend context that builds the DTOs — read the call chain.)
+- DI: add `get()` for the new param wherever `PortalSyncAdapter(...)` is constructed (grep `PortalSyncAdapter(`).
+
+- [ ] **Step 4: Run to verify pass** — same command → PASS. Then full `./gradlew :shared:testAndroidHostTest` GREEN.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncDtos.kt shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapter.kt shared/src/commonMain/kotlin/com/devil/phoenixproject/di shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapterTest.kt
+git commit -m "feat(1rm): send velocity-estimated 1RM in exercise sync DTO (#517)"
+```
+
+> NOTE: this is a parity-critical sync-DTO change. The portal Tasks 2–4 consume `velocityEstimatedOneRepMaxKg` (camelCase wire format).
+
+---
+
+### Task 2 [PORTAL]: Supabase migration — add the column + regen types
+
+**Files:**
+- Create: `phoenix-portal/supabase/migrations/<timestamp>_add_velocity_estimated_1rm_kg.sql`
+- Modify (generated): `phoenix-portal/src/lib/database.types.ts`
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- Add velocity-estimated 1RM (VBT) alongside the rep-based estimated_1rm_kg.
+-- Nullable + additive; never overwrites estimated_1rm_kg.
+ALTER TABLE public.exercise_progress
+  ADD COLUMN IF NOT EXISTS velocity_estimated_1rm_kg numeric;
+```
+Name the file with the project's migration timestamp convention (match an existing file in `supabase/migrations/`).
+
+- [ ] **Step 2: Apply locally + regen types**
+
+Run (from `phoenix-portal`): apply the migration to the dev DB (the project's usual path — `supabase db push`/`supabase migration up`, or the apply step the repo documents), then `npm run gen:types`.
+Expected: `database.types.ts` now lists `velocity_estimated_1rm_kg: number | null` on `exercise_progress` Row/Insert/Update.
+
+- [ ] **Step 3: Verify typecheck** — `npm run typecheck` → no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd phoenix-portal
+git add supabase/migrations/ src/lib/database.types.ts
+git commit -m "feat(1rm): add exercise_progress.velocity_estimated_1rm_kg column (#517)"
+```
+
+---
+
+### Task 3 [PORTAL]: Builder — carry the velocity estimate into `exercise_progress` rows
+
+**Files:**
+- Modify: `supabase/functions/_shared/exerciseProgressRows.ts`
+- Test: `supabase/functions/_shared/__tests__/exerciseProgressRows.test.ts` (create if absent; else extend)
+
+**Interfaces:**
+- Produces: `ProgressExerciseInput.velocityEstimatedOneRepMaxKg?: number | null`; `ExerciseProgressRow.velocity_estimated_1rm_kg: number | null`. The builder copies it **verbatim** (no recompute, no fallback) — null when absent.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { buildExerciseProgressRows } from '../exerciseProgressRows.ts';
+
+Deno.test('carries velocity_estimated_1rm_kg verbatim, null when absent', () => {
+  const rows = buildExerciseProgressRows([{
+    id: 's1', startedAt: '2026-06-01T00:00:00Z',
+    exercises: [
+      { name: 'Bench', exerciseId: 'ex1', estimatedOneRepMaxKg: 100, velocityEstimatedOneRepMaxKg: 92, sets: [{ weightKg: 80, actualReps: 5 }] },
+      { name: 'Row',   exerciseId: 'ex2', estimatedOneRepMaxKg: 90,  sets: [{ weightKg: 60, actualReps: 5 }] }, // no velocity
+    ],
+  }], 'user1', null);
+  assertEquals(rows[0].velocity_estimated_1rm_kg, 92);
+  assertEquals(rows[1].velocity_estimated_1rm_kg, null);
+  assertEquals(rows[0].estimated_1rm_kg, 100); // rep-based untouched
+});
+```
+Use the repo's test runner for `_shared` (Deno test, or the Vitest shim the repo uses — match an existing `_shared` test). If `_shared` has no test harness, add the assertion to whichever suite already exercises `buildExerciseProgressRows` (e.g. `src/lib/__tests__/sync-exercise-progress.test.ts`).
+
+- [ ] **Step 2: Run to verify failure** → property missing.
+
+- [ ] **Step 3: Implement**
+- Add `velocityEstimatedOneRepMaxKg?: number | null;` to `ProgressExerciseInput`.
+- Add `velocity_estimated_1rm_kg: number | null;` to `ExerciseProgressRow`.
+- In the `rows.push({...})` object, add `velocity_estimated_1rm_kg: exercise.velocityEstimatedOneRepMaxKg ?? null,`. Do NOT touch the `estimated_1rm_kg` logic.
+
+- [ ] **Step 4: Run to verify pass** → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add supabase/functions/_shared/exerciseProgressRows.ts supabase/functions/_shared/__tests__/ src/lib/__tests__/sync-exercise-progress.test.ts
+git commit -m "feat(1rm): store velocity_estimated_1rm_kg in exercise_progress rows (#517)"
+```
+
+---
+
+### Task 4 [PORTAL]: Wire the push DTO type + pull echo
+
+**Files:**
+- Modify: `supabase/functions/mobile-sync-push/index.ts` (the exercise/session DTO type whose exercises feed `buildExerciseProgressRows`), `supabase/functions/mobile-sync-pull/index.ts`
+- Test: `src/lib/__tests__/sync-push-schema.test.ts`
+
+- [ ] **Step 1: Push side** — In `mobile-sync-push/index.ts`, find the TypeScript interface for the exercise inside a pushed session (the type whose objects are passed as `exercises` into `buildExerciseProgressRows`, carrying `estimatedOneRepMaxKg`). Add `velocityEstimatedOneRepMaxKg?: number | null;` to it. Confirm the mapping that constructs `ProgressExerciseInput` for the builder forwards the field (if it maps explicitly, add `velocityEstimatedOneRepMaxKg: ex.velocityEstimatedOneRepMaxKg ?? null`; if it spreads/passes the object through, the field flows automatically). The `exercise_progress` insert already inserts the full `ExerciseProgressRow` (incl. the new column from Task 3), so no separate insert change is needed — VERIFY this by reading the insert call.
+
+- [ ] **Step 2: Pull side** — In `mobile-sync-pull/index.ts`, check whether the pull returns `exercise_progress` (grep `exercise_progress`). If it does, add `velocity_estimated_1rm_kg` to the selected columns / echoed shape (tolerate null). If the pull does NOT return exercise_progress, note that in the commit message and skip — nothing to do.
+
+- [ ] **Step 3: Test** — extend `sync-push-schema.test.ts` (and `sync-exercise-progress.test.ts`) to push a payload whose exercise has `velocityEstimatedOneRepMaxKg` and assert the resulting `exercise_progress` row carries `velocity_estimated_1rm_kg` (and that a payload WITHOUT it yields null — back-compat). Mirror the existing schema test's harness.
+Run: `cd phoenix-portal && npm test -- sync` → GREEN; `npm run typecheck` → clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add supabase/functions/mobile-sync-push/index.ts supabase/functions/mobile-sync-pull/index.ts src/lib/__tests__/
+git commit -m "feat(1rm): plumb velocity-estimated 1RM through sync push/pull (#517)"
+```
+
+---
+
+### Task 5 [PORTAL]: Schema + transform — expose `velocityEstimated1RM`
+
+**Files:**
+- Modify: `src/schemas/transforms.ts` (+ the exercise-progress schema/type it feeds)
+- Test: `src/schemas/__tests__/transforms.test.ts` (or the existing transforms test)
+
+**Interfaces:**
+- Produces: a transformed exercise-progress object with `velocityEstimated1RM?: number` = `velocity_estimated_1rm_kg * WEIGHT_MULTIPLIER` (display units), `undefined` when the column is null.
+
+- [ ] **Step 1: Failing test**
+
+```ts
+it('exposes velocityEstimated1RM with the weight multiplier, undefined when null', () => {
+  expect(transformExerciseProgress({ ...base, velocity_estimated_1rm_kg: 92 }).velocityEstimated1RM)
+    .toBe(92 * WEIGHT_MULTIPLIER);
+  expect(transformExerciseProgress({ ...base, velocity_estimated_1rm_kg: null }).velocityEstimated1RM)
+    .toBeUndefined();
+});
+```
+READ how `transforms.ts` maps `estimated_1rm_kg` (the existing rep-based field) and mirror it exactly (same `WEIGHT_MULTIPLIER`, same null handling), naming the new field `velocityEstimated1RM`. Match the actual transform function name in the file.
+
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** the mapping in `transforms.ts` + the schema/type that declares the field.
+- [ ] **Step 4: Run → PASS; `npm run typecheck` clean.**
+- [ ] **Step 5: Commit** `feat(1rm): transform velocity_estimated_1rm_kg to display units (#517)`
+
+---
+
+### Task 6 [PORTAL]: UI — show the velocity estimate distinctly
+
+**Files:**
+- Modify: `src/app/components/ExerciseProgress.tsx`, `src/app/components/analytics/ExerciseDeepDive.tsx`
+
+- [ ] **Step 1: ExerciseProgress.tsx** — locate where the rep-based estimate is shown (the `label="Overall Est. 1RM"` stat ~`:310` and the "Estimated 1RM Trend" panel ~`:454`). Do three things:
+  1. **Relabel** the existing stat from "Overall Est. 1RM" → **"Rep-based 1RM (formula)"** so the contrast is explicit.
+  2. **Add a distinct stat** **"Velocity 1RM (VBT)"** sourced from the most-recent non-null `velocityEstimated1RM` across the exercise's progress data (`const velocity1RM = [...data].reverse().find(d => d.velocityEstimated1RM != null)?.velocityEstimated1RM`). Render it **only when present** (no data → omit entirely).
+  3. Add a short tooltip/help next to the pair: "Rep-based = estimated from weight×reps via a formula. Velocity-based = estimated from cable speed (MCV) captured by the trainer." Reuse the component's existing tooltip/help primitive (do not invent one).
+  Do **not** add a velocity series to the trend chart (deferred — see Global Constraints).
+
+- [ ] **Step 2: ExerciseDeepDive.tsx** — make the same distinction wherever it surfaces the estimated 1RM (relabel rep-based + add the velocity stat when present + the same explanatory copy), reusing the screen's existing stat/label components.
+
+- [ ] **Step 3: Verify**
+Run: `cd phoenix-portal && npm run typecheck` → clean; `npm test` → GREEN (existing component/snapshot tests still pass; update snapshots intentionally if labels changed, reviewing the diff). If there are no component tests for these, manual verification is the handoff: run `npm run dev`, open an exercise with VBT history → both estimates appear, distinctly labeled; an exercise without it shows only the rep-based one.
+
+- [ ] **Step 4: Commit** `feat(1rm): display velocity 1RM distinctly from rep-based estimate (#517)`
+
+---
+
+## Self-Review
+
+**Spec coverage:** separate field, never clobber — Tasks 1–3 (additive `velocity_estimated_1rm_kg`) ✓; mobile authoritative/verbatim — Task 3 (no recompute) ✓; per-cable ×2 display — Task 5 ✓; push stores / pull echoes — Tasks 3–4 ✓; distinct UI + tooltip + hidden-when-null — Task 6 ✓; backward compatible (nullable) — Tasks 1–5 ✓; scaling-basis parity excluded — not present ✓. Spec open-item resolved: `exercise_progress` is per-session; velocity value is current → shown as a current-value stat, trend deferred (Global Constraints).
+
+**Placeholder scan:** Each portal task says "READ X and mirror it" with the concrete file/anchor because the exact transform/DTO/test-harness names live in the portal repo and must be matched verbatim — read-then-match, not "TBD". Mobile Task 1 carries real code. No "add error handling"/"etc.".
+
+**Type consistency:** `velocityEstimatedOneRepMaxKg` (camelCase, mobile DTO + push DTO + `ProgressExerciseInput`), `velocity_estimated_1rm_kg` (snake_case, DB column + `ExerciseProgressRow`), `velocityEstimated1RM` (portal transform/UI). The case transitions (DTO→row→transform) mirror the existing `estimatedOneRepMaxKg`→`estimated_1rm_kg`→`estimated1RM` chain exactly. ✓
+
+**Cross-repo ordering:** Mobile Task 1 defines the wire field the portal Tasks 3–4 consume; do Task 1 first (or at least before Task 4's schema test that pushes the field). Tasks 2→3→4→5→6 are the portal sequence.
+
+**Deferred / handoffs:** velocity **trend series** (needs as-of-session values); the **scaling-basis parity** plan; Edge Function **deploy** to Supabase (user/ops decision); manual UI verification (no guaranteed component-test coverage).

--- a/docs/superpowers/specs/2026-06-26-velocity-1rm-phase6-portal-display-design.md
+++ b/docs/superpowers/specs/2026-06-26-velocity-1rm-phase6-portal-display-design.md
@@ -1,0 +1,61 @@
+# Velocity-1RM Phase 6 (Display) — Portal Parity: Surface the Velocity Estimate — Design
+
+**Issue:** [#517](https://github.com/9thLevelSoftware/Project-Phoenix-MP/issues/517)
+**Date:** 2026-06-26
+**Status:** Approved (design), pending implementation plan
+**Scope:** Cross-repo — `Project-Phoenix-MP` (mobile) + `phoenix-portal` (web).
+
+## Summary
+
+Sync the mobile-computed **velocity-estimated 1RM** to the portal and display it in the exercise analytics views as a metric that is **clearly distinct** from the existing rep-based (Brzycki/Epley hybrid) estimate, so users never conflate the two.
+
+This is **display/analytics only**. It does NOT change any weight programming. Making the portal's routine builder resolve `% of estimated-1RM` (scaling-basis parity) is a **separate follow-up spec** because it changes parity-critical routine-weight math.
+
+## Decisions
+
+- **Never clobber the rep-based estimate.** `velocity_estimated_1rm_kg` is a brand-new field/column, fully separate from the existing `estimated_1rm_kg` (rep-based hybrid). Both are stored and shown.
+- **Mobile is authoritative** for the velocity estimate (it's computed on-device from BLE MCV). The portal stores and displays it verbatim; it never recomputes it.
+- **Additive + backward compatible.** The new field is nullable everywhere. Legacy payloads/rows without it simply don't show the velocity metric; the rep-based estimate is untouched.
+- **Per-cable convention** (per the monorepo parity rules): the DB/DTO value is per-cable; the portal multiplies by `WEIGHT_MULTIPLIER` (2) for display, exactly as it already does for `estimated_1rm_kg`.
+- **UI: obviously distinct.** The two estimates are labeled and visually separated so a user can tell at a glance which is the velocity (VBT) estimate and which is the formula estimate.
+
+## Cross-repo architecture
+
+### A. Mobile (`Project-Phoenix-MP`)
+- `data/sync/PortalSyncDtos.kt`: add `val velocityEstimatedOneRepMaxKg: Float? = null` to `PortalExerciseDto` (camelCase wire format), beside the existing `estimatedOneRepMaxKg` (`:92`).
+- `data/sync/PortalSyncAdapter.kt`: when building each `PortalExerciseDto` (near `:291` where `estimatedOneRepMaxKg = OneRepMaxCalculator.estimate(...)`), also populate `velocityEstimatedOneRepMaxKg` from `VelocityOneRepMaxRepository.getLatestPassing(exerciseId, profileId)?.estimatedPerCableKg` (per-cable, null when no passing estimate). The adapter gains a dependency on `VelocityOneRepMaxRepository` (already DI-registered).
+- Sync-push test: extend the existing push-schema/limits tests to assert the new field serializes (and is omitted/null-safe when absent).
+
+### B. Portal DB (`phoenix-portal`)
+- Supabase migration: `ALTER TABLE exercise_progress ADD COLUMN velocity_estimated_1rm_kg numeric;` (nullable).
+- Regenerate `src/lib/database.types.ts` (`npm run gen:types`).
+
+### C. Edge Functions (`phoenix-portal/supabase/functions`)
+- `mobile-sync-push/index.ts`: add `velocityEstimatedOneRepMaxKg?: number` to the exercise DTO type (near `:345`) and write `velocity_estimated_1rm_kg: a.velocityEstimatedOneRepMaxKg ?? null` into the `exercise_progress` upsert (alongside `estimated_1rm_kg` at `~:2228`). Do NOT touch the existing `estimated_1rm_kg` / hybrid-fallback logic.
+- `mobile-sync-pull/index.ts`: include `velocity_estimated_1rm_kg` in the `exercise_progress` selection/echo if the pull returns exercise progress (mobile is authoritative, so pull just echoes it; tolerate null).
+
+### D. Portal types/transforms (`phoenix-portal/src`)
+- `src/schemas/transforms.ts` (and the relevant exercise-progress schema): map `velocity_estimated_1rm_kg` → a `velocityEstimated1RM` field, applying `WEIGHT_MULTIPLIER` (2) for display, mirroring how `estimated_1rm_kg` is handled. Null/absent → undefined (metric hidden).
+
+### E. Portal UI (`phoenix-portal/src/app/components`)
+In `ExerciseProgress.tsx` and `analytics/ExerciseDeepDive.tsx`:
+- Surface the velocity estimate as a **distinct, clearly-labeled** metric next to the existing one. Suggested labels: **"Velocity 1RM (VBT)"** vs relabel the existing **"Overall Est. 1RM"** → **"Rep-based 1RM (formula)"** so the contrast is explicit.
+- Add a short tooltip/help text explaining: rep-based = estimated from weight×reps via a formula; velocity-based = estimated from bar/cable speed (MCV) captured by the trainer.
+- Trend chart: add a **separate, distinctly-colored velocity series** to the "Estimated 1RM Trend" chart IF the velocity value is available per data point. (Planning detail — confirm how `exercise_progress` rows are keyed: if it's latest-state-per-exercise rather than per-session, the velocity value is a single current stat and the trend series is deferred. Show the current-value stat regardless.)
+- The velocity metric is **hidden entirely** when null (no data), so users without VBT history see no change.
+
+## Weight convention (parity-critical)
+Per-cable in the DB/DTO; ×2 (`WEIGHT_MULTIPLIER`) for portal display — identical to the existing `estimated_1rm_kg` handling. No new convention introduced.
+
+## Testing
+- **Mobile:** push-schema/serialization test for the new DTO field; adapter populates it from the velocity repo (unit test with a fake).
+- **Portal:** `sync-push-schema.test.ts` / `sync-exercise-progress.test.ts` extended to cover the new column round-trip; transforms test for the ×2 + null handling; `npm run typecheck` after `gen:types`; a component/render check that the two estimates render distinctly and that the velocity metric is hidden when null.
+
+## Out of scope (separate specs)
+- **Scaling-basis parity** — the portal routine builder resolving `% of estimated-1RM` / `% of max-volume PR` like `ResolveRoutineWeightsUseCase`. Parity-critical routine-weight math; its own spec.
+- Velocity-1RM trend history in the portal beyond the current value, if `exercise_progress` is latest-state only.
+
+## Open items to confirm during planning
+- How `exercise_progress` rows are keyed (latest-state vs per-session) → determines whether a velocity **trend series** is feasible now or is the current-value stat only.
+- Whether `mobile-sync-pull` actually returns `exercise_progress` (if not, only push + portal-direct reads matter).
+- Exact portal labels/tooltip copy (product/voice decision).

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -208,8 +208,8 @@ sqldelight {
     databases {
         create("VitruvianDatabase") {
             packageName.set("com.devil.phoenixproject.database")
-            // Version 38 = initial schema (1) + 37 migrations (1.sqm through 37.sqm).
-            version = 38
+            // Version 39 = initial schema (1) + 38 migrations (1.sqm through 38.sqm).
+            version = 39
         }
     }
 }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -208,8 +208,8 @@ sqldelight {
     databases {
         create("VitruvianDatabase") {
             packageName.set("com.devil.phoenixproject.database")
-            // Version 36 = initial schema (1) + 35 migrations (1.sqm through 35.sqm).
-            version = 36
+            // Version 38 = initial schema (1) + 37 migrations (1.sqm through 37.sqm).
+            version = 38
         }
     }
 }

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/local/SchemaParityTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/local/SchemaParityTest.kt
@@ -334,7 +334,7 @@ class SchemaParityTest {
     // ==================== HELPERS ====================
 
     companion object {
-        private const val CURRENT_VERSION = 38L
+        private const val CURRENT_VERSION = 39L
 
         /**
          * Transient tables are intermediate artifacts of table-rebuild migrations

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/migration/MigrationManagerTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/migration/MigrationManagerTest.kt
@@ -563,6 +563,7 @@ class MigrationManagerTest {
             warmupSets = "",
             defaultRackItemIds = "[]",
             rackBehaviorOverrides = "{}",
+            scalingBasis = null,
         )
     }
 

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightCompletedSetRepositoryTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightCompletedSetRepositoryTest.kt
@@ -151,6 +151,7 @@ class SqlDelightCompletedSetRepositoryTest {
             warmupSets = "",
             defaultRackItemIds = "[]",
             rackBehaviorOverrides = "{}",
+            scalingBasis = null,
         )
     }
 

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepositoryTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepositoryTest.kt
@@ -460,6 +460,87 @@ class SqlDelightSyncRepositoryTest {
         assertEquals("""["vest"]""", exercise.defaultRackItemIds)
     }
 
+    @Test
+    fun `mergePortalRoutines preserves local scalingBasis across portal pull`() = runTest {
+        database.vitruvianDatabaseQueries.insertRoutine(
+            id = "routine-scaling-basis",
+            name = "Scaling Basis",
+            description = "",
+            createdAt = 1_700_000_000_000,
+            lastUsed = null,
+            useCount = 0,
+            profile_id = "active-profile",
+            groupId = null,
+        )
+        database.vitruvianDatabaseQueries.insertRoutineExercise(
+            id = "rex-scaling-basis",
+            routineId = "routine-scaling-basis",
+            exerciseName = "Deadlift",
+            exerciseMuscleGroup = "Back",
+            exerciseEquipment = "Cable",
+            exerciseDefaultCableConfig = "DOUBLE",
+            exerciseId = null,
+            cableConfig = "DOUBLE",
+            orderIndex = 0,
+            setReps = "5",
+            weightPerCableKg = 60.0,
+            setWeights = "",
+            mode = "OldSchool",
+            eccentricLoad = 100,
+            echoLevel = 1,
+            progressionKg = 0.0,
+            restSeconds = 90,
+            duration = null,
+            setRestSeconds = "[]",
+            perSetRestTime = 0,
+            isAMRAP = 0,
+            supersetId = null,
+            orderInSuperset = 0,
+            usePercentOfPR = 0,
+            weightPercentOfPR = 80,
+            prTypeForScaling = "MAX_WEIGHT",
+            setWeightsPercentOfPR = null,
+            stallDetectionEnabled = 1,
+            stopAtTop = 0,
+            repCountTiming = "TOP",
+            setEchoLevels = "",
+            warmupSets = "",
+            defaultRackItemIds = "[]",
+            rackBehaviorOverrides = "{}",
+            scalingBasis = "ESTIMATED_1RM",
+        )
+
+        repository.mergePortalRoutines(
+            routines = listOf(
+                PullRoutineDto(
+                    id = "routine-scaling-basis",
+                    userId = "user",
+                    name = "Scaling Basis Remote",
+                    updatedAt = 1_700_000_000_200,
+                    exercises = listOf(
+                        PullRoutineExerciseDto(
+                            id = "rex-scaling-basis",
+                            routineId = "routine-scaling-basis",
+                            name = "Deadlift",
+                            muscleGroup = "Back",
+                            orderIndex = 0,
+                            reps = 5,
+                            weight = 65f,
+                        ),
+                    ),
+                ),
+            ),
+            lastSync = 1_700_000_000_100,
+            profileId = "active-profile",
+        )
+
+        val exercise = database.vitruvianDatabaseQueries
+            .selectExercisesByRoutine("routine-scaling-basis")
+            .executeAsList()
+            .single()
+        assertEquals("ESTIMATED_1RM", exercise.scalingBasis)
+    }
+
     private fun insertHistoricalSession(
         id: String,
         timestamp: Long,

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepositoryTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepositoryTest.kt
@@ -426,6 +426,7 @@ class SqlDelightSyncRepositoryTest {
             warmupSets = "",
             defaultRackItemIds = """["vest"]""",
             rackBehaviorOverrides = "{}",
+            scalingBasis = null,
         )
 
         repository.mergePortalRoutines(

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightTrainingCycleRepositoryTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightTrainingCycleRepositoryTest.kt
@@ -239,6 +239,7 @@ class SqlDelightTrainingCycleRepositoryTest {
             warmupSets = "",
             defaultRackItemIds = "[]",
             rackBehaviorOverrides = "{}",
+            scalingBasis = null,
         )
     }
 }

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightVelocityOneRepMaxRepositoryTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightVelocityOneRepMaxRepositoryTest.kt
@@ -88,4 +88,21 @@ class SqlDelightVelocityOneRepMaxRepositoryTest {
         repo.insert(result(90f, passed = false), exerciseId = "ex2", computedAt = 1_000L, profileId = "default")
         assertNull(repo.getLatestPassing("ex2", "default"))
     }
+
+    @Test
+    fun `getAllPassing returns only passing rows for the profile ordered by exercise then time`() = runTest {
+        val db = createInMemoryTestDatabase()
+        seedExercise(db, id = "exA"); seedExercise(db, id = "exB")
+        val repo = SqlDelightVelocityOneRepMaxRepository(db)
+        repo.insert(result(100f, passed = true), "exA", computedAt = 1L, profileId = "default")
+        repo.insert(result(110f, passed = true), "exA", computedAt = 2L, profileId = "default")
+        repo.insert(result(90f, passed = false), "exA", computedAt = 3L, profileId = "default") // excluded
+        repo.insert(result(80f, passed = true), "exB", computedAt = 1L, profileId = "default")
+        repo.insert(result(200f, passed = true), "exA", computedAt = 1L, profileId = "other") // other profile
+
+        val all = repo.getAllPassing("default")
+        assertEquals(3, all.size)
+        assertEquals(listOf("exA", "exA", "exB"), all.map { it.exerciseId })
+        assertEquals(listOf(100f, 110f, 80f), all.map { it.estimatedPerCableKg })
+    }
 }

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightVelocityOneRepMaxRepositoryTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightVelocityOneRepMaxRepositoryTest.kt
@@ -5,6 +5,7 @@ import com.devil.phoenixproject.domain.onerepmax.VelocityOneRepMaxResult
 import com.devil.phoenixproject.testutil.createTestDatabase
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
@@ -104,5 +105,16 @@ class SqlDelightVelocityOneRepMaxRepositoryTest {
         assertEquals(3, all.size)
         assertEquals(listOf("exA", "exA", "exB"), all.map { it.exerciseId })
         assertEquals(listOf(100f, 110f, 80f), all.map { it.estimatedPerCableKg })
+    }
+
+    // Issue #517 Phase 5 T1
+    @Test
+    fun `hasEstimates reflects presence of rows`() = runTest {
+        val db = createInMemoryTestDatabase()
+        seedExercise(db, id = "ex1")
+        val repo = SqlDelightVelocityOneRepMaxRepository(db)
+        assertFalse(repo.hasEstimates("ex1", "default"))
+        repo.insert(result(100f, passed = true), "ex1", computedAt = 1L, profileId = "default")
+        assertTrue(repo.hasEstimates("ex1", "default"))
     }
 }

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepositoryRoutineScalingTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepositoryRoutineScalingTest.kt
@@ -1,0 +1,104 @@
+package com.devil.phoenixproject.data.repository
+
+import com.devil.phoenixproject.domain.model.Exercise
+import com.devil.phoenixproject.domain.model.Routine
+import com.devil.phoenixproject.domain.model.RoutineExercise
+import com.devil.phoenixproject.domain.model.ScalingBasis
+import com.devil.phoenixproject.testutil.FakeExerciseRepository
+import com.devil.phoenixproject.testutil.createTestDatabase
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Round-trip test for RoutineExercise.scalingBasis persistence (issue #517 Phase 3).
+ * Verifies that the new nullable TEXT column survives a save → read cycle via the
+ * repository, including the ScalingBasis enum serialisation/deserialisation.
+ */
+class SqlDelightWorkoutRepositoryRoutineScalingTest {
+
+    private lateinit var database: com.devil.phoenixproject.database.VitruvianDatabase
+    private lateinit var exerciseRepository: FakeExerciseRepository
+    private lateinit var repository: SqlDelightWorkoutRepository
+
+    @Before
+    fun setup() {
+        database = createTestDatabase()
+        exerciseRepository = FakeExerciseRepository()
+        repository = SqlDelightWorkoutRepository(database, exerciseRepository)
+    }
+
+    @Test
+    fun `routine exercise persists and reads back scalingBasis ESTIMATED_1RM`() = runTest {
+        val exerciseId = "bench-press-scaling"
+        val exercise = Exercise(
+            id = exerciseId,
+            name = "Bench Press",
+            muscleGroup = "Chest",
+            equipment = "Cable",
+        )
+        exerciseRepository.addExercise(exercise)
+
+        val routineId = "routine-scaling-basis"
+        val routineExercise = RoutineExercise(
+            id = "rex-scaling-basis",
+            exercise = exercise,
+            orderIndex = 0,
+            setReps = listOf(10, 10, 10),
+            weightPerCableKg = 50f,
+            scalingBasis = ScalingBasis.ESTIMATED_1RM,
+        )
+        val routine = Routine(
+            id = routineId,
+            name = "Scaling Basis Test Routine",
+            exercises = listOf(routineExercise),
+        )
+
+        repository.saveRoutine(routine)
+
+        val loaded = repository.getRoutineById(routineId)
+        assertNotNull(loaded, "Routine should be found after save")
+        assertEquals(1, loaded.exercises.size, "Routine should have 1 exercise")
+
+        val loadedExercise = loaded.exercises.first { it.id == routineExercise.id }
+        assertEquals(ScalingBasis.ESTIMATED_1RM, loadedExercise.scalingBasis,
+            "scalingBasis should round-trip as ESTIMATED_1RM")
+    }
+
+    @Test
+    fun `routine exercise with null scalingBasis reads back as null`() = runTest {
+        val exerciseId = "squat-scaling-null"
+        val exercise = Exercise(
+            id = exerciseId,
+            name = "Squat",
+            muscleGroup = "Legs",
+            equipment = "Cable",
+        )
+        exerciseRepository.addExercise(exercise)
+
+        val routineId = "routine-scaling-null"
+        val routineExercise = RoutineExercise(
+            id = "rex-scaling-null",
+            exercise = exercise,
+            orderIndex = 0,
+            setReps = listOf(10),
+            weightPerCableKg = 30f,
+            scalingBasis = null,
+        )
+        val routine = Routine(
+            id = routineId,
+            name = "Null Scaling Basis Routine",
+            exercises = listOf(routineExercise),
+        )
+
+        repository.saveRoutine(routine)
+
+        val loaded = repository.getRoutineById(routineId)
+        assertNotNull(loaded, "Routine should be found after save")
+        val loadedExercise = loaded.exercises.first { it.id == routineExercise.id }
+        assertEquals(null, loadedExercise.scalingBasis,
+            "null scalingBasis should round-trip as null")
+    }
+}

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepositoryVelocityPointsTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepositoryVelocityPointsTest.kt
@@ -5,6 +5,7 @@ import com.devil.phoenixproject.database.VitruvianDatabase
 import com.devil.phoenixproject.testutil.createTestDatabase
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
 
 class SqlDelightWorkoutRepositoryVelocityPointsTest {
@@ -188,5 +189,24 @@ class SqlDelightWorkoutRepositoryVelocityPointsTest {
         assertEquals(1, points.size, "Only the session with non-null MCV and working reps should qualify")
         assertEquals(48f, points.first().loadPerCableKg)
         assertEquals(900f, points.first().mcvMmS)
+    }
+
+    // Issue #517 Phase 5 T1
+    @Test
+    fun `getExerciseIdsWithVelocityData returns distinct mcv-bearing exercises`() = runTest {
+        val db = createInMemoryTestDatabase()
+        seedExercise(db, id = "exA"); seedExercise(db, id = "exB")
+        val exerciseRepo = SqlDelightExerciseRepository(db, ExerciseImporter(db))
+        val repo = SqlDelightWorkoutRepository(db, exerciseRepo)
+
+        // two MCV-bearing sets for exA — must appear only once (DISTINCT)
+        seedSession(db, exerciseId = "exA", weightPerCableKg = 40f, workingAvgWeightKg = 40f, avgMcvMmS = 800f, timestamp = 1L, workingReps = 5, profileId = "default")
+        seedSession(db, exerciseId = "exA", weightPerCableKg = 60f, workingAvgWeightKg = 60f, avgMcvMmS = 500f, timestamp = 2L, workingReps = 5, profileId = "default")
+        // exB has null MCV — must be excluded
+        seedSession(db, exerciseId = "exB", weightPerCableKg = 50f, workingAvgWeightKg = 50f, avgMcvMmS = null, timestamp = 1L, workingReps = 5, profileId = "default")
+
+        val ids = repo.getExerciseIdsWithVelocityData("default")
+        assertEquals(listOf("exA"), ids)
+        assertTrue(ids.none { it == "exB" }, "exB (null MCV) must be excluded")
     }
 }

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/e2e/WorkoutFlowE2ETest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/e2e/WorkoutFlowE2ETest.kt
@@ -66,7 +66,7 @@ class WorkoutFlowE2ETest {
         fakeCompletedSetRepository = FakeCompletedSetRepository()
         fakeRepMetricRepository = FakeRepMetricRepository()
         repCounter = RepCounterFromMachine()
-        resolveWeightsUseCase = ResolveRoutineWeightsUseCase(fakePersonalRecordRepository, fakeExerciseRepository)
+        resolveWeightsUseCase = ResolveRoutineWeightsUseCase(fakePersonalRecordRepository, fakeExerciseRepository, com.devil.phoenixproject.testutil.FakeVelocityOneRepMaxRepository())
 
         viewModel = MainViewModel(
             bleRepository = fakeBleRepository,

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/e2e/WorkoutFlowE2ETest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/e2e/WorkoutFlowE2ETest.kt
@@ -113,6 +113,11 @@ class WorkoutFlowE2ETest {
                 override suspend fun hasEstimates(exerciseId: String, profileId: String): Boolean = false
             },
             countVelocityOneRepMaxImprovementsUseCase = CountVelocityOneRepMaxImprovementsUseCase(),
+            backfillVelocityOneRepMaxUseCase = com.devil.phoenixproject.domain.usecase.BackfillVelocityOneRepMaxUseCase(
+                exerciseIds = { emptyList() },
+                hasEstimates = { _, _ -> false },
+                computeAllTime = { _, _, _ -> null },
+            ),
         )
 
         robot = WorkoutRobot(viewModel, fakeBleRepository)

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/e2e/WorkoutFlowE2ETest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/e2e/WorkoutFlowE2ETest.kt
@@ -110,6 +110,7 @@ class WorkoutFlowE2ETest {
                 override suspend fun getLatestPassing(exerciseId: String, profileId: String): com.devil.phoenixproject.data.repository.VelocityOneRepMaxEntity? = null
                 override suspend fun getAllPassing(profileId: String): List<com.devil.phoenixproject.data.repository.VelocityOneRepMaxEntity> = emptyList()
                 override fun getHistory(exerciseId: String, profileId: String): kotlinx.coroutines.flow.Flow<List<com.devil.phoenixproject.data.repository.VelocityOneRepMaxEntity>> = kotlinx.coroutines.flow.flowOf(emptyList())
+                override suspend fun hasEstimates(exerciseId: String, profileId: String): Boolean = false
             },
             countVelocityOneRepMaxImprovementsUseCase = CountVelocityOneRepMaxImprovementsUseCase(),
         )

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/e2e/WorkoutFlowE2ETest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/e2e/WorkoutFlowE2ETest.kt
@@ -3,6 +3,7 @@ package com.devil.phoenixproject.e2e
 import com.devil.phoenixproject.data.repository.SettingsEquipmentRackRepository
 import com.devil.phoenixproject.domain.model.ProgramMode
 import com.devil.phoenixproject.domain.usecase.ApplyEquipmentRackLoadUseCase
+import com.devil.phoenixproject.domain.usecase.CountVelocityOneRepMaxImprovementsUseCase
 import com.devil.phoenixproject.domain.usecase.RecommendWeightAdjustmentUseCase
 import com.devil.phoenixproject.domain.usecase.RepCounterFromMachine
 import com.devil.phoenixproject.domain.usecase.ResolveRoutineWeightsUseCase
@@ -110,6 +111,7 @@ class WorkoutFlowE2ETest {
                 override suspend fun getAllPassing(profileId: String): List<com.devil.phoenixproject.data.repository.VelocityOneRepMaxEntity> = emptyList()
                 override fun getHistory(exerciseId: String, profileId: String): kotlinx.coroutines.flow.Flow<List<com.devil.phoenixproject.data.repository.VelocityOneRepMaxEntity>> = kotlinx.coroutines.flow.flowOf(emptyList())
             },
+            countVelocityOneRepMaxImprovementsUseCase = CountVelocityOneRepMaxImprovementsUseCase(),
         )
 
         robot = WorkoutRobot(viewModel, fakeBleRepository)

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/e2e/WorkoutFlowE2ETest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/e2e/WorkoutFlowE2ETest.kt
@@ -20,6 +20,7 @@ import com.devil.phoenixproject.testutil.FakePersonalRecordRepository
 import com.devil.phoenixproject.testutil.FakePreferencesManager
 import com.devil.phoenixproject.testutil.FakeRepMetricRepository
 import com.devil.phoenixproject.testutil.FakeTrainingCycleRepository
+import com.devil.phoenixproject.testutil.FakeVelocityOneRepMaxRepository
 import com.devil.phoenixproject.testutil.FakeWorkoutRepository
 import com.devil.phoenixproject.testutil.TestCoroutineRule
 import com.russhwolf.settings.MapSettings
@@ -66,7 +67,7 @@ class WorkoutFlowE2ETest {
         fakeCompletedSetRepository = FakeCompletedSetRepository()
         fakeRepMetricRepository = FakeRepMetricRepository()
         repCounter = RepCounterFromMachine()
-        resolveWeightsUseCase = ResolveRoutineWeightsUseCase(fakePersonalRecordRepository, fakeExerciseRepository, com.devil.phoenixproject.testutil.FakeVelocityOneRepMaxRepository())
+        resolveWeightsUseCase = ResolveRoutineWeightsUseCase(fakePersonalRecordRepository, fakeExerciseRepository, FakeVelocityOneRepMaxRepository())
 
         viewModel = MainViewModel(
             bleRepository = fakeBleRepository,

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/e2e/WorkoutFlowE2ETest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/e2e/WorkoutFlowE2ETest.kt
@@ -107,6 +107,7 @@ class WorkoutFlowE2ETest {
             velocityOneRepMaxRepository = object : com.devil.phoenixproject.data.repository.VelocityOneRepMaxRepository {
                 override suspend fun insert(result: com.devil.phoenixproject.domain.onerepmax.VelocityOneRepMaxResult, exerciseId: String, computedAt: Long, profileId: String) {}
                 override suspend fun getLatestPassing(exerciseId: String, profileId: String): com.devil.phoenixproject.data.repository.VelocityOneRepMaxEntity? = null
+                override suspend fun getAllPassing(profileId: String): List<com.devil.phoenixproject.data.repository.VelocityOneRepMaxEntity> = emptyList()
                 override fun getHistory(exerciseId: String, profileId: String): kotlinx.coroutines.flow.Flow<List<com.devil.phoenixproject.data.repository.VelocityOneRepMaxEntity>> = kotlinx.coroutines.flow.flowOf(emptyList())
             },
         )

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/manager/GamificationManagerTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/manager/GamificationManagerTest.kt
@@ -216,4 +216,50 @@ class GamificationManagerTest {
             managerScope.cancel()
         }
     }
+
+    @Test
+    fun `checkVelocityOneRepMaxBadges awards bronze at one improvement`() = runTest {
+        val managerScope = CoroutineScope(coroutineContext + SupervisorJob())
+        try {
+            val manager = GamificationManager(
+                gamificationRepository = fakeGamificationRepository,
+                personalRecordRepository = fakePersonalRecordRepository,
+                exerciseRepository = fakeExerciseRepository,
+                hapticEvents = hapticEvents,
+                scope = managerScope,
+                gamificationEnabled = MutableStateFlow(true),
+            )
+
+            val earned = manager.checkVelocityOneRepMaxBadges(improvementCount = 1, profileId = "default")
+            advanceUntilIdle()
+
+            assertTrue(earned.any { it.id == "velocity_1rm_1" })
+            assertFalse(earned.any { it.id == "velocity_1rm_5" })
+        } finally {
+            managerScope.cancel()
+        }
+    }
+
+    @Test
+    fun `checkVelocityOneRepMaxBadges does not re-award already earned`() = runTest {
+        val managerScope = CoroutineScope(coroutineContext + SupervisorJob())
+        try {
+            val manager = GamificationManager(
+                gamificationRepository = fakeGamificationRepository,
+                personalRecordRepository = fakePersonalRecordRepository,
+                exerciseRepository = fakeExerciseRepository,
+                hapticEvents = hapticEvents,
+                scope = managerScope,
+                gamificationEnabled = MutableStateFlow(true),
+            )
+
+            manager.checkVelocityOneRepMaxBadges(1, "default")
+            val again = manager.checkVelocityOneRepMaxBadges(1, "default")
+            advanceUntilIdle()
+
+            assertTrue(again.isEmpty())
+        } finally {
+            managerScope.cancel()
+        }
+    }
 }

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/manager/SettingsManagerTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/manager/SettingsManagerTest.kt
@@ -89,6 +89,24 @@ class SettingsManagerTest {
     }
 
     @Test
+    fun `setVelocityOneRepMaxBackfillDone persists to preference-backed flow`() = runTest {
+        val managerScope = CoroutineScope(coroutineContext + SupervisorJob())
+        try {
+            val manager = SettingsManager(fakePreferencesManager, fakeBleRepository, managerScope)
+
+            assertFalse(manager.velocityOneRepMaxBackfillDone.value)
+
+            manager.setVelocityOneRepMaxBackfillDone(true)
+            advanceUntilIdle()
+
+            assertTrue(fakePreferencesManager.preferencesFlow.value.velocityOneRepMaxBackfillDone)
+            assertTrue(manager.velocityOneRepMaxBackfillDone.value)
+        } finally {
+            managerScope.cancel()
+        }
+    }
+
+    @Test
     fun `weight conversion and formatting preserves legacy behavior`() = runTest {
         val managerScope = CoroutineScope(coroutineContext + SupervisorJob())
         try {

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/manager/SettingsManagerTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/manager/SettingsManagerTest.kt
@@ -1,5 +1,6 @@
 package com.devil.phoenixproject.presentation.manager
 
+import com.devil.phoenixproject.domain.model.ScalingBasis
 import com.devil.phoenixproject.domain.model.UserPreferences
 import com.devil.phoenixproject.domain.model.WeightUnit
 import com.devil.phoenixproject.testutil.FakeBleRepository
@@ -64,6 +65,24 @@ class SettingsManagerTest {
 
             assertEquals(WeightUnit.KG, fakePreferencesManager.preferencesFlow.value.weightUnit)
             assertEquals(WeightUnit.KG, manager.userPreferences.value.weightUnit)
+        } finally {
+            managerScope.cancel()
+        }
+    }
+
+    @Test
+    fun `setDefaultScalingBasis persists to preference-backed flow`() = runTest {
+        val managerScope = CoroutineScope(coroutineContext + SupervisorJob())
+        try {
+            val manager = SettingsManager(fakePreferencesManager, fakeBleRepository, managerScope)
+
+            assertEquals(ScalingBasis.MAX_WEIGHT_PR, manager.defaultScalingBasis.value)
+
+            manager.setDefaultScalingBasis(ScalingBasis.ESTIMATED_1RM)
+            advanceUntilIdle()
+
+            assertEquals(ScalingBasis.ESTIMATED_1RM, fakePreferencesManager.preferencesFlow.value.defaultScalingBasis)
+            assertEquals(ScalingBasis.ESTIMATED_1RM, manager.defaultScalingBasis.value)
         } finally {
             managerScope.cancel()
         }

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModelTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModelTest.kt
@@ -8,6 +8,7 @@ import com.devil.phoenixproject.domain.model.PRType
 import com.devil.phoenixproject.domain.model.PersonalRecord
 import com.devil.phoenixproject.domain.model.ProgramMode
 import com.devil.phoenixproject.domain.model.RoutineExercise
+import com.devil.phoenixproject.domain.model.ScalingBasis
 import com.devil.phoenixproject.domain.model.WeightUnit
 import com.devil.phoenixproject.domain.model.WorkoutPhase
 import com.devil.phoenixproject.presentation.screen.shouldShowCableOnlyExerciseControls
@@ -454,6 +455,62 @@ class ExerciseConfigViewModelTest {
         assertEquals(45f, viewModel.currentExercisePR.value?.weightPerCableKg)
     }
 
+    @Test
+    fun `initialize and save preserve explicit scalingBasis`() = runTest {
+        val viewModel = ExerciseConfigViewModel()
+        val exercise = benchRoutineExercise(
+            id = "rex-scaling-basis",
+            setReps = listOf(10),
+            weightPerCableKg = 20f,
+            scalingBasis = ScalingBasis.ESTIMATED_1RM,
+        )
+
+        viewModel.initialize(
+            exercise = exercise,
+            unit = WeightUnit.KG,
+            toDisplay = { value, _ -> value },
+            toKg = { value, _ -> value },
+        )
+
+        assertEquals(ScalingBasis.ESTIMATED_1RM, viewModel.scalingBasis.value)
+
+        viewModel.onScalingBasisChange(ScalingBasis.MAX_VOLUME_PR)
+        assertEquals(ScalingBasis.MAX_VOLUME_PR, viewModel.scalingBasis.value)
+
+        var saved: RoutineExercise? = null
+        viewModel.onSave { updated -> saved = updated }
+
+        assertNotNull(saved)
+        assertEquals(ScalingBasis.MAX_VOLUME_PR, saved.scalingBasis)
+    }
+
+    @Test
+    fun `initialize with null scalingBasis derives from prTypeForScaling`() = runTest {
+        val viewModel = ExerciseConfigViewModel()
+        val exercise = benchRoutineExercise(
+            id = "rex-scaling-null",
+            setReps = listOf(10),
+            weightPerCableKg = 20f,
+        )
+
+        viewModel.initialize(
+            exercise = exercise,
+            unit = WeightUnit.KG,
+            toDisplay = { value, _ -> value },
+            toKg = { value, _ -> value },
+        )
+
+        // null scalingBasis means back-compat derivation — effectiveScalingBasis should derive
+        assertNull(viewModel.scalingBasis.value)
+
+        var saved: RoutineExercise? = null
+        viewModel.onSave { updated -> saved = updated }
+
+        assertNotNull(saved)
+        assertNull(saved.scalingBasis)
+        assertEquals(ScalingBasis.MAX_WEIGHT_PR, saved.effectiveScalingBasis)
+    }
+
     private fun benchRoutineExercise(
         id: String,
         setReps: List<Int?>,
@@ -463,6 +520,7 @@ class ExerciseConfigViewModelTest {
         weightPercentOfPR: Int = 80,
         setWeightsPercentOfPR: List<Int> = emptyList(),
         defaultRackItemIds: List<String> = emptyList(),
+        scalingBasis: ScalingBasis? = null,
     ) = RoutineExercise(
         id = id,
         exercise = Exercise(
@@ -483,6 +541,7 @@ class ExerciseConfigViewModelTest {
         weightPercentOfPR = weightPercentOfPR,
         setWeightsPercentOfPR = setWeightsPercentOfPR,
         defaultRackItemIds = defaultRackItemIds,
+        scalingBasis = scalingBasis,
     )
 
     private fun weightPR(weight: Float) = PersonalRecord(

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModelTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModelTest.kt
@@ -485,6 +485,73 @@ class ExerciseConfigViewModelTest {
     }
 
     @Test
+    fun `legacy null scalingBasis with MAX_VOLUME prType resolves basis and baseline to volume PR`() = runTest {
+        val database = createTestDatabase()
+        val queries = database.vitruvianDatabaseQueries
+        val repository = SqlDelightPersonalRecordRepository(database)
+        val viewModel = ExerciseConfigViewModel(repository)
+        val exercise = benchRoutineExercise(
+            id = "rex-legacy-volume",
+            setReps = listOf(10),
+            weightPerCableKg = 5f,
+            setWeightsPerCableKg = listOf(5f),
+            usePercentOfPR = true,
+            weightPercentOfPR = 80,
+            // Legacy upgraded row: no explicit scalingBasis, but prTypeForScaling = MAX_VOLUME
+            scalingBasis = null,
+            prTypeForScaling = PRType.MAX_VOLUME,
+        )
+
+        insertExercise(queries, id = "bench-1", name = "Bench Press")
+        // Max-weight PR (heavier) and a distinct max-volume PR (lighter, more reps)
+        queries.insertRecord(
+            exerciseId = "bench-1",
+            exerciseName = "Bench Press",
+            weight = 60.0,
+            reps = 3,
+            oneRepMax = 66.0,
+            achievedAt = 1_000L,
+            workoutMode = "Old School",
+            prType = PRType.MAX_WEIGHT.name,
+            volume = 180.0,
+            phase = "COMBINED",
+            profile_id = "default",
+            cable_count = null,
+        )
+        queries.insertRecord(
+            exerciseId = "bench-1",
+            exerciseName = "Bench Press",
+            weight = 40.0,
+            reps = 12,
+            oneRepMax = 56.0,
+            achievedAt = 2_000L,
+            workoutMode = "Old School",
+            prType = PRType.MAX_VOLUME.name,
+            volume = 480.0,
+            phase = "COMBINED",
+            profile_id = "default",
+            cable_count = null,
+        )
+
+        viewModel.initialize(
+            exercise = exercise,
+            unit = WeightUnit.KG,
+            toDisplay = { value, _ -> value },
+            toKg = { value, _ -> value },
+            profileId = "default",
+        )
+
+        // Editor basis must derive to MAX_VOLUME_PR (not default MAX_WEIGHT_PR)
+        assertEquals(ScalingBasis.MAX_VOLUME_PR, viewModel.effectiveScalingBasis())
+        // Baseline + per-set weights resolve off the VOLUME PR (40kg), not the weight PR (60kg).
+        waitForCondition { viewModel.baselineKgForCurrentBasis() == 40f }
+        assertEquals(40f, viewModel.baselineKgForCurrentBasis())
+        // Per-set rows must re-sync to 80% of the volume PR once it loads (Finding B).
+        waitForCondition { viewModel.sets.value.first().weightPerCable == 32f }
+        assertEquals(32f, viewModel.sets.value.first().weightPerCable)
+    }
+
+    @Test
     fun `initialize with null scalingBasis derives from prTypeForScaling`() = runTest {
         val viewModel = ExerciseConfigViewModel()
         val exercise = benchRoutineExercise(
@@ -521,6 +588,7 @@ class ExerciseConfigViewModelTest {
         setWeightsPercentOfPR: List<Int> = emptyList(),
         defaultRackItemIds: List<String> = emptyList(),
         scalingBasis: ScalingBasis? = null,
+        prTypeForScaling: PRType = PRType.MAX_WEIGHT,
     ) = RoutineExercise(
         id = id,
         exercise = Exercise(
@@ -542,6 +610,7 @@ class ExerciseConfigViewModelTest {
         setWeightsPercentOfPR = setWeightsPercentOfPR,
         defaultRackItemIds = defaultRackItemIds,
         scalingBasis = scalingBasis,
+        prTypeForScaling = prTypeForScaling,
     )
 
     private fun weightPR(weight: Float) = PersonalRecord(

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModelTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModelTest.kt
@@ -125,6 +125,7 @@ class MainViewModelTest {
                 override suspend fun getLatestPassing(exerciseId: String, profileId: String): com.devil.phoenixproject.data.repository.VelocityOneRepMaxEntity? = null
                 override suspend fun getAllPassing(profileId: String): List<com.devil.phoenixproject.data.repository.VelocityOneRepMaxEntity> = emptyList()
                 override fun getHistory(exerciseId: String, profileId: String): kotlinx.coroutines.flow.Flow<List<com.devil.phoenixproject.data.repository.VelocityOneRepMaxEntity>> = kotlinx.coroutines.flow.flowOf(emptyList())
+                override suspend fun hasEstimates(exerciseId: String, profileId: String): Boolean = false
             },
             countVelocityOneRepMaxImprovementsUseCase = CountVelocityOneRepMaxImprovementsUseCase(),
         )

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModelTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModelTest.kt
@@ -31,6 +31,7 @@ import com.devil.phoenixproject.testutil.FakePersonalRecordRepository
 import com.devil.phoenixproject.testutil.FakePreferencesManager
 import com.devil.phoenixproject.testutil.FakeRepMetricRepository
 import com.devil.phoenixproject.testutil.FakeTrainingCycleRepository
+import com.devil.phoenixproject.testutil.FakeVelocityOneRepMaxRepository
 import com.devil.phoenixproject.testutil.FakeWorkoutRepository
 import com.devil.phoenixproject.testutil.TestCoroutineRule
 import com.russhwolf.settings.MapSettings
@@ -81,7 +82,7 @@ class MainViewModelTest {
         fakeCompletedSetRepository = FakeCompletedSetRepository()
         fakeRepMetricRepository = FakeRepMetricRepository()
         repCounter = RepCounterFromMachine()
-        resolveWeightsUseCase = ResolveRoutineWeightsUseCase(fakePersonalRecordRepository, fakeExerciseRepository, com.devil.phoenixproject.testutil.FakeVelocityOneRepMaxRepository())
+        resolveWeightsUseCase = ResolveRoutineWeightsUseCase(fakePersonalRecordRepository, fakeExerciseRepository, FakeVelocityOneRepMaxRepository())
 
         viewModel = MainViewModel(
             bleRepository = fakeBleRepository,

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModelTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModelTest.kt
@@ -17,6 +17,7 @@ import com.devil.phoenixproject.domain.model.WorkoutMetric
 import com.devil.phoenixproject.domain.model.WorkoutParameters
 import com.devil.phoenixproject.domain.model.WorkoutState
 import com.devil.phoenixproject.domain.usecase.ApplyEquipmentRackLoadUseCase
+import com.devil.phoenixproject.domain.usecase.CountVelocityOneRepMaxImprovementsUseCase
 import com.devil.phoenixproject.domain.usecase.RecommendWeightAdjustmentUseCase
 import com.devil.phoenixproject.domain.usecase.RepCounterFromMachine
 import com.devil.phoenixproject.domain.usecase.ResolveRoutineWeightsUseCase
@@ -125,6 +126,7 @@ class MainViewModelTest {
                 override suspend fun getAllPassing(profileId: String): List<com.devil.phoenixproject.data.repository.VelocityOneRepMaxEntity> = emptyList()
                 override fun getHistory(exerciseId: String, profileId: String): kotlinx.coroutines.flow.Flow<List<com.devil.phoenixproject.data.repository.VelocityOneRepMaxEntity>> = kotlinx.coroutines.flow.flowOf(emptyList())
             },
+            countVelocityOneRepMaxImprovementsUseCase = CountVelocityOneRepMaxImprovementsUseCase(),
         )
     }
 

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModelTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModelTest.kt
@@ -128,6 +128,11 @@ class MainViewModelTest {
                 override suspend fun hasEstimates(exerciseId: String, profileId: String): Boolean = false
             },
             countVelocityOneRepMaxImprovementsUseCase = CountVelocityOneRepMaxImprovementsUseCase(),
+            backfillVelocityOneRepMaxUseCase = com.devil.phoenixproject.domain.usecase.BackfillVelocityOneRepMaxUseCase(
+                exerciseIds = { emptyList() },
+                hasEstimates = { _, _ -> false },
+                computeAllTime = { _, _, _ -> null },
+            ),
         )
     }
 

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModelTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModelTest.kt
@@ -81,7 +81,7 @@ class MainViewModelTest {
         fakeCompletedSetRepository = FakeCompletedSetRepository()
         fakeRepMetricRepository = FakeRepMetricRepository()
         repCounter = RepCounterFromMachine()
-        resolveWeightsUseCase = ResolveRoutineWeightsUseCase(fakePersonalRecordRepository, fakeExerciseRepository)
+        resolveWeightsUseCase = ResolveRoutineWeightsUseCase(fakePersonalRecordRepository, fakeExerciseRepository, com.devil.phoenixproject.testutil.FakeVelocityOneRepMaxRepository())
 
         viewModel = MainViewModel(
             bleRepository = fakeBleRepository,

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModelTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModelTest.kt
@@ -122,6 +122,7 @@ class MainViewModelTest {
             velocityOneRepMaxRepository = object : com.devil.phoenixproject.data.repository.VelocityOneRepMaxRepository {
                 override suspend fun insert(result: com.devil.phoenixproject.domain.onerepmax.VelocityOneRepMaxResult, exerciseId: String, computedAt: Long, profileId: String) {}
                 override suspend fun getLatestPassing(exerciseId: String, profileId: String): com.devil.phoenixproject.data.repository.VelocityOneRepMaxEntity? = null
+                override suspend fun getAllPassing(profileId: String): List<com.devil.phoenixproject.data.repository.VelocityOneRepMaxEntity> = emptyList()
                 override fun getHistory(exerciseId: String, profileId: String): kotlinx.coroutines.flow.Flow<List<com.devil.phoenixproject.data.repository.VelocityOneRepMaxEntity>> = kotlinx.coroutines.flow.flowOf(emptyList())
             },
         )

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/util/DataBackupManagerRoutineNameTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/util/DataBackupManagerRoutineNameTest.kt
@@ -8,6 +8,7 @@ import com.devil.phoenixproject.domain.model.RackItemBehavior
 import com.devil.phoenixproject.domain.model.RackItemCategory
 import com.devil.phoenixproject.domain.model.Routine
 import com.devil.phoenixproject.domain.model.RoutineExercise
+import com.devil.phoenixproject.domain.model.ScalingBasis
 import com.devil.phoenixproject.domain.model.WorkoutSession
 import com.devil.phoenixproject.testutil.FakeExerciseRepository
 import com.devil.phoenixproject.testutil.createTestDatabase
@@ -1043,6 +1044,51 @@ class DataBackupManagerRoutineNameTest {
             .executeAsList()
             .single()
         assertEquals("""["vest"]""", importedExercise.defaultRackItemIds)
+    }
+
+    @Test
+    fun `backup round-trip preserves routine exercise scalingBasis`() = runTest {
+        // Issue #517 Phase 3: a user who sets scalingBasis (e.g. ESTIMATED_1RM) must not
+        // silently lose it across export -> import. Mirrors the v4 rack-defaults round-trip.
+        val sourceManager = TestDataBackupManager(database)
+        workoutRepository.saveRoutine(
+            buildRoutine(
+                routineId = "routine-scaling-backup",
+                routineName = "Scaling Backup",
+                exerciseId = "exercise-scaling-backup",
+                exerciseName = "Bench Press",
+            ).let { routine ->
+                routine.copy(
+                    exercises = routine.exercises.map { exercise ->
+                        exercise.copy(scalingBasis = ScalingBasis.ESTIMATED_1RM)
+                    },
+                )
+            },
+        )
+
+        // Confirm it was persisted on the source DB before export.
+        val sourceExercise = database.vitruvianDatabaseQueries
+            .selectAllRoutineExercisesSync()
+            .executeAsList()
+            .single()
+        assertEquals("ESTIMATED_1RM", sourceExercise.scalingBasis, "scalingBasis must persist on source DB")
+
+        val backupJson = sourceManager.exportToJson()
+        val targetDatabase = createTestDatabase()
+        val targetManager = TestDataBackupManager(targetDatabase)
+
+        val importResult = targetManager.importFromJson(backupJson)
+        assertTrue(importResult.isSuccess, "Backup import must succeed: ${importResult.exceptionOrNull()?.message}")
+
+        val importedExercise = targetDatabase.vitruvianDatabaseQueries
+            .selectAllRoutineExercisesSync()
+            .executeAsList()
+            .single()
+        assertEquals(
+            "ESTIMATED_1RM",
+            importedExercise.scalingBasis,
+            "scalingBasis must survive export -> import round-trip",
+        )
     }
 
     @Test

--- a/shared/src/androidMain/kotlin/com/devil/phoenixproject/di/PlatformModule.android.kt
+++ b/shared/src/androidMain/kotlin/com/devil/phoenixproject/di/PlatformModule.android.kt
@@ -99,6 +99,7 @@ actual val platformModule: Module = module {
             computeVelocityOneRepMaxUseCase = get(),
             recordPersonalMvtSampleUseCase = get(),
             velocityOneRepMaxRepository = get(),
+            countVelocityOneRepMaxImprovementsUseCase = get(),
         )
     }
 }

--- a/shared/src/androidMain/kotlin/com/devil/phoenixproject/di/PlatformModule.android.kt
+++ b/shared/src/androidMain/kotlin/com/devil/phoenixproject/di/PlatformModule.android.kt
@@ -100,6 +100,7 @@ actual val platformModule: Module = module {
             recordPersonalMvtSampleUseCase = get(),
             velocityOneRepMaxRepository = get(),
             countVelocityOneRepMaxImprovementsUseCase = get(),
+            backfillVelocityOneRepMaxUseCase = get(),
         )
     }
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/BadgeDefinitions.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/BadgeDefinitions.kt
@@ -212,6 +212,35 @@ object BadgeDefinitions {
             requirement = PRsAchieved(100),
         ),
 
+        // ==================== VELOCITY 1RM BADGES (VBT-estimated improvements) ====================
+        Badge(
+            id = "velocity_1rm_1",
+            name = "Velocity Breakthrough",
+            description = "Improved your velocity-estimated 1RM on any lift",
+            category = STRENGTH,
+            iconResource = "trophy",
+            tier = BRONZE,
+            requirement = VelocityOneRepMaxImprovements(1),
+        ),
+        Badge(
+            id = "velocity_1rm_5",
+            name = "Velocity Climber",
+            description = "5 velocity-estimated 1RM improvements",
+            category = STRENGTH,
+            iconResource = "trophy",
+            tier = SILVER,
+            requirement = VelocityOneRepMaxImprovements(5),
+        ),
+        Badge(
+            id = "velocity_1rm_15",
+            name = "Velocity Master",
+            description = "15 velocity-estimated 1RM improvements",
+            category = STRENGTH,
+            iconResource = "trophy",
+            tier = GOLD,
+            requirement = VelocityOneRepMaxImprovements(15),
+        ),
+
         // ==================== VOLUME BADGES (Rep count) ====================
         Badge(
             id = "reps_100",

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/MigrationStatements.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/MigrationStatements.kt
@@ -895,5 +895,10 @@ WHERE gs.rowid = (
     )""",
     )
 
+    // Migration 38: per-routine-exercise scaling basis (% of estimated 1RM) — issue #517 Phase 3.
+    38 -> listOf(
+        "ALTER TABLE RoutineExercise ADD COLUMN scalingBasis TEXT",
+    )
+
     else -> emptyList()
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/SchemaManifest.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/SchemaManifest.kt
@@ -873,7 +873,7 @@ internal val manifestTables: List<SchemaTableOperation> = listOf(
 
     // RoutineExercise -- initial schema, full current shape
     // Columns added by later migrations: superset fields (m4), PR scaling (m7),
-    // routine programming (m18), behavior overrides (m20)
+    // routine programming (m18), behavior overrides (m20), scalingBasis (m38)
     SchemaTableOperation(
         table = "RoutineExercise",
         createSql = """
@@ -905,6 +905,7 @@ internal val manifestTables: List<SchemaTableOperation> = listOf(
                 weightPercentOfPR INTEGER NOT NULL DEFAULT 80,
                 prTypeForScaling TEXT NOT NULL DEFAULT 'MAX_WEIGHT',
                 setWeightsPercentOfPR TEXT,
+                scalingBasis TEXT,
                 stallDetectionEnabled INTEGER NOT NULL DEFAULT 1,
                 stopAtTop INTEGER NOT NULL DEFAULT 0,
                 repCountTiming TEXT NOT NULL DEFAULT 'TOP',
@@ -1266,6 +1267,8 @@ internal val manifestColumns: List<SchemaHealOperation> = listOf(
     SchemaHealOperation("RoutineExercise", "defaultRackItemIds", "ALTER TABLE RoutineExercise ADD COLUMN defaultRackItemIds TEXT NOT NULL DEFAULT '[]'"),
     // Migration 35: equipment rack behavior overrides
     SchemaHealOperation("RoutineExercise", "rackBehaviorOverrides", "ALTER TABLE RoutineExercise ADD COLUMN rackBehaviorOverrides TEXT NOT NULL DEFAULT '{}'"),
+    // Migration 38: velocity-based 1RM scaling basis (issue #517 Phase 3)
+    SchemaHealOperation("RoutineExercise", "scalingBasis", "ALTER TABLE RoutineExercise ADD COLUMN scalingBasis TEXT"),
     // Migration 20 (healed outside .sqm): rep detection behavior
     SchemaHealOperation("RoutineExercise", "stallDetectionEnabled", "ALTER TABLE RoutineExercise ADD COLUMN stallDetectionEnabled INTEGER NOT NULL DEFAULT 1"),
     SchemaHealOperation("RoutineExercise", "stopAtTop", "ALTER TABLE RoutineExercise ADD COLUMN stopAtTop INTEGER NOT NULL DEFAULT 0"),

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/preferences/PreferencesManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/preferences/PreferencesManager.kt
@@ -3,6 +3,7 @@ package com.devil.phoenixproject.data.preferences
 import com.devil.phoenixproject.domain.model.EchoLevel
 import com.devil.phoenixproject.domain.model.ProgramMode
 import com.devil.phoenixproject.domain.model.RepCountTiming
+import com.devil.phoenixproject.domain.model.ScalingBasis
 import com.devil.phoenixproject.domain.model.UserPreferences
 import com.devil.phoenixproject.domain.model.WeightUnit
 import com.devil.phoenixproject.util.BackupDestination
@@ -152,6 +153,9 @@ interface PreferencesManager {
     // Issue #424: Suggestion-only next-set weight recommendations
     suspend fun setWeightSuggestionsEnabled(enabled: Boolean)
 
+    // Issue #517: Default scaling basis for % of 1RM routine weight resolution
+    suspend fun setDefaultScalingBasis(basis: ScalingBasis)
+
     suspend fun getSingleExerciseDefaults(exerciseId: String): SingleExerciseDefaults?
     suspend fun saveSingleExerciseDefaults(defaults: SingleExerciseDefaults)
     suspend fun clearAllSingleExerciseDefaults()
@@ -210,6 +214,7 @@ class SettingsPreferencesManager(private val settings: Settings) : PreferencesMa
         private const val KEY_VELOCITY_LOSS_THRESHOLD = "velocity_loss_threshold_percent"
         private const val KEY_AUTO_END_VELOCITY_LOSS = "auto_end_on_velocity_loss"
         private const val KEY_WEIGHT_SUGGESTIONS_ENABLED = "weight_suggestions_enabled"
+        private const val KEY_DEFAULT_SCALING_BASIS = "default_scaling_basis"
 
         // Permissions onboarding (health + microphone)
         private const val KEY_PERMISSIONS_ONBOARDING_SHOWN = "permissions_onboarding_shown"
@@ -259,6 +264,9 @@ class SettingsPreferencesManager(private val settings: Settings) : PreferencesMa
             velocityLossThresholdPercent = settings.getInt(KEY_VELOCITY_LOSS_THRESHOLD, 20).coerceIn(10, 50),
             autoEndOnVelocityLoss = settings.getBoolean(KEY_AUTO_END_VELOCITY_LOSS, false),
             weightSuggestionsEnabled = settings.getBoolean(KEY_WEIGHT_SUGGESTIONS_ENABLED, true),
+            defaultScalingBasis = settings.getStringOrNull(KEY_DEFAULT_SCALING_BASIS)?.let {
+                runCatching { ScalingBasis.valueOf(it) }.getOrNull()
+            } ?: ScalingBasis.MAX_WEIGHT_PR,
         )
     }
 
@@ -522,5 +530,10 @@ class SettingsPreferencesManager(private val settings: Settings) : PreferencesMa
     override suspend fun setWeightSuggestionsEnabled(enabled: Boolean) {
         settings.putBoolean(KEY_WEIGHT_SUGGESTIONS_ENABLED, enabled)
         updateAndEmit { copy(weightSuggestionsEnabled = enabled) }
+    }
+
+    override suspend fun setDefaultScalingBasis(basis: ScalingBasis) {
+        settings.putString(KEY_DEFAULT_SCALING_BASIS, basis.name)
+        updateAndEmit { copy(defaultScalingBasis = basis) }
     }
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/preferences/PreferencesManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/preferences/PreferencesManager.kt
@@ -156,6 +156,9 @@ interface PreferencesManager {
     // Issue #517: Default scaling basis for % of 1RM routine weight resolution
     suspend fun setDefaultScalingBasis(basis: ScalingBasis)
 
+    // Issue #517: Run-once flag for velocity 1RM backfill
+    suspend fun setVelocityOneRepMaxBackfillDone(done: Boolean)
+
     suspend fun getSingleExerciseDefaults(exerciseId: String): SingleExerciseDefaults?
     suspend fun saveSingleExerciseDefaults(defaults: SingleExerciseDefaults)
     suspend fun clearAllSingleExerciseDefaults()
@@ -215,6 +218,7 @@ class SettingsPreferencesManager(private val settings: Settings) : PreferencesMa
         private const val KEY_AUTO_END_VELOCITY_LOSS = "auto_end_on_velocity_loss"
         private const val KEY_WEIGHT_SUGGESTIONS_ENABLED = "weight_suggestions_enabled"
         private const val KEY_DEFAULT_SCALING_BASIS = "default_scaling_basis"
+        private const val KEY_VELOCITY_1RM_BACKFILL_DONE = "velocity_1rm_backfill_done"
 
         // Permissions onboarding (health + microphone)
         private const val KEY_PERMISSIONS_ONBOARDING_SHOWN = "permissions_onboarding_shown"
@@ -267,6 +271,7 @@ class SettingsPreferencesManager(private val settings: Settings) : PreferencesMa
             defaultScalingBasis = settings.getStringOrNull(KEY_DEFAULT_SCALING_BASIS)?.let {
                 runCatching { ScalingBasis.valueOf(it) }.getOrNull()
             } ?: ScalingBasis.MAX_WEIGHT_PR,
+            velocityOneRepMaxBackfillDone = settings.getBoolean(KEY_VELOCITY_1RM_BACKFILL_DONE, false),
         )
     }
 
@@ -535,5 +540,10 @@ class SettingsPreferencesManager(private val settings: Settings) : PreferencesMa
     override suspend fun setDefaultScalingBasis(basis: ScalingBasis) {
         settings.putString(KEY_DEFAULT_SCALING_BASIS, basis.name)
         updateAndEmit { copy(defaultScalingBasis = basis) }
+    }
+
+    override suspend fun setVelocityOneRepMaxBackfillDone(done: Boolean) {
+        settings.putBoolean(KEY_VELOCITY_1RM_BACKFILL_DONE, done)
+        updateAndEmit { copy(velocityOneRepMaxBackfillDone = done) }
     }
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightGamificationRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightGamificationRepository.kt
@@ -688,6 +688,12 @@ class SqlDelightGamificationRepository(db: VitruvianDatabase) : GamificationRepo
             // which tracks session-scoped consecutive quality sets. Not evaluated via DB stats.
             false
         }
+
+        is BadgeRequirement.VelocityOneRepMaxImprovements -> {
+            // Awarded by VelocityOneRepMaxRepository when cumulative improvement count meets threshold.
+            // Not evaluated via aggregate GamificationStats — handled outside this stats-based path.
+            false
+        }
     }
 
     override suspend fun getBadgeProgress(badgeId: String, profileId: String): Pair<Int, Int>? {
@@ -775,6 +781,8 @@ class SqlDelightGamificationRepository(db: VitruvianDatabase) : GamificationRepo
                 is BadgeRequirement.RoutinesCreated -> getCreatedRoutinesCount(profileId)
 
                 is BadgeRequirement.QualityStreak -> 0 // Session-scoped, not tracked in DB
+
+                is BadgeRequirement.VelocityOneRepMaxImprovements -> 0 // Awarded by VelocityOneRepMaxRepository
             }
 
             Pair(current, badge.getTargetValue())

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightGamificationRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightGamificationRepository.kt
@@ -690,8 +690,7 @@ class SqlDelightGamificationRepository(db: VitruvianDatabase) : GamificationRepo
         }
 
         is BadgeRequirement.VelocityOneRepMaxImprovements -> {
-            // Awarded by VelocityOneRepMaxRepository when cumulative improvement count meets threshold.
-            // Not evaluated via aggregate GamificationStats — handled outside this stats-based path.
+            // Awarded by GamificationManager.checkVelocityOneRepMaxBadges() via the post-save hook in MainViewModel.
             false
         }
     }
@@ -782,7 +781,7 @@ class SqlDelightGamificationRepository(db: VitruvianDatabase) : GamificationRepo
 
                 is BadgeRequirement.QualityStreak -> 0 // Session-scoped, not tracked in DB
 
-                is BadgeRequirement.VelocityOneRepMaxImprovements -> 0 // Awarded by VelocityOneRepMaxRepository
+                is BadgeRequirement.VelocityOneRepMaxImprovements -> 0 // Awarded by GamificationManager.checkVelocityOneRepMaxBadges() via the post-save hook in MainViewModel.
             }
 
             Pair(current, badge.getTargetValue())

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt
@@ -710,6 +710,7 @@ class SqlDelightSyncRepository(
                                 rackBehaviorOverrides = exercise.rackBehaviorOverrides
                                     ?: localRackOverridesByExerciseId[exercise.id]
                                     ?: "{}",
+                                scalingBasis = null,
                             )
                         }
                     } else {
@@ -1844,6 +1845,7 @@ class SqlDelightSyncRepository(
                                 rackBehaviorOverrides = exercise.rackBehaviorOverrides
                                     ?: localRackOverridesByExerciseId[exercise.id]
                                     ?: "{}",
+                                scalingBasis = null,
                             )
                         }
                     }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt
@@ -575,6 +575,8 @@ class SqlDelightSyncRepository(
                             .associate { it.id to it.defaultRackItemIds }
                         val localRackOverridesByExerciseId = localExerciseRows
                             .associate { it.id to it.rackBehaviorOverrides }
+                        val localScalingBasisByExerciseId = localExerciseRows
+                            .associate { it.id to it.scalingBasis }
 
                         // Replace routine exercises and supersets: delete existing then insert portal versions
                         queries.deleteRoutineExercises(portalRoutine.id)
@@ -710,7 +712,7 @@ class SqlDelightSyncRepository(
                                 rackBehaviorOverrides = exercise.rackBehaviorOverrides
                                     ?: localRackOverridesByExerciseId[exercise.id]
                                     ?: "{}",
-                                scalingBasis = null,
+                                scalingBasis = localScalingBasisByExerciseId[exercise.id],
                             )
                         }
                     } else {
@@ -1723,6 +1725,8 @@ class SqlDelightSyncRepository(
                             .associate { it.id to it.defaultRackItemIds }
                         val localRackOverridesByExerciseId = localExerciseRows2
                             .associate { it.id to it.rackBehaviorOverrides }
+                        val localScalingBasisByExerciseId = localExerciseRows2
+                            .associate { it.id to it.scalingBasis }
 
                         queries.deleteRoutineExercises(portalRoutine.id)
                         queries.deleteSupersetsByRoutine(portalRoutine.id)
@@ -1845,7 +1849,7 @@ class SqlDelightSyncRepository(
                                 rackBehaviorOverrides = exercise.rackBehaviorOverrides
                                     ?: localRackOverridesByExerciseId[exercise.id]
                                     ?: "{}",
-                                scalingBasis = null,
+                                scalingBasis = localScalingBasisByExerciseId[exercise.id],
                             )
                         }
                     }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepository.kt
@@ -1154,6 +1154,11 @@ class SqlDelightWorkoutRepository(private val db: VitruvianDatabase, private val
         }
     }
 
+    override suspend fun getExerciseIdsWithVelocityData(profileId: String): List<String> =
+        withContext(Dispatchers.IO) {
+            queries.selectExerciseIdsWithVelocityData(profileId).executeAsList()
+        }
+
     override fun getAllPhaseStatistics(): Flow<List<PhaseStatisticsData>> = queries.selectAllPhaseStats {
             id,
             sessionId,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepository.kt
@@ -9,6 +9,7 @@ import com.devil.phoenixproject.domain.model.EchoLevel
 import com.devil.phoenixproject.domain.model.Exercise
 import com.devil.phoenixproject.domain.model.PRType
 import com.devil.phoenixproject.domain.model.ProgramMode
+import com.devil.phoenixproject.domain.model.ScalingBasis
 import com.devil.phoenixproject.domain.model.RackItemBehavior
 import com.devil.phoenixproject.domain.model.Routine
 import com.devil.phoenixproject.domain.model.RoutineExercise
@@ -414,6 +415,7 @@ class SqlDelightWorkoutRepository(private val db: VitruvianDatabase, private val
                     warmupSets = warmupSets,
                     defaultRackItemIds = defaultRackItemIds,
                     rackBehaviorOverrides = rackBehaviorOverrides,
+                    scalingBasis = row.scalingBasis?.let { runCatching { ScalingBasis.valueOf(it) }.getOrNull() },
                 )
             } catch (e: Exception) {
                 Logger.e(e) { "Failed to map routine exercise: ${row.exerciseId}" }
@@ -738,6 +740,7 @@ class SqlDelightWorkoutRepository(private val db: VitruvianDatabase, private val
             } else {
                 json.encodeToString(exercise.rackBehaviorOverrides)
             },
+            scalingBasis = exercise.scalingBasis?.name,
         )
     }
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/VelocityOneRepMaxRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/VelocityOneRepMaxRepository.kt
@@ -24,6 +24,7 @@ data class VelocityOneRepMaxEntity(
 interface VelocityOneRepMaxRepository {
     suspend fun insert(result: VelocityOneRepMaxResult, exerciseId: String, computedAt: Long, profileId: String)
     suspend fun getLatestPassing(exerciseId: String, profileId: String): VelocityOneRepMaxEntity?
+    suspend fun getAllPassing(profileId: String): List<VelocityOneRepMaxEntity>
     fun getHistory(exerciseId: String, profileId: String): Flow<List<VelocityOneRepMaxEntity>>
 }
 
@@ -58,6 +59,11 @@ class SqlDelightVelocityOneRepMaxRepository(private val db: VitruvianDatabase) :
     override suspend fun getLatestPassing(exerciseId: String, profileId: String): VelocityOneRepMaxEntity? =
         withContext(Dispatchers.IO) {
             queries.selectLatestPassingVelocityOneRepMax(exerciseId, profileId, ::map).executeAsOneOrNull()
+        }
+
+    override suspend fun getAllPassing(profileId: String): List<VelocityOneRepMaxEntity> =
+        withContext(Dispatchers.IO) {
+            queries.selectAllPassingVelocityOneRepMaxByProfile(profileId, ::map).executeAsList()
         }
 
     override fun getHistory(exerciseId: String, profileId: String): Flow<List<VelocityOneRepMaxEntity>> =

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/VelocityOneRepMaxRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/VelocityOneRepMaxRepository.kt
@@ -26,6 +26,9 @@ interface VelocityOneRepMaxRepository {
     suspend fun getLatestPassing(exerciseId: String, profileId: String): VelocityOneRepMaxEntity?
     suspend fun getAllPassing(profileId: String): List<VelocityOneRepMaxEntity>
     fun getHistory(exerciseId: String, profileId: String): Flow<List<VelocityOneRepMaxEntity>>
+
+    /** Issue #517 Phase 5 T1: returns true if any (non-deleted) estimate exists for this exercise/profile. */
+    suspend fun hasEstimates(exerciseId: String, profileId: String): Boolean
 }
 
 class SqlDelightVelocityOneRepMaxRepository(private val db: VitruvianDatabase) : VelocityOneRepMaxRepository {
@@ -68,4 +71,9 @@ class SqlDelightVelocityOneRepMaxRepository(private val db: VitruvianDatabase) :
 
     override fun getHistory(exerciseId: String, profileId: String): Flow<List<VelocityOneRepMaxEntity>> =
         queries.selectVelocityOneRepMaxByExercise(exerciseId, profileId, ::map).asFlow().mapToList(Dispatchers.IO)
+
+    override suspend fun hasEstimates(exerciseId: String, profileId: String): Boolean =
+        withContext(Dispatchers.IO) {
+            queries.countVelocityOneRepMaxByExercise(exerciseId, profileId).executeAsOne() > 0L
+        }
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/WorkoutRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/WorkoutRepository.kt
@@ -148,6 +148,14 @@ interface WorkoutRepository {
         profileId: String,
         sinceTimestampMs: Long,
     ): List<WorkoutVelocityPoint>
+
+    /**
+     * Issue #517 Phase 5 T1: enumerate distinct exercise IDs that have at least one
+     * non-deleted set with a captured MCV value and at least one working rep, for the
+     * given profile. Used by the velocity-1RM pipeline to decide which exercises are
+     * ready to estimate.
+     */
+    suspend fun getExerciseIdsWithVelocityData(profileId: String): List<String>
 }
 
 /**

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/di/DomainModule.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/di/DomainModule.kt
@@ -15,6 +15,7 @@ import com.devil.phoenixproject.domain.onerepmax.VelocityOneRepMaxEstimator
 import com.devil.phoenixproject.domain.usecase.ApplyEquipmentRackLoadUseCase
 import com.devil.phoenixproject.domain.usecase.ApplyRoutineModifierUseCase
 import com.devil.phoenixproject.domain.usecase.ComputeVelocityOneRepMaxUseCase
+import com.devil.phoenixproject.domain.usecase.CountVelocityOneRepMaxImprovementsUseCase
 import com.devil.phoenixproject.domain.usecase.MvtExerciseView
 import com.devil.phoenixproject.domain.usecase.ProgressionUseCase
 import com.devil.phoenixproject.domain.usecase.RecommendWeightAdjustmentUseCase
@@ -71,6 +72,7 @@ val domainModule = module {
         )
     }
     single { RecordPersonalMvtSampleUseCase(get()) }
+    single { CountVelocityOneRepMaxImprovementsUseCase() }
 
     // Migration
     single { MigrationManager(get(), get<UserProfileRepository>(), get<GamificationRepository>()) }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/di/DomainModule.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/di/DomainModule.kt
@@ -37,7 +37,7 @@ val domainModule = module {
     single { ProgressionUseCase(get(), get()) }
     single { RecommendWeightAdjustmentUseCase() }
     single { ApplyEquipmentRackLoadUseCase() }
-    factory { ResolveRoutineWeightsUseCase(get(), get()) }
+    factory { ResolveRoutineWeightsUseCase(get(), get(), get()) }
     factory { ApplyRoutineModifierUseCase(get(), get()) }
     factory { RoutineTimeEstimator(get()) }
     single { TemplateConverter(get()) }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/di/DomainModule.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/di/DomainModule.kt
@@ -14,6 +14,7 @@ import com.devil.phoenixproject.domain.onerepmax.MvtProvider
 import com.devil.phoenixproject.domain.onerepmax.VelocityOneRepMaxEstimator
 import com.devil.phoenixproject.domain.usecase.ApplyEquipmentRackLoadUseCase
 import com.devil.phoenixproject.domain.usecase.ApplyRoutineModifierUseCase
+import com.devil.phoenixproject.domain.usecase.BackfillVelocityOneRepMaxUseCase
 import com.devil.phoenixproject.domain.usecase.ComputeVelocityOneRepMaxUseCase
 import com.devil.phoenixproject.domain.usecase.CountVelocityOneRepMaxImprovementsUseCase
 import com.devil.phoenixproject.domain.usecase.MvtExerciseView
@@ -73,6 +74,16 @@ val domainModule = module {
     }
     single { RecordPersonalMvtSampleUseCase(get()) }
     single { CountVelocityOneRepMaxImprovementsUseCase() }
+    single {
+        val workoutRepo = get<WorkoutRepository>()
+        val velRepo = get<VelocityOneRepMaxRepository>()
+        val compute = get<ComputeVelocityOneRepMaxUseCase>()
+        BackfillVelocityOneRepMaxUseCase(
+            exerciseIds = { profile -> workoutRepo.getExerciseIdsWithVelocityData(profile) },
+            hasEstimates = { id, profile -> velRepo.hasEstimates(id, profile) },
+            computeAllTime = { id, profile, now -> compute(id, profile, now, windowDays = 3650) },
+        )
+    }
 
     // Migration
     single { MigrationManager(get(), get<UserProfileRepository>(), get<GamificationRepository>()) }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/Gamification.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/Gamification.kt
@@ -94,6 +94,9 @@ sealed class BadgeRequirement {
 
     /** Consecutive sets with average quality score above threshold (session-scoped) */
     data class QualityStreak(val sets: Int, val minScore: Int) : BadgeRequirement()
+
+    /** Cumulative velocity-estimated 1RM improvements (>=2.5% over prior best) across all exercises. */
+    data class VelocityOneRepMaxImprovements(val count: Int) : BadgeRequirement()
 }
 
 /**
@@ -135,6 +138,7 @@ data class Badge(
         is BadgeRequirement.RoutinesCompleted -> "$currentValue/${req.count} routines"
         is BadgeRequirement.RoutinesCreated -> "$currentValue/${req.count} routines"
         is BadgeRequirement.QualityStreak -> "$currentValue/${req.sets} sets (>${req.minScore})"
+        is BadgeRequirement.VelocityOneRepMaxImprovements -> "$currentValue/${req.count} velocity 1RMs"
     }
 
     /**
@@ -163,6 +167,7 @@ data class Badge(
         is BadgeRequirement.RoutinesCompleted -> req.count
         is BadgeRequirement.RoutinesCreated -> req.count
         is BadgeRequirement.QualityStreak -> req.sets
+        is BadgeRequirement.VelocityOneRepMaxImprovements -> req.count
     }
 }
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/Routine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/Routine.kt
@@ -113,6 +113,7 @@ data class RoutineExercise(
     val weightPercentOfPR: Int = 80, // Percentage (e.g., 80 = 80%)
     val prTypeForScaling: PRType = PRType.MAX_WEIGHT, // Which PR type to scale from
     val setWeightsPercentOfPR: List<Int> = emptyList(), // Per-set percentages
+    val scalingBasis: ScalingBasis? = null, // null = derive from prTypeForScaling (legacy/back-compat)
     // Variable warm-up sets (Phase 35C: Issue #30)
     // Each WarmupSet defines reps and a percentage of working weight.
     // Executed before working sets as separate BLE stop/start cycles.
@@ -130,6 +131,10 @@ data class RoutineExercise(
     // Computed property for backwards compatibility
     val sets: Int get() = setReps.size
     val reps: Int get() = setReps.firstOrNull() ?: 10
+
+    /** The resolved scaling baseline; derives from prTypeForScaling for legacy rows. */
+    val effectiveScalingBasis: ScalingBasis
+        get() = scalingBasis ?: ScalingBasis.fromPrType(prTypeForScaling)
 
     // Helper to get rest time for specific set (with fallback to 60s default)
     fun getRestForSet(setIndex: Int): Int = setRestSeconds.getOrNull(setIndex) ?: 60

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/ScalingBasis.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/ScalingBasis.kt
@@ -1,0 +1,16 @@
+package com.devil.phoenixproject.domain.model
+
+/** Baseline a routine exercise's percentage weight scales from. */
+enum class ScalingBasis {
+    MAX_WEIGHT_PR,
+    MAX_VOLUME_PR,
+    ESTIMATED_1RM,
+    ;
+
+    companion object {
+        fun fromPrType(prType: PRType): ScalingBasis = when (prType) {
+            PRType.MAX_WEIGHT -> MAX_WEIGHT_PR
+            PRType.MAX_VOLUME -> MAX_VOLUME_PR
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/UserPreferences.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/UserPreferences.kt
@@ -49,6 +49,8 @@ data class UserPreferences(
     val weightSuggestionsEnabled: Boolean = true,
     // Issue #517: Default scaling basis for % of 1RM routine weight resolution
     val defaultScalingBasis: ScalingBasis = ScalingBasis.MAX_WEIGHT_PR,
+    // Issue #517: Run-once flag — true after the velocity 1RM backfill has completed
+    val velocityOneRepMaxBackfillDone: Boolean = false,
 ) {
     /**
      * Get the effective weight increment in the user's display unit.

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/UserPreferences.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/UserPreferences.kt
@@ -47,6 +47,8 @@ data class UserPreferences(
     val autoEndOnVelocityLoss: Boolean = false,
     // Issue #424: Suggestion-only next-set weight recommendations
     val weightSuggestionsEnabled: Boolean = true,
+    // Issue #517: Default scaling basis for % of 1RM routine weight resolution
+    val defaultScalingBasis: ScalingBasis = ScalingBasis.MAX_WEIGHT_PR,
 ) {
     /**
      * Get the effective weight increment in the user's display unit.

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/BackfillVelocityOneRepMaxUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/BackfillVelocityOneRepMaxUseCase.kt
@@ -1,0 +1,28 @@
+package com.devil.phoenixproject.domain.usecase
+
+import com.devil.phoenixproject.domain.onerepmax.VelocityOneRepMaxResult
+
+/**
+ * Backfills velocity-based 1RM estimates for exercises that have no existing estimate.
+ *
+ * For each exercise belonging to the profile: if an estimate already exists (`hasEstimates`
+ * returns true) the exercise is skipped. Otherwise `computeAllTime` is called, which both
+ * computes and persists the estimate using the full historical window. The use case returns
+ * the count of newly created estimates (non-null `computeAllTime` results).
+ *
+ * Designed to run once at startup (guarded by the `velocityOneRepMaxBackfillDone` preference).
+ */
+class BackfillVelocityOneRepMaxUseCase(
+    private val exerciseIds: suspend (profileId: String) -> List<String>,
+    private val hasEstimates: suspend (exerciseId: String, profileId: String) -> Boolean,
+    private val computeAllTime: suspend (exerciseId: String, profileId: String, nowMs: Long) -> VelocityOneRepMaxResult?,
+) {
+    suspend operator fun invoke(profileId: String, nowMs: Long): Int {
+        var created = 0
+        for (id in exerciseIds(profileId)) {
+            if (hasEstimates(id, profileId)) continue
+            if (computeAllTime(id, profileId, nowMs) != null) created++
+        }
+        return created
+    }
+}

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/ComputeVelocityOneRepMaxUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/ComputeVelocityOneRepMaxUseCase.kt
@@ -16,9 +16,9 @@ class ComputeVelocityOneRepMaxUseCase(
     private val estimator: VelocityOneRepMaxEstimator,
     private val persist: suspend (result: VelocityOneRepMaxResult, exerciseId: String, computedAt: Long, profileId: String) -> Unit,
 ) {
-    suspend operator fun invoke(exerciseId: String, profileId: String, nowMs: Long): VelocityOneRepMaxResult? {
+    suspend operator fun invoke(exerciseId: String, profileId: String, nowMs: Long, windowDays: Int = WINDOW_DAYS): VelocityOneRepMaxResult? {
         val exercise = exerciseLookup(exerciseId) ?: return null
-        val sinceMs = nowMs - WINDOW_DAYS * DAY_MS
+        val sinceMs = nowMs - windowDays.toLong() * DAY_MS
         val points = workoutPoints(exerciseId, profileId, sinceMs)
         val personal = personalMvtLookup(exerciseId, profileId)
         val mvt = mvtProvider.resolve(

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/CountVelocityOneRepMaxImprovementsUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/CountVelocityOneRepMaxImprovementsUseCase.kt
@@ -1,0 +1,27 @@
+package com.devil.phoenixproject.domain.usecase
+
+import com.devil.phoenixproject.data.repository.VelocityOneRepMaxEntity
+
+/** Counts cumulative velocity-1RM improvements (>= prior best x 1.025) across all exercises. */
+class CountVelocityOneRepMaxImprovementsUseCase {
+    operator fun invoke(passingEstimates: List<VelocityOneRepMaxEntity>): Int {
+        var improvements = 0
+        passingEstimates.groupBy { it.exerciseId }.forEach { (_, rows) ->
+            var best: Float? = null
+            rows.sortedBy { it.computedAt }.forEach { row ->
+                val prior = best
+                if (prior != null && row.estimatedPerCableKg >= prior * IMPROVEMENT_FACTOR) {
+                    improvements++
+                    best = row.estimatedPerCableKg
+                } else if (prior == null || row.estimatedPerCableKg > prior) {
+                    best = row.estimatedPerCableKg
+                }
+            }
+        }
+        return improvements
+    }
+
+    companion object {
+        const val IMPROVEMENT_FACTOR = 1.025f
+    }
+}

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/RecordPersonalMvtSampleUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/RecordPersonalMvtSampleUseCase.kt
@@ -15,7 +15,7 @@ class RecordPersonalMvtSampleUseCase(private val personalMvtRepo: PersonalMvtRep
         muscleGroups: String,
         sessionMcvMmS: Float,
     ): Boolean {
-        if (sessionMcvMmS <= 0f) return false
+        if (!(sessionMcvMmS > 0f)) return false
         val sampleMs = sessionMcvMmS / 1000f
         val patternDefault = classifyMovementPattern(exerciseName, muscleGroups).defaultMvtMs
         if (sampleMs > patternDefault * FAILURE_PROXY_FACTOR) return false

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/RecordPersonalMvtSampleUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/RecordPersonalMvtSampleUseCase.kt
@@ -15,7 +15,9 @@ class RecordPersonalMvtSampleUseCase(private val personalMvtRepo: PersonalMvtRep
         muscleGroups: String,
         sessionMcvMmS: Float,
     ): Boolean {
-        if (!(sessionMcvMmS > 0f)) return false
+        // isNaN() guard is explicit so a linter cannot "simplify" it to `<= 0f` and silently
+        // reintroduce the NaN bypass (NaN <= 0f is false).
+        if (sessionMcvMmS.isNaN() || sessionMcvMmS <= 0f) return false
         val sampleMs = sessionMcvMmS / 1000f
         val patternDefault = classifyMovementPattern(exerciseName, muscleGroups).defaultMvtMs
         if (sampleMs > patternDefault * FAILURE_PROXY_FACTOR) return false

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/ResolveRoutineWeightsUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/ResolveRoutineWeightsUseCase.kt
@@ -72,6 +72,19 @@ class ResolveRoutineWeightsUseCase(
                 profileId,
             )?.estimatedPerCableKg?.takeIf { it > 0 }
         } ?: exerciseRepository.getExerciseById(exerciseId)?.oneRepMaxKg?.takeIf { it > 0 }
+            // Last-resort baseline for ESTIMATED_1RM only: when there is no velocity estimate
+            // and no stored Exercise.oneRepMaxKg, fall back to the max-weight PR before going absolute.
+            ?: (
+                if (exercise.effectiveScalingBasis == ScalingBasis.ESTIMATED_1RM) {
+                    prRepository.getBestWeightPRForWorkoutMode(
+                        exerciseId,
+                        mode.displayName,
+                        profileId,
+                    )?.weightPerCableKg?.takeIf { it > 0 }
+                } else {
+                    null
+                }
+                )
 
         return if (scalingWeight != null) {
             ResolvedExerciseWeights(

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/ResolveRoutineWeightsUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/ResolveRoutineWeightsUseCase.kt
@@ -2,11 +2,12 @@ package com.devil.phoenixproject.domain.usecase
 
 import com.devil.phoenixproject.data.repository.ExerciseRepository
 import com.devil.phoenixproject.data.repository.PersonalRecordRepository
+import com.devil.phoenixproject.data.repository.VelocityOneRepMaxRepository
 import com.devil.phoenixproject.data.repository.getBestVolumePRForWorkoutMode
 import com.devil.phoenixproject.data.repository.getBestWeightPRForWorkoutMode
-import com.devil.phoenixproject.domain.model.PRType
 import com.devil.phoenixproject.domain.model.ProgramMode
 import com.devil.phoenixproject.domain.model.RoutineExercise
+import com.devil.phoenixproject.domain.model.ScalingBasis
 
 /**
  * Use case for resolving PR percentage weights to absolute values at workout start time.
@@ -19,6 +20,7 @@ import com.devil.phoenixproject.domain.model.RoutineExercise
 class ResolveRoutineWeightsUseCase(
     private val prRepository: PersonalRecordRepository,
     private val exerciseRepository: ExerciseRepository,
+    private val velocityOneRepMaxRepository: VelocityOneRepMaxRepository,
 ) {
     /**
      * Resolves RoutineExercise weights from PR percentages to absolute values.
@@ -51,26 +53,25 @@ class ResolveRoutineWeightsUseCase(
             fallbackReason = "Exercise has no ID for PR lookup",
         )
 
-        // Lookup PR for this exercise filtered by mode and profile
-        val pr = when (exercise.prTypeForScaling) {
-            PRType.MAX_WEIGHT -> prRepository.getBestWeightPRForWorkoutMode(
+        // Lookup scaling baseline for this exercise filtered by mode and profile
+        val scalingWeight: Float? = when (exercise.effectiveScalingBasis) {
+            ScalingBasis.MAX_WEIGHT_PR -> prRepository.getBestWeightPRForWorkoutMode(
                 exerciseId,
                 mode.displayName,
                 profileId,
-            )
+            )?.weightPerCableKg?.takeIf { it > 0 }
 
-            PRType.MAX_VOLUME -> prRepository.getBestVolumePRForWorkoutMode(
+            ScalingBasis.MAX_VOLUME_PR -> prRepository.getBestVolumePRForWorkoutMode(
                 exerciseId,
                 mode.displayName,
                 profileId,
-            )
-        }
+            )?.weightPerCableKg?.takeIf { it > 0 }
 
-        val prWeight = pr?.weightPerCableKg?.takeIf { it > 0 }
-        val storedOneRepMax = exerciseRepository.getExerciseById(exerciseId)
-            ?.oneRepMaxKg
-            ?.takeIf { it > 0 }
-        val scalingWeight = prWeight ?: storedOneRepMax
+            ScalingBasis.ESTIMATED_1RM -> velocityOneRepMaxRepository.getLatestPassing(
+                exerciseId,
+                profileId,
+            )?.estimatedPerCableKg?.takeIf { it > 0 }
+        } ?: exerciseRepository.getExerciseById(exerciseId)?.oneRepMaxKg?.takeIf { it > 0 }
 
         return if (scalingWeight != null) {
             ResolvedExerciseWeights(

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -2946,6 +2946,9 @@ class ActiveSessionEngine(
 
             // Issue #252: Exclude warmup time from session duration
             val effectiveStart = if (coordinator.warmupCompleteTimeMs > 0L) coordinator.warmupCompleteTimeMs else coordinator.workoutStartTime
+            // Capture biomechanics summary before building session (mirrors saveWorkoutSession() pattern;
+            // biomechanicsEngine.reset() is not called on this path before this point).
+            val bioSummary = coordinator.biomechanicsEngine.getSetSummary()
             val session = WorkoutSession(
                 timestamp = coordinator.workoutStartTime,
                 mode = params.programMode.displayName,
@@ -2982,6 +2985,7 @@ class ActiveSessionEngine(
                 burnoutAvgWeightKg = if (params.isEchoMode) summary.burnoutAvgWeightKg else null,
                 peakWeightKg = if (params.isEchoMode) summary.peakWeightKg else null,
                 rpe = coordinator._currentSetRpe.value,
+                avgMcvMmS = bioSummary?.avgMcvMmS,
                 // C4: profileId was missing from manual-stop path — matches saveWorkoutSession() pattern
                 profileId = userProfileRepository.activeProfile.value?.id ?: "default",
             )

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -2986,6 +2986,10 @@ class ActiveSessionEngine(
                 peakWeightKg = if (params.isEchoMode) summary.peakWeightKg else null,
                 rpe = coordinator._currentSetRpe.value,
                 avgMcvMmS = bioSummary?.avgMcvMmS,
+                avgAsymmetryPercent = bioSummary?.avgAsymmetryPercent,
+                totalVelocityLossPercent = bioSummary?.totalVelocityLossPercent,
+                dominantSide = bioSummary?.dominantSide,
+                strengthProfile = bioSummary?.strengthProfile?.name,
                 // C4: profileId was missing from manual-stop path — matches saveWorkoutSession() pattern
                 profileId = userProfileRepository.activeProfile.value?.id ?: "default",
             )
@@ -3041,6 +3045,11 @@ class ActiveSessionEngine(
                 profileId = userProfileRepository.activeProfile.value?.id ?: "default",
                 sessionMcvMmS = session.avgMcvMmS,
             )
+
+            // Reset biomechanics engine after manual-stop — mirrors handleSetCompletion() (~line 3821).
+            // Safe: processPostSaveEvents() is the last consumer of bioSummary/session.avgMcvMmS;
+            // nothing below this point reads bioSummary or calls getSetSummary().
+            coordinator.biomechanicsEngine.reset()
 
             if (hasPR && completedSetId != null) {
                 completedSetRepository.markAsPr(completedSetId)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/GamificationManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/GamificationManager.kt
@@ -317,6 +317,34 @@ class GamificationManager(
     }
 
     /**
+     * Check for and award velocity-1RM improvement badges.
+     * Mirrors processSetQualityEvent — called from the post-save hook in MainViewModel
+     * after CountVelocityOneRepMaxImprovementsUseCase tallies cumulative improvements.
+     *
+     * @param improvementCount Total cumulative velocity-1RM improvements across all exercises.
+     * @param profileId Active profile ID for profile-scoped badge awarding.
+     * @return List of newly awarded badges (empty if none earned or gamification disabled).
+     */
+    suspend fun checkVelocityOneRepMaxBadges(improvementCount: Int, profileId: String = "default"): List<Badge> {
+        if (!gamificationEnabled.value) return emptyList()
+        val candidates = BadgeDefinitions.allBadges.filter {
+            it.requirement is BadgeRequirement.VelocityOneRepMaxImprovements
+        }
+        val newlyEarned = mutableListOf<Badge>()
+        for (badge in candidates) {
+            val req = badge.requirement as BadgeRequirement.VelocityOneRepMaxImprovements
+            if (improvementCount >= req.count && !gamificationRepository.isBadgeEarned(badge.id, profileId)) {
+                if (gamificationRepository.awardBadge(badge.id, profileId)) newlyEarned.add(badge)
+            }
+        }
+        if (newlyEarned.isNotEmpty()) {
+            hapticEvents.emit(HapticEvent.BADGE_EARNED)
+            _badgeEarnedEvents.emit(newlyEarned)
+        }
+        return newlyEarned
+    }
+
+    /**
      * Reset quality streak counter. Called when starting a new workout session.
      */
     fun resetQualityStreak() {

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/GamificationManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/GamificationManager.kt
@@ -340,6 +340,7 @@ class GamificationManager(
         if (newlyEarned.isNotEmpty()) {
             hapticEvents.emit(HapticEvent.BADGE_EARNED)
             _badgeEarnedEvents.emit(newlyEarned)
+            Logger.d("Velocity 1RM badges earned: ${newlyEarned.map { it.name }}")
         }
         return newlyEarned
     }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/SettingsManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/SettingsManager.kt
@@ -44,6 +44,11 @@ class SettingsManager(
         .map { it.defaultScalingBasis }
         .stateIn(scope, SharingStarted.Eagerly, ScalingBasis.MAX_WEIGHT_PR)
 
+    // Issue #517: Run-once flag — true after the velocity 1RM backfill has completed
+    val velocityOneRepMaxBackfillDone: StateFlow<Boolean> = userPreferences
+        .map { it.velocityOneRepMaxBackfillDone }
+        .stateIn(scope, SharingStarted.Eagerly, false)
+
     // Issue #167: Autoplay is now derived from summaryCountdownSeconds
     // - summaryCountdownSeconds == 0 (Unlimited) = autoplay OFF (manual control)
     // - summaryCountdownSeconds != 0 (-1 or 5-30) = autoplay ON (auto-advance)
@@ -154,6 +159,10 @@ class SettingsManager(
 
     fun setDefaultScalingBasis(basis: ScalingBasis) {
         scope.launch { preferencesManager.setDefaultScalingBasis(basis) }
+    }
+
+    fun setVelocityOneRepMaxBackfillDone(done: Boolean) {
+        scope.launch { preferencesManager.setVelocityOneRepMaxBackfillDone(done) }
     }
 
     fun setColorScheme(schemeIndex: Int) {

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/SettingsManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/SettingsManager.kt
@@ -4,6 +4,7 @@ import co.touchlab.kermit.Logger
 import com.devil.phoenixproject.data.preferences.PreferencesManager
 import com.devil.phoenixproject.data.repository.BleRepository
 import com.devil.phoenixproject.domain.model.RepCountTiming
+import com.devil.phoenixproject.domain.model.ScalingBasis
 import com.devil.phoenixproject.domain.model.UserPreferences
 import com.devil.phoenixproject.domain.model.WeightUnit
 import com.devil.phoenixproject.util.format
@@ -37,6 +38,11 @@ class SettingsManager(
     val gamificationEnabled: StateFlow<Boolean> = userPreferences
         .map { it.gamificationEnabled }
         .stateIn(scope, SharingStarted.Eagerly, true)
+
+    // Issue #517: Default scaling basis for % of 1RM routine weight resolution
+    val defaultScalingBasis: StateFlow<ScalingBasis> = userPreferences
+        .map { it.defaultScalingBasis }
+        .stateIn(scope, SharingStarted.Eagerly, ScalingBasis.MAX_WEIGHT_PR)
 
     // Issue #167: Autoplay is now derived from summaryCountdownSeconds
     // - summaryCountdownSeconds == 0 (Unlimited) = autoplay OFF (manual control)
@@ -144,6 +150,10 @@ class SettingsManager(
 
     fun setWeightSuggestionsEnabled(enabled: Boolean) {
         scope.launch { preferencesManager.setWeightSuggestionsEnabled(enabled) }
+    }
+
+    fun setDefaultScalingBasis(basis: ScalingBasis) {
+        scope.launch { preferencesManager.setDefaultScalingBasis(basis) }
     }
 
     fun setColorScheme(schemeIndex: Int) {

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/navigation/NavGraph.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/navigation/NavGraph.kt
@@ -396,6 +396,9 @@ fun NavGraph(
                     autoEndOnVelocityLoss = userPreferences.autoEndOnVelocityLoss,
                     onAutoEndOnVelocityLossChange = { viewModel.setAutoEndOnVelocityLoss(it) },
                     stallDetectionEnabled = userPreferences.stallDetectionEnabled,
+                    // Issue #517: system-wide default scaling basis
+                    defaultScalingBasis = userPreferences.defaultScalingBasis,
+                    onDefaultScalingBasisChange = { viewModel.setDefaultScalingBasis(it) },
                 )
             }
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseEditBottomSheet.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseEditBottomSheet.kt
@@ -183,16 +183,22 @@ fun ExerciseEditBottomSheet(
     // Resolved baseline weight for the currently-selected scaling basis, mirroring
     // ResolveRoutineWeightsUseCase so the editor preview matches workout-start resolution.
     val effectiveScalingBasis = scalingBasis ?: ScalingBasis.MAX_WEIGHT_PR
+    val maxWeightBaselineKg = currentExercisePR?.weightPerCableKg?.takeIf { it > 0 }
+    val maxVolumeBaselineKg = currentMaxVolumePR?.weightPerCableKg?.takeIf { it > 0 }
+    val velocityBaselineKg = velocityEstimateKg?.takeIf { it > 0 }
+    val storedBaselineKg = storedOneRepMaxKg?.takeIf { it > 0 }
     val baselineWeightKg: Float? = when (effectiveScalingBasis) {
-        ScalingBasis.MAX_WEIGHT_PR ->
-            currentExercisePR?.weightPerCableKg?.takeIf { it > 0 }
-        ScalingBasis.MAX_VOLUME_PR ->
-            currentMaxVolumePR?.weightPerCableKg?.takeIf { it > 0 }
-        ScalingBasis.ESTIMATED_1RM ->
-            velocityEstimateKg?.takeIf { it > 0 }
-                ?: storedOneRepMaxKg?.takeIf { it > 0 }
-                ?: currentExercisePR?.weightPerCableKg?.takeIf { it > 0 }
+        ScalingBasis.MAX_WEIGHT_PR -> maxWeightBaselineKg
+        ScalingBasis.MAX_VOLUME_PR -> maxVolumeBaselineKg
+        ScalingBasis.ESTIMATED_1RM -> velocityBaselineKg ?: storedBaselineKg ?: maxWeightBaselineKg
     }
+    // True if a baseline exists for AT LEAST ONE basis. Used to gate the % toggle and
+    // warning so the user can enable scaling and switch to a basis that has data, rather
+    // than being locked out when only the currently-selected basis lacks a baseline (#517).
+    val hasAnyBaseline = maxWeightBaselineKg != null ||
+        maxVolumeBaselineKg != null ||
+        velocityBaselineKg != null ||
+        storedBaselineKg != null
 
     val weightSuffix = if (weightUnit == WeightUnit.LB) "lbs" else "kg"
     val maxWeight = if (weightUnit == WeightUnit.LB) 242f else 110f // 110kg per cable max
@@ -367,6 +373,7 @@ fun ExerciseEditBottomSheet(
                         currentExercisePR = currentExercisePR,
                         scalingBasis = scalingBasis,
                         baselineWeightKg = baselineWeightKg,
+                        hasAnyBaseline = hasAnyBaseline,
                         weightUnit = weightUnit,
                         formatWeight = formatWeight,
                         onUsePercentOfPRChange = viewModel::onUsePercentOfPRChange,
@@ -1256,11 +1263,17 @@ fun WeightConfigurationCard(
     scalingBasis: ScalingBasis? = null,
     /**
      * Resolved baseline weight (kg/cable) for the currently-selected scaling basis.
-     * When non-null the toggle is enabled and the preview uses this weight.
+     * When non-null the resolved-weight preview is shown and uses this weight.
      * Callers should mirror ResolveRoutineWeightsUseCase's resolution order so the
      * editor preview matches what the workout will actually start from.
      */
     baselineWeightKg: Float? = null,
+    /**
+     * True if a baseline exists for at least one scaling basis. Gates the % toggle and
+     * the warning so the user can enable scaling and switch to a basis that has data,
+     * even when the currently-selected basis lacks a baseline (Issue #517).
+     */
+    hasAnyBaseline: Boolean = baselineWeightKg != null,
     weightUnit: WeightUnit,
     formatWeight: (Float, WeightUnit) -> String,
     onUsePercentOfPRChange: (Boolean) -> Unit,
@@ -1321,76 +1334,19 @@ fun WeightConfigurationCard(
                 Switch(
                     checked = usePercentOfPR,
                     onCheckedChange = onUsePercentOfPRChange,
-                    // Enable the toggle whenever a baseline exists for the selected basis —
-                    // not just when a max-weight PR exists (fixes ESTIMATED_1RM gating bug).
-                    enabled = baselineWeightKg != null,
+                    // Enable the toggle whenever a baseline exists for ANY basis — the user
+                    // can then switch to the basis that has data (fixes ESTIMATED_1RM lockout).
+                    enabled = hasAnyBaseline,
                 )
             }
 
-            // Show percentage controls when toggle is ON and a baseline exists for the selected basis
+            // When scaling is ON, the basis selector is ALWAYS available so the user can
+            // switch to a basis that has data; the resolved-weight preview only appears when
+            // the currently-selected basis actually has a baseline (Issue #517).
             val effectiveBasisForControls = scalingBasis ?: ScalingBasis.MAX_WEIGHT_PR
-            if (usePercentOfPR && baselineWeightKg != null) {
+            if (usePercentOfPR) {
+                // Issue #517: 3-way scaling basis selector (always shown while scaling enabled)
                 Spacer(modifier = Modifier.height(Spacing.medium))
-
-                // Calculate resolved weight from the selected basis's baseline (not always max-weight PR)
-                val resolvedWeight = (baselineWeightKg * weightPercentOfPR / 100f)
-                    .let { (it * 2).roundToInt() / 2f } // Round to 0.5kg
-
-                // Display current percentage and resolved weight
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Text(
-                        text = when (effectiveBasisForControls) {
-                            ScalingBasis.ESTIMATED_1RM -> "$weightPercentOfPR% of Est. 1RM"
-                            ScalingBasis.MAX_VOLUME_PR -> "$weightPercentOfPR% of Max-volume PR"
-                            ScalingBasis.MAX_WEIGHT_PR ->
-                                "$weightPercentOfPR% of ${currentExercisePR?.phase?.displayLabel() ?: "Max-weight"} PR"
-                        },
-                        style = MaterialTheme.typography.titleLarge,
-                        fontWeight = FontWeight.Bold,
-                        color = MaterialTheme.colorScheme.primary,
-                    )
-                    Text(
-                        text = "= ${formatWeight(resolvedWeight, weightUnit)}/cable",
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.Medium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-
-                Spacer(modifier = Modifier.height(Spacing.small))
-
-                // Percentage slider (50% - 120%, 5% increments)
-                ExpressiveSlider(
-                    value = weightPercentOfPR.toFloat(),
-                    onValueChange = { onWeightPercentOfPRChange(it.toInt()) },
-                    valueRange = 50f..120f,
-                    steps = 13, // (120-50)/5 - 1 = 13 steps for 5% increments
-                    modifier = Modifier.fillMaxWidth(),
-                )
-
-                Spacer(modifier = Modifier.height(Spacing.small))
-
-                // Common preset buttons
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(Spacing.small),
-                ) {
-                    listOf(70, 80, 90, 100).forEach { percent ->
-                        FilterChip(
-                            selected = weightPercentOfPR == percent,
-                            onClick = { onWeightPercentOfPRChange(percent) },
-                            label = { Text(stringResource(Res.string.percent_label, percent)) },
-                            modifier = Modifier.weight(1f),
-                        )
-                    }
-                }
-
-                // Issue #517: 3-way scaling basis selector
-                Spacer(modifier = Modifier.height(Spacing.small))
                 Text(
                     text = "Scale from",
                     style = MaterialTheme.typography.labelMedium,
@@ -1414,10 +1370,79 @@ fun WeightConfigurationCard(
                         }
                     }
                 }
+
+                if (baselineWeightKg != null) {
+                    Spacer(modifier = Modifier.height(Spacing.medium))
+
+                    // Resolved weight from the selected basis's baseline (not always max-weight PR)
+                    val resolvedWeight = (baselineWeightKg * weightPercentOfPR / 100f)
+                        .let { (it * 2).roundToInt() / 2f } // Round to 0.5kg
+
+                    // Display current percentage and resolved weight
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = when (effectiveBasisForControls) {
+                                ScalingBasis.ESTIMATED_1RM -> "$weightPercentOfPR% of Est. 1RM"
+                                ScalingBasis.MAX_VOLUME_PR -> "$weightPercentOfPR% of Max-volume PR"
+                                ScalingBasis.MAX_WEIGHT_PR ->
+                                    "$weightPercentOfPR% of ${currentExercisePR?.phase?.displayLabel() ?: "Max-weight"} PR"
+                            },
+                            style = MaterialTheme.typography.titleLarge,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.primary,
+                        )
+                        Text(
+                            text = "= ${formatWeight(resolvedWeight, weightUnit)}/cable",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Medium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.height(Spacing.small))
+
+                    // Percentage slider (50% - 120%, 5% increments)
+                    ExpressiveSlider(
+                        value = weightPercentOfPR.toFloat(),
+                        onValueChange = { onWeightPercentOfPRChange(it.toInt()) },
+                        valueRange = 50f..120f,
+                        steps = 13, // (120-50)/5 - 1 = 13 steps for 5% increments
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+
+                    Spacer(modifier = Modifier.height(Spacing.small))
+
+                    // Common preset buttons
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(Spacing.small),
+                    ) {
+                        listOf(70, 80, 90, 100).forEach { percent ->
+                            FilterChip(
+                                selected = weightPercentOfPR == percent,
+                                onClick = { onWeightPercentOfPRChange(percent) },
+                                label = { Text(stringResource(Res.string.percent_label, percent)) },
+                                modifier = Modifier.weight(1f),
+                            )
+                        }
+                    }
+                } else {
+                    // Selected basis has no baseline — guide the user to pick one that does.
+                    Spacer(modifier = Modifier.height(Spacing.small))
+                    Text(
+                        text = "No data for the selected basis yet. Pick a basis with a recorded baseline.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
             }
 
-            // Show warning when no baseline is available for the selected basis and toggle is off
-            if (baselineWeightKg == null && !usePercentOfPR) {
+            // Show warning when no baseline is available for any basis and toggle is off
+            if (!hasAnyBaseline && !usePercentOfPR) {
                 Spacer(modifier = Modifier.height(Spacing.small))
                 Surface(
                     modifier = Modifier.fillMaxWidth(),

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseEditBottomSheet.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseEditBottomSheet.kt
@@ -67,6 +67,7 @@ import com.devil.phoenixproject.data.repository.ExerciseRepository
 import com.devil.phoenixproject.data.repository.ExerciseVideoEntity
 import com.devil.phoenixproject.data.repository.PersonalRecordRepository
 import com.devil.phoenixproject.data.repository.UserProfileRepository
+import com.devil.phoenixproject.data.repository.VelocityOneRepMaxRepository
 import com.devil.phoenixproject.domain.model.EccentricLoad
 import com.devil.phoenixproject.domain.model.EchoLevel
 import com.devil.phoenixproject.domain.model.PersonalRecord
@@ -121,8 +122,9 @@ fun ExerciseEditBottomSheet(
     buttonText: String = "Save",
     weightStepOverride: Float = 0f, // Issue #266/#410: 0 = use default for unit
 ) {
-    // Create local ViewModel instance with PersonalRecordRepository for PR lookups
-    val viewModel = remember { ExerciseConfigViewModel(personalRecordRepository) }
+    // Create local ViewModel instance with repositories for PR and velocity-1RM lookups
+    val velocityOneRepMaxRepository: VelocityOneRepMaxRepository = koinInject()
+    val viewModel = remember { ExerciseConfigViewModel(personalRecordRepository, velocityOneRepMaxRepository, exerciseRepository) }
     val userProfileRepository: UserProfileRepository = koinInject()
     val activeProfile by userProfileRepository.activeProfile.collectAsState()
     val activeProfileId = activeProfile?.id ?: "default"
@@ -172,6 +174,25 @@ fun ExerciseEditBottomSheet(
     val weightPercentOfPR by viewModel.weightPercentOfPR.collectAsState()
     // Issue #517: per-exercise scaling basis selector
     val scalingBasis by viewModel.scalingBasis.collectAsState()
+
+    // Additional baselines for the 3-way scaling basis (Issue #517 gating + preview fix)
+    val currentMaxVolumePR by viewModel.currentMaxVolumePR.collectAsState()
+    val velocityEstimateKg by viewModel.velocityEstimateKg.collectAsState()
+    val storedOneRepMaxKg by viewModel.storedOneRepMaxKg.collectAsState()
+
+    // Resolved baseline weight for the currently-selected scaling basis, mirroring
+    // ResolveRoutineWeightsUseCase so the editor preview matches workout-start resolution.
+    val effectiveScalingBasis = scalingBasis ?: ScalingBasis.MAX_WEIGHT_PR
+    val baselineWeightKg: Float? = when (effectiveScalingBasis) {
+        ScalingBasis.MAX_WEIGHT_PR ->
+            currentExercisePR?.weightPerCableKg?.takeIf { it > 0 }
+        ScalingBasis.MAX_VOLUME_PR ->
+            currentMaxVolumePR?.weightPerCableKg?.takeIf { it > 0 }
+        ScalingBasis.ESTIMATED_1RM ->
+            velocityEstimateKg?.takeIf { it > 0 }
+                ?: storedOneRepMaxKg?.takeIf { it > 0 }
+                ?: currentExercisePR?.weightPerCableKg?.takeIf { it > 0 }
+    }
 
     val weightSuffix = if (weightUnit == WeightUnit.LB) "lbs" else "kg"
     val maxWeight = if (weightUnit == WeightUnit.LB) 242f else 110f // 110kg per cable max
@@ -345,6 +366,7 @@ fun ExerciseEditBottomSheet(
                         weightPercentOfPR = weightPercentOfPR,
                         currentExercisePR = currentExercisePR,
                         scalingBasis = scalingBasis,
+                        baselineWeightKg = baselineWeightKg,
                         weightUnit = weightUnit,
                         formatWeight = formatWeight,
                         onUsePercentOfPRChange = viewModel::onUsePercentOfPRChange,
@@ -1232,6 +1254,13 @@ fun WeightConfigurationCard(
     weightPercentOfPR: Int,
     currentExercisePR: PersonalRecord?,
     scalingBasis: ScalingBasis? = null,
+    /**
+     * Resolved baseline weight (kg/cable) for the currently-selected scaling basis.
+     * When non-null the toggle is enabled and the preview uses this weight.
+     * Callers should mirror ResolveRoutineWeightsUseCase's resolution order so the
+     * editor preview matches what the workout will actually start from.
+     */
+    baselineWeightKg: Float? = null,
     weightUnit: WeightUnit,
     formatWeight: (Float, WeightUnit) -> String,
     onUsePercentOfPRChange: (Boolean) -> Unit,
@@ -1272,11 +1301,18 @@ fun WeightConfigurationCard(
                         fontWeight = if (usePercentOfPR) FontWeight.Bold else FontWeight.Normal,
                         color = if (usePercentOfPR) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface,
                     )
+                    // Subtitle: describes which baseline will be used
+                    val effectiveBasis = scalingBasis ?: ScalingBasis.MAX_WEIGHT_PR
                     Text(
-                        text = currentExercisePR?.let { pr ->
-                            "Scale weight based on your ${pr.phase.displayLabel().lowercase()} personal record"
-                        } ?: run {
-                            "No PR set for this exercise"
+                        text = when {
+                            baselineWeightKg != null && effectiveBasis == ScalingBasis.ESTIMATED_1RM ->
+                                "Scale weight based on your velocity 1RM estimate"
+                            baselineWeightKg != null && effectiveBasis == ScalingBasis.MAX_VOLUME_PR ->
+                                "Scale weight based on your max-volume personal record"
+                            currentExercisePR != null ->
+                                "Scale weight based on your ${currentExercisePR.phase.displayLabel().lowercase()} personal record"
+                            else ->
+                                "No baseline available for the selected scaling type"
                         },
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -1285,17 +1321,19 @@ fun WeightConfigurationCard(
                 Switch(
                     checked = usePercentOfPR,
                     onCheckedChange = onUsePercentOfPRChange,
-                    enabled = currentExercisePR != null,
+                    // Enable the toggle whenever a baseline exists for the selected basis —
+                    // not just when a max-weight PR exists (fixes ESTIMATED_1RM gating bug).
+                    enabled = baselineWeightKg != null,
                 )
             }
 
-            // Show percentage controls when toggle is ON and PR exists
-            val prForScaling = currentExercisePR
-            if (usePercentOfPR && prForScaling != null) {
+            // Show percentage controls when toggle is ON and a baseline exists for the selected basis
+            val effectiveBasisForControls = scalingBasis ?: ScalingBasis.MAX_WEIGHT_PR
+            if (usePercentOfPR && baselineWeightKg != null) {
                 Spacer(modifier = Modifier.height(Spacing.medium))
 
-                // Calculate resolved weight
-                val resolvedWeight = (prForScaling.weightPerCableKg * weightPercentOfPR / 100f)
+                // Calculate resolved weight from the selected basis's baseline (not always max-weight PR)
+                val resolvedWeight = (baselineWeightKg * weightPercentOfPR / 100f)
                     .let { (it * 2).roundToInt() / 2f } // Round to 0.5kg
 
                 // Display current percentage and resolved weight
@@ -1305,7 +1343,12 @@ fun WeightConfigurationCard(
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Text(
-                        text = "$weightPercentOfPR% of ${prForScaling.phase.displayLabel()} PR",
+                        text = when (effectiveBasisForControls) {
+                            ScalingBasis.ESTIMATED_1RM -> "$weightPercentOfPR% of Est. 1RM"
+                            ScalingBasis.MAX_VOLUME_PR -> "$weightPercentOfPR% of Max-volume PR"
+                            ScalingBasis.MAX_WEIGHT_PR ->
+                                "$weightPercentOfPR% of ${currentExercisePR?.phase?.displayLabel() ?: "Max-weight"} PR"
+                        },
                         style = MaterialTheme.typography.titleLarge,
                         fontWeight = FontWeight.Bold,
                         color = MaterialTheme.colorScheme.primary,
@@ -1360,13 +1403,12 @@ fun WeightConfigurationCard(
                     ScalingBasis.MAX_VOLUME_PR to "Max-volume PR",
                     ScalingBasis.ESTIMATED_1RM to "Est. 1RM",
                 )
-                val effectiveBasis = scalingBasis ?: ScalingBasis.MAX_WEIGHT_PR
                 SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
                     basisOptions.forEachIndexed { index, (basis, label) ->
                         SegmentedButton(
                             shape = SegmentedButtonDefaults.itemShape(index = index, count = basisOptions.size),
                             onClick = { onScalingBasisChange(basis) },
-                            selected = effectiveBasis == basis,
+                            selected = effectiveBasisForControls == basis,
                         ) {
                             Text(label, maxLines = 1)
                         }
@@ -1374,8 +1416,8 @@ fun WeightConfigurationCard(
                 }
             }
 
-            // Show warning if no PR available and toggle is off
-            if (currentExercisePR == null && !usePercentOfPR) {
+            // Show warning when no baseline is available for the selected basis and toggle is off
+            if (baselineWeightKg == null && !usePercentOfPR) {
                 Spacer(modifier = Modifier.height(Spacing.small))
                 Surface(
                     modifier = Modifier.fillMaxWidth(),
@@ -1394,7 +1436,7 @@ fun WeightConfigurationCard(
                             modifier = Modifier.size(16.dp),
                         )
                         Text(
-                            text = "Complete a workout to set your PR and enable percentage scaling",
+                            text = "Complete a workout to record data and enable percentage scaling",
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onTertiaryContainer,
                         )

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseEditBottomSheet.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseEditBottomSheet.kt
@@ -174,6 +174,7 @@ fun ExerciseEditBottomSheet(
     val weightPercentOfPR by viewModel.weightPercentOfPR.collectAsState()
     // Issue #517: per-exercise scaling basis selector
     val scalingBasis by viewModel.scalingBasis.collectAsState()
+    val prTypeForScaling by viewModel.prTypeForScaling.collectAsState()
 
     // Additional baselines for the 3-way scaling basis (Issue #517 gating + preview fix)
     val currentMaxVolumePR by viewModel.currentMaxVolumePR.collectAsState()
@@ -182,7 +183,9 @@ fun ExerciseEditBottomSheet(
 
     // Resolved baseline weight for the currently-selected scaling basis, mirroring
     // ResolveRoutineWeightsUseCase so the editor preview matches workout-start resolution.
-    val effectiveScalingBasis = scalingBasis ?: ScalingBasis.MAX_WEIGHT_PR
+    // For legacy rows with no explicit scalingBasis, derive it from prTypeForScaling
+    // (same as RoutineExercise.effectiveScalingBasis) instead of defaulting to MAX_WEIGHT_PR.
+    val effectiveScalingBasis = scalingBasis ?: ScalingBasis.fromPrType(prTypeForScaling)
     val maxWeightBaselineKg = currentExercisePR?.weightPerCableKg?.takeIf { it > 0 }
     val maxVolumeBaselineKg = currentMaxVolumePR?.weightPerCableKg?.takeIf { it > 0 }
     val velocityBaselineKg = velocityEstimateKg?.takeIf { it > 0 }
@@ -371,7 +374,7 @@ fun ExerciseEditBottomSheet(
                         usePercentOfPR = usePercentOfPR,
                         weightPercentOfPR = weightPercentOfPR,
                         currentExercisePR = currentExercisePR,
-                        scalingBasis = scalingBasis,
+                        effectiveScalingBasis = effectiveScalingBasis,
                         baselineWeightKg = baselineWeightKg,
                         hasAnyBaseline = hasAnyBaseline,
                         weightUnit = weightUnit,
@@ -1260,7 +1263,11 @@ fun WeightConfigurationCard(
     usePercentOfPR: Boolean,
     weightPercentOfPR: Int,
     currentExercisePR: PersonalRecord?,
-    scalingBasis: ScalingBasis? = null,
+    /**
+     * The basis actually in effect (already derived via effectiveScalingBasis, i.e.
+     * scalingBasis ?: fromPrType(prTypeForScaling)) so legacy rows select the right basis.
+     */
+    effectiveScalingBasis: ScalingBasis = ScalingBasis.MAX_WEIGHT_PR,
     /**
      * Resolved baseline weight (kg/cable) for the currently-selected scaling basis.
      * When non-null the resolved-weight preview is shown and uses this weight.
@@ -1315,12 +1322,11 @@ fun WeightConfigurationCard(
                         color = if (usePercentOfPR) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface,
                     )
                     // Subtitle: describes which baseline will be used
-                    val effectiveBasis = scalingBasis ?: ScalingBasis.MAX_WEIGHT_PR
                     Text(
                         text = when {
-                            baselineWeightKg != null && effectiveBasis == ScalingBasis.ESTIMATED_1RM ->
+                            baselineWeightKg != null && effectiveScalingBasis == ScalingBasis.ESTIMATED_1RM ->
                                 "Scale weight based on your velocity 1RM estimate"
-                            baselineWeightKg != null && effectiveBasis == ScalingBasis.MAX_VOLUME_PR ->
+                            baselineWeightKg != null && effectiveScalingBasis == ScalingBasis.MAX_VOLUME_PR ->
                                 "Scale weight based on your max-volume personal record"
                             currentExercisePR != null ->
                                 "Scale weight based on your ${currentExercisePR.phase.displayLabel().lowercase()} personal record"
@@ -1343,7 +1349,7 @@ fun WeightConfigurationCard(
             // When scaling is ON, the basis selector is ALWAYS available so the user can
             // switch to a basis that has data; the resolved-weight preview only appears when
             // the currently-selected basis actually has a baseline (Issue #517).
-            val effectiveBasisForControls = scalingBasis ?: ScalingBasis.MAX_WEIGHT_PR
+            val effectiveBasisForControls = effectiveScalingBasis
             if (usePercentOfPR) {
                 // Issue #517: 3-way scaling basis selector (always shown while scaling enabled)
                 Spacer(modifier = Modifier.height(Spacing.medium))

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseEditBottomSheet.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseEditBottomSheet.kt
@@ -73,6 +73,7 @@ import com.devil.phoenixproject.domain.model.PersonalRecord
 import com.devil.phoenixproject.domain.model.RackItem
 import com.devil.phoenixproject.domain.model.RepCountTiming
 import com.devil.phoenixproject.domain.model.RoutineExercise
+import com.devil.phoenixproject.domain.model.ScalingBasis
 import com.devil.phoenixproject.domain.model.WarmupSet
 import com.devil.phoenixproject.domain.model.WeightUnit
 import com.devil.phoenixproject.domain.model.WorkoutMode
@@ -169,6 +170,8 @@ fun ExerciseEditBottomSheet(
     // PR percentage scaling state (Issue #57)
     val usePercentOfPR by viewModel.usePercentOfPR.collectAsState()
     val weightPercentOfPR by viewModel.weightPercentOfPR.collectAsState()
+    // Issue #517: per-exercise scaling basis selector
+    val scalingBasis by viewModel.scalingBasis.collectAsState()
 
     val weightSuffix = if (weightUnit == WeightUnit.LB) "lbs" else "kg"
     val maxWeight = if (weightUnit == WeightUnit.LB) 242f else 110f // 110kg per cable max
@@ -341,10 +344,12 @@ fun ExerciseEditBottomSheet(
                         usePercentOfPR = usePercentOfPR,
                         weightPercentOfPR = weightPercentOfPR,
                         currentExercisePR = currentExercisePR,
+                        scalingBasis = scalingBasis,
                         weightUnit = weightUnit,
                         formatWeight = formatWeight,
                         onUsePercentOfPRChange = viewModel::onUsePercentOfPRChange,
                         onWeightPercentOfPRChange = viewModel::onWeightPercentOfPRChange,
+                        onScalingBasisChange = viewModel::onScalingBasisChange,
                     )
                 }
 
@@ -1226,10 +1231,12 @@ fun WeightConfigurationCard(
     usePercentOfPR: Boolean,
     weightPercentOfPR: Int,
     currentExercisePR: PersonalRecord?,
+    scalingBasis: ScalingBasis? = null,
     weightUnit: WeightUnit,
     formatWeight: (Float, WeightUnit) -> String,
     onUsePercentOfPRChange: (Boolean) -> Unit,
     onWeightPercentOfPRChange: (Int) -> Unit,
+    onScalingBasisChange: (ScalingBasis) -> Unit = {},
 ) {
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -1336,6 +1343,33 @@ fun WeightConfigurationCard(
                             label = { Text(stringResource(Res.string.percent_label, percent)) },
                             modifier = Modifier.weight(1f),
                         )
+                    }
+                }
+
+                // Issue #517: 3-way scaling basis selector
+                Spacer(modifier = Modifier.height(Spacing.small))
+                Text(
+                    text = "Scale from",
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.height(Spacing.extraSmall))
+                val basisOptions = listOf(
+                    ScalingBasis.MAX_WEIGHT_PR to "Max-weight PR",
+                    ScalingBasis.MAX_VOLUME_PR to "Max-volume PR",
+                    ScalingBasis.ESTIMATED_1RM to "Est. 1RM",
+                )
+                val effectiveBasis = scalingBasis ?: ScalingBasis.MAX_WEIGHT_PR
+                SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                    basisOptions.forEachIndexed { index, (basis, label) ->
+                        SegmentedButton(
+                            shape = SegmentedButtonDefaults.itemShape(index = index, count = basisOptions.size),
+                            onClick = { onScalingBasisChange(basis) },
+                            selected = effectiveBasis == basis,
+                        ) {
+                            Text(label, maxLines = 1)
+                        }
                     }
                 }
             }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RoutineEditorScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RoutineEditorScreen.kt
@@ -779,6 +779,8 @@ fun RoutineEditorScreen(
                     exercise = selectedExercise,
                     orderIndex = state.exercises.size,
                     weightPerCableKg = 5f,
+                    // Issue #517: seed new exercises from the system-wide default scaling basis
+                    scalingBasis = userPreferences.defaultScalingBasis,
                     // If adding to a superset, set the superset reference
                     supersetId = supersetForAddExercise?.id,
                     orderInSuperset = supersetForAddExercise?.let { ss ->

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SettingsTab.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SettingsTab.kt
@@ -110,6 +110,7 @@ import com.devil.phoenixproject.data.integration.HealthBodyWeightSyncManager
 import com.devil.phoenixproject.data.repository.UserProfileRepository
 import com.devil.phoenixproject.data.sync.SyncTriggerManager
 import com.devil.phoenixproject.domain.model.IntegrationProvider
+import com.devil.phoenixproject.domain.model.ScalingBasis
 import com.devil.phoenixproject.domain.model.WeightUnit
 import com.devil.phoenixproject.presentation.components.ConfirmEditTextField
 import com.devil.phoenixproject.presentation.components.CountdownDropdown
@@ -341,6 +342,9 @@ fun SettingsTab(
     autoEndOnVelocityLoss: Boolean = false,
     onAutoEndOnVelocityLossChange: (Boolean) -> Unit = {},
     stallDetectionEnabled: Boolean = true,
+    // Issue #517: System-wide default scaling basis for % of 1RM
+    defaultScalingBasis: ScalingBasis = ScalingBasis.MAX_WEIGHT_PR,
+    onDefaultScalingBasisChange: (ScalingBasis) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val focusManager = LocalFocusManager.current
@@ -1353,6 +1357,41 @@ fun SettingsTab(
                         checked = weightSuggestionsEnabled,
                         onCheckedChange = onWeightSuggestionsEnabledChange,
                     )
+                }
+
+                Spacer(modifier = Modifier.height(Spacing.medium))
+
+                // Issue #517: Default scaling basis for % of 1RM / VBT weight scaling
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    Text(
+                        "Default Weight Scaling Basis",
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.Medium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        "Baseline used when scaling routine weights by percentage",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(modifier = Modifier.height(Spacing.small))
+                    val scalingBasisOptions = listOf(
+                        ScalingBasis.MAX_WEIGHT_PR to "Max-weight PR",
+                        ScalingBasis.MAX_VOLUME_PR to "Max-volume PR",
+                        ScalingBasis.ESTIMATED_1RM to "Est. 1RM",
+                    )
+                    SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                        scalingBasisOptions.forEachIndexed { index, (basis, label) ->
+                            SegmentedButton(
+                                shape = SegmentedButtonDefaults.itemShape(index = index, count = scalingBasisOptions.size),
+                                onClick = { onDefaultScalingBasisChange(basis) },
+                                selected = defaultScalingBasis == basis,
+                            ) {
+                                Text(label, maxLines = 1)
+                            }
+                        }
+                    }
                 }
 
                 Spacer(modifier = Modifier.height(Spacing.medium))

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModel.kt
@@ -318,6 +318,22 @@ class ExerciseConfigViewModel constructor(
                 logWarning("Failed to load volume PR for exercise=$exerciseId, mode=$workoutMode: ${e.message}")
                 _currentMaxVolumePR.value = null
             }
+            // The volume PR loads after the weight-PR sync above; re-sync so a MAX_VOLUME_PR
+            // exercise picks up the just-loaded baseline instead of staying on stale weights.
+            resyncSetWeightsIfBaselineReady()
+        }
+    }
+
+    /**
+     * Re-resolve visible set weights against the current basis baseline, but only when
+     * percentage scaling is enabled AND a baseline for the current basis is now available.
+     * Safe to call repeatedly after each async baseline load — syncSetWeightsToPercentOfPR
+     * only reads the stored percentages and rewrites set weights, so it cannot re-trigger a
+     * load or loop.
+     */
+    private fun resyncSetWeightsIfBaselineReady() {
+        if (_usePercentOfPR.value && baselineKgForCurrentBasis() != null) {
+            syncSetWeightsToPercentOfPR()
         }
     }
 
@@ -336,6 +352,8 @@ class ExerciseConfigViewModel constructor(
                     logWarning("Failed to load velocity estimate for exercise=$exerciseId: ${e.message}")
                     _velocityEstimateKg.value = null
                 }
+                // Re-sync after the velocity baseline lands (ESTIMATED_1RM may now resolve).
+                resyncSetWeightsIfBaselineReady()
             }
             if (exerciseRepository != null) {
                 try {
@@ -346,13 +364,21 @@ class ExerciseConfigViewModel constructor(
                     logWarning("Failed to load stored 1RM for exercise=$exerciseId: ${e.message}")
                     _storedOneRepMaxKg.value = null
                 }
-            }
-            // If the selected basis depends on these baselines, re-resolve visible set weights.
-            if (_usePercentOfPR.value && _scalingBasis.value == ScalingBasis.ESTIMATED_1RM) {
-                syncSetWeightsToPercentOfPR()
+                // Re-sync after the stored-1RM fallback lands.
+                resyncSetWeightsIfBaselineReady()
             }
         }
     }
+
+    /**
+     * The basis the editor/workout-start actually use. Mirrors
+     * RoutineExercise.effectiveScalingBasis: when no explicit scalingBasis is set
+     * (legacy/back-compat rows), derive it from prTypeForScaling so the editor matches
+     * ResolveRoutineWeightsUseCase (e.g. a legacy row with prTypeForScaling=MAX_VOLUME
+     * resolves to MAX_VOLUME_PR, not the default MAX_WEIGHT_PR).
+     */
+    fun effectiveScalingBasis(): ScalingBasis =
+        _scalingBasis.value ?: ScalingBasis.fromPrType(_prTypeForScaling.value)
 
     /**
      * Resolves the baseline weight (kg/cable) for the currently-selected scaling basis,
@@ -364,8 +390,7 @@ class ExerciseConfigViewModel constructor(
      * Returns null when no data is available for the selected basis (controls preview and gating).
      */
     fun baselineKgForCurrentBasis(): Float? {
-        val basis = _scalingBasis.value ?: ScalingBasis.MAX_WEIGHT_PR
-        return when (basis) {
+        return when (effectiveScalingBasis()) {
             ScalingBasis.MAX_WEIGHT_PR ->
                 _currentExercisePR.value?.weightPerCableKg?.takeIf { it > 0 }
             ScalingBasis.MAX_VOLUME_PR ->

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModel.kt
@@ -12,6 +12,7 @@ import com.devil.phoenixproject.domain.model.PersonalRecord
 import com.devil.phoenixproject.domain.model.RackItemBehavior
 import com.devil.phoenixproject.domain.model.RepCountTiming
 import com.devil.phoenixproject.domain.model.RoutineExercise
+import com.devil.phoenixproject.domain.model.ScalingBasis
 import com.devil.phoenixproject.domain.model.WarmupSet
 import com.devil.phoenixproject.domain.model.WeightUnit
 import com.devil.phoenixproject.domain.model.WorkoutMode
@@ -111,6 +112,10 @@ class ExerciseConfigViewModel constructor(
 
     private val _prTypeForScaling = MutableStateFlow(PRType.MAX_WEIGHT)
     val prTypeForScaling: StateFlow<PRType> = _prTypeForScaling.asStateFlow()
+
+    // Issue #517: Velocity 1RM scaling basis (null = derive from prTypeForScaling for back-compat)
+    private val _scalingBasis = MutableStateFlow<ScalingBasis?>(null)
+    val scalingBasis: StateFlow<ScalingBasis?> = _scalingBasis.asStateFlow()
 
     private var setWeightsPercentOfPR: List<Int> = emptyList()
     private val pendingPercentOfPREditWeights = mutableMapOf<String, Float>()
@@ -225,6 +230,8 @@ class ExerciseConfigViewModel constructor(
         _usePercentOfPR.value = exercise.usePercentOfPR
         _weightPercentOfPR.value = exercise.weightPercentOfPR
         _prTypeForScaling.value = exercise.prTypeForScaling
+        // Issue #517: load explicit scalingBasis (null preserved for back-compat derivation)
+        _scalingBasis.value = exercise.scalingBasis
         pendingPercentOfPREditWeights.clear()
         setWeightsPercentOfPR = normalizeSetWeightPercentages(
             source = exercise.setWeightsPercentOfPR,
@@ -356,6 +363,11 @@ class ExerciseConfigViewModel constructor(
 
     fun onPRTypeForScalingChange(prType: PRType) {
         _prTypeForScaling.value = prType
+    }
+
+    // Issue #517: explicit 3-way scaling basis selector
+    fun onScalingBasisChange(basis: ScalingBasis) {
+        _scalingBasis.value = basis
     }
 
     // Warm-up set handlers (Issue #30)
@@ -652,6 +664,8 @@ class ExerciseConfigViewModel constructor(
             weightPercentOfPR = _weightPercentOfPR.value,
             prTypeForScaling = _prTypeForScaling.value,
             setWeightsPercentOfPR = resolvedSetWeightsPercentOfPR,
+            // Issue #517: persist explicit scaling basis (null = back-compat derivation from prTypeForScaling)
+            scalingBasis = _scalingBasis.value,
             // Warm-up sets (Issue #30)
             warmupSets = _warmupSets.value,
             defaultRackItemIds = _defaultRackItemIds.value,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModel.kt
@@ -347,6 +347,10 @@ class ExerciseConfigViewModel constructor(
                     _storedOneRepMaxKg.value = null
                 }
             }
+            // If the selected basis depends on these baselines, re-resolve visible set weights.
+            if (_usePercentOfPR.value && _scalingBasis.value == ScalingBasis.ESTIMATED_1RM) {
+                syncSetWeightsToPercentOfPR()
+            }
         }
     }
 
@@ -448,6 +452,11 @@ class ExerciseConfigViewModel constructor(
     // Issue #517: explicit 3-way scaling basis selector
     fun onScalingBasisChange(basis: ScalingBasis) {
         _scalingBasis.value = basis
+        // Re-resolve visible set weights against the newly-selected basis baseline
+        // so the editor table matches what ResolveRoutineWeightsUseCase will use.
+        if (_usePercentOfPR.value) {
+            syncSetWeightsToPercentOfPR()
+        }
     }
 
     // Warm-up set handlers (Issue #30)
@@ -557,42 +566,45 @@ class ExerciseConfigViewModel constructor(
         )
     }
 
-    private fun resolvedSetWeightsKgFromCurrentPR(): List<Float>? {
-        val pr = _currentExercisePR.value ?: return null
-        if (!_usePercentOfPR.value || pr.weightPerCableKg <= 0f) return null
-        applyPendingPercentOfPREdits(pr)
+    // Issue #517: per-set weights resolve against the SELECTED scaling basis baseline
+    // (baselineKgForCurrentBasis), not just the max-weight PR. When the basis is
+    // MAX_WEIGHT_PR the baseline IS the max-weight PR, so behavior is unchanged.
+    private fun resolvedSetWeightsKgFromCurrentBasis(): List<Float>? {
+        val baselineKg = baselineKgForCurrentBasis() ?: return null
+        if (!_usePercentOfPR.value || baselineKg <= 0f) return null
+        applyPendingPercentOfPREdits(baselineKg)
         ensureSetWeightPercentages()
         return setWeightsPercentOfPR.map { percent ->
-            (pr.weightPerCableKg * percent / 100f).roundToHalfKg()
+            (baselineKg * percent / 100f).roundToHalfKg()
         }
     }
 
     private fun syncSetWeightsToPercentOfPR() {
-        val resolvedWeightsKg = resolvedSetWeightsKgFromCurrentPR() ?: return
+        val resolvedWeightsKg = resolvedSetWeightsKgFromCurrentBasis() ?: return
         _sets.value = _sets.value.mapIndexed { index, set ->
             val resolvedWeightKg = resolvedWeightsKg.getOrNull(index) ?: return@mapIndexed set
             set.copy(weightPerCable = kgToDisplay(resolvedWeightKg, weightUnit))
         }
     }
 
-    private fun percentFromDisplayWeight(displayWeight: Float, pr: PersonalRecord): Int {
+    private fun percentFromDisplayWeight(displayWeight: Float, baselineKg: Float): Int {
         val weightKg = displayToKg(displayWeight, weightUnit)
-        return ((weightKg / pr.weightPerCableKg) * 100f).roundToInt().coerceIn(50, 120)
+        return ((weightKg / baselineKg) * 100f).roundToInt().coerceIn(50, 120)
     }
 
-    private fun displayWeightFromPercent(percent: Int, pr: PersonalRecord): Float {
-        val resolvedWeightKg = (pr.weightPerCableKg * percent / 100f).roundToHalfKg()
+    private fun displayWeightFromPercent(percent: Int, baselineKg: Float): Float {
+        val resolvedWeightKg = (baselineKg * percent / 100f).roundToHalfKg()
         return kgToDisplay(resolvedWeightKg, weightUnit)
     }
 
-    private fun applyPendingPercentOfPREdits(pr: PersonalRecord) {
+    private fun applyPendingPercentOfPREdits(baselineKg: Float) {
         if (pendingPercentOfPREditWeights.isEmpty()) return
         ensureSetWeightPercentages()
         val setsById = _sets.value.mapIndexed { index, set -> set.id to index }.toMap()
 
         pendingPercentOfPREditWeights.forEach { (setId, displayWeight) ->
             val setIndex = setsById[setId] ?: return@forEach
-            val percent = percentFromDisplayWeight(displayWeight, pr)
+            val percent = percentFromDisplayWeight(displayWeight, baselineKg)
             setWeightsPercentOfPR = setWeightsPercentOfPR.mapIndexed { index, existing ->
                 if (index == setIndex) percent else existing
             }
@@ -600,9 +612,9 @@ class ExerciseConfigViewModel constructor(
         pendingPercentOfPREditWeights.clear()
     }
 
-    private fun updateSetPercentFromDisplayWeight(setIndex: Int, displayWeight: Float, pr: PersonalRecord): Int {
+    private fun updateSetPercentFromDisplayWeight(setIndex: Int, displayWeight: Float, baselineKg: Float): Int {
         ensureSetWeightPercentages()
-        val percent = percentFromDisplayWeight(displayWeight, pr)
+        val percent = percentFromDisplayWeight(displayWeight, baselineKg)
         setWeightsPercentOfPR = setWeightsPercentOfPR.mapIndexed { index, existing ->
             if (index == setIndex) percent else existing
         }
@@ -619,11 +631,11 @@ class ExerciseConfigViewModel constructor(
         val setIndex = _sets.value.indexOfFirst { it.id == setId }
         if (setIndex < 0) return
 
-        val pr = _currentExercisePR.value
-        val nextWeight = if (_usePercentOfPR.value && pr != null && pr.weightPerCableKg > 0f) {
+        val baselineKg = baselineKgForCurrentBasis()
+        val nextWeight = if (_usePercentOfPR.value && baselineKg != null && baselineKg > 0f) {
             pendingPercentOfPREditWeights.remove(setId)
-            val percent = updateSetPercentFromDisplayWeight(setIndex, weight, pr)
-            displayWeightFromPercent(percent, pr)
+            val percent = updateSetPercentFromDisplayWeight(setIndex, weight, baselineKg)
+            displayWeightFromPercent(percent, baselineKg)
         } else {
             if (_usePercentOfPR.value) {
                 pendingPercentOfPREditWeights[setId] = weight
@@ -709,7 +721,7 @@ class ExerciseConfigViewModel constructor(
         logDebug("Rest times to save: $restTimes")
         logDebug("Weights to save: ${_sets.value.map { displayToKg(it.weightPerCable, weightUnit) }}")
 
-        val resolvedSetWeightsKg = resolvedSetWeightsKgFromCurrentPR()
+        val resolvedSetWeightsKg = resolvedSetWeightsKgFromCurrentBasis()
             ?: _sets.value.map { displayToKg(it.weightPerCable, weightUnit) }
         val resolvedSetWeightsPercentOfPR = if (_usePercentOfPR.value) {
             normalizeSetWeightPercentages(

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModel.kt
@@ -3,7 +3,10 @@ package com.devil.phoenixproject.presentation.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
+import com.devil.phoenixproject.data.repository.ExerciseRepository
 import com.devil.phoenixproject.data.repository.PersonalRecordRepository
+import com.devil.phoenixproject.data.repository.VelocityOneRepMaxRepository
+import com.devil.phoenixproject.data.repository.getBestVolumePRForWorkoutMode
 import com.devil.phoenixproject.data.repository.getBestWeightPRForWorkoutMode
 import com.devil.phoenixproject.domain.model.EccentricLoad
 import com.devil.phoenixproject.domain.model.EchoLevel
@@ -47,6 +50,8 @@ data class SetConfiguration(
 
 class ExerciseConfigViewModel constructor(
     private val personalRecordRepository: PersonalRecordRepository? = null,
+    private val velocityOneRepMaxRepository: VelocityOneRepMaxRepository? = null,
+    private val exerciseRepository: ExerciseRepository? = null,
 ) : ViewModel() {
 
     private val log = Logger.withTag("ExerciseConfigViewModel")
@@ -62,6 +67,18 @@ class ExerciseConfigViewModel constructor(
     // PR state for the current exercise/mode combination
     private val _currentExercisePR = MutableStateFlow<PersonalRecord?>(null)
     val currentExercisePR: StateFlow<PersonalRecord?> = _currentExercisePR.asStateFlow()
+
+    // Max-volume PR for the current exercise/mode (used when scalingBasis == MAX_VOLUME_PR)
+    private val _currentMaxVolumePR = MutableStateFlow<PersonalRecord?>(null)
+    val currentMaxVolumePR: StateFlow<PersonalRecord?> = _currentMaxVolumePR.asStateFlow()
+
+    // Latest passing velocity-based 1RM estimate (kg per cable) for ESTIMATED_1RM basis
+    private val _velocityEstimateKg = MutableStateFlow<Float?>(null)
+    val velocityEstimateKg: StateFlow<Float?> = _velocityEstimateKg.asStateFlow()
+
+    // Stored Exercise.oneRepMaxKg (manual/VBT input) — fallback within ESTIMATED_1RM basis
+    private val _storedOneRepMaxKg = MutableStateFlow<Float?>(null)
+    val storedOneRepMaxKg: StateFlow<Float?> = _storedOneRepMaxKg.asStateFlow()
 
     // Convenience accessor for just the PR weight (useful for PRIndicator component)
     val currentExercisePRWeight: Float?
@@ -244,9 +261,10 @@ class ExerciseConfigViewModel constructor(
         _defaultRackItemIds.value = exercise.defaultRackItemIds.filter { it.isNotBlank() }.distinct()
         _rackBehaviorOverrides.value = exercise.rackBehaviorOverrides
 
-        // Load PR for the current exercise and mode
+        // Load PR for the current exercise and mode; also load mode-independent baselines
         exercise.exercise.id?.let { exerciseId ->
             loadPRForExercise(exerciseId, _selectedMode.value.displayName)
+            loadModeIndependentBaselines(exerciseId)
         }
 
         _initialized.value = true
@@ -273,7 +291,8 @@ class ExerciseConfigViewModel constructor(
 
     /**
      * Load the personal record for the given exercise and workout mode.
-     * This updates currentExercisePR which can be used by PRIndicator components.
+     * This updates currentExercisePR (max-weight) and currentMaxVolumePR,
+     * both of which are used by PRIndicator components and the scaling preview.
      */
     fun loadPRForExercise(exerciseId: String, workoutMode: String) {
         if (personalRecordRepository == null) {
@@ -290,6 +309,67 @@ class ExerciseConfigViewModel constructor(
                 logWarning("Failed to load PR for exercise=$exerciseId, mode=$workoutMode, profile=$activeProfileId: ${e.message}")
                 _currentExercisePR.value = null
             }
+            // Also load max-volume PR (mode-dependent, so reload on mode change)
+            try {
+                val volumePR = personalRecordRepository.getBestVolumePRForWorkoutMode(exerciseId, workoutMode, activeProfileId)
+                _currentMaxVolumePR.value = volumePR
+                logDebug("Loaded volume PR for exercise=$exerciseId, mode=$workoutMode: ${volumePR?.weightPerCableKg ?: "none"}")
+            } catch (e: Exception) {
+                logWarning("Failed to load volume PR for exercise=$exerciseId, mode=$workoutMode: ${e.message}")
+                _currentMaxVolumePR.value = null
+            }
+        }
+    }
+
+    /**
+     * Load mode-independent baselines: velocity estimate and stored Exercise.oneRepMaxKg.
+     * Called once per initialize; these do not change when the workout mode selector changes.
+     */
+    private fun loadModeIndependentBaselines(exerciseId: String) {
+        viewModelScope.launch {
+            if (velocityOneRepMaxRepository != null) {
+                try {
+                    val estimate = velocityOneRepMaxRepository.getLatestPassing(exerciseId, activeProfileId)
+                    _velocityEstimateKg.value = estimate?.estimatedPerCableKg?.takeIf { it > 0 }
+                    logDebug("Loaded velocity estimate for exercise=$exerciseId: ${_velocityEstimateKg.value ?: "none"}")
+                } catch (e: Exception) {
+                    logWarning("Failed to load velocity estimate for exercise=$exerciseId: ${e.message}")
+                    _velocityEstimateKg.value = null
+                }
+            }
+            if (exerciseRepository != null) {
+                try {
+                    val ex = exerciseRepository.getExerciseById(exerciseId)
+                    _storedOneRepMaxKg.value = ex?.oneRepMaxKg?.takeIf { it > 0 }
+                    logDebug("Loaded stored 1RM for exercise=$exerciseId: ${_storedOneRepMaxKg.value ?: "none"}")
+                } catch (e: Exception) {
+                    logWarning("Failed to load stored 1RM for exercise=$exerciseId: ${e.message}")
+                    _storedOneRepMaxKg.value = null
+                }
+            }
+        }
+    }
+
+    /**
+     * Resolves the baseline weight (kg/cable) for the currently-selected scaling basis,
+     * mirroring ResolveRoutineWeightsUseCase's resolution order:
+     *   MAX_WEIGHT_PR  → max-weight PR
+     *   MAX_VOLUME_PR  → max-volume PR
+     *   ESTIMATED_1RM  → velocity estimate → stored Exercise.oneRepMaxKg → max-weight PR (last resort)
+     *
+     * Returns null when no data is available for the selected basis (controls preview and gating).
+     */
+    fun baselineKgForCurrentBasis(): Float? {
+        val basis = _scalingBasis.value ?: ScalingBasis.MAX_WEIGHT_PR
+        return when (basis) {
+            ScalingBasis.MAX_WEIGHT_PR ->
+                _currentExercisePR.value?.weightPerCableKg?.takeIf { it > 0 }
+            ScalingBasis.MAX_VOLUME_PR ->
+                _currentMaxVolumePR.value?.weightPerCableKg?.takeIf { it > 0 }
+            ScalingBasis.ESTIMATED_1RM ->
+                _velocityEstimateKg.value?.takeIf { it > 0 }
+                    ?: _storedOneRepMaxKg.value?.takeIf { it > 0 }
+                    ?: _currentExercisePR.value?.weightPerCableKg?.takeIf { it > 0 }
         }
     }
 
@@ -447,15 +527,16 @@ class ExerciseConfigViewModel constructor(
     }
 
     /**
-     * Calculate the resolved weight based on current PR and percentage settings.
-     * Returns null if PR is not available or percentage scaling is disabled.
+     * Calculate the resolved preview weight for the currently-selected scaling basis.
+     * Returns null if no baseline is available for the selected basis, or if percentage
+     * scaling is disabled.
      */
     fun calculateResolvedWeight(): Float? {
-        val pr = _currentExercisePR.value ?: return null
         if (!_usePercentOfPR.value) return null
+        val baseline = baselineKgForCurrentBasis() ?: return null
         val percent = _weightPercentOfPR.value
         if (percent <= 0) return null
-        return (pr.weightPerCableKg * percent / 100f).roundToHalfKg()
+        return (baseline * percent / 100f).roundToHalfKg()
     }
 
     private fun Float.roundToHalfKg(): Float = (this * 2).roundToInt() / 2f

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
@@ -673,6 +673,7 @@ class MainViewModel constructor(
                     preferencesManager.setVelocityOneRepMaxBackfillDone(true)
                 }
             } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
                 Logger.w(e) { "VELOCITY_1RM: backfill failed" }
             }
         }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
@@ -673,8 +673,16 @@ class MainViewModel constructor(
                         } ?: userProfileRepository.allProfiles.value
                         ).map { it.id }.ifEmpty { listOf(activeProfileId.value) }
                     val now = com.devil.phoenixproject.domain.model.currentTimeMillis()
+                    // Per-profile try/catch so one profile's failure can't abort the rest, and the
+                    // run-once flag is still set afterwards (a failed profile is covered later by its
+                    // own new workouts / hasEstimates idempotency rather than blocking every launch).
                     for (profileId in profileIds) {
-                        backfillVelocityOneRepMaxUseCase(profileId, now)
+                        try {
+                            backfillVelocityOneRepMaxUseCase(profileId, now)
+                        } catch (e: Exception) {
+                            if (e is kotlinx.coroutines.CancellationException) throw e
+                            Logger.w(e) { "VELOCITY_1RM: backfill failed for profile=$profileId" }
+                        }
                     }
                     preferencesManager.setVelocityOneRepMaxBackfillDone(true)
                 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
@@ -51,6 +51,7 @@ import com.devil.phoenixproject.domain.model.WorkoutSession
 import com.devil.phoenixproject.domain.model.WorkoutState
 import com.devil.phoenixproject.domain.usecase.ApplyEquipmentRackLoadUseCase
 import com.devil.phoenixproject.domain.usecase.ApplyRoutineModifierUseCase
+import com.devil.phoenixproject.domain.usecase.BackfillVelocityOneRepMaxUseCase
 import com.devil.phoenixproject.domain.usecase.ComputeVelocityOneRepMaxUseCase
 import com.devil.phoenixproject.domain.usecase.CountVelocityOneRepMaxImprovementsUseCase
 import com.devil.phoenixproject.domain.usecase.RecommendWeightAdjustmentUseCase
@@ -118,6 +119,8 @@ class MainViewModel constructor(
     // Exposed as a public val so ExerciseDetailScreen can query the latest passing estimate.
     val velocityOneRepMaxRepository: VelocityOneRepMaxRepository,
     private val countVelocityOneRepMaxImprovementsUseCase: CountVelocityOneRepMaxImprovementsUseCase,
+    // Issue #517: one-time startup backfill of velocity-1RM estimates for historical data.
+    private val backfillVelocityOneRepMaxUseCase: BackfillVelocityOneRepMaxUseCase,
 ) : ViewModel() {
 
     // Shared haptic events flow - created here, passed to both GamificationManager and WorkoutSessionManager
@@ -647,6 +650,24 @@ class MainViewModel constructor(
             _hapticEvents.emit(HapticEvent.REP_COUNT_ANNOUNCED(5))
             kotlinx.coroutines.delay(1000)
             _hapticEvents.emit(HapticEvent.WORKOUT_COMPLETE)
+        }
+    }
+
+    // ===== Velocity-1RM Backfill (Issue #517) =====
+
+    init {
+        // Run once at startup: backfill velocity-1RM estimates for historical sets.
+        // Gated by a run-once preference flag so it never re-runs after the first successful pass.
+        viewModelScope.launch(kotlinx.coroutines.NonCancellable) {
+            try {
+                if (!settingsManager.velocityOneRepMaxBackfillDone.value) {
+                    val profile = activeProfileId.value
+                    backfillVelocityOneRepMaxUseCase(profile, com.devil.phoenixproject.domain.model.currentTimeMillis())
+                    preferencesManager.setVelocityOneRepMaxBackfillDone(true)
+                }
+            } catch (e: Exception) {
+                Logger.w(e) { "VELOCITY_1RM: backfill failed" }
+            }
         }
     }
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
@@ -52,6 +52,7 @@ import com.devil.phoenixproject.domain.model.WorkoutState
 import com.devil.phoenixproject.domain.usecase.ApplyEquipmentRackLoadUseCase
 import com.devil.phoenixproject.domain.usecase.ApplyRoutineModifierUseCase
 import com.devil.phoenixproject.domain.usecase.ComputeVelocityOneRepMaxUseCase
+import com.devil.phoenixproject.domain.usecase.CountVelocityOneRepMaxImprovementsUseCase
 import com.devil.phoenixproject.domain.usecase.RecommendWeightAdjustmentUseCase
 import com.devil.phoenixproject.domain.usecase.RecordPersonalMvtSampleUseCase
 import com.devil.phoenixproject.domain.usecase.RepCounterFromMachine
@@ -116,6 +117,7 @@ class MainViewModel constructor(
     private val recordPersonalMvtSampleUseCase: RecordPersonalMvtSampleUseCase,
     // Exposed as a public val so ExerciseDetailScreen can query the latest passing estimate.
     val velocityOneRepMaxRepository: VelocityOneRepMaxRepository,
+    private val countVelocityOneRepMaxImprovementsUseCase: CountVelocityOneRepMaxImprovementsUseCase,
 ) : ViewModel() {
 
     // Shared haptic events flow - created here, passed to both GamificationManager and WorkoutSessionManager
@@ -138,7 +140,7 @@ class MainViewModel constructor(
             .stateIn(viewModelScope, SharingStarted.Eagerly, "default")
 
     // === Phase 2b: GamificationManager (extracted from this class) ===
-    val gamificationManager = GamificationManager(
+    val gamificationManager: GamificationManager = GamificationManager(
         gamificationRepository,
         personalRecordRepository,
         exerciseRepository,
@@ -154,6 +156,10 @@ class MainViewModel constructor(
                 }
             }
             computeVelocityOneRepMaxUseCase(exId, profile, com.devil.phoenixproject.domain.model.currentTimeMillis())
+            val improvements = countVelocityOneRepMaxImprovementsUseCase(
+                velocityOneRepMaxRepository.getAllPassing(profile),
+            )
+            gamificationManager.checkVelocityOneRepMaxBadges(improvements, profile)
         },
     )
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
@@ -76,6 +76,8 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
@@ -661,7 +663,12 @@ class MainViewModel constructor(
         viewModelScope.launch(kotlinx.coroutines.NonCancellable) {
             try {
                 if (!settingsManager.velocityOneRepMaxBackfillDone.value) {
-                    val profile = activeProfileId.value
+                    // activeProfileId.value is "default" until the real profile loads async,
+                    // so await the loaded profile (10s timeout fallback to default for
+                    // genuine default-only users whose activeProfile stays null).
+                    val profile = kotlinx.coroutines.withTimeoutOrNull(10_000) {
+                        userProfileRepository.activeProfile.filterNotNull().first().id
+                    } ?: activeProfileId.value
                     backfillVelocityOneRepMaxUseCase(profile, com.devil.phoenixproject.domain.model.currentTimeMillis())
                     preferencesManager.setVelocityOneRepMaxBackfillDone(true)
                 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
@@ -663,13 +663,19 @@ class MainViewModel constructor(
         viewModelScope.launch(kotlinx.coroutines.NonCancellable) {
             try {
                 if (!settingsManager.velocityOneRepMaxBackfillDone.value) {
-                    // activeProfileId.value is "default" until the real profile loads async,
-                    // so await the loaded profile (10s timeout fallback to default for
-                    // genuine default-only users whose activeProfile stays null).
-                    val profile = kotlinx.coroutines.withTimeoutOrNull(10_000) {
-                        userProfileRepository.activeProfile.filterNotNull().first().id
-                    } ?: activeProfileId.value
-                    backfillVelocityOneRepMaxUseCase(profile, com.devil.phoenixproject.domain.model.currentTimeMillis())
+                    // Backfill EVERY profile's history (not just the active one): the run-once flag
+                    // is global, so a profile skipped here would never be backfilled. Await the
+                    // loaded profile list (10s timeout fallback to the active profile id for genuine
+                    // single-profile installs whose list stays empty).
+                    val profileIds = (
+                        kotlinx.coroutines.withTimeoutOrNull(10_000) {
+                            userProfileRepository.allProfiles.first { it.isNotEmpty() }
+                        } ?: userProfileRepository.allProfiles.value
+                        ).map { it.id }.ifEmpty { listOf(activeProfileId.value) }
+                    val now = com.devil.phoenixproject.domain.model.currentTimeMillis()
+                    for (profileId in profileIds) {
+                        backfillVelocityOneRepMaxUseCase(profileId, now)
+                    }
                     preferencesManager.setVelocityOneRepMaxBackfillDone(true)
                 }
             } catch (e: Exception) {

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
@@ -38,6 +38,7 @@ import com.devil.phoenixproject.domain.model.RackLoadAdjustment
 import com.devil.phoenixproject.domain.model.RepCount
 import com.devil.phoenixproject.domain.model.RepCountTiming
 import com.devil.phoenixproject.domain.model.Routine
+import com.devil.phoenixproject.domain.model.ScalingBasis
 import com.devil.phoenixproject.domain.model.RoutineExercise
 import com.devil.phoenixproject.domain.model.RoutineFlowState
 import com.devil.phoenixproject.domain.model.RoutineGroup
@@ -334,6 +335,8 @@ class MainViewModel constructor(
     fun setVelocityLossThreshold(percent: Int) = settingsManager.setVelocityLossThreshold(percent)
     fun setAutoEndOnVelocityLoss(enabled: Boolean) = settingsManager.setAutoEndOnVelocityLoss(enabled)
     fun setWeightSuggestionsEnabled(enabled: Boolean) = settingsManager.setWeightSuggestionsEnabled(enabled)
+    // Issue #517: system-wide default scaling basis
+    fun setDefaultScalingBasis(basis: ScalingBasis) = settingsManager.setDefaultScalingBasis(basis)
 
     // Backup stats for Settings UI
     private val _backupStats = kotlinx.coroutines.flow.MutableStateFlow<BackupStats?>(null)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/BackupModels.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/BackupModels.kt
@@ -171,6 +171,9 @@ data class RoutineExerciseBackup(
     val defaultRackItemIds: List<String> = emptyList(),
     // Per-exercise rack behavior overrides (Issues #521/#526)
     val rackBehaviorOverrides: String = "{}",
+    // Velocity-based 1RM scaling basis (issue #517 Phase 3); enum name or null.
+    // Default null keeps pre-existing backup files loadable.
+    val scalingBasis: String? = null,
 )
 
 /**

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/DataBackupManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/DataBackupManager.kt
@@ -612,7 +612,9 @@ abstract class BaseDataBackupManager(
                                 warmupSets = exercise.warmupSets,
                                 defaultRackItemIds = sanitizeRackItemIds(exercise.defaultRackItemIds),
                                 rackBehaviorOverrides = exercise.rackBehaviorOverrides,
-                                scalingBasis = null,
+                                scalingBasis = exercise.scalingBasis?.let {
+                                    runCatching { com.devil.phoenixproject.domain.model.ScalingBasis.valueOf(it) }.getOrNull()
+                                }?.name,
                             )
                         }
                         if (inserted != null) routineExercisesImported++
@@ -1335,7 +1337,9 @@ abstract class BaseDataBackupManager(
                                                         warmupSets = exercise.warmupSets,
                                                         defaultRackItemIds = sanitizeRackItemIds(exercise.defaultRackItemIds),
                                                         rackBehaviorOverrides = exercise.rackBehaviorOverrides,
-                                                        scalingBasis = null,
+                                                        scalingBasis = exercise.scalingBasis?.let {
+                                                            runCatching { com.devil.phoenixproject.domain.model.ScalingBasis.valueOf(it) }.getOrNull()
+                                                        }?.name,
                                                     )
                                                 }
                                                 if (inserted != null) {
@@ -2330,6 +2334,8 @@ abstract class BaseDataBackupManager(
         warmupSets = exercise.warmupSets,
         defaultRackItemIds = decodeRackItemIds(exercise.defaultRackItemIds),
         rackBehaviorOverrides = exercise.rackBehaviorOverrides,
+        // scalingBasis is stored as the enum name (TEXT) on the DB row; persist it verbatim.
+        scalingBasis = exercise.scalingBasis,
     )
 
     private fun decodeRackItemIds(encoded: String): List<String> = runCatching {

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/DataBackupManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/DataBackupManager.kt
@@ -612,6 +612,7 @@ abstract class BaseDataBackupManager(
                                 warmupSets = exercise.warmupSets,
                                 defaultRackItemIds = sanitizeRackItemIds(exercise.defaultRackItemIds),
                                 rackBehaviorOverrides = exercise.rackBehaviorOverrides,
+                                scalingBasis = null,
                             )
                         }
                         if (inserted != null) routineExercisesImported++
@@ -1334,6 +1335,7 @@ abstract class BaseDataBackupManager(
                                                         warmupSets = exercise.warmupSets,
                                                         defaultRackItemIds = sanitizeRackItemIds(exercise.defaultRackItemIds),
                                                         rackBehaviorOverrides = exercise.rackBehaviorOverrides,
+                                                        scalingBasis = null,
                                                     )
                                                 }
                                                 if (inserted != null) {

--- a/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
+++ b/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
@@ -481,6 +481,19 @@ SELECT * FROM VelocityOneRepMaxEstimate
 WHERE profile_id = :profileId AND passedQualityGate = 1 AND deletedAt IS NULL
 ORDER BY exerciseId ASC, computedAt ASC;
 
+-- Issue #517 Phase 5 T1: enumerate exercises that have at least one MCV-bearing set.
+-- Used by the velocity-1RM pipeline to decide which exercises are ready to estimate.
+selectExerciseIdsWithVelocityData:
+SELECT DISTINCT exerciseId FROM WorkoutSession
+WHERE profile_id = :profileId AND exerciseId IS NOT NULL
+  AND deletedAt IS NULL AND avgMcvMmS IS NOT NULL AND workingReps > 0;
+
+-- Issue #517 Phase 5 T1: count existing estimates for a given exercise/profile.
+-- Returns 0 when the exercise has never been estimated.
+countVelocityOneRepMaxByExercise:
+SELECT COUNT(*) FROM VelocityOneRepMaxEstimate
+WHERE exerciseId = :exerciseId AND profile_id = :profileId AND deletedAt IS NULL;
+
 -- ==================== PERSONAL MVT TABLE ====================
 -- Personalized Minimum Velocity Threshold per exercise/profile (issue #517).
 -- Stored alongside the exercise; used by VelocityOneRepMaxEstimator to override

--- a/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
+++ b/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
@@ -476,6 +476,11 @@ AND passedQualityGate = 1 AND deletedAt IS NULL
 ORDER BY computedAt DESC, id DESC
 LIMIT 1;
 
+selectAllPassingVelocityOneRepMaxByProfile:
+SELECT * FROM VelocityOneRepMaxEstimate
+WHERE profile_id = :profileId AND passedQualityGate = 1 AND deletedAt IS NULL
+ORDER BY exerciseId ASC, computedAt ASC;
+
 -- ==================== PERSONAL MVT TABLE ====================
 -- Personalized Minimum Velocity Threshold per exercise/profile (issue #517).
 -- Stored alongside the exercise; used by VelocityOneRepMaxEstimator to override

--- a/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
+++ b/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
@@ -240,6 +240,8 @@ CREATE TABLE RoutineExercise (
     weightPercentOfPR INTEGER NOT NULL DEFAULT 80,
     prTypeForScaling TEXT NOT NULL DEFAULT 'MAX_WEIGHT',
     setWeightsPercentOfPR TEXT,
+    -- Velocity-based 1RM scaling basis (issue #517 Phase 3); null = derive from prTypeForScaling
+    scalingBasis TEXT,
     -- Per-exercise behavior overrides (PR #245)
     stallDetectionEnabled INTEGER NOT NULL DEFAULT 1,
     stopAtTop INTEGER NOT NULL DEFAULT 0,
@@ -1115,9 +1117,9 @@ INSERT INTO RoutineExercise (
     perSetRestTime, isAMRAP, supersetId, orderInSuperset,
     usePercentOfPR, weightPercentOfPR, prTypeForScaling, setWeightsPercentOfPR,
     stallDetectionEnabled, stopAtTop, repCountTiming, setEchoLevels, warmupSets, defaultRackItemIds,
-    rackBehaviorOverrides
+    rackBehaviorOverrides, scalingBasis
 )
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 -- Insert with IGNORE for import (won't overwrite existing)
 insertRoutineExerciseIgnore:
@@ -1128,9 +1130,9 @@ INSERT OR IGNORE INTO RoutineExercise (
     perSetRestTime, isAMRAP, supersetId, orderInSuperset,
     usePercentOfPR, weightPercentOfPR, prTypeForScaling, setWeightsPercentOfPR,
     stallDetectionEnabled, stopAtTop, repCountTiming, setEchoLevels, warmupSets, defaultRackItemIds,
-    rackBehaviorOverrides
+    rackBehaviorOverrides, scalingBasis
 )
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 deleteRoutineExercises:
 DELETE FROM RoutineExercise WHERE routineId = ?;

--- a/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/migrations/38.sqm
+++ b/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/migrations/38.sqm
@@ -1,0 +1,2 @@
+-- Migration 38: per-routine-exercise scaling basis (% of estimated 1RM) — issue #517 Phase 3.
+ALTER TABLE RoutineExercise ADD COLUMN scalingBasis TEXT;

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/local/VelocityOneRepMaxBadgeDefinitionsTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/local/VelocityOneRepMaxBadgeDefinitionsTest.kt
@@ -1,0 +1,27 @@
+package com.devil.phoenixproject.data.local
+
+import com.devil.phoenixproject.domain.model.BadgeCategory
+import com.devil.phoenixproject.domain.model.BadgeRequirement
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class VelocityOneRepMaxBadgeDefinitionsTest {
+    @Test fun `three tiered velocity 1RM badges exist with STRENGTH category`() {
+        val ids = listOf("velocity_1rm_1", "velocity_1rm_5", "velocity_1rm_15")
+        val badges = ids.map { id -> assertNotNull(BadgeDefinitions.getBadgeById(id), "missing $id") }
+        badges.forEach { assertEquals(BadgeCategory.STRENGTH, it.category) }
+        assertEquals(
+            listOf(1, 5, 15),
+            badges.map { (it.requirement as BadgeRequirement.VelocityOneRepMaxImprovements).count },
+        )
+    }
+
+    @Test fun `velocity 1RM badges are distinct from PR badges`() {
+        val velocity = BadgeDefinitions.allBadges.filter { it.requirement is BadgeRequirement.VelocityOneRepMaxImprovements }
+        val pr = BadgeDefinitions.allBadges.filter { it.requirement is BadgeRequirement.PRsAchieved }
+        assertTrue(velocity.isNotEmpty() && pr.isNotEmpty())
+        assertTrue(velocity.none { v -> pr.any { it.id == v.id } })
+    }
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/ConflictResolutionTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/ConflictResolutionTest.kt
@@ -237,6 +237,7 @@ class ConflictResolutionTest {
             warmupSets = "",
             defaultRackItemIds = "[]",
             rackBehaviorOverrides = "{}",
+            scalingBasis = null,
         )
 
         // Verify exercise exists

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/ScalingBasisTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/ScalingBasisTest.kt
@@ -1,0 +1,31 @@
+package com.devil.phoenixproject.domain.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ScalingBasisTest {
+    @Test fun `fromPrType maps PR types`() {
+        assertEquals(ScalingBasis.MAX_WEIGHT_PR, ScalingBasis.fromPrType(PRType.MAX_WEIGHT))
+        assertEquals(ScalingBasis.MAX_VOLUME_PR, ScalingBasis.fromPrType(PRType.MAX_VOLUME))
+    }
+
+    @Test fun `effectiveScalingBasis uses explicit value when set`() {
+        val ex = sampleRoutineExercise().copy(scalingBasis = ScalingBasis.ESTIMATED_1RM)
+        assertEquals(ScalingBasis.ESTIMATED_1RM, ex.effectiveScalingBasis)
+    }
+
+    @Test fun `effectiveScalingBasis derives from prTypeForScaling when null`() {
+        val ex = sampleRoutineExercise().copy(scalingBasis = null, prTypeForScaling = PRType.MAX_VOLUME)
+        assertEquals(ScalingBasis.MAX_VOLUME_PR, ex.effectiveScalingBasis)
+    }
+}
+
+fun sampleRoutineExercise(): RoutineExercise = RoutineExercise(
+    id = "test-exercise",
+    exercise = Exercise(
+        name = "Bench Press",
+        muscleGroup = "Chest",
+    ),
+    orderIndex = 0,
+    weightPerCableKg = 50f,
+)

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/BackfillVelocityOneRepMaxUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/BackfillVelocityOneRepMaxUseCaseTest.kt
@@ -1,0 +1,30 @@
+package com.devil.phoenixproject.domain.usecase
+
+import com.devil.phoenixproject.domain.onerepmax.VelocityOneRepMaxResult
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private fun dummyResult() = VelocityOneRepMaxResult(
+    estimatedPerCableKg = 100f,
+    mvtUsedMs = 300f,
+    r2 = 0.95f,
+    distinctLoads = 3,
+    passedQualityGate = true,
+)
+
+class BackfillVelocityOneRepMaxUseCaseTest {
+
+    @Test
+    fun `backfills only exercises without an existing estimate`() = runTest {
+        val computed = mutableListOf<String>()
+        val useCase = BackfillVelocityOneRepMaxUseCase(
+            exerciseIds = { _ -> listOf("exA", "exB", "exC") },
+            hasEstimates = { id, _ -> id == "exB" }, // exB already has one
+            computeAllTime = { id, _, _ -> computed += id; if (id == "exC") null else dummyResult() }, // exC ineligible
+        )
+        val created = useCase("default", nowMs = 1_000L)
+        assertEquals(listOf("exA", "exC"), computed) // exB skipped
+        assertEquals(1, created)                      // only exA produced an estimate
+    }
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/ComputeVelocityOneRepMaxUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/ComputeVelocityOneRepMaxUseCaseTest.kt
@@ -70,4 +70,30 @@ class ComputeVelocityOneRepMaxUseCaseTest {
         assertEquals(null, useCase("ex1", "default", nowMs = 1L))
         assertEquals(0, inserted.size)
     }
+
+    @Test fun `respects custom windowDays parameter for point filtering`() = runTest {
+        val points = listOf(
+            WorkoutVelocityPoint(40f, 1200f, timestampMs = 5L, workingReps = 5),
+            WorkoutVelocityPoint(80f, 600f, timestampMs = 6L, workingReps = 5),
+        )
+        val inserted = mutableListOf<VelocityOneRepMaxResult>()
+        var capturedSinceMs = -1L
+        val useCase = ComputeVelocityOneRepMaxUseCase(
+            workoutPoints = { _, _, since -> capturedSinceMs = since; points },
+            exerciseLookup = { _ -> FakeExercise(name = "Back Squat", muscleGroups = "Legs", mvtOverrideMs = null) },
+            personalMvtLookup = { _, _ -> null },
+            mvtProvider = MvtProvider(),
+            estimator = VelocityOneRepMaxEstimator(AssessmentEngine()),
+            persist = { result, _, _, _ -> inserted += result },
+        )
+
+        val nowMs = 1_000_000L
+        val windowDays = 3650
+        val result = useCase("ex1", "default", nowMs, windowDays)
+        assertNotNull(result)
+        assertTrue(result.passedQualityGate)
+        assertEquals(1, inserted.size)
+        // 3650-day window: sinceMs = nowMs - 3650 * DAY_MS
+        assertEquals(nowMs - 3650L * 86_400_000L, capturedSinceMs)
+    }
 }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/CountVelocityOneRepMaxImprovementsUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/CountVelocityOneRepMaxImprovementsUseCaseTest.kt
@@ -1,0 +1,26 @@
+package com.devil.phoenixproject.domain.usecase
+
+import com.devil.phoenixproject.data.repository.VelocityOneRepMaxEntity
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CountVelocityOneRepMaxImprovementsUseCaseTest {
+    private val useCase = CountVelocityOneRepMaxImprovementsUseCase()
+    private fun e(ex: String, kg: Float, t: Long) =
+        VelocityOneRepMaxEntity(0, ex, kg, 0.3f, 0.95f, 3, true, t, "default")
+
+    @Test fun `counts improvements above 2_5 percent per exercise`() {
+        // exA: 100 (base) -> 103 (+3% improvement) -> 104 (<2.5% over 103, no) -> 110 (improvement over 104)
+        val points = listOf(
+            e("exA", 100f, 1), e("exA", 103f, 2), e("exA", 104f, 3), e("exA", 110f, 4),
+            e("exB", 50f, 1), e("exB", 60f, 2), // exB: base -> +20% improvement
+        )
+        assertEquals(3, useCase(points)) // exA:2 + exB:1
+    }
+
+    @Test fun `single estimate per exercise is not an improvement`() {
+        assertEquals(0, useCase(listOf(e("exA", 100f, 1), e("exB", 80f, 1))))
+    }
+
+    @Test fun `empty input is zero`() = assertEquals(0, useCase(emptyList()))
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/RecordPersonalMvtSampleUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/RecordPersonalMvtSampleUseCaseTest.kt
@@ -35,6 +35,14 @@ class RecordPersonalMvtSampleUseCaseTest {
         assertEquals(null, repo.get("ex1", "default"))
     }
 
+    @Test fun `rejects NaN session MCV without writing to repo`() = runTest {
+        val repo = FakePersonalMvtRepo()
+        val useCase = RecordPersonalMvtSampleUseCase(repo)
+        val result = useCase("ex1", "default", "Back Squat", "Legs", sessionMcvMmS = Float.NaN)
+        assertFalse(result)
+        assertEquals(null, repo.get("ex1", "default"))
+    }
+
     @Test fun `rolling mean across samples`() = runTest {
         val repo = FakePersonalMvtRepo()
         val useCase = RecordPersonalMvtSampleUseCase(repo)

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/ResolveRoutineWeightsUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/ResolveRoutineWeightsUseCaseTest.kt
@@ -656,6 +656,46 @@ class ResolveRoutineWeightsUseCaseTest {
     }
 
     @Test
+    fun `ESTIMATED_1RM falls back to max-weight PR when no estimate and no stored 1RM`() = runTest {
+        // Given: no velocity estimate, no stored oneRepMaxKg, but a max-weight PR exists
+        velocityRepository.latestPassing = null
+        prRepository.addRecord(
+            PersonalRecord(
+                id = 1,
+                exerciseId = "bench-press",
+                exerciseName = "Bench Press",
+                weightPerCableKg = 60f,
+                reps = 5,
+                oneRepMax = 70f,
+                timestamp = 1000L,
+                workoutMode = "Old School",
+                prType = PRType.MAX_WEIGHT,
+                volume = 300f,
+            ),
+        )
+
+        val routineExercise = RoutineExercise(
+            id = "routine-ex-1rm-pr-fallback",
+            exercise = testExercise,
+            orderIndex = 0,
+            weightPerCableKg = 30f,
+            usePercentOfPR = true,
+            weightPercentOfPR = 80,
+            scalingBasis = ScalingBasis.ESTIMATED_1RM,
+            programMode = ProgramMode.OldSchool,
+        )
+
+        val result = useCase(routineExercise)
+
+        // 80% of 60 (max-weight PR) = 48 kg — must scale off PR, not drop to absolute 30
+        assertEquals(48f, result.baseWeight)
+        assertEquals(60f, result.usedPR)
+        assertEquals(80, result.percentOfPR)
+        assertTrue(result.isFromPR)
+        assertNull(result.fallbackReason)
+    }
+
+    @Test
     fun `set weights default to base percentage when no per-set percentages defined`() = runTest {
         // Given: Exercise uses PR percentage for base weight, but no per-set percentages
         prRepository.addRecord(

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/ResolveRoutineWeightsUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/ResolveRoutineWeightsUseCaseTest.kt
@@ -1,13 +1,16 @@
 package com.devil.phoenixproject.domain.usecase
 
+import com.devil.phoenixproject.data.repository.VelocityOneRepMaxEntity
 import com.devil.phoenixproject.domain.model.Exercise
 import com.devil.phoenixproject.domain.model.PRType
 import com.devil.phoenixproject.domain.model.PersonalRecord
 import com.devil.phoenixproject.domain.model.ProgramMode
 import com.devil.phoenixproject.domain.model.RoutineExercise
+import com.devil.phoenixproject.domain.model.ScalingBasis
 import com.devil.phoenixproject.domain.model.WorkoutPhase
 import com.devil.phoenixproject.testutil.FakeExerciseRepository
 import com.devil.phoenixproject.testutil.FakePersonalRecordRepository
+import com.devil.phoenixproject.testutil.FakeVelocityOneRepMaxRepository
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -27,6 +30,7 @@ class ResolveRoutineWeightsUseCaseTest {
 
     private lateinit var prRepository: FakePersonalRecordRepository
     private lateinit var exerciseRepository: FakeExerciseRepository
+    private lateinit var velocityRepository: FakeVelocityOneRepMaxRepository
     private lateinit var useCase: ResolveRoutineWeightsUseCase
 
     private val testExercise = Exercise(
@@ -41,7 +45,8 @@ class ResolveRoutineWeightsUseCaseTest {
         prRepository.reset()
         exerciseRepository = FakeExerciseRepository()
         exerciseRepository.reset()
-        useCase = ResolveRoutineWeightsUseCase(prRepository, exerciseRepository)
+        velocityRepository = FakeVelocityOneRepMaxRepository()
+        useCase = ResolveRoutineWeightsUseCase(prRepository, exerciseRepository, velocityRepository)
     }
 
     // ========== Test 1: Resolves percentage to absolute weight using PR ==========
@@ -583,6 +588,71 @@ class ResolveRoutineWeightsUseCaseTest {
 
         assertEquals(90f, result.baseWeight)
         assertEquals(90f, result.usedPR)
+    }
+
+    // ========== Tests for ESTIMATED_1RM scaling basis (#517) ==========
+
+    @Test
+    fun `ESTIMATED_1RM uses latest passing velocity estimate`() = runTest {
+        // Given: velocity repo returns an estimate of 100 kg per-cable for this exercise
+        velocityRepository.latestPassing = VelocityOneRepMaxEntity(
+            id = 1L,
+            exerciseId = "bench-press",
+            estimatedPerCableKg = 100f,
+            mvtUsedMs = 0.3f,
+            r2 = 0.98f,
+            distinctLoads = 4,
+            passedQualityGate = true,
+            computedAt = 1000L,
+            profileId = "default",
+        )
+
+        val routineExercise = RoutineExercise(
+            id = "routine-ex-1rm",
+            exercise = testExercise,
+            orderIndex = 0,
+            weightPerCableKg = 30f,
+            usePercentOfPR = true,
+            weightPercentOfPR = 80,
+            scalingBasis = ScalingBasis.ESTIMATED_1RM,
+            programMode = ProgramMode.OldSchool,
+        )
+
+        val result = useCase(routineExercise)
+
+        // 80% of 100 = 80 kg
+        assertEquals(80f, result.baseWeight)
+        assertEquals(100f, result.usedPR)
+        assertEquals(80, result.percentOfPR)
+        assertTrue(result.isFromPR)
+        assertNull(result.fallbackReason)
+    }
+
+    @Test
+    fun `ESTIMATED_1RM falls back to stored 1RM when no estimate exists`() = runTest {
+        // Given: velocity repo returns null; exercise has oneRepMaxKg = 120f
+        velocityRepository.latestPassing = null
+        exerciseRepository.addExercise(testExercise.copy(oneRepMaxKg = 120f))
+
+        val routineExercise = RoutineExercise(
+            id = "routine-ex-1rm-fallback",
+            exercise = testExercise,
+            orderIndex = 0,
+            weightPerCableKg = 30f,
+            usePercentOfPR = true,
+            weightPercentOfPR = 80,
+            scalingBasis = ScalingBasis.ESTIMATED_1RM,
+            programMode = ProgramMode.OldSchool,
+        )
+
+        val result = useCase(routineExercise)
+
+        // 80% of 120 = 96 kg
+        assertEquals(96f, result.baseWeight)
+        assertEquals(120f, result.usedPR)
+        assertEquals(80, result.percentOfPR)
+        assertTrue(result.isFromPR)
+        assertNull(result.fallbackReason)
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/DWSMTestHarness.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/DWSMTestHarness.kt
@@ -65,7 +65,7 @@ class DWSMTestHarness(val testScope: TestScope) {
     val fakeEquipmentRackRepo = SettingsEquipmentRackRepository(MapSettings())
 
     val repCounter = RepCounterFromMachine()
-    val resolveWeightsUseCase = ResolveRoutineWeightsUseCase(fakePRRepo, fakeExerciseRepo)
+    val resolveWeightsUseCase = ResolveRoutineWeightsUseCase(fakePRRepo, fakeExerciseRepo, FakeVelocityOneRepMaxRepository())
     val applyRoutineModifierUseCase = ApplyRoutineModifierUseCase(fakePRRepo, fakeExerciseRepo)
     val recommendWeightAdjustmentUseCase = RecommendWeightAdjustmentUseCase()
     val applyEquipmentRackLoadUseCase = ApplyEquipmentRackLoadUseCase()

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakePreferencesManager.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakePreferencesManager.kt
@@ -166,4 +166,8 @@ class FakePreferencesManager : PreferencesManager {
     override suspend fun setDefaultScalingBasis(basis: ScalingBasis) {
         _preferencesFlow.value = _preferencesFlow.value.copy(defaultScalingBasis = basis)
     }
+
+    override suspend fun setVelocityOneRepMaxBackfillDone(done: Boolean) {
+        _preferencesFlow.value = _preferencesFlow.value.copy(velocityOneRepMaxBackfillDone = done)
+    }
 }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakePreferencesManager.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakePreferencesManager.kt
@@ -3,6 +3,7 @@ package com.devil.phoenixproject.testutil
 import com.devil.phoenixproject.data.preferences.JustLiftDefaults
 import com.devil.phoenixproject.data.preferences.PreferencesManager
 import com.devil.phoenixproject.data.preferences.SingleExerciseDefaults
+import com.devil.phoenixproject.domain.model.ScalingBasis
 import com.devil.phoenixproject.domain.model.UserPreferences
 import com.devil.phoenixproject.domain.model.WeightUnit
 import com.devil.phoenixproject.util.BackupDestination
@@ -160,5 +161,9 @@ class FakePreferencesManager : PreferencesManager {
 
     override suspend fun setWeightSuggestionsEnabled(enabled: Boolean) {
         _preferencesFlow.value = _preferencesFlow.value.copy(weightSuggestionsEnabled = enabled)
+    }
+
+    override suspend fun setDefaultScalingBasis(basis: ScalingBasis) {
+        _preferencesFlow.value = _preferencesFlow.value.copy(defaultScalingBasis = basis)
     }
 }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeVelocityOneRepMaxRepository.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeVelocityOneRepMaxRepository.kt
@@ -13,9 +13,12 @@ import kotlinx.coroutines.flow.flowOf
  */
 class FakeVelocityOneRepMaxRepository : VelocityOneRepMaxRepository {
     var latestPassing: VelocityOneRepMaxEntity? = null
+    var allPassing: List<VelocityOneRepMaxEntity> = emptyList()
 
     override suspend fun getLatestPassing(exerciseId: String, profileId: String): VelocityOneRepMaxEntity? =
         latestPassing?.takeIf { it.exerciseId == exerciseId && it.profileId == profileId }
+    override suspend fun getAllPassing(profileId: String): List<VelocityOneRepMaxEntity> =
+        allPassing.filter { it.profileId == profileId }
     override fun getHistory(exerciseId: String, profileId: String): Flow<List<VelocityOneRepMaxEntity>> = flowOf(emptyList())
     override suspend fun insert(result: VelocityOneRepMaxResult, exerciseId: String, computedAt: Long, profileId: String) = Unit
 }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeVelocityOneRepMaxRepository.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeVelocityOneRepMaxRepository.kt
@@ -20,5 +20,6 @@ class FakeVelocityOneRepMaxRepository : VelocityOneRepMaxRepository {
     override suspend fun getAllPassing(profileId: String): List<VelocityOneRepMaxEntity> =
         allPassing.filter { it.profileId == profileId }
     override fun getHistory(exerciseId: String, profileId: String): Flow<List<VelocityOneRepMaxEntity>> = flowOf(emptyList())
+    // Note: no-op — set allPassing/latestPassing directly for read tests.
     override suspend fun insert(result: VelocityOneRepMaxResult, exerciseId: String, computedAt: Long, profileId: String) = Unit
 }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeVelocityOneRepMaxRepository.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeVelocityOneRepMaxRepository.kt
@@ -8,12 +8,14 @@ import kotlinx.coroutines.flow.flowOf
 
 /**
  * Fake VelocityOneRepMaxRepository for testing.
- * Set [latestPassing] to control what [getLatestPassing] returns.
+ * Set [latestPassing] to control what [getLatestPassing] returns; it is only returned
+ * when the requested exerciseId/profileId match the configured entity's ids.
  */
 class FakeVelocityOneRepMaxRepository : VelocityOneRepMaxRepository {
     var latestPassing: VelocityOneRepMaxEntity? = null
 
-    override suspend fun getLatestPassing(exerciseId: String, profileId: String): VelocityOneRepMaxEntity? = latestPassing
+    override suspend fun getLatestPassing(exerciseId: String, profileId: String): VelocityOneRepMaxEntity? =
+        latestPassing?.takeIf { it.exerciseId == exerciseId && it.profileId == profileId }
     override fun getHistory(exerciseId: String, profileId: String): Flow<List<VelocityOneRepMaxEntity>> = flowOf(emptyList())
     override suspend fun insert(result: VelocityOneRepMaxResult, exerciseId: String, computedAt: Long, profileId: String) = Unit
 }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeVelocityOneRepMaxRepository.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeVelocityOneRepMaxRepository.kt
@@ -1,0 +1,19 @@
+package com.devil.phoenixproject.testutil
+
+import com.devil.phoenixproject.data.repository.VelocityOneRepMaxEntity
+import com.devil.phoenixproject.data.repository.VelocityOneRepMaxRepository
+import com.devil.phoenixproject.domain.onerepmax.VelocityOneRepMaxResult
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+
+/**
+ * Fake VelocityOneRepMaxRepository for testing.
+ * Set [latestPassing] to control what [getLatestPassing] returns.
+ */
+class FakeVelocityOneRepMaxRepository : VelocityOneRepMaxRepository {
+    var latestPassing: VelocityOneRepMaxEntity? = null
+
+    override suspend fun getLatestPassing(exerciseId: String, profileId: String): VelocityOneRepMaxEntity? = latestPassing
+    override fun getHistory(exerciseId: String, profileId: String): Flow<List<VelocityOneRepMaxEntity>> = flowOf(emptyList())
+    override suspend fun insert(result: VelocityOneRepMaxResult, exerciseId: String, computedAt: Long, profileId: String) = Unit
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeVelocityOneRepMaxRepository.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeVelocityOneRepMaxRepository.kt
@@ -15,6 +15,13 @@ class FakeVelocityOneRepMaxRepository : VelocityOneRepMaxRepository {
     var latestPassing: VelocityOneRepMaxEntity? = null
     var allPassing: List<VelocityOneRepMaxEntity> = emptyList()
 
+    /**
+     * Issue #517 Phase 5 T1: controls what [hasEstimates] returns. Default is false
+     * (no estimates on record). Override in tests that exercise the "already has
+     * estimates" branch.
+     */
+    var hasEstimatesResult: Boolean = false
+
     override suspend fun getLatestPassing(exerciseId: String, profileId: String): VelocityOneRepMaxEntity? =
         latestPassing?.takeIf { it.exerciseId == exerciseId && it.profileId == profileId }
     override suspend fun getAllPassing(profileId: String): List<VelocityOneRepMaxEntity> =
@@ -22,4 +29,5 @@ class FakeVelocityOneRepMaxRepository : VelocityOneRepMaxRepository {
     override fun getHistory(exerciseId: String, profileId: String): Flow<List<VelocityOneRepMaxEntity>> = flowOf(emptyList())
     // Note: no-op — set allPassing/latestPassing directly for read tests.
     override suspend fun insert(result: VelocityOneRepMaxResult, exerciseId: String, computedAt: Long, profileId: String) = Unit
+    override suspend fun hasEstimates(exerciseId: String, profileId: String): Boolean = hasEstimatesResult
 }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeWorkoutRepository.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeWorkoutRepository.kt
@@ -282,4 +282,15 @@ class FakeWorkoutRepository : WorkoutRepository {
                 workingReps = s.workingReps,
             )
         }
+
+    override suspend fun getExerciseIdsWithVelocityData(profileId: String): List<String> =
+        sessions.values
+            .filter { s ->
+                s.profileId == profileId &&
+                    s.avgMcvMmS != null &&
+                    s.workingReps > 0 &&
+                    s.exerciseId != null
+            }
+            .map { it.exerciseId!! }
+            .distinct()
 }

--- a/shared/src/iosMain/kotlin/com/devil/phoenixproject/di/PlatformModule.ios.kt
+++ b/shared/src/iosMain/kotlin/com/devil/phoenixproject/di/PlatformModule.ios.kt
@@ -124,6 +124,7 @@ actual val platformModule: Module = module {
             recordPersonalMvtSampleUseCase = get(),
             velocityOneRepMaxRepository = get(),
             countVelocityOneRepMaxImprovementsUseCase = get(),
+            backfillVelocityOneRepMaxUseCase = get(),
         )
     }
 }

--- a/shared/src/iosMain/kotlin/com/devil/phoenixproject/di/PlatformModule.ios.kt
+++ b/shared/src/iosMain/kotlin/com/devil/phoenixproject/di/PlatformModule.ios.kt
@@ -123,6 +123,7 @@ actual val platformModule: Module = module {
             computeVelocityOneRepMaxUseCase = get(),
             recordPersonalMvtSampleUseCase = get(),
             velocityOneRepMaxRepository = get(),
+            countVelocityOneRepMaxImprovementsUseCase = get(),
         )
     }
 }


### PR DESCRIPTION
## Velocity-1RM — review fixes + Phases 3–5 (mobile) · #517

Completes the **mobile** side of velocity-based 1RM on top of the merged foundation (#597). One branch so it merges together. (Phase 6 — phoenix-portal parity — lives in the other repo and is tracked separately.)

### A — post-merge fixes (from #597's automated reviews)
- **P1 / upgrade-critical:** SQLDelight `version` was left at 36 despite migrations 36/37 → bumped (now **39** with Phase 3's migration) so upgrades run deterministically.
- **HIGH:** `RecordPersonalMvtSampleUseCase` `<= 0f` let `NaN` corrupt the personal-MVT mean → guarded with `!(x > 0f)` + test.
- **P2:** manual-stop sets persisted null MCV → now populate `avgMcvMmS` from the biomechanics summary, mirroring the normal path.

### B — Phase 3: `% of 1RM` scaling basis
Additive `ScalingBasis { MAX_WEIGHT_PR, MAX_VOLUME_PR, ESTIMATED_1RM }` + a nullable `RoutineExercise.scalingBasis` column (migration 38, schema **v39**). The **synced** `prTypeForScaling` is untouched (`effectiveScalingBasis` derives from it when null). `ESTIMATED_1RM` resolves: latest passing velocity estimate → stored 1RM → max-weight PR → absolute. System-wide `defaultScalingBasis` preference seeds new exercises; per-exercise 3-way selector + settings control; backup/restore round-trips the field.

### C — Phase 4: distinct velocity-1RM badges
Tiered `STRENGTH` badges (1/5/15 cumulative improvements; an "improvement" = a passing estimate ≥ that exercise's prior best × 1.025), counted statelessly from history and awarded via the existing gamification flow from the post-save hook. No schema change.

### D — Phase 5: one-time historical backfill
On first launch after update (background, off the critical path), computes a current velocity-1RM per already-trained exercise from **all** MCV history. Idempotent: a run-once flag + per-exercise skip. Awaits the loaded active profile before running. No schema change.

### Testing
Full `:shared:testAndroidHostTest` suite green; `:androidApp:assembleDebug` builds. Every task TDD'd, per-task reviewed + fixed, and each phase got a phase-level review.

### Known / deferred
- **Portal parity (Phase 6, `phoenix-portal` repo):** `scalingBasis` is intentionally null on sync push; the portal still scales off `prTypeForScaling`, so mobile/portal weights can diverge until portal parity lands. Expected, not a sync bug.
- **Backfill is keyed by a global run-once flag**, so a multi-profile user gets their *first-active* profile backfilled; other profiles populate from new workouts going forward (acceptable per the one-time design).
- **Manual device handoffs (no Compose UI test harness):** verify the basis selectors, the "VELOCITY 1RM" display, that workout-start weights resolve from the estimate, badge awards, and that backfill populates estimates for an existing-history user.
- Personalized-MVT capture currently uses set-average MCV rather than last-rep RIR≈0 velocity (gated ≥3 samples; defaults dominate until refined).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
