### PR TITLE
feat(1rm): send velocity-estimated 1RM in exercise sync DTO (#517)

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapter.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapter.kt
@@ -76,13 +76,26 @@ object PortalSyncAdapter {
      */
     data class PortalSessionBuildResult(val sessions: List<PortalWorkoutSessionDto>, val telemetry: List<PortalRepTelemetryDto>)
 
-    fun toPortalWorkoutSessions(sessionsWithReps: List<SessionWithReps>, userId: String): List<PortalWorkoutSessionDto> = toPortalWorkoutSessionsWithTelemetry(sessionsWithReps, userId).sessions
+    fun toPortalWorkoutSessions(
+        sessionsWithReps: List<SessionWithReps>,
+        userId: String,
+        velocityEstimatesByExerciseId: Map<String, Float> = emptyMap(),
+    ): List<PortalWorkoutSessionDto> = toPortalWorkoutSessionsWithTelemetry(sessionsWithReps, userId, velocityEstimatesByExerciseId).sessions
 
     /**
      * Build portal workout sessions AND correctly-keyed telemetry in one pass.
      * Telemetry setIds are guaranteed to match the generated set IDs in the exercises.
+     *
+     * [velocityEstimatesByExerciseId] maps catalog exerciseId → latest passing
+     * velocity-based 1RM (per-cable kg). The caller (SyncManager) precomputes it
+     * from VelocityOneRepMaxRepository in a suspend context; the adapter stays
+     * pure. Exercises not present in the map get a null velocity estimate.
      */
-    fun toPortalWorkoutSessionsWithTelemetry(sessionsWithReps: List<SessionWithReps>, userId: String): PortalSessionBuildResult {
+    fun toPortalWorkoutSessionsWithTelemetry(
+        sessionsWithReps: List<SessionWithReps>,
+        userId: String,
+        velocityEstimatesByExerciseId: Map<String, Float> = emptyMap(),
+    ): PortalSessionBuildResult {
         // Group: null routineSessionId = standalone, non-null = routine group
         val standalone = sessionsWithReps.filter { it.session.routineSessionId == null }
         val routineGroups = sessionsWithReps
@@ -94,14 +107,14 @@ object PortalSyncAdapter {
 
         // Standalone sessions: each becomes its own portal workout
         for (swr in standalone) {
-            val (session, telemetry) = buildPortalSession(listOf(swr), userId, routineSessionId = null)
+            val (session, telemetry) = buildPortalSession(listOf(swr), userId, routineSessionId = null, velocityEstimatesByExerciseId)
             resultSessions.add(session)
             resultTelemetry.addAll(telemetry)
         }
 
         // Routine groups: each group becomes one portal workout
         for ((routineSessionId, group) in routineGroups) {
-            val (session, telemetry) = buildPortalSession(group, userId, routineSessionId)
+            val (session, telemetry) = buildPortalSession(group, userId, routineSessionId, velocityEstimatesByExerciseId)
             resultSessions.add(session)
             resultTelemetry.addAll(telemetry)
         }
@@ -113,6 +126,7 @@ object PortalSyncAdapter {
         sessionsWithReps: List<SessionWithReps>,
         userId: String,
         routineSessionId: String?,
+        velocityEstimatesByExerciseId: Map<String, Float> = emptyMap(),
     ): Pair<PortalWorkoutSessionDto, List<PortalRepTelemetryDto>> {
         val sorted = sessionsWithReps.sortedBy { it.session.timestamp }
         val first = sorted.first().session
@@ -135,7 +149,7 @@ object PortalSyncAdapter {
 
         // Build exercise entries with telemetry (setIds are generated inside)
         val exerciseBundles = sorted.mapIndexed { index, swr ->
-            buildPortalExerciseWithTelemetry(swr, portalSessionId, index)
+            buildPortalExerciseWithTelemetry(swr, portalSessionId, index, velocityEstimatesByExerciseId)
         }
         val exercises = exerciseBundles.map { it.exercise }
         val telemetry = exerciseBundles.flatMap { it.telemetry }
@@ -241,7 +255,12 @@ object PortalSyncAdapter {
      * The generated setId is shared between the set DTO and the telemetry points,
      * ensuring FK consistency when inserted into the portal database.
      */
-    private fun buildPortalExerciseWithTelemetry(swr: SessionWithReps, portalSessionId: String, orderIndex: Int): ExerciseWithTelemetry {
+    private fun buildPortalExerciseWithTelemetry(
+        swr: SessionWithReps,
+        portalSessionId: String,
+        orderIndex: Int,
+        velocityEstimatesByExerciseId: Map<String, Float> = emptyMap(),
+    ): ExerciseWithTelemetry {
         val session = swr.session
         // Use stable mobile session ID as exercise ID so repeated syncs
         // upsert the same row instead of creating duplicates (issue #33).
@@ -292,6 +311,10 @@ object PortalSyncAdapter {
                 session.weightPerCableKg,
                 session.totalReps,
             ).takeIf { it > 0f },
+            // Velocity-based (VBT) estimate, looked up by catalog exerciseId from
+            // the precomputed map. Distinct from the rep-based estimate above; null
+            // when this exercise has no exerciseId or no passing velocity estimate.
+            velocityEstimatedOneRepMaxKg = session.exerciseId?.let { velocityEstimatesByExerciseId[it] },
             sets = listOf(set),
         )
         return ExerciseWithTelemetry(exercise, telemetry)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncDtos.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncDtos.kt
@@ -90,6 +90,17 @@ data class PortalExerciseDto(
      * only recomputes when this field is absent (legacy payloads).
      */
     val estimatedOneRepMaxKg: Float? = null,
+    /**
+     * Velocity-based (VBT) estimated 1RM (per-cable kg) for this exercise,
+     * computed on-device from BLE mean concentric velocity (see
+     * VelocityOneRepMaxEstimator). This is a SEPARATE metric from the rep-based
+     * [estimatedOneRepMaxKg] (Brzycki/Epley hybrid) and must never overwrite it.
+     * It is the latest passing estimate for this exercise/profile at push time
+     * (a rolling current value, not as-of-session). Null when the exercise has
+     * no exerciseId or no passing velocity estimate. The portal stores this
+     * verbatim in exercise_progress.velocity_estimated_1rm_kg and never recomputes.
+     */
+    val velocityEstimatedOneRepMaxKg: Float? = null,
     val sets: List<PortalSetDto> = emptyList(),
 )
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/SyncManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/SyncManager.kt
@@ -9,6 +9,7 @@ import com.devil.phoenixproject.data.repository.RepMetricRepository
 import com.devil.phoenixproject.data.repository.SubscriptionStatus
 import com.devil.phoenixproject.data.repository.SyncRepository
 import com.devil.phoenixproject.data.repository.UserProfileRepository
+import com.devil.phoenixproject.data.repository.VelocityOneRepMaxRepository
 import com.devil.phoenixproject.domain.model.CharacterClass
 import com.devil.phoenixproject.domain.model.IntegrationProvider
 import com.devil.phoenixproject.domain.model.RpgProfile
@@ -127,6 +128,7 @@ class SyncManager(
     private val repMetricRepository: RepMetricRepository,
     private val userProfileRepository: UserProfileRepository,
     private val externalActivityRepository: ExternalActivityRepository,
+    private val velocityOneRepMaxRepository: VelocityOneRepMaxRepository,
     private val rateLimiter: ClientRateLimiter = ClientRateLimiter(),
 ) {
     companion object {
@@ -761,10 +763,25 @@ class SyncManager(
         // exercise IDs may be missing remotely even after a successful sync.
         val customExerciseDtos = syncRepository.getCustomExercisesModifiedSince(0L)
 
-        // 7. Build portal session + telemetry DTOs (telemetry setIds match generated exercise set IDs)
+        // 7. Build the velocity-based 1RM map (catalog exerciseId → latest passing
+        // per-cable estimate) for the exercises in this push. Looked up here (suspend
+        // context with repo + profile) so the pure adapter just attaches the value.
+        // Distinct from the rep-based estimate the adapter computes inline.
+        val velocityEstimatesByExerciseId = sessionsWithReps
+            .mapNotNull { it.session.exerciseId }
+            .distinct()
+            .mapNotNull { exId ->
+                velocityOneRepMaxRepository.getLatestPassing(exId, activeProfileId)
+                    ?.estimatedPerCableKg
+                    ?.let { exId to it }
+            }
+            .toMap()
+
+        // 7b. Build portal session + telemetry DTOs (telemetry setIds match generated exercise set IDs)
         val buildResult = PortalSyncAdapter.toPortalWorkoutSessionsWithTelemetry(
             sessionsWithReps,
             userId,
+            velocityEstimatesByExerciseId,
         )
 
         // Gate telemetry push behind the Inferno tier. Force-curve / 50 Hz session

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/SyncManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/SyncManager.kt
@@ -764,16 +764,24 @@ class SyncManager(
         val customExerciseDtos = syncRepository.getCustomExercisesModifiedSince(0L)
 
         // 7. Build the velocity-based 1RM map (catalog exerciseId → latest passing
-        // per-cable estimate) for the exercises in this push. Looked up here (suspend
-        // context with repo + profile) so the pure adapter just attaches the value.
-        // Distinct from the rep-based estimate the adapter computes inline.
-        val velocityEstimatesByExerciseId = sessionsWithReps
-            .mapNotNull { it.session.exerciseId }
-            .distinct()
-            .mapNotNull { exId ->
-                velocityOneRepMaxRepository.getLatestPassing(exId, activeProfileId)
-                    ?.estimatedPerCableKg
-                    ?.let { exId to it }
+        // per-cable estimate). Looked up here (suspend context with repo + profile)
+        // so the pure adapter just attaches the value. Distinct from the rep-based
+        // estimate the adapter computes inline.
+        //
+        // Single query for the whole profile (getAllPassing) instead of one
+        // getLatestPassing per distinct exercise — avoids an N+1 during full sync.
+        // getAllPassing returns the full passing history; pick the latest per
+        // exercise with the SAME ordering as getLatestPassing (computedAt DESC,
+        // then id DESC as the tie-break) so the two paths agree exactly. The
+        // adapter only reads keys for exercises actually in this push, so a
+        // superset map is harmless.
+        val velocityEstimatesByExerciseId = velocityOneRepMaxRepository
+            .getAllPassing(activeProfileId)
+            .groupBy { it.exerciseId }
+            .mapNotNull { (exId, estimates) ->
+                estimates
+                    .maxWithOrNull(compareBy({ it.computedAt }, { it.id }))
+                    ?.let { exId to it.estimatedPerCableKg }
             }
             .toMap()
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/di/SyncModule.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/di/SyncModule.kt
@@ -31,6 +31,7 @@ val syncModule = module {
             repMetricRepository = get(),
             userProfileRepository = get(),
             externalActivityRepository = get(),
+            velocityOneRepMaxRepository = get(),
         )
     }
     single<HealthBodyWeightReader> { HealthIntegrationBodyWeightReader(get()) }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/PortalPullPaginationTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/PortalPullPaginationTest.kt
@@ -6,6 +6,7 @@ import com.devil.phoenixproject.testutil.FakePortalApiClient
 import com.devil.phoenixproject.testutil.FakeRepMetricRepository
 import com.devil.phoenixproject.testutil.FakeSyncRepository
 import com.devil.phoenixproject.testutil.FakeUserProfileRepository
+import com.devil.phoenixproject.testutil.FakeVelocityOneRepMaxRepository
 import com.russhwolf.settings.MapSettings
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -41,6 +42,7 @@ class PortalPullPaginationTest {
     private val fakeRepMetricRepo = FakeRepMetricRepository()
     private val fakeUserProfileRepo = FakeUserProfileRepository()
     private val fakeExternalActivityRepo = FakeExternalActivityRepository()
+    private val fakeVelocityRepo = FakeVelocityOneRepMaxRepository()
 
     private fun createManager() = SyncManager(
         apiClient = fakeApi,
@@ -50,6 +52,7 @@ class PortalPullPaginationTest {
         repMetricRepository = fakeRepMetricRepo,
         userProfileRepository = fakeUserProfileRepo,
         externalActivityRepository = fakeExternalActivityRepo,
+        velocityOneRepMaxRepository = fakeVelocityRepo,
     )
 
     private fun authenticate(userId: String = "user-123") {

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/PortalPushLimitsTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/PortalPushLimitsTest.kt
@@ -10,6 +10,7 @@ import com.devil.phoenixproject.testutil.FakePortalApiClient
 import com.devil.phoenixproject.testutil.FakeRepMetricRepository
 import com.devil.phoenixproject.testutil.FakeSyncRepository
 import com.devil.phoenixproject.testutil.FakeUserProfileRepository
+import com.devil.phoenixproject.testutil.FakeVelocityOneRepMaxRepository
 import com.russhwolf.settings.MapSettings
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -41,6 +42,7 @@ class PortalPushLimitsTest {
     private val fakeRepMetricRepo = FakeRepMetricRepository()
     private val fakeUserProfileRepo = FakeUserProfileRepository()
     private val fakeExternalActivityRepo = FakeExternalActivityRepository()
+    private val fakeVelocityRepo = FakeVelocityOneRepMaxRepository()
 
     private fun createManager() = SyncManager(
         apiClient = fakeApi,
@@ -50,6 +52,7 @@ class PortalPushLimitsTest {
         repMetricRepository = fakeRepMetricRepo,
         userProfileRepository = fakeUserProfileRepo,
         externalActivityRepository = fakeExternalActivityRepo,
+        velocityOneRepMaxRepository = fakeVelocityRepo,
     )
 
     private fun authenticate(userId: String = "user-123") {
@@ -220,6 +223,7 @@ class PortalPushLimitsTest {
             repMetricRepository = fakeRepMetricRepo,
             userProfileRepository = fakeUserProfileRepo,
             externalActivityRepository = fakeExternalActivityRepo,
+            velocityOneRepMaxRepository = fakeVelocityRepo,
         )
 
         mgr.sync()
@@ -253,6 +257,7 @@ class PortalPushLimitsTest {
             repMetricRepository = fakeRepMetricRepo,
             userProfileRepository = fakeUserProfileRepo,
             externalActivityRepository = fakeExternalActivityRepo,
+            velocityOneRepMaxRepository = fakeVelocityRepo,
         )
 
         mgr.sync()
@@ -322,6 +327,7 @@ class PortalPushLimitsTest {
             repMetricRepository = fakeRepMetricRepo,
             userProfileRepository = fakeUserProfileRepo,
             externalActivityRepository = fakeExternalActivityRepo,
+            velocityOneRepMaxRepository = fakeVelocityRepo,
         )
 
         val result = mgr.sync()
@@ -359,6 +365,7 @@ class PortalPushLimitsTest {
             repMetricRepository = fakeRepMetricRepo,
             userProfileRepository = fakeUserProfileRepo,
             externalActivityRepository = fakeExternalActivityRepo,
+            velocityOneRepMaxRepository = fakeVelocityRepo,
         )
 
         mgr.sync()

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapterTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapterTest.kt
@@ -1015,12 +1015,89 @@ class PortalSyncAdapterTest {
         assertTrue(abs(estimate - 67.5f) < 0.01f, "expected 67.5, got $estimate")
     }
 
+    // ========== Velocity-estimated 1RM in sync payload (Phase 6) ==========
+
+    @Test
+    fun `exercise dto carries velocity estimate from the map keyed by catalog exerciseId`() {
+        val sessions = listOf(
+            makeSessionWithReps(
+                sessionId = "s1",
+                routineSessionId = null,
+                exerciseName = "Bench Press",
+                exerciseId = "ex1",
+                weightPerCableKg = 60f,
+                totalReps = 5,
+            ),
+        )
+
+        val result = PortalSyncAdapter.toPortalWorkoutSessions(
+            sessions,
+            "user-1",
+            velocityEstimatesByExerciseId = mapOf("ex1" to 92f),
+        )
+
+        val exercise = result[0].exercises[0]
+        assertFloatEquals(92f, exercise.velocityEstimatedOneRepMaxKg!!)
+        // Rep-based estimate is still computed independently: 60 * 36 / 32 = 67.5
+        assertNotNull(exercise.estimatedOneRepMaxKg)
+        assertFloatEquals(67.5f, exercise.estimatedOneRepMaxKg!!)
+    }
+
+    @Test
+    fun `exercise dto velocity estimate is null when not in the map`() {
+        val sessions = listOf(
+            makeSessionWithReps(
+                sessionId = "s1",
+                exerciseName = "Bench Press",
+                exerciseId = "ex1",
+            ),
+        )
+
+        // Map has a different exercise; the rep-based estimate must be unaffected.
+        val result = PortalSyncAdapter.toPortalWorkoutSessions(
+            sessions,
+            "user-1",
+            velocityEstimatesByExerciseId = mapOf("other-ex" to 80f),
+        )
+
+        val exercise = result[0].exercises[0]
+        assertNull(exercise.velocityEstimatedOneRepMaxKg)
+        assertNotNull(exercise.estimatedOneRepMaxKg)
+    }
+
+    @Test
+    fun `exercise dto velocity estimate is null when exerciseId is null`() {
+        val sessions = listOf(
+            makeSessionWithReps(sessionId = "s1", exerciseName = "Bench Press", exerciseId = null),
+        )
+
+        val result = PortalSyncAdapter.toPortalWorkoutSessions(
+            sessions,
+            "user-1",
+            velocityEstimatesByExerciseId = mapOf("ex1" to 92f),
+        )
+
+        assertNull(result[0].exercises[0].velocityEstimatedOneRepMaxKg)
+    }
+
+    @Test
+    fun `exercise dto velocity estimate defaults to null with no map argument`() {
+        val sessions = listOf(
+            makeSessionWithReps(sessionId = "s1", exerciseName = "Bench Press", exerciseId = "ex1"),
+        )
+
+        val result = PortalSyncAdapter.toPortalWorkoutSessions(sessions, "user-1")
+
+        assertNull(result[0].exercises[0].velocityEstimatedOneRepMaxKg)
+    }
+
     // ========== Factory Helpers ==========
 
     private fun makeSessionWithReps(
         sessionId: String = "session-${idCounter++}",
         routineSessionId: String? = null,
         exerciseName: String? = "Test Exercise",
+        exerciseId: String? = null,
         routineName: String? = null,
         mode: String = "Old School",
         timestamp: Long = 1700000000000L + (idCounter * 1000),
@@ -1044,6 +1121,7 @@ class PortalSyncAdapterTest {
             duration = durationMs,
             totalReps = totalReps,
             exerciseName = exerciseName,
+            exerciseId = exerciseId,
             routineSessionId = routineSessionId,
             routineName = routineName,
             totalVolumeKg = totalVolumeKg,

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/PortalTokenRefreshTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/PortalTokenRefreshTest.kt
@@ -7,6 +7,7 @@ import com.devil.phoenixproject.testutil.FakePortalApiClient
 import com.devil.phoenixproject.testutil.FakeRepMetricRepository
 import com.devil.phoenixproject.testutil.FakeSyncRepository
 import com.devil.phoenixproject.testutil.FakeUserProfileRepository
+import com.devil.phoenixproject.testutil.FakeVelocityOneRepMaxRepository
 import com.russhwolf.settings.MapSettings
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -46,6 +47,7 @@ class PortalTokenRefreshTest {
     private val fakeRepMetricRepo = FakeRepMetricRepository()
     private val fakeUserProfileRepo = FakeUserProfileRepository()
     private val fakeExternalActivityRepo = FakeExternalActivityRepository()
+    private val fakeVelocityRepo = FakeVelocityOneRepMaxRepository()
 
     private fun createManager() = SyncManager(
         apiClient = fakeApi,
@@ -55,6 +57,7 @@ class PortalTokenRefreshTest {
         repMetricRepository = fakeRepMetricRepo,
         userProfileRepository = fakeUserProfileRepo,
         externalActivityRepository = fakeExternalActivityRepo,
+        velocityOneRepMaxRepository = fakeVelocityRepo,
     )
 
     // ==================== isTokenExpired Buffer ====================

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/SyncManagerTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/SyncManagerTest.kt
@@ -5,6 +5,7 @@ import com.devil.phoenixproject.data.repository.SubscriptionStatus
 import com.devil.phoenixproject.domain.model.Exercise
 import com.devil.phoenixproject.domain.model.ExternalActivity
 import com.devil.phoenixproject.domain.model.IntegrationProvider
+import com.devil.phoenixproject.data.repository.VelocityOneRepMaxEntity
 import com.devil.phoenixproject.domain.model.PRType
 import com.devil.phoenixproject.domain.model.PersonalRecord
 import com.devil.phoenixproject.domain.model.Routine
@@ -434,6 +435,83 @@ class SyncManagerTest {
             "Legacy set-level hint should prefer the normal concentric weight PR when present",
         )
     }
+
+    @Test
+    fun syncAttachesLatestPassingVelocityEstimateToExerciseDto() = runTest {
+        // Issue #517 Phase 6: the push payload's exercise DTO carries the velocity-
+        // based 1RM from getAllPassing, picking the LATEST passing estimate per
+        // exercise (max computedAt) — same ordering as getLatestPassing. An exercise
+        // with no passing estimate stays null.
+        setupAuthenticated()
+        val withEstimate = "bench-press"
+        val withoutEstimate = "row"
+        val timestamp = 1_740_916_800_000L
+        fakeSyncRepo.workoutSessionsToReturn = listOf(
+            makeWorkoutSession(
+                id = "session-vel-1",
+                timestamp = timestamp,
+                exerciseId = withEstimate,
+                exerciseName = "Bench Press",
+            ),
+            makeWorkoutSession(
+                id = "session-vel-2",
+                timestamp = timestamp + 1000L,
+                exerciseId = withoutEstimate,
+                exerciseName = "Row",
+            ),
+        )
+        // Two passing estimates for the same exercise; the newer (computedAt) wins.
+        fakeVelocityRepo.allPassing = listOf(
+            makeVelocityEntity(
+                id = 1,
+                exerciseId = withEstimate,
+                estimatedPerCableKg = 80f,
+                computedAt = 1_000L,
+            ),
+            makeVelocityEntity(
+                id = 2,
+                exerciseId = withEstimate,
+                estimatedPerCableKg = 95f,
+                computedAt = 2_000L,
+            ),
+        )
+        fakeApi.pushResult = Result.success(
+            PortalSyncPushResponse(syncTime = "2026-03-02T12:00:00Z"),
+        )
+
+        val result = createManager().sync()
+
+        assertTrue(result.isSuccess)
+        val payload = assertNotNull(fakeApi.lastPushPayload, "Push payload should be captured")
+        val exercises = payload.sessions.flatMap { it.exercises }
+        assertEquals(
+            95f,
+            exercises.single { it.exerciseId == withEstimate }.velocityEstimatedOneRepMaxKg,
+            "Latest passing velocity estimate (max computedAt) should be attached",
+        )
+        assertNull(
+            exercises.single { it.exerciseId == withoutEstimate }.velocityEstimatedOneRepMaxKg,
+            "Exercise with no passing estimate should have a null velocity 1RM",
+        )
+    }
+
+    private fun makeVelocityEntity(
+        id: Long,
+        exerciseId: String,
+        estimatedPerCableKg: Float,
+        computedAt: Long,
+        profileId: String = "default",
+    ): VelocityOneRepMaxEntity = VelocityOneRepMaxEntity(
+        id = id,
+        exerciseId = exerciseId,
+        estimatedPerCableKg = estimatedPerCableKg,
+        mvtUsedMs = 0.3f,
+        r2 = 0.95f,
+        distinctLoads = 3,
+        passedQualityGate = true,
+        computedAt = computedAt,
+        profileId = profileId,
+    )
 
     @Test
     fun syncStampsPushedPersonalRecordsToPreventResend() = runTest {

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/SyncManagerTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/SyncManagerTest.kt
@@ -17,6 +17,7 @@ import com.devil.phoenixproject.testutil.FakePortalApiClient
 import com.devil.phoenixproject.testutil.FakeRepMetricRepository
 import com.devil.phoenixproject.testutil.FakeSyncRepository
 import com.devil.phoenixproject.testutil.FakeUserProfileRepository
+import com.devil.phoenixproject.testutil.FakeVelocityOneRepMaxRepository
 import com.russhwolf.settings.MapSettings
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -45,6 +46,7 @@ class SyncManagerTest {
     private val fakeRepMetricRepo = FakeRepMetricRepository()
     private val fakeUserProfileRepo = FakeUserProfileRepository()
     private val fakeExternalActivityRepo = FakeExternalActivityRepository()
+    private val fakeVelocityRepo = FakeVelocityOneRepMaxRepository()
     private val json = Json { encodeDefaults = true }
 
     private fun createManager() = SyncManager(
@@ -55,6 +57,7 @@ class SyncManagerTest {
         repMetricRepository = fakeRepMetricRepo,
         userProfileRepository = fakeUserProfileRepo,
         externalActivityRepository = fakeExternalActivityRepo,
+        velocityOneRepMaxRepository = fakeVelocityRepo,
     )
 
     /**


### PR DESCRIPTION
## Phase 6 (mobile half) — velocity-1RM portal display

Mobile side of the cross-repo Phase 6 work for #517. Ships the on-device velocity-based (VBT) 1RM to the portal so it can be displayed **distinctly** from the rep-based formula estimate. Display-only — no weight-programming changes.

### What changed
- **`PortalExerciseDto.velocityEstimatedOneRepMaxKg`** — brand-new, nullable, additive field (per-cable kg), beside the existing rep-based `estimatedOneRepMaxKg`. Never overwrites it.
- **`SyncManager`** precomputes a `catalogExerciseId → latest passing velocity estimate` map (suspend context, via `VelocityOneRepMaxRepository`) and passes it to `PortalSyncAdapter`. Null when the exercise has no `exerciseId` or no passing velocity estimate.
- **`PortalSyncAdapter`** stays a pure `object` — it just attaches the value from the map (no repo dependency, fully unit-testable).
- DI (`SyncModule`) + 4 `SyncManager` test fixtures updated for the new constructor param.

### Notes
- The plan assumed the adapter was DI-constructed; it's a stateless `object`, so I threaded a precomputed map instead (purer + easier to test than fake-repo injection).
- Parity-critical sync-DTO change: the portal PR (9thLevelSoftware/phoenix-portal) consumes `velocityEstimatedOneRepMaxKg` (camelCase wire format). **Land mobile before deploying the portal `mobile-sync-push` change.**

### Verification
- `./gradlew :shared:testAndroidHostTest` — green (4 new adapter tests).
- `./gradlew :androidApp:assembleDebug` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)