### PR TITLE
fix(ble): retry reps notification subscription on GATT busy

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/ble/KableBleConnectionManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/ble/KableBleConnectionManager.kt
@@ -10,6 +10,7 @@ import com.devil.phoenixproject.util.BleConstants
 import com.devil.phoenixproject.util.HardwareDetection
 import com.devil.phoenixproject.util.rethrowIfCancellation
 import com.juul.kable.Advertisement
+import com.juul.kable.Characteristic
 import com.juul.kable.Peripheral
 import com.juul.kable.Scanner
 import com.juul.kable.State
@@ -19,6 +20,7 @@ import kotlin.time.Clock
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.TimeoutCancellationException
@@ -871,94 +873,164 @@ class KableBleConnectionManager(
             connectedDeviceAddress,
         )
 
-        // ===== FIRMWARE VERSION READ (best effort) =====
-        // Try to read firmware version from Device Information Service
-        scope.launch {
-            tryReadFirmwareVersion(p)
-            tryReadVitruvianVersion(p)
-        }
-
-        // ===== CORE NOTIFICATIONS =====
-
         // NOTE: Standard NUS RX (6e400003) does NOT exist on Vitruvian devices.
         // The device uses custom characteristics for notifications instead.
         // Skipping observation of non-existent rxCharacteristic to avoid errors.
         // Command responses (if any) come through device-specific characteristics.
 
-        // Observe REPS characteristic for rep completion events (CRITICAL for rep counting!)
+        // ===== CRITICAL NOTIFICATION: REPS (rep counting) =====
+        // RCA (2026-06-28): Kable issues the reps CCCD (descriptor) write when this
+        // flow is first collected, OUTSIDE BleOperationQueue. If it races another
+        // in-flight GATT op during setup it fails with ERROR_GATT_WRITE_REQUEST_BUSY
+        // and the old code tore the subscription down permanently — rep counting was
+        // silently dead until a manual Bluetooth toggle. We now (1) subscribe reps
+        // FIRST and alone, and (2) retry/resubscribe on transient busy so it
+        // self-heals. [repsReady] completes once the CCCD write lands.
+        val repsReady = CompletableDeferred<Unit>()
         scope.launch {
+            observeRepsWithRetry(p) { repsReady.complete(Unit) }
+        }
+
+        // ===== Everything else waits for the reps CCCD write to land (bounded) =====
+        // Deferring the firmware reads, non-critical observes, and the polling read
+        // flood until reps is subscribed gives the critical CCCD write a
+        // contention-free window, so it normally succeeds on the first attempt.
+        // Fail-open: if reps never subscribes we still start polling after a timeout.
+        scope.launch {
+            withTimeoutOrNull(BleConstants.Timing.REPS_SUBSCRIBE_READY_TIMEOUT_MS) {
+                repsReady.await()
+            }
+            if (peripheral !== p) return@launch // disconnected/replaced while we waited
+
+            // Firmware/version reads (best effort, diagnostic only) — own coroutine so
+            // their up-to-2s timeouts never delay polling start.
+            scope.launch {
+                tryReadFirmwareVersion(p)
+                tryReadVitruvianVersion(p)
+            }
+
+            // Non-critical notifications (logging only): VERSION + MODE.
+            startNonCriticalObserve(p, versionCharacteristic, "VERSION")
+            startNonCriticalObserve(p, modeCharacteristic, "MODE")
+
+            // ===== POLLING (delegated to MetricPollingEngine) =====
+            discoMode.stop()
+            pollingEngine.startAll(p)
+        }
+    }
+
+    /**
+     * Observe the REPS characteristic with bounded busy-retry and automatic
+     * resubscribe (CRITICAL for rep counting).
+     *
+     * The reps notification CCCD (descriptor) write is performed by Kable's
+     * [Peripheral.observe] flow on first collection, OUTSIDE [bleQueue], so it can
+     * race other in-flight GATT operations during connection setup and fail with
+     * Android `ERROR_GATT_WRITE_REQUEST_BUSY` ("WriteRequestBusy"). The previous
+     * implementation caught that error once and let the flow complete, leaving reps
+     * permanently unsubscribed for the whole session. This retries the subscription
+     * (mirroring [BleOperationQueue.write]'s busy-retry) so a transient collision
+     * self-heals instead of requiring the user to toggle Bluetooth.
+     *
+     * @param p the peripheral to observe; the loop exits if it is replaced/disconnected
+     * @param onReady invoked once, when the subscription's CCCD write succeeds
+     */
+    private suspend fun observeRepsWithRetry(p: Peripheral, onReady: () -> Unit) {
+        var attempt = 0
+        while (peripheral === p) {
             try {
-                log.i { "Starting REPS characteristic notifications (rep events)" }
-                p.observe(repsCharacteristic)
-                    .catch { e ->
-                        e.rethrowIfCancellation()
-                        log.e { "Reps observation error: ${e.message}" }
-                        logRepo.error(
-                            LogEventType.ERROR,
-                            "Reps notification error",
-                            connectedDeviceName,
-                            connectedDeviceAddress,
-                            e.message,
-                        )
-                    }
+                log.i { "Starting REPS characteristic notifications (attempt ${attempt + 1})" }
+                p.observe(repsCharacteristic) {
+                    // onSubscription: CCCD write landed — reps notifications are live.
+                    attempt = 0
+                    onReady()
+                    log.i { "REPS notifications enabled" }
+                }
                     .collect { data ->
                         log.d { "REPS notification received: ${data.size} bytes" }
                         onRepEventFromCharacteristic(data)
                     }
+                // Flow completed without error — only happens on cancel/disconnect.
+                return
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
-                e.rethrowIfCancellation()
-                log.e { "Failed to observe Reps: ${e.message}" }
-                logRepo.error(
-                    LogEventType.ERROR,
-                    "Failed to enable Reps notifications",
+                // Connection gone? Stop — a fresh connect() will resubscribe.
+                if (peripheral !== p) {
+                    log.d { "Reps observe stopped: peripheral replaced/disconnected" }
+                    return
+                }
+                attempt++
+                val transient = isTransientObservationError(e)
+                log.e { "Reps observation error (attempt $attempt, transient=$transient): ${e.message}" }
+                if (!transient || attempt >= BleConstants.Timing.REPS_SUBSCRIBE_MAX_ATTEMPTS) {
+                    log.e { "Reps subscription failed permanently after $attempt attempt(s) — rep counting unavailable" }
+                    logRepo.error(
+                        LogEventType.ERROR,
+                        "Rep counting unavailable — reconnect required",
+                        connectedDeviceName,
+                        connectedDeviceAddress,
+                        "${e.message} (after $attempt attempt(s), transient=$transient)",
+                    )
+                    return
+                }
+                logRepo.warning(
+                    LogEventType.NOTIFICATION,
+                    "Reps notification busy — retrying",
                     connectedDeviceName,
                     connectedDeviceAddress,
-                    e.message,
+                    "${e.message} (attempt $attempt/${BleConstants.Timing.REPS_SUBSCRIBE_MAX_ATTEMPTS})",
                 )
+                delay(repsBackoffMs(attempt))
             }
         }
+    }
 
-        // Observe VERSION characteristic (for firmware info logging)
+    /**
+     * Observe a non-critical (logging-only) notification characteristic. Failures
+     * are logged at warn and never affect the connection — unlike reps, these are
+     * not retried because no app behavior depends on them.
+     */
+    private fun startNonCriticalObserve(p: Peripheral, characteristic: Characteristic, label: String) {
         scope.launch {
             try {
-                log.d { "Starting VERSION characteristic notifications" }
-                p.observe(versionCharacteristic)
+                log.d { "Starting $label characteristic notifications" }
+                p.observe(characteristic)
                     .catch { e ->
                         e.rethrowIfCancellation()
-                        log.w { "Version observation error (non-fatal): ${e.message}" }
+                        log.w { "$label observation error (non-fatal): ${e.message}" }
                     }
                     .collect { data ->
-                        val hexString = data.joinToString(" ") { it.toHexString() }
-                        log.i { "VERSION CHARACTERISTIC DATA RECEIVED" }
-                        log.i { "  Size: ${data.size} bytes, Hex: $hexString" }
+                        log.d { "$label notification: ${data.size} bytes" }
                     }
             } catch (e: Exception) {
                 e.rethrowIfCancellation()
-                log.d { "VERSION notifications not available (expected): ${e.message}" }
+                log.d { "$label notifications not available (expected): ${e.message}" }
             }
         }
+    }
 
-        // Observe MODE characteristic (for mode change logging)
-        scope.launch {
-            try {
-                log.d { "Starting MODE characteristic notifications" }
-                p.observe(modeCharacteristic)
-                    .catch { e ->
-                        e.rethrowIfCancellation()
-                        log.w { "Mode observation error (non-fatal): ${e.message}" }
-                    }
-                    .collect { data ->
-                        log.d { "MODE notification: ${data.size} bytes" }
-                    }
-            } catch (e: Exception) {
-                e.rethrowIfCancellation()
-                log.d { "MODE notifications not available (expected): ${e.message}" }
-            }
-        }
+    /**
+     * Exponential backoff (ms) for reps resubscribe attempts: 100, 200, 400, 800,
+     * capped at [BleConstants.Timing.REPS_SUBSCRIBE_BACKOFF_MAX_MS].
+     */
+    internal fun repsBackoffMs(attempt: Int): Long =
+        (BleConstants.Timing.REPS_SUBSCRIBE_BACKOFF_BASE_MS shl (attempt - 1).coerceAtLeast(0))
+            .coerceAtMost(BleConstants.Timing.REPS_SUBSCRIBE_BACKOFF_MAX_MS)
 
-        // ===== POLLING (delegated to MetricPollingEngine) =====
-        discoMode.stop()
-        pollingEngine.startAll(p)
+    /**
+     * Classify an observation/CCCD-write failure as transient (worth retrying).
+     *
+     * Defaults to transient so busy-variant messages we have not catalogued (the
+     * exact failure mode behind the original bug) are still retried; only clear
+     * disconnect/cancel signals are treated as permanent. Retries are bounded by
+     * [BleConstants.Timing.REPS_SUBSCRIBE_MAX_ATTEMPTS], so an over-classification
+     * costs at most a few short backoffs.
+     */
+    internal fun isTransientObservationError(e: Throwable): Boolean {
+        val msg = e.message?.lowercase() ?: return true
+        val permanentMarkers = listOf("not connected", "disconnected", "cancel")
+        return permanentMarkers.none { msg.contains(it) }
     }
 
     // -------------------------------------------------------------------------

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/ble/KableBleConnectionManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/ble/KableBleConnectionManager.kt
@@ -885,7 +885,9 @@ class KableBleConnectionManager(
         // and the old code tore the subscription down permanently — rep counting was
         // silently dead until a manual Bluetooth toggle. We now (1) subscribe reps
         // FIRST and alone, and (2) retry/resubscribe on transient busy so it
-        // self-heals. [repsReady] completes once the CCCD write lands.
+        // self-heals. [repsReady] is released once the reps subscription settles —
+        // either the CCCD write lands OR it permanently gives up — so the gated work
+        // below never waits longer than necessary.
         val repsReady = CompletableDeferred<Unit>()
         scope.launch {
             observeRepsWithRetry(p) { repsReady.complete(Unit) }
@@ -933,9 +935,11 @@ class KableBleConnectionManager(
      * self-heals instead of requiring the user to toggle Bluetooth.
      *
      * @param p the peripheral to observe; the loop exits if it is replaced/disconnected
-     * @param onReady invoked once, when the subscription's CCCD write succeeds
+     * @param onSettled invoked exactly once when the subscription settles — either the
+     *   CCCD write succeeds OR retries are permanently exhausted. Lets the caller
+     *   release work gated on the subscription without waiting for a timeout.
      */
-    private suspend fun observeRepsWithRetry(p: Peripheral, onReady: () -> Unit) {
+    private suspend fun observeRepsWithRetry(p: Peripheral, onSettled: () -> Unit) {
         var attempt = 0
         while (peripheral === p) {
             try {
@@ -943,7 +947,7 @@ class KableBleConnectionManager(
                 p.observe(repsCharacteristic) {
                     // onSubscription: CCCD write landed — reps notifications are live.
                     attempt = 0
-                    onReady()
+                    onSettled()
                     log.i { "REPS notifications enabled" }
                 }
                     .collect { data ->
@@ -972,6 +976,9 @@ class KableBleConnectionManager(
                         connectedDeviceAddress,
                         "${e.message} (after $attempt attempt(s), transient=$transient)",
                     )
+                    // Release the gate now so polling does not wait out the full
+                    // REPS_SUBSCRIBE_READY_TIMEOUT_MS — there is nothing left to wait for.
+                    onSettled()
                     return
                 }
                 logRepo.warning(
@@ -1015,7 +1022,9 @@ class KableBleConnectionManager(
      * capped at [BleConstants.Timing.REPS_SUBSCRIBE_BACKOFF_MAX_MS].
      */
     internal fun repsBackoffMs(attempt: Int): Long =
-        (BleConstants.Timing.REPS_SUBSCRIBE_BACKOFF_BASE_MS shl (attempt - 1).coerceAtLeast(0))
+        // coerceIn(0, 30) guards the shift amount: a stray large attempt can never
+        // wrap the Long shift (Kotlin shifts mod 64); 30 bits is far beyond the cap.
+        (BleConstants.Timing.REPS_SUBSCRIBE_BACKOFF_BASE_MS shl (attempt - 1).coerceIn(0, 30))
             .coerceAtMost(BleConstants.Timing.REPS_SUBSCRIBE_BACKOFF_MAX_MS)
 
     /**

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/BleConstants.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/BleConstants.kt
@@ -181,6 +181,20 @@ object BleConstants {
         const val STATE_TRANSITION_DWELL_MS = 200L
         const val WAITING_FOR_REST_TIMEOUT_MS = 3000L
         const val MAX_CONSECUTIVE_TIMEOUTS = 5
+
+        // Reps notification subscription resilience.
+        // RCA (2026-06-28): the reps CCCD (descriptor) write is issued by Kable's
+        // observe() flow OUTSIDE BleOperationQueue, so it can race other in-flight
+        // GATT operations during the connection-setup burst and fail with Android
+        // ERROR_GATT_WRITE_REQUEST_BUSY ("WriteRequestBusy"). The failure was caught
+        // once and the subscription torn down permanently — rep counting was silently
+        // dead for the whole session until the user toggled Bluetooth (forcing a
+        // reconnect that re-rolled the race). These bound an automatic busy-retry /
+        // resubscribe so the failure self-heals.
+        const val REPS_SUBSCRIBE_MAX_ATTEMPTS = 5
+        const val REPS_SUBSCRIBE_BACKOFF_BASE_MS = 100L // 100, 200, 400, 800 (capped)
+        const val REPS_SUBSCRIBE_BACKOFF_MAX_MS = 800L
+        const val REPS_SUBSCRIBE_READY_TIMEOUT_MS = 2000L // fail-open gate for polling/non-critical observes
     }
 
     // -------------------------------------------------------------------------

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/ble/KableBleConnectionManagerTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/ble/KableBleConnectionManagerTest.kt
@@ -297,6 +297,44 @@ class KableBleConnectionManagerTest {
         )
     }
 
+    // =========================================================================
+    // Reps subscription resilience (RCA 2026-06-28: WriteRequestBusy)
+    // =========================================================================
+
+    @Test
+    fun `isTransientObservationError treats busy and GATT errors as transient`() {
+        val (manager, _) = createTestManager()
+        // The exact failure from the field log:
+        assertTrue(manager.isTransientObservationError(Exception("Write failed: WriteRequestBusy")))
+        assertTrue(manager.isTransientObservationError(Exception("GATT error status 133")))
+        assertTrue(manager.isTransientObservationError(Exception("device busy")))
+    }
+
+    @Test
+    fun `isTransientObservationError treats null message as transient (default retry)`() {
+        val (manager, _) = createTestManager()
+        assertTrue(manager.isTransientObservationError(RuntimeException()))
+    }
+
+    @Test
+    fun `isTransientObservationError treats disconnect and cancel as permanent`() {
+        val (manager, _) = createTestManager()
+        assertFalse(manager.isTransientObservationError(Exception("Peripheral is not connected")))
+        assertFalse(manager.isTransientObservationError(Exception("Disconnected from device")))
+        assertFalse(manager.isTransientObservationError(Exception("operation was cancelled")))
+    }
+
+    @Test
+    fun `repsBackoffMs grows exponentially then caps`() {
+        val (manager, _) = createTestManager()
+        assertEquals(100L, manager.repsBackoffMs(1))
+        assertEquals(200L, manager.repsBackoffMs(2))
+        assertEquals(400L, manager.repsBackoffMs(3))
+        assertEquals(800L, manager.repsBackoffMs(4))
+        assertEquals(800L, manager.repsBackoffMs(5)) // capped
+        assertEquals(800L, manager.repsBackoffMs(10)) // still capped, no overflow
+    }
+
     @Test
     fun `shutdown cancels lifecycle jobs and clears scan state`() = runTest {
         val (manager, tracker) = createTestManager()

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/ble/KableBleConnectionManagerTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/ble/KableBleConnectionManagerTest.kt
@@ -311,7 +311,7 @@ class KableBleConnectionManagerTest {
     }
 
     @Test
-    fun `isTransientObservationError treats null message as transient (default retry)`() {
+    fun `isTransientObservationError treats null message as transient by default`() {
         val (manager, _) = createTestManager()
         assertTrue(manager.isTransientObservationError(RuntimeException()))
     }


### PR DESCRIPTION
## Problem

A user reported the app stopped counting reps; toggling Bluetooth off/on fixed it. RCA from their connection log:

- **Conn #1 (18:10:42.092):** "Enabling BLE notifications…" → **8 ms later `[ERROR]` Reps notification error — Write failed: `WriteRequestBusy`** → **zero `REP_RECEIVED` events** for the entire session.
- User toggled Bluetooth → `DISCONNECT` 18:11:09.
- **Conn #2 (18:11:13.480):** same setup, **no busy error**, reps flow normally from 18:11:22 (`source=reps-characteristic`).

Machine was healthy throughout (`faults=None`, temps normal) — this was purely the app's BLE setup.

## Root cause

Kable issues the reps **CCCD descriptor write** (enable-notifications) when the `observe()` flow is first collected, and that write goes **outside** `BleOperationQueue` — so the app's own GATT serialization doesn't cover it. During setup, `startObservingNotifications()` fired three `observe()` collections (reps/version/mode) + firmware reads + `pollingEngine.startAll()` within ~8 ms, while a 34-byte command write was still settling. On Android (API 33+, one GATT write in flight at a time) the reps CCCD write got `ERROR_GATT_WRITE_REQUEST_BUSY`. Kable's default handler propagated it through the flow; the old `.catch {}` logged and let the flow **complete** → reps unsubscribed permanently, **no retry**. Reps is the only rep source on Vitruvian (no standard NUS RX), so the session counted nothing. It's a timing race; the Bluetooth toggle just re-rolled it.

## Fix (`KableBleConnectionManager.startObservingNotifications`, `BleConstants`)

Mirrors the existing `BleOperationQueue.write()` busy-retry pattern:

1. **Self-healing reps subscription** — `observeRepsWithRetry()` retries/resubscribes on transient busy with exponential backoff (100→200→400→800 ms, max 5 attempts). Recovers in ~100 ms automatically instead of needing a manual Bluetooth toggle. Permanent failure surfaces a clear "Rep counting unavailable — reconnect required".
2. **Contention removal** — reps subscribes **first and alone**; firmware reads, non-critical version/mode observes, and the polling read-flood are gated behind the reps CCCD write landing (`repsReady`, fail-open after 2 s), so the critical write normally succeeds on the first try.

## Tests

- `:shared:testAndroidHostTest` BLE package: **177 tests, 0 failures** (4 new — transient-error classifier + backoff curve).
- Mobile-only BLE; no sync-DTO / 1RM / portal-parity surface touched.

## Not verified here

⚠️ **Needs one real-device connect/disconnect cycle** — a BLE timing race can't be reproduced off-hardware. Logic is unit-tested and matches the proven command-write retry pattern, but confirm on the trainer before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3KXNewdGghVDifCA37ZFd
