### PR TITLE
Add upcoming-set Weight Change / Rep controls

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/Models.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/Models.kt
@@ -158,6 +158,7 @@ sealed class RoutineFlowState {
         val setIndex: Int,
         val adjustedWeight: Float,
         val adjustedReps: Int,
+        val adjustedProgressionKg: Float = 0f,
         val echoLevel: EchoLevel? = null,
         val eccentricLoadPercent: Int? = null,
     ) : RoutineFlowState()

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/WeightChangePerRepControl.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/WeightChangePerRepControl.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.contentDescription
@@ -16,6 +17,7 @@ import androidx.compose.ui.semantics.semantics
 import com.devil.phoenixproject.domain.model.WeightUnit
 import com.devil.phoenixproject.ui.theme.Spacing
 import com.devil.phoenixproject.util.UnitConverter
+import kotlin.math.abs
 
 private const val MAX_PROGRESS_KG_DISPLAY = 3f
 private const val MAX_PROGRESS_LB_DISPLAY = 6f
@@ -37,11 +39,19 @@ fun WeightChangePerRepControl(
     label: String = "Weight Change / Rep",
 ) {
     val maxProgression = if (weightUnit == WeightUnit.LB) MAX_PROGRESS_LB_DISPLAY else MAX_PROGRESS_KG_DISPLAY
-    val currentDisplay = kgToDisplay(valueKg, weightUnit).coerceIn(-maxProgression, maxProgression)
-    val valueText = formatProgressionPerRep(currentDisplay, weightUnit)
+    val clampedDisplay = kgToDisplay(valueKg, weightUnit).coerceIn(-maxProgression, maxProgression)
+    val clampedValueKg = displayToKg(clampedDisplay, weightUnit)
+    val valueText = formatProgressionPerRep(clampedDisplay, weightUnit)
+
+    LaunchedEffect(clampedValueKg, valueKg, weightUnit) {
+        if (abs(valueKg - clampedValueKg) > 0.0001f) {
+            onValueChangeKg(clampedValueKg)
+        }
+    }
+
     val accentColor = when {
-        currentDisplay > 0f -> MaterialTheme.colorScheme.primary
-        currentDisplay < 0f -> MaterialTheme.colorScheme.error
+        clampedDisplay > 0f -> MaterialTheme.colorScheme.primary
+        clampedDisplay < 0f -> MaterialTheme.colorScheme.error
         else -> MaterialTheme.colorScheme.onSurfaceVariant
     }
 
@@ -70,10 +80,10 @@ fun WeightChangePerRepControl(
         Spacer(modifier = Modifier.height(Spacing.small))
 
         ExpressiveSlider(
-            value = currentDisplay,
+            value = clampedDisplay,
             onValueChange = { displayValue ->
-                val clampedDisplay = displayValue.coerceIn(-maxProgression, maxProgression)
-                onValueChangeKg(displayToKg(clampedDisplay, weightUnit))
+                val selectedDisplay = displayValue.coerceIn(-maxProgression, maxProgression)
+                onValueChangeKg(displayToKg(selectedDisplay, weightUnit))
             },
             valueRange = -maxProgression..maxProgression,
             remoteStep = 0.1f,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/WeightChangePerRepControl.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/WeightChangePerRepControl.kt
@@ -1,0 +1,94 @@
+package com.devil.phoenixproject.presentation.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import com.devil.phoenixproject.domain.model.WeightUnit
+import com.devil.phoenixproject.ui.theme.Spacing
+import com.devil.phoenixproject.util.UnitConverter
+
+private const val MAX_PROGRESS_KG_DISPLAY = 3f
+private const val MAX_PROGRESS_LB_DISPLAY = 6f
+
+/**
+ * Display-unit-aware signed per-rep progression/regression control.
+ *
+ * The slider operates in the user's display unit for predictable touch/remote steps,
+ * then reports the selected value back in kilograms for WorkoutParameters storage.
+ */
+@Composable
+fun WeightChangePerRepControl(
+    valueKg: Float,
+    weightUnit: WeightUnit,
+    kgToDisplay: (Float, WeightUnit) -> Float,
+    displayToKg: (Float, WeightUnit) -> Float,
+    onValueChangeKg: (Float) -> Unit,
+    modifier: Modifier = Modifier,
+    label: String = "Weight Change / Rep",
+) {
+    val maxProgression = if (weightUnit == WeightUnit.LB) MAX_PROGRESS_LB_DISPLAY else MAX_PROGRESS_KG_DISPLAY
+    val currentDisplay = kgToDisplay(valueKg, weightUnit).coerceIn(-maxProgression, maxProgression)
+    val valueText = formatProgressionPerRep(currentDisplay, weightUnit)
+    val accentColor = when {
+        currentDisplay > 0f -> MaterialTheme.colorScheme.primary
+        currentDisplay < 0f -> MaterialTheme.colorScheme.error
+        else -> MaterialTheme.colorScheme.onSurfaceVariant
+    }
+
+    Column(
+        modifier = modifier.semantics {
+            contentDescription = "$label, $valueText"
+        },
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = valueText,
+                style = MaterialTheme.typography.titleMedium,
+                color = accentColor,
+            )
+        }
+
+        Spacer(modifier = Modifier.height(Spacing.small))
+
+        ExpressiveSlider(
+            value = currentDisplay,
+            onValueChange = { displayValue ->
+                val clampedDisplay = displayValue.coerceIn(-maxProgression, maxProgression)
+                onValueChangeKg(displayToKg(clampedDisplay, weightUnit))
+            },
+            valueRange = -maxProgression..maxProgression,
+            remoteStep = 0.1f,
+            trackColor = accentColor,
+            thumbColor = accentColor,
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
+fun formatProgressionPerRep(displayValue: Float, weightUnit: WeightUnit): String {
+    val sign = when {
+        displayValue > 0f -> "+"
+        else -> ""
+    }
+    val unit = weightUnit.name.lowercase()
+    return "$sign${UnitConverter.formatDecimal(displayValue)} $unit/rep"
+}

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -4621,11 +4621,11 @@ class ActiveSessionEngine(
                 repCounter.resetCountsOnly()
                 resetAutoStopState()
                 // ActiveWorkoutScreen only navigates to SetReady when workoutState is Idle.
-                // Leaving Resting/SetSummary here strands the user on the rest/summary UI
-                // while routineFlowState is already SetReady; a second Skip Rest /
-                // startNextSet() would advance past the deferred set entirely.
-                coordinator._workoutState.value = WorkoutState.Idle
+                // Leaving Resting/SetSummary after SetReady setup strands the user on the
+                // rest/summary UI; once the SetReady state has preserved any rest-screen
+                // edits, flip the workout state to Idle so navigation can occur.
                 flowDelegate?.enterSetReady(nextExIdx, nextSetIdx)
+                coordinator._workoutState.value = WorkoutState.Idle
             } else {
                 // Same-entry set advance (isChangingExercise == false). Preserve the
                 // existing behaviour so that manual rest-screen weight/rep edits

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -2031,6 +2031,7 @@ class ActiveSessionEngine(
      * parameters as user-adjusted during rest.
      */
     fun setWorkoutParametersInternal(params: WorkoutParameters) {
+        coordinator._userAdjustedWeightDuringRest = false
         coordinator._workoutParameters.value = params
     }
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -1911,6 +1911,8 @@ class ActiveSessionEngine(
         Logger.d("ActiveSessionEngine") { "LOAD BASELINE: Reset to 0 (disabled)" }
     }
 
+    private fun clampUpcomingProgressionKg(valueKg: Float): Float = valueKg.coerceIn(-3f, 3f)
+
     fun updateWorkoutParameters(params: WorkoutParameters) {
         // Defense: reject near-zero weight writes in Just Lift mode.
         // The JustLiftScreen param-sync LaunchedEffect can fire before defaults
@@ -4172,7 +4174,7 @@ class ActiveSessionEngine(
                         programMode = exerciseForNextSet.programMode,
                         echoLevel = exerciseForNextSet.getEchoLevelForSet(nextSetIdx),
                         eccentricLoad = exerciseForNextSet.eccentricLoad,
-                        progressionRegressionKg = exerciseForNextSet.progressionKg,
+                        progressionRegressionKg = clampUpcomingProgressionKg(exerciseForNextSet.progressionKg),
                         selectedExerciseId = exerciseForNextSet.exercise.id,
                         isAMRAP = nextIsAMRAP,
                         stallDetectionEnabled = exerciseForNextSet.stallDetectionEnabled,
@@ -4403,6 +4405,11 @@ class ActiveSessionEngine(
             } else {
                 targetReps ?: 0
             }
+            val setProgressionKg = if (coordinator._userAdjustedWeightDuringRest) {
+                currentParams.progressionRegressionKg
+            } else {
+                clampUpcomingProgressionKg(currentExercise.progressionKg)
+            }
             coordinator._userAdjustedWeightDuringRest = false
 
             val isLastSet = coordinator._currentSetIndex.value >= currentExercise.setReps.size - 1
@@ -4413,7 +4420,7 @@ class ActiveSessionEngine(
                 weightPerCableKg = setWeight,
                 isAMRAP = nextIsAMRAP,
                 stallDetectionEnabled = currentExercise.stallDetectionEnabled,
-                progressionRegressionKg = currentExercise.progressionKg,
+                progressionRegressionKg = setProgressionKg,
             )
             Logger.d { "advanceToNextSetInSingleExercise: Issue #203 - setIdx=${coordinator._currentSetIndex.value}, isAMRAP=$nextIsAMRAP" }
 
@@ -4511,29 +4518,34 @@ class ActiveSessionEngine(
 
             val nextSetReps = nextExercise.setReps.getOrNull(nextSetIdx)
             val currentParams = coordinator._workoutParameters.value
+            val preserveRestEdits = coordinator._userAdjustedWeightDuringRest
 
-            val nextSetWeight = if (coordinator._userAdjustedWeightDuringRest) {
+            val nextSetWeight = if (preserveRestEdits) {
                 currentParams.weightPerCableKg
             } else {
                 nextExercise.setWeightsPerCableKg.getOrNull(nextSetIdx)
                     ?: nextExercise.weightPerCableKg
             }
-            val nextReps = if (coordinator._userAdjustedWeightDuringRest) {
+            val nextReps = if (preserveRestEdits) {
                 currentParams.reps
             } else {
                 nextSetReps ?: 0
             }
-            val nextEchoLevel = if (coordinator._userAdjustedWeightDuringRest) {
+            val nextEchoLevel = if (preserveRestEdits) {
                 currentParams.echoLevel
             } else {
                 nextExercise.getEchoLevelForSet(nextSetIdx)
             }
-            val nextEccentricLoad = if (coordinator._userAdjustedWeightDuringRest) {
+            val nextEccentricLoad = if (preserveRestEdits) {
                 currentParams.eccentricLoad
             } else {
                 nextExercise.eccentricLoad
             }
-            coordinator._userAdjustedWeightDuringRest = false
+            val nextProgressionKg = if (preserveRestEdits) {
+                currentParams.progressionRegressionKg
+            } else {
+                clampUpcomingProgressionKg(nextExercise.progressionKg)
+            }
 
             val nextIsBodyweight = isBodyweightExercise(nextExercise)
 
@@ -4568,7 +4580,7 @@ class ActiveSessionEngine(
                 programMode = carryProgramMode,
                 echoLevel = carryEchoLevel,
                 eccentricLoad = carryEccentricLoad,
-                progressionRegressionKg = nextExercise.progressionKg,
+                progressionRegressionKg = nextProgressionKg,
                 selectedExerciseId = nextExercise.exercise.id,
                 isAMRAP = nextIsAMRAP,
                 stallDetectionEnabled = nextExercise.stallDetectionEnabled,
@@ -4623,7 +4635,9 @@ class ActiveSessionEngine(
                 resetAutoStopState()
                 startWorkoutOrSetReady()
             }
+            coordinator._userAdjustedWeightDuringRest = false
         } else {
+            coordinator._userAdjustedWeightDuringRest = false
             Logger.d { "startNextSetOrExercise: No more steps - showing routine complete" }
             // Issue #395: Write aggregate health workout BEFORE clearing routine state
             writeRoutineHealthData()

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/DefaultWorkoutSessionManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/DefaultWorkoutSessionManager.kt
@@ -589,6 +589,7 @@ class DefaultWorkoutSessionManager(
     fun enterSetReadyWithAdjustments(exerciseIndex: Int, setIndex: Int, adjustedWeight: Float, adjustedReps: Int) = routineFlowManager.enterSetReadyWithAdjustments(exerciseIndex, setIndex, adjustedWeight, adjustedReps)
     fun updateSetReadyWeight(weight: Float) = routineFlowManager.updateSetReadyWeight(weight)
     fun updateSetReadyReps(reps: Int) = routineFlowManager.updateSetReadyReps(reps)
+    fun updateSetReadyProgressionKg(valueKg: Float) = routineFlowManager.updateSetReadyProgressionKg(valueKg)
     fun updateSetReadyEchoLevel(level: EchoLevel) = routineFlowManager.updateSetReadyEchoLevel(level)
     fun updateSetReadyEccentricLoad(percent: Int) = routineFlowManager.updateSetReadyEccentricLoad(percent)
     fun startSetFromReady() = routineFlowManager.startSetFromReady()

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/RoutineFlowManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/RoutineFlowManager.kt
@@ -105,6 +105,11 @@ class RoutineFlowManager(
 
     private fun clampUpcomingProgressionKg(valueKg: Float): Float = valueKg.coerceIn(-3f, 3f)
 
+    private fun shouldPreserveRestEditedProgression(): Boolean =
+        coordinator._userAdjustedWeightDuringRest &&
+            (coordinator._workoutState.value is WorkoutState.Resting ||
+                coordinator._workoutState.value is WorkoutState.SetSummary)
+
     private fun markExerciseSkipped(index: Int) {
         coordinator._skippedExercises.update { it + index }
         coordinator._completedExercises.update { it - index }
@@ -1011,10 +1016,14 @@ class RoutineFlowManager(
         // Issue #129: Check raw value for AMRAP before fallback
         val rawSetReps = exercise.setReps.getOrNull(setIndex)
         val setReps = rawSetReps ?: exercise.reps
-        val progressionKg = if (coordinator._userAdjustedWeightDuringRest) {
+        val preserveRestEditedProgression = shouldPreserveRestEditedProgression()
+        val progressionKg = if (preserveRestEditedProgression) {
             clampUpcomingProgressionKg(coordinator._workoutParameters.value.progressionRegressionKg)
         } else {
             clampUpcomingProgressionKg(exercise.progressionKg)
+        }
+        if (!preserveRestEditedProgression) {
+            coordinator._userAdjustedWeightDuringRest = false
         }
 
         coordinator._routineFlowState.value = RoutineFlowState.SetReady(
@@ -1088,10 +1097,14 @@ class RoutineFlowManager(
         coordinator._currentSetIndex.value = setIndex
         // Issue #534: recompute rack load adjustment for the body-weight effective load formula
         applyDefaultRackSelectionForExercise(exercise)
-        val progressionKg = if (coordinator._userAdjustedWeightDuringRest) {
+        val preserveRestEditedProgression = shouldPreserveRestEditedProgression()
+        val progressionKg = if (preserveRestEditedProgression) {
             clampUpcomingProgressionKg(coordinator._workoutParameters.value.progressionRegressionKg)
         } else {
             clampUpcomingProgressionKg(exercise.progressionKg)
+        }
+        if (!preserveRestEditedProgression) {
+            coordinator._userAdjustedWeightDuringRest = false
         }
 
         coordinator._routineFlowState.value = RoutineFlowState.SetReady(

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/RoutineFlowManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/RoutineFlowManager.kt
@@ -103,6 +103,8 @@ class RoutineFlowManager(
      */
     internal lateinit var lifecycleDelegate: WorkoutLifecycleDelegate
 
+    private fun clampUpcomingProgressionKg(valueKg: Float): Float = valueKg.coerceIn(-3f, 3f)
+
     private fun markExerciseSkipped(index: Int) {
         coordinator._skippedExercises.update { it + index }
         coordinator._completedExercises.update { it - index }
@@ -1009,13 +1011,18 @@ class RoutineFlowManager(
         // Issue #129: Check raw value for AMRAP before fallback
         val rawSetReps = exercise.setReps.getOrNull(setIndex)
         val setReps = rawSetReps ?: exercise.reps
+        val progressionKg = if (coordinator._userAdjustedWeightDuringRest) {
+            clampUpcomingProgressionKg(coordinator._workoutParameters.value.progressionRegressionKg)
+        } else {
+            clampUpcomingProgressionKg(exercise.progressionKg)
+        }
 
         coordinator._routineFlowState.value = RoutineFlowState.SetReady(
             exerciseIndex = exerciseIndex,
             setIndex = setIndex,
             adjustedWeight = setWeight,
             adjustedReps = setReps,
-            adjustedProgressionKg = exercise.progressionKg,
+            adjustedProgressionKg = progressionKg,
             echoLevel = if (exercise.programMode is ProgramMode.Echo) exercise.echoLevel else null,
             eccentricLoadPercent = if (exercise.programMode is ProgramMode.Echo) exercise.eccentricLoad.percentage else null,
         )
@@ -1060,7 +1067,7 @@ class RoutineFlowManager(
             repCountTiming = exercise.repCountTiming,
             stopAtTop = exercise.stopAtTop,
             isAMRAP = isSetAmrap,
-            progressionRegressionKg = exercise.progressionKg,
+            progressionRegressionKg = progressionKg,
             isJustLift = false,
             useAutoStart = false,
         )
@@ -1081,13 +1088,18 @@ class RoutineFlowManager(
         coordinator._currentSetIndex.value = setIndex
         // Issue #534: recompute rack load adjustment for the body-weight effective load formula
         applyDefaultRackSelectionForExercise(exercise)
+        val progressionKg = if (coordinator._userAdjustedWeightDuringRest) {
+            clampUpcomingProgressionKg(coordinator._workoutParameters.value.progressionRegressionKg)
+        } else {
+            clampUpcomingProgressionKg(exercise.progressionKg)
+        }
 
         coordinator._routineFlowState.value = RoutineFlowState.SetReady(
             exerciseIndex = exerciseIndex,
             setIndex = setIndex,
             adjustedWeight = adjustedWeight,
             adjustedReps = adjustedReps,
-            adjustedProgressionKg = exercise.progressionKg,
+            adjustedProgressionKg = progressionKg,
             echoLevel = if (exercise.programMode is ProgramMode.Echo) exercise.echoLevel else null,
             eccentricLoadPercent = if (exercise.programMode is ProgramMode.Echo) exercise.eccentricLoad.percentage else null,
         )
@@ -1126,7 +1138,7 @@ class RoutineFlowManager(
             repCountTiming = exercise.repCountTiming,
             stopAtTop = exercise.stopAtTop,
             isAMRAP = isSetAmrap,
-            progressionRegressionKg = exercise.progressionKg,
+            progressionRegressionKg = progressionKg,
             isJustLift = false,
             useAutoStart = false,
         )
@@ -1163,7 +1175,7 @@ class RoutineFlowManager(
     fun updateSetReadyProgressionKg(valueKg: Float) {
         val state = coordinator._routineFlowState.value
         if (state is RoutineFlowState.SetReady) {
-            val clampedValue = valueKg.coerceIn(-3f, 3f)
+            val clampedValue = clampUpcomingProgressionKg(valueKg)
             coordinator._routineFlowState.value = state.copy(adjustedProgressionKg = clampedValue)
             coordinator._workoutParameters.value = coordinator._workoutParameters.value.copy(
                 progressionRegressionKg = clampedValue,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/RoutineFlowManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/RoutineFlowManager.kt
@@ -1015,6 +1015,7 @@ class RoutineFlowManager(
             setIndex = setIndex,
             adjustedWeight = setWeight,
             adjustedReps = setReps,
+            adjustedProgressionKg = exercise.progressionKg,
             echoLevel = if (exercise.programMode is ProgramMode.Echo) exercise.echoLevel else null,
             eccentricLoadPercent = if (exercise.programMode is ProgramMode.Echo) exercise.eccentricLoad.percentage else null,
         )
@@ -1086,6 +1087,7 @@ class RoutineFlowManager(
             setIndex = setIndex,
             adjustedWeight = adjustedWeight,
             adjustedReps = adjustedReps,
+            adjustedProgressionKg = exercise.progressionKg,
             echoLevel = if (exercise.programMode is ProgramMode.Echo) exercise.echoLevel else null,
             eccentricLoadPercent = if (exercise.programMode is ProgramMode.Echo) exercise.eccentricLoad.percentage else null,
         )
@@ -1155,6 +1157,21 @@ class RoutineFlowManager(
     }
 
     /**
+     * Update per-rep progression/regression for the upcoming set only.
+     * Stored internally in kg and intentionally does not mutate RoutineExercise defaults.
+     */
+    fun updateSetReadyProgressionKg(valueKg: Float) {
+        val state = coordinator._routineFlowState.value
+        if (state is RoutineFlowState.SetReady) {
+            val clampedValue = valueKg.coerceIn(-3f, 3f)
+            coordinator._routineFlowState.value = state.copy(adjustedProgressionKg = clampedValue)
+            coordinator._workoutParameters.value = coordinator._workoutParameters.value.copy(
+                progressionRegressionKg = clampedValue,
+            )
+        }
+    }
+
+    /**
      * Update echo level in set-ready state for Echo mode.
      */
     fun updateSetReadyEchoLevel(level: EchoLevel) {
@@ -1200,6 +1217,7 @@ class RoutineFlowManager(
         coordinator._workoutParameters.value = coordinator._workoutParameters.value.copy(
             weightPerCableKg = state.adjustedWeight,
             reps = state.adjustedReps,
+            progressionRegressionKg = state.adjustedProgressionKg,
             isJustLift = false,
         )
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RestTimerCard.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RestTimerCard.kt
@@ -146,7 +146,6 @@ fun RestTimerCard(
     // Local state for editing parameters
     var editedReps by remember(nextExerciseReps) { mutableStateOf(nextExerciseReps ?: 10) }
     var editedWeight by remember(nextExerciseWeight) { mutableStateOf(nextExerciseWeight ?: 20f) }
-    var editedProgressionKg by remember(nextExerciseProgressionKg) { mutableStateOf(nextExerciseProgressionKg ?: 0f) }
     var editedEchoLevel by remember(echoLevel) { mutableStateOf(echoLevel ?: EchoLevel.HARDER) }
     var editedEccentricPercent by remember(eccentricLoadPercent) { mutableStateOf(eccentricLoadPercent ?: 100) }
 
@@ -532,12 +531,11 @@ fun RestTimerCard(
                                 displayToKg != null
                             ) {
                                 WeightChangePerRepControl(
-                                    valueKg = editedProgressionKg,
+                                    valueKg = nextExerciseProgressionKg,
                                     weightUnit = weightUnit,
                                     kgToDisplay = kgToDisplay,
                                     displayToKg = displayToKg,
                                     onValueChangeKg = { newValueKg ->
-                                        editedProgressionKg = newValueKg
                                         onUpdateProgressionKg.invoke(newValueKg)
                                     },
                                 )

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RestTimerCard.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RestTimerCard.kt
@@ -61,6 +61,7 @@ import com.devil.phoenixproject.domain.model.WeightUnit
 import com.devil.phoenixproject.domain.model.percentLabel
 import com.devil.phoenixproject.presentation.components.ExpressiveSlider
 import com.devil.phoenixproject.presentation.components.SliderWithButtons
+import com.devil.phoenixproject.presentation.components.WeightChangePerRepControl
 import com.devil.phoenixproject.ui.theme.Spacing
 import com.devil.phoenixproject.util.Constants
 import org.jetbrains.compose.resources.stringResource
@@ -107,6 +108,7 @@ fun RestTimerCard(
     totalSets: Int,
     nextExerciseWeight: Float? = null,
     nextExerciseReps: Int? = null,
+    nextExerciseProgressionKg: Float? = null,
     nextExerciseMode: String? = null,
     currentExerciseIndex: Int? = null,
     totalExercises: Int? = null,
@@ -126,6 +128,9 @@ fun RestTimerCard(
     onEndWorkout: () -> Unit,
     onUpdateReps: ((Int) -> Unit)? = null,
     onUpdateWeight: ((Float) -> Unit)? = null,
+    onUpdateProgressionKg: ((Float) -> Unit)? = null,
+    kgToDisplay: ((Float, WeightUnit) -> Float)? = null,
+    displayToKg: ((Float, WeightUnit) -> Float)? = null,
     // Echo mode specific
     programMode: ProgramMode? = null,
     echoLevel: EchoLevel? = null,
@@ -141,6 +146,7 @@ fun RestTimerCard(
     // Local state for editing parameters
     var editedReps by remember(nextExerciseReps) { mutableStateOf(nextExerciseReps ?: 10) }
     var editedWeight by remember(nextExerciseWeight) { mutableStateOf(nextExerciseWeight ?: 20f) }
+    var editedProgressionKg by remember(nextExerciseProgressionKg) { mutableStateOf(nextExerciseProgressionKg ?: 0f) }
     var editedEchoLevel by remember(echoLevel) { mutableStateOf(echoLevel ?: EchoLevel.HARDER) }
     var editedEccentricPercent by remember(eccentricLoadPercent) { mutableStateOf(eccentricLoadPercent ?: 100) }
 
@@ -428,7 +434,7 @@ fun RestTimerCard(
             // Issue #222: Never show for bodyweight exercises
             val showConfigCard = !isLastExercise && !isNextExerciseBodyweight && (
                 (isEchoMode && (echoLevel != null || nextExerciseReps != null)) ||
-                    (!isEchoMode && (nextExerciseWeight != null || nextExerciseReps != null))
+                    (!isEchoMode && (nextExerciseWeight != null || nextExerciseReps != null || nextExerciseProgressionKg != null))
                 )
 
             if (showConfigCard) {
@@ -516,6 +522,24 @@ fun RestTimerCard(
                                     formatValue = { formatWeightWithUnit(it, weightUnit) },
                                     deltaText = deltaText,
                                     isDeltaPositive = deltaKg >= 0f,
+                                )
+                            }
+
+                            if (
+                                nextExerciseProgressionKg != null &&
+                                onUpdateProgressionKg != null &&
+                                kgToDisplay != null &&
+                                displayToKg != null
+                            ) {
+                                WeightChangePerRepControl(
+                                    valueKg = editedProgressionKg,
+                                    weightUnit = weightUnit,
+                                    kgToDisplay = kgToDisplay,
+                                    displayToKg = displayToKg,
+                                    onValueChangeKg = { newValueKg ->
+                                        editedProgressionKg = newValueKg
+                                        onUpdateProgressionKg.invoke(newValueKg)
+                                    },
                                 )
                             }
                         }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SetReadyScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SetReadyScreen.kt
@@ -78,6 +78,7 @@ import com.devil.phoenixproject.presentation.components.ExpressiveSlider
 import com.devil.phoenixproject.presentation.components.SliderWithButtons
 import com.devil.phoenixproject.presentation.components.VideoPlayer
 import com.devil.phoenixproject.presentation.components.WeightRecommendationCard
+import com.devil.phoenixproject.presentation.components.WeightChangePerRepControl
 import com.devil.phoenixproject.presentation.navigation.NavigationRoutes
 import com.devil.phoenixproject.presentation.viewmodel.MainViewModel
 import com.devil.phoenixproject.ui.theme.Spacing
@@ -321,10 +322,10 @@ fun SetReadyScreen(navController: NavController, viewModel: MainViewModel, exerc
                 .padding(horizontal = 16.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            // Header - Set X of Y
+            // Compact header - exercise, set picker, and mode/bodyweight context.
             Card(
                 modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(16.dp),
+                shape = RoundedCornerShape(14.dp),
                 colors = CardDefaults.cardColors(
                     containerColor = MaterialTheme.colorScheme.primaryContainer,
                 ),
@@ -332,120 +333,95 @@ fun SetReadyScreen(navController: NavController, viewModel: MainViewModel, exerc
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(16.dp),
+                        .padding(horizontal = 12.dp, vertical = 8.dp),
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
                     // Issue #142: Display exercise name prominently
                     Text(
                         currentExercise.exercise.name,
-                        style = MaterialTheme.typography.titleLarge,
+                        style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.Bold,
                         color = MaterialTheme.colorScheme.onPrimaryContainer,
+                        textAlign = TextAlign.Center,
                     )
                     Spacer(Modifier.height(4.dp))
-                    // Issue #541: Make "Set X of Y" a tappable set picker. The label is the
-                    // dropdown anchor; tapping it opens a menu of every set index in the current
-                    // exercise. Selecting an entry calls viewModel.enterSetReady(ex, pickedSet) which
-                    // the engine layer already supports (RoutineFlowManager.kt:886). This is the
-                    // parity surface for the reporter's "no set selector" bug.
-                    //
-                    // a11y: the anchor Text is marked with Role.DropdownList so screen readers
-                    // announce it as an interactive picker rather than a static label. We avoid
-                    // OutlinedTextField(readOnly=true) here because the label lives inside a
-                    // primaryContainer card whose on-color doesn't match the OutlinedTextField's
-                    // default chrome; the existing in-file bodyweight variant picker uses that
-                    // pattern but lives in a surfaceContainerHighest card where it blends cleanly.
-                    ExposedDropdownMenuBox(
-                        expanded = setPickerExpanded && currentExercise.setReps.size > 1,
-                        onExpandedChange = { requested ->
-                            // Respect the requested state from the Material3 API (e.g. for
-                            // accessibility services or external state changes) but only honor
-                            // opens when there is more than one set to pick from.
-                            if (currentExercise.setReps.size > 1) {
-                                setPickerExpanded = requested
-                            } else {
-                                setPickerExpanded = false
-                            }
-                        },
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
+                        verticalAlignment = Alignment.CenterVertically,
                     ) {
-                        Text(
-                            text = "Set ${setReadyState.setIndex + 1} of ${currentExercise.setReps.size}" +
-                                if (currentExercise.setReps.size > 1) "  \u25BE" else "",
-                            style = MaterialTheme.typography.titleMedium,
-                            fontWeight = FontWeight.Medium,
-                            color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.9f),
-                            modifier = Modifier
-                                .menuAnchor()
-                                .semantics {
-                                    role = Role.DropdownList
-                                    contentDescription = "Set selector, currently set " +
-                                        "${setReadyState.setIndex + 1} of " +
-                                        "${currentExercise.setReps.size}"
-                                    if (currentExercise.setReps.size > 1) {
-                                        stateDescription = "Tap to choose a different set"
-                                    }
-                                },
-                        )
-                        ExposedDropdownMenu(
+                        // Issue #541: Make "Set X of Y" a tappable set picker. The label is the
+                        // dropdown anchor; tapping it opens a menu of every set index in the current
+                        // exercise. Selecting an entry calls viewModel.enterSetReady(ex, pickedSet) which
+                        // the engine layer already supports. Keep Role.DropdownList and descriptions.
+                        ExposedDropdownMenuBox(
                             expanded = setPickerExpanded && currentExercise.setReps.size > 1,
-                            onDismissRequest = { setPickerExpanded = false },
+                            onExpandedChange = { requested ->
+                                if (currentExercise.setReps.size > 1) {
+                                    setPickerExpanded = requested
+                                } else {
+                                    setPickerExpanded = false
+                                }
+                            },
                         ) {
-                            currentExercise.setReps.indices.forEach { setIdx ->
-                                DropdownMenuItem(
-                                    text = {
-                                        Text(
-                                            "Set ${setIdx + 1}" +
-                                                if (setIdx == setReadyState.setIndex) "  (current)" else "",
-                                            style = MaterialTheme.typography.bodyMedium,
-                                        )
-                                    },
-                                    onClick = {
-                                        setPickerExpanded = false
-                                        if (setIdx != setReadyState.setIndex) {
-                                            // enterSetReady is the engine-level "jump to (ex, set)"
-                                            // API and updates routineFlowState, currentSetIndex, and
-                                            // warm-up state for the new set. No workout state change.
-                                            viewModel.enterSetReady(
-                                                setReadyState.exerciseIndex,
-                                                setIdx,
-                                            )
+                            Text(
+                                text = "Set ${setReadyState.setIndex + 1} of ${currentExercise.setReps.size}" +
+                                    if (currentExercise.setReps.size > 1) "  \u25BE" else "",
+                                style = MaterialTheme.typography.labelLarge,
+                                fontWeight = FontWeight.Medium,
+                                color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.9f),
+                                modifier = Modifier
+                                    .menuAnchor()
+                                    .semantics {
+                                        role = Role.DropdownList
+                                        contentDescription = "Set selector, currently set " +
+                                            "${setReadyState.setIndex + 1} of " +
+                                            "${currentExercise.setReps.size}"
+                                        if (currentExercise.setReps.size > 1) {
+                                            stateDescription = "Tap to choose a different set"
                                         }
                                     },
-                                )
+                            )
+                            ExposedDropdownMenu(
+                                expanded = setPickerExpanded && currentExercise.setReps.size > 1,
+                                onDismissRequest = { setPickerExpanded = false },
+                            ) {
+                                currentExercise.setReps.indices.forEach { setIdx ->
+                                    DropdownMenuItem(
+                                        text = {
+                                            Text(
+                                                "Set ${setIdx + 1}" +
+                                                    if (setIdx == setReadyState.setIndex) "  (current)" else "",
+                                                style = MaterialTheme.typography.bodyMedium,
+                                            )
+                                        },
+                                        onClick = {
+                                            setPickerExpanded = false
+                                            if (setIdx != setReadyState.setIndex) {
+                                                viewModel.enterSetReady(
+                                                    setReadyState.exerciseIndex,
+                                                    setIdx,
+                                                )
+                                            }
+                                        },
+                                    )
+                                }
                             }
                         }
-                    }
-                    // Issue #222: Show "Bodyweight • XXs" for bodyweight, mode name for cable
-                    if (isBodyweight) {
-                        val durationText = currentExercise.duration?.let { "${it}s" } ?: "Timed"
                         Text(
-                            "Bodyweight • $durationText",
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f),
-                        )
-                    } else {
-                        Text(
-                            currentExercise.programMode.displayName,
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f),
+                            text = if (isBodyweight) {
+                                val durationText = currentExercise.duration?.let { "${it}s" } ?: "Timed"
+                                "Bodyweight • $durationText"
+                            } else {
+                                currentExercise.programMode.displayName
+                            },
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.72f),
                         )
                     }
                 }
             }
 
             Spacer(Modifier.height(12.dp))
-
-            // Video thumbnail
-            if (enableVideoPlayback) {
-                VideoPlayer(
-                    videoUrl = videoEntity?.videoUrl,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(140.dp)
-                        .clip(RoundedCornerShape(12.dp)),
-                )
-                Spacer(Modifier.height(12.dp))
-            }
 
             // Issue #229/#427: Bodyweight variant picker (runtime state, carried across sets)
             if (isBodyweight) {
@@ -540,28 +516,6 @@ fun SetReadyScreen(navController: NavController, viewModel: MainViewModel, exerc
                     Spacer(Modifier.height(12.dp))
                 }
             }
-
-            EquipmentRackSelectionCard(
-                rackItems = rackItems,
-                activeRackItemIds = activeRackItemIds,
-                behaviorOverrides = runtimeBehaviorOverrides,
-                weightUnit = weightUnit,
-                formatWeight = viewModel::formatWeight,
-                onSelectionChange = viewModel::updateActiveRackSelection,
-                onBehaviorOverrideChange = { newOverrides ->
-                    runtimeBehaviorOverrides = newOverrides
-                    viewModel.updateActiveRackBehaviorOverrides(newOverrides)
-                    pendingOverridesToSave = newOverrides
-                    showSaveOverridePrompt = true
-                },
-                onManageRack = { navController.navigate(NavigationRoutes.EquipmentRack.route) },
-                showBehaviorOverrides = true,
-                // Issue #582: regression tag for Compose UI / screenshot tests that
-                // verify the Equipment Rack card is reachable on cable SetReady.
-                modifier = Modifier.testTag(SetReadyTestTags.RACK_CARD),
-            )
-
-            Spacer(Modifier.height(12.dp))
 
             // Configuration card - matching RestTimerCard style
             // Issue #222: Hide for bodyweight exercises (no cable settings to configure)
@@ -690,9 +644,52 @@ fun SetReadyScreen(navController: NavController, viewModel: MainViewModel, exerc
                                     )
                                 }
                             }
+
+                            WeightChangePerRepControl(
+                                valueKg = setReadyState.adjustedProgressionKg,
+                                weightUnit = weightUnit,
+                                kgToDisplay = viewModel::kgToDisplay,
+                                displayToKg = viewModel::displayToKg,
+                                onValueChangeKg = { viewModel.updateSetReadyProgressionKg(it) },
+                                modifier = Modifier.testTag(SetReadyTestTags.PROGRESSION_CONTROL),
+                            )
                         }
                     }
                 }
+            }
+
+            EquipmentRackSelectionCard(
+                rackItems = rackItems,
+                activeRackItemIds = activeRackItemIds,
+                behaviorOverrides = runtimeBehaviorOverrides,
+                weightUnit = weightUnit,
+                formatWeight = viewModel::formatWeight,
+                onSelectionChange = viewModel::updateActiveRackSelection,
+                onBehaviorOverrideChange = { newOverrides ->
+                    runtimeBehaviorOverrides = newOverrides
+                    viewModel.updateActiveRackBehaviorOverrides(newOverrides)
+                    pendingOverridesToSave = newOverrides
+                    showSaveOverridePrompt = true
+                },
+                onManageRack = { navController.navigate(NavigationRoutes.EquipmentRack.route) },
+                showBehaviorOverrides = true,
+                // Issue #582: regression tag for Compose UI / screenshot tests that
+                // verify the Equipment Rack card is reachable on cable SetReady.
+                modifier = Modifier.testTag(SetReadyTestTags.RACK_CARD),
+            )
+
+            Spacer(Modifier.height(12.dp))
+
+            // Video thumbnail stays available but no longer pushes primary set configuration down.
+            if (enableVideoPlayback) {
+                VideoPlayer(
+                    videoUrl = videoEntity?.videoUrl,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(96.dp)
+                        .clip(RoundedCornerShape(12.dp)),
+                )
+                Spacer(Modifier.height(12.dp))
             }
             // Issue #582: a trailing `Spacer(Modifier.weight(1f))` was removed here
             // because `Modifier.weight` is not allowed inside a vertically-scrollable
@@ -870,4 +867,7 @@ private fun SetReadyEccentricLoadSlider(percent: Int, onPercentChange: (Int) -> 
 object SetReadyTestTags {
     /** EquipmentRackSelectionCard root inside SetReadyScreen. Issue #582. */
     const val RACK_CARD: String = "set_ready_rack_card"
+
+    /** Weight Change / Rep control inside cable non-Echo Set Configuration. Issue #604. */
+    const val PROGRESSION_CONTROL: String = "set_ready_progression_control"
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/WorkoutTab.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/WorkoutTab.kt
@@ -679,8 +679,7 @@ fun WorkoutTab(
                             nextExerciseName.startsWith(it.exercise.name) ||
                             nextExerciseName.startsWith(it.exercise.displayName)
                     }
-                    val nextEquipment = nextExercise?.exercise?.equipment ?: ""
-                    val isNextBodyweight = nextEquipment.isEmpty() || nextEquipment.equals("bodyweight", ignoreCase = true)
+                    val isNextBodyweight = nextExercise?.exercise?.hasCableAccessory != true
                     val showNextProgression = !isNextBodyweight && workoutParameters.programMode != ProgramMode.Echo
 
                     RestTimerCard(

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/WorkoutTab.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/WorkoutTab.kt
@@ -681,6 +681,7 @@ fun WorkoutTab(
                     }
                     val nextEquipment = nextExercise?.exercise?.equipment ?: ""
                     val isNextBodyweight = nextEquipment.isEmpty() || nextEquipment.equals("bodyweight", ignoreCase = true)
+                    val showNextProgression = !isNextBodyweight && workoutParameters.programMode != ProgramMode.Echo
 
                     RestTimerCard(
                         restSecondsRemaining = workoutState.restSecondsRemaining,
@@ -690,6 +691,7 @@ fun WorkoutTab(
                         totalSets = workoutState.totalSets,
                         nextExerciseWeight = workoutParameters.weightPerCableKg,
                         nextExerciseReps = workoutParameters.reps,
+                        nextExerciseProgressionKg = if (showNextProgression) workoutParameters.progressionRegressionKg else null,
                         nextExerciseMode = workoutParameters.programMode.displayName,
                         currentExerciseIndex = if (loadedRoutine != null) currentExerciseIndex else null,
                         totalExercises = loadedRoutine?.exercises?.size,
@@ -713,6 +715,11 @@ fun WorkoutTab(
                         onUpdateWeight = { newWeight ->
                             onUpdateParameters(workoutParameters.copy(weightPerCableKg = newWeight))
                         },
+                        onUpdateProgressionKg = { newValueKg ->
+                            onUpdateParameters(workoutParameters.copy(progressionRegressionKg = newValueKg))
+                        },
+                        kgToDisplay = kgToDisplay,
+                        displayToKg = displayToKg,
                         // Echo mode specific
                         programMode = workoutParameters.programMode,
                         echoLevel = workoutParameters.echoLevel,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
@@ -516,6 +516,7 @@ class MainViewModel constructor(
     fun enterSetReadyWithAdjustments(exerciseIndex: Int, setIndex: Int, adjustedWeight: Float, adjustedReps: Int) = workoutSessionManager.enterSetReadyWithAdjustments(exerciseIndex, setIndex, adjustedWeight, adjustedReps)
     fun updateSetReadyWeight(weight: Float) = workoutSessionManager.updateSetReadyWeight(weight)
     fun updateSetReadyReps(reps: Int) = workoutSessionManager.updateSetReadyReps(reps)
+    fun updateSetReadyProgressionKg(valueKg: Float) = workoutSessionManager.updateSetReadyProgressionKg(valueKg)
     fun updateSetReadyEchoLevel(level: EchoLevel) = workoutSessionManager.updateSetReadyEchoLevel(level)
     fun updateSetReadyEccentricLoad(percent: Int) = workoutSessionManager.updateSetReadyEccentricLoad(percent)
     fun startSetFromReady() = workoutSessionManager.startSetFromReady()

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/RestTimerProgressionWiringTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/RestTimerProgressionWiringTest.kt
@@ -1,0 +1,84 @@
+package com.devil.phoenixproject.presentation
+
+import com.devil.phoenixproject.testutil.readProjectFile
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Issue #604 source-level guards for Rest Timer next-set Weight Change / Rep wiring.
+ *
+ * The repo already uses source-level UI wiring tests for SetReady/JustLift when a
+ * full Compose UI harness would be heavier than the regression being guarded.
+ */
+class RestTimerProgressionWiringTest {
+
+    @Test
+    fun workoutTab_passesProgressionToRestTimer() {
+        val src = readWorkoutTabSource()
+
+        assertTrue(
+            src.contains("nextExerciseProgressionKg = if (showNextProgression) workoutParameters.progressionRegressionKg else null"),
+            "WorkoutTab.kt must pass WorkoutParameters.progressionRegressionKg into RestTimerCard during WorkoutState.Resting.",
+        )
+        assertTrue(
+            src.contains("workoutParameters.copy(progressionRegressionKg = newValueKg)"),
+            "Rest Timer progression edits must update WorkoutParameters through onUpdateParameters(...copy(progressionRegressionKg=...)).",
+        )
+        assertTrue(
+            src.contains("workoutParameters.programMode != ProgramMode.Echo"),
+            "WorkoutTab.kt must guard Rest Timer progression for non-Echo next sets only.",
+        )
+    }
+
+    @Test
+    fun restTimerCard_rendersProgressionInNextSetConfiguration() {
+        val src = readRestTimerCardSource()
+
+        assertTrue(
+            src.contains("WeightChangePerRepControl"),
+            "RestTimerCard.kt must render the shared Weight Change / Rep control in NEXT SET CONFIGURATION.",
+        )
+        assertTrue(
+            src.contains("nextExerciseProgressionKg != null"),
+            "RestTimerCard.kt must render Weight Change / Rep only when a progression value is supplied.",
+        )
+        assertTrue(
+            src.contains("onUpdateProgressionKg.invoke(newValueKg)"),
+            "RestTimerCard.kt must call the progression update callback when the control changes.",
+        )
+    }
+
+    @Test
+    fun restTimerCard_preservesTimerAndActionControls() {
+        val src = readRestTimerCardSource()
+
+        listOf(
+            "liveRegion = LiveRegionMode.Polite",
+            "rest_next_set_config",
+            "cd_add_30_seconds",
+            "rest_pause",
+            "rest_resume",
+            "cd_reset_timer",
+            "cd_skip_rest",
+            "cd_end_workout",
+        ).forEach { required ->
+            assertTrue(
+                src.contains(required),
+                "RestTimerCard.kt must preserve timer/accessibility/action wiring: missing $required",
+            )
+        }
+    }
+
+    private fun readWorkoutTabSource(): String {
+        val src = readProjectFile("src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/WorkoutTab.kt")
+        assertNotNull(src, "Could not locate WorkoutTab.kt")
+        return src
+    }
+
+    private fun readRestTimerCardSource(): String {
+        val src = readProjectFile("src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RestTimerCard.kt")
+        assertNotNull(src, "Could not locate RestTimerCard.kt")
+        return src
+    }
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/RestTimerProgressionWiringTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/RestTimerProgressionWiringTest.kt
@@ -2,6 +2,7 @@ package com.devil.phoenixproject.presentation
 
 import com.devil.phoenixproject.testutil.readProjectFile
 import kotlin.test.Test
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -47,6 +48,59 @@ class RestTimerProgressionWiringTest {
             src.contains("onUpdateProgressionKg.invoke(newValueKg)"),
             "RestTimerCard.kt must call the progression update callback when the control changes.",
         )
+        assertTrue(
+            src.contains("valueKg = nextExerciseProgressionKg"),
+            "RestTimerCard.kt must pass the latest parent value into WeightChangePerRepControl.",
+        )
+        assertFalse(
+            src.contains("editedProgressionKg"),
+            "RestTimer progression must be controlled by WorkoutParameters, not duplicated in local component state.",
+        )
+    }
+
+    @Test
+    fun activeSessionEngine_preservesRestProgressionEditsWhenAdvancing() {
+        val src = readActiveSessionEngineSource()
+
+        assertTrue(
+            src.contains("val preserveRestEdits = coordinator._userAdjustedWeightDuringRest"),
+            "ActiveSessionEngine must snapshot rest-screen user edits before advancing.",
+        )
+        assertTrue(
+            src.contains("val nextProgressionKg = if (preserveRestEdits)") &&
+                src.contains("currentParams.progressionRegressionKg") &&
+                src.contains("progressionRegressionKg = nextProgressionKg"),
+            "Routine rest advance must preserve WorkoutParameters.progressionRegressionKg when the user edits Rest Timer config.",
+        )
+        assertTrue(
+            src.contains("val setProgressionKg = if (coordinator._userAdjustedWeightDuringRest)") &&
+                src.contains("progressionRegressionKg = setProgressionKg"),
+            "Single-exercise rest advance must preserve WorkoutParameters.progressionRegressionKg when the user edits Rest Timer config.",
+        )
+        assertTrue(
+            src.contains("clampUpcomingProgressionKg(nextExercise.progressionKg)") &&
+                src.contains("clampUpcomingProgressionKg(exerciseForNextSet.progressionKg)"),
+            "Rest Timer defaults must be clamped to the signed-off control range before display/advance.",
+        )
+    }
+
+    @Test
+    fun weightChangeControlSyncsClampedDisplayValueBackToParent() {
+        val src = readWeightChangeControlSource()
+
+        assertTrue(
+            src.contains("val clampedDisplay = kgToDisplay(valueKg, weightUnit).coerceIn"),
+            "WeightChangePerRepControl must clamp in display units.",
+        )
+        assertTrue(
+            src.contains("val clampedValueKg = displayToKg(clampedDisplay, weightUnit)"),
+            "WeightChangePerRepControl must convert the displayed clamp back to kg.",
+        )
+        assertTrue(
+            src.contains("LaunchedEffect(clampedValueKg, valueKg, weightUnit)") &&
+                src.contains("onValueChangeKg(clampedValueKg)"),
+            "WeightChangePerRepControl must sync out-of-range parent values back to the displayed kg value.",
+        )
     }
 
     @Test
@@ -79,6 +133,18 @@ class RestTimerProgressionWiringTest {
     private fun readRestTimerCardSource(): String {
         val src = readProjectFile("src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RestTimerCard.kt")
         assertNotNull(src, "Could not locate RestTimerCard.kt")
+        return src
+    }
+
+    private fun readActiveSessionEngineSource(): String {
+        val src = readProjectFile("src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt")
+        assertNotNull(src, "Could not locate ActiveSessionEngine.kt")
+        return src
+    }
+
+    private fun readWeightChangeControlSource(): String {
+        val src = readProjectFile("src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/WeightChangePerRepControl.kt")
+        assertNotNull(src, "Could not locate WeightChangePerRepControl.kt")
         return src
     }
 }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/RestTimerProgressionWiringTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/RestTimerProgressionWiringTest.kt
@@ -30,6 +30,14 @@ class RestTimerProgressionWiringTest {
             src.contains("workoutParameters.programMode != ProgramMode.Echo"),
             "WorkoutTab.kt must guard Rest Timer progression for non-Echo next sets only.",
         )
+        assertTrue(
+            src.contains("nextExercise?.exercise?.hasCableAccessory != true"),
+            "WorkoutTab.kt must use the canonical Exercise.hasCableAccessory bodyweight guard before showing Rest Timer progression.",
+        )
+        assertFalse(
+            src.contains("nextEquipment.isEmpty()") || src.contains("nextEquipment.equals(\"bodyweight\""),
+            "WorkoutTab.kt must not infer bodyweight from raw equipment strings for Rest Timer progression gating.",
+        )
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/SetReadyScreenScrollWiringTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/SetReadyScreenScrollWiringTest.kt
@@ -214,6 +214,54 @@ class SetReadyScreenScrollWiringTest {
     }
 
     @Test
+    fun setReadyProgressionControl_isTaggedForRegressionTests() {
+        val src = readSetReadyScreenSource()
+
+        assertTrue(
+            src.contains("testTag(SetReadyTestTags.PROGRESSION_CONTROL)"),
+            "SetReadyScreen.kt must tag the Weight Change / Rep control so issue #604 can be guarded by UI/screenshot tests.",
+        )
+        assertTrue(
+            src.contains("\"set_ready_progression_control\""),
+            "SetReadyTestTags.PROGRESSION_CONTROL must stringify to \"set_ready_progression_control\".",
+        )
+    }
+
+    @Test
+    fun setReadyProgressionControl_wiresToViewModel() {
+        val src = readSetReadyScreenSource()
+
+        assertTrue(
+            src.contains("WeightChangePerRepControl"),
+            "Cable non-Echo SetReady configuration must render WeightChangePerRepControl for issue #604.",
+        )
+        assertTrue(
+            src.contains("valueKg = setReadyState.adjustedProgressionKg"),
+            "SetReadyScreen.kt must seed Weight Change / Rep from RoutineFlowState.SetReady.adjustedProgressionKg.",
+        )
+        assertTrue(
+            src.contains("viewModel.updateSetReadyProgressionKg(it)"),
+            "SetReadyScreen.kt must route Weight Change / Rep edits through MainViewModel.updateSetReadyProgressionKg.",
+        )
+    }
+
+    @Test
+    fun setReadyConfiguration_appearsBeforeVideo() {
+        val src = readSetReadyScreenSource()
+        val configIdx = src.indexOf("if (isEchoMode) \"ECHO SETTINGS\" else \"SET CONFIGURATION\"")
+        val rackIdx = src.indexOf("testTag(SetReadyTestTags.RACK_CARD)")
+        val videoIdx = src.indexOf("Video thumbnail stays available")
+
+        assertTrue(configIdx >= 0, "SetReady SET CONFIGURATION label must exist.")
+        assertTrue(rackIdx >= 0, "SetReady equipment rack tag must exist.")
+        assertTrue(videoIdx >= 0, "SetReady compact/lower video block must exist.")
+        assertTrue(
+            configIdx < rackIdx && rackIdx < videoIdx,
+            "Issue #604 signed-off layout requires Set Configuration before Equipment Rack, with video moved below primary controls.",
+        )
+    }
+
+    @Test
     fun equipmentRackCard_callSiteUsesIssueScopeComment() {
         val src = readSetReadyScreenSource()
 

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMRoutineFlowTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMRoutineFlowTest.kt
@@ -16,6 +16,7 @@ import com.devil.phoenixproject.testutil.TestFixtures
 import com.devil.phoenixproject.testutil.WorkoutStateFixtures
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -70,6 +71,44 @@ class DWSMRoutineFlowTest {
             routine.exercises[0].exercise.id,
             params.selectedExerciseId,
             "Selected exercise ID should match first exercise",
+        )
+        harness.cleanup()
+    }
+
+    @Test
+    fun loadRoutine_clearsStaleIdleRestEditFlagBeforeSeedingProgression() = runTest {
+        val harness = DWSMTestHarness(this)
+        val baseRoutine = WorkoutStateFixtures.createTestRoutine(
+            weightKg = 30f,
+            repsPerSet = 12,
+        )
+        val routine = baseRoutine.copy(
+            exercises = baseRoutine.exercises.mapIndexed { index, exercise ->
+                if (index == 0) exercise.copy(progressionKg = -0.75f) else exercise
+            },
+        )
+        routine.exercises.forEach { harness.fakeExerciseRepo.addExercise(it.exercise) }
+        advanceUntilIdle()
+
+        harness.dwsm.updateWorkoutParameters(
+            harness.dwsm.coordinator.workoutParameters.value.copy(progressionRegressionKg = 2.5f),
+        )
+        assertTrue(
+            harness.dwsm.coordinator._userAdjustedWeightDuringRest,
+            "Idle parameter edits can set the rest-edit preservation flag before a routine is loaded.",
+        )
+
+        harness.dwsm.loadRoutine(routine)
+        advanceUntilIdle()
+
+        assertFalse(
+            harness.dwsm.coordinator._userAdjustedWeightDuringRest,
+            "Loading a routine through internal parameter seeding must clear stale rest-edit flags.",
+        )
+        assertEquals(
+            -0.75f,
+            harness.dwsm.coordinator.workoutParameters.value.progressionRegressionKg,
+            "Routine load must seed progression from the first routine exercise, not a stale pre-routine edit.",
         )
         harness.cleanup()
     }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMRoutineFlowTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMRoutineFlowTest.kt
@@ -423,6 +423,143 @@ class DWSMRoutineFlowTest {
         harness.cleanup()
     }
 
+    @Test
+    fun enterSetReady_seedsAdjustedProgressionFromRoutineExercise() = runTest {
+        val harness = DWSMTestHarness(this)
+        val routine = Routine(
+            id = "routine-progress-set-ready",
+            name = "Progress Set Ready",
+            exercises = listOf(
+                RoutineExercise(
+                    id = "re-progress-set-ready",
+                    exercise = TestFixtures.benchPress,
+                    orderIndex = 0,
+                    setReps = listOf(8),
+                    weightPerCableKg = 32f,
+                    setWeightsPerCableKg = listOf(32f),
+                    programMode = ProgramMode.OldSchool,
+                    progressionKg = 1.25f,
+                ),
+            ),
+        )
+        routine.exercises.forEach { harness.fakeExerciseRepo.addExercise(it.exercise) }
+        advanceUntilIdle()
+
+        harness.dwsm.loadRoutine(routine)
+        advanceUntilIdle()
+        harness.dwsm.enterSetReady(0, 0)
+
+        val state = harness.dwsm.coordinator.routineFlowState.value
+        assertIs<RoutineFlowState.SetReady>(state)
+        assertEquals(1.25f, state.adjustedProgressionKg)
+        assertEquals(1.25f, harness.dwsm.coordinator.workoutParameters.value.progressionRegressionKg)
+        assertEquals(
+            1.25f,
+            routine.exercises.single().progressionKg,
+            "Set Ready runtime progression must not mutate the saved routine default.",
+        )
+        harness.cleanup()
+    }
+
+    @Test
+    fun enterSetReadyWithAdjustments_seedsAdjustedProgressionFromRoutineExercise() = runTest {
+        val harness = DWSMTestHarness(this)
+        val routine = Routine(
+            id = "routine-progress-adjusted",
+            name = "Progress Adjusted",
+            exercises = listOf(
+                RoutineExercise(
+                    id = "re-progress-adjusted",
+                    exercise = TestFixtures.benchPress,
+                    orderIndex = 0,
+                    setReps = listOf(10),
+                    weightPerCableKg = 30f,
+                    setWeightsPerCableKg = listOf(30f),
+                    programMode = ProgramMode.OldSchool,
+                    progressionKg = -0.75f,
+                ),
+            ),
+        )
+        routine.exercises.forEach { harness.fakeExerciseRepo.addExercise(it.exercise) }
+        advanceUntilIdle()
+
+        harness.dwsm.loadRoutine(routine)
+        advanceUntilIdle()
+        harness.dwsm.enterSetReadyWithAdjustments(0, 0, adjustedWeight = 34f, adjustedReps = 7)
+
+        val state = harness.dwsm.coordinator.routineFlowState.value
+        assertIs<RoutineFlowState.SetReady>(state)
+        assertEquals(34f, state.adjustedWeight)
+        assertEquals(7, state.adjustedReps)
+        assertEquals(-0.75f, state.adjustedProgressionKg)
+        assertEquals(-0.75f, harness.dwsm.coordinator.workoutParameters.value.progressionRegressionKg)
+        harness.cleanup()
+    }
+
+    @Test
+    fun updateSetReadyProgressionKg_updatesStateAndWorkoutParameters() = runTest {
+        val harness = DWSMTestHarness(this)
+        val routine = WorkoutStateFixtures.createTestRoutine(exerciseCount = 1, setsPerExercise = 1)
+        val routineWithProgression = routine.copy(
+            exercises = listOf(routine.exercises.single().copy(progressionKg = 0.5f)),
+        )
+        routineWithProgression.exercises.forEach { harness.fakeExerciseRepo.addExercise(it.exercise) }
+        advanceUntilIdle()
+
+        harness.dwsm.loadRoutine(routineWithProgression)
+        advanceUntilIdle()
+        harness.dwsm.enterSetReady(0, 0)
+        harness.dwsm.updateSetReadyProgressionKg(-2.5f)
+
+        val state = harness.dwsm.coordinator.routineFlowState.value
+        assertIs<RoutineFlowState.SetReady>(state)
+        assertEquals(-2.5f, state.adjustedProgressionKg)
+        assertEquals(-2.5f, harness.dwsm.coordinator.workoutParameters.value.progressionRegressionKg)
+        assertEquals(
+            0.5f,
+            routineWithProgression.exercises.single().progressionKg,
+            "Updating Set Ready progression is an upcoming-set override only.",
+        )
+
+        harness.dwsm.updateSetReadyProgressionKg(9f)
+        val clampedState = harness.dwsm.coordinator.routineFlowState.value
+        assertIs<RoutineFlowState.SetReady>(clampedState)
+        assertEquals(3f, clampedState.adjustedProgressionKg)
+        assertEquals(3f, harness.dwsm.coordinator.workoutParameters.value.progressionRegressionKg)
+        harness.cleanup()
+    }
+
+    @Test
+    fun startSetFromReady_usesAdjustedProgressionKg() = runTest {
+        val harness = DWSMTestHarness(this)
+        val routine = WorkoutStateFixtures.createTestRoutine(exerciseCount = 1, setsPerExercise = 1)
+        val routineWithProgression = routine.copy(
+            exercises = listOf(routine.exercises.single().copy(progressionKg = 0.25f)),
+        )
+        routineWithProgression.exercises.forEach { harness.fakeExerciseRepo.addExercise(it.exercise) }
+        harness.fakeBleRepo.simulateConnect("Vee_Test")
+        advanceUntilIdle()
+
+        harness.dwsm.loadRoutine(routineWithProgression)
+        advanceUntilIdle()
+        harness.dwsm.enterSetReady(0, 0)
+        harness.dwsm.updateSetReadyProgressionKg(1.5f)
+        harness.dwsm.startSetFromReady()
+        advanceUntilIdle()
+
+        assertEquals(
+            1.5f,
+            harness.dwsm.coordinator.workoutParameters.value.progressionRegressionKg,
+            "Starting from Set Ready must keep the adjusted per-rep progression in WorkoutParameters.",
+        )
+        assertEquals(
+            0.25f,
+            routineWithProgression.exercises.single().progressionKg,
+            "Starting from Set Ready must not mutate the saved routine default.",
+        )
+        harness.cleanup()
+    }
+
     // ===== C. Navigation =====
 
     @Test

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMRoutineFlowTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMRoutineFlowTest.kt
@@ -462,6 +462,44 @@ class DWSMRoutineFlowTest {
     }
 
     @Test
+    fun enterSetReady_clampsOutOfRangeRoutineProgressionToControlRange() = runTest {
+        val harness = DWSMTestHarness(this)
+        val routine = Routine(
+            id = "routine-progress-set-ready-clamp",
+            name = "Progress Set Ready Clamp",
+            exercises = listOf(
+                RoutineExercise(
+                    id = "re-progress-set-ready-clamp",
+                    exercise = TestFixtures.benchPress,
+                    orderIndex = 0,
+                    setReps = listOf(8),
+                    weightPerCableKg = 32f,
+                    setWeightsPerCableKg = listOf(32f),
+                    programMode = ProgramMode.OldSchool,
+                    progressionKg = 5f,
+                ),
+            ),
+        )
+        routine.exercises.forEach { harness.fakeExerciseRepo.addExercise(it.exercise) }
+        advanceUntilIdle()
+
+        harness.dwsm.loadRoutine(routine)
+        advanceUntilIdle()
+        harness.dwsm.enterSetReady(0, 0)
+
+        val state = harness.dwsm.coordinator.routineFlowState.value
+        assertIs<RoutineFlowState.SetReady>(state)
+        assertEquals(3f, state.adjustedProgressionKg)
+        assertEquals(3f, harness.dwsm.coordinator.workoutParameters.value.progressionRegressionKg)
+        assertEquals(
+            5f,
+            routine.exercises.single().progressionKg,
+            "Clamping the runtime Set Ready value must not mutate the saved routine default.",
+        )
+        harness.cleanup()
+    }
+
+    @Test
     fun enterSetReadyWithAdjustments_seedsAdjustedProgressionFromRoutineExercise() = runTest {
         val harness = DWSMTestHarness(this)
         val routine = Routine(

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMRoutineFlowTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMRoutineFlowTest.kt
@@ -500,6 +500,57 @@ class DWSMRoutineFlowTest {
     }
 
     @Test
+    fun enterSetReady_ignoresStaleIdleRestEditFlagWhenSeedingProgression() = runTest {
+        val harness = DWSMTestHarness(this)
+        val routine = Routine(
+            id = "routine-progress-stale-flag",
+            name = "Progress Stale Flag",
+            exercises = listOf(
+                RoutineExercise(
+                    id = "re-progress-stale-first",
+                    exercise = TestFixtures.benchPress,
+                    orderIndex = 0,
+                    setReps = listOf(8),
+                    weightPerCableKg = 32f,
+                    setWeightsPerCableKg = listOf(32f),
+                    programMode = ProgramMode.OldSchool,
+                    progressionKg = 2.5f,
+                ),
+                RoutineExercise(
+                    id = "re-progress-stale-second",
+                    exercise = TestFixtures.bicepCurl,
+                    orderIndex = 1,
+                    setReps = listOf(10),
+                    weightPerCableKg = 18f,
+                    setWeightsPerCableKg = listOf(18f),
+                    programMode = ProgramMode.OldSchool,
+                    progressionKg = -1.25f,
+                ),
+            ),
+        )
+        routine.exercises.forEach { harness.fakeExerciseRepo.addExercise(it.exercise) }
+        advanceUntilIdle()
+
+        harness.dwsm.loadRoutine(routine)
+        advanceUntilIdle()
+        harness.dwsm.updateWorkoutParameters(
+            harness.dwsm.coordinator.workoutParameters.value.copy(progressionRegressionKg = 2.5f),
+        )
+        harness.dwsm.enterSetReady(1, 0)
+
+        val state = harness.dwsm.coordinator.routineFlowState.value
+        assertIs<RoutineFlowState.SetReady>(state)
+        assertEquals(-1.25f, state.adjustedProgressionKg)
+        assertEquals(-1.25f, harness.dwsm.coordinator.workoutParameters.value.progressionRegressionKg)
+        assertEquals(
+            false,
+            harness.dwsm.coordinator._userAdjustedWeightDuringRest,
+            "Entering Set Ready from Idle must clear the stale rest-edit flag.",
+        )
+        harness.cleanup()
+    }
+
+    @Test
     fun enterSetReadyWithAdjustments_seedsAdjustedProgressionFromRoutineExercise() = runTest {
         val harness = DWSMTestHarness(this)
         val routine = Routine(

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/WarmupProgressionTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/WarmupProgressionTest.kt
@@ -146,4 +146,46 @@ class WarmupProgressionTest {
 
         harness.cleanup()
     }
+
+    @Test
+    fun `working set after warm-up uses Set Ready progression override`() = runTest {
+        val harness = DWSMTestHarness(this)
+        val routine = warmupRoutine()
+        routine.exercises.forEach { harness.fakeExerciseRepo.addExercise(it.exercise) }
+        harness.fakeBleRepo.simulateConnect("Vee_Test")
+
+        harness.dwsm.loadRoutine(routine)
+        advanceUntilIdle()
+        harness.dwsm.enterSetReady(0, 0)
+        harness.dwsm.updateSetReadyProgressionKg(1.25f)
+
+        harness.fakeBleRepo.commandsReceived.clear()
+        harness.dwsm.startSetFromReady()
+        advanceUntilIdle()
+
+        val warmupPacket = harness.firstActivationPacket()
+        assertEquals(
+            0f,
+            readFloatLE(warmupPacket, BleConstants.ActivationPacket.OFFSET_PROGRESSION),
+            "Warm-up set should still send 0 per-rep progression even when Set Ready overrides the working set.",
+        )
+
+        harness.fakeBleRepo.commandsReceived.clear()
+        harness.activeSessionEngine.handleSetCompletion()
+        advanceUntilIdle()
+
+        val workingPacket = harness.firstActivationPacket()
+        assertEquals(
+            1.25f,
+            readFloatLE(workingPacket, BleConstants.ActivationPacket.OFFSET_PROGRESSION),
+            "Working set after warm-up should use the upcoming-set Set Ready progression override.",
+        )
+
+        assertEquals(
+            progressionKg,
+            routine.exercises.single().progressionKg,
+            "Set Ready override must not mutate the saved routine default progression.",
+        )
+        harness.cleanup()
+    }
 }


### PR DESCRIPTION
Closes #604

## Summary
- Compact the mobile Set Ready header and move the primary Set Configuration card above the equipment rack/video area so the controls are reached with less scrolling.
- Add a shared display-unit-aware `Weight Change / Rep` control for cable, non-Echo upcoming sets on Set Ready and Rest Timer.
- Propagate the runtime override through `RoutineFlowState.SetReady.adjustedProgressionKg` and `WorkoutParameters.progressionRegressionKg` without mutating saved routine defaults.
- Preserve Echo/bodyweight behavior by hiding the new control for those modes, and preserve Rest Timer countdown/live-region/timer actions.

## User-facing release note
Mobile workout flow:
- Made the Set Ready screen more compact so key set controls are easier to reach with less scrolling.
- Added `Weight Change / Rep` to upcoming-set configuration for cable, non-Echo exercises on Set Ready and Rest Timer.
- The new control supports signed kg/lb display and applies to the upcoming set only.
- Echo and bodyweight sets continue to hide this control until a mode-specific behavior is designed.

Support note:
> That adjustment is intentionally set-scoped. It changes the next set you are about to perform, but it does not overwrite your saved routine defaults. To change the routine default, edit the exercise in the routine editor.

## Verification
PASS:
```bash
export JAVA_HOME="$(brew --prefix openjdk@17)"
export PATH="$JAVA_HOME/bin:$PATH"
export ANDROID_HOME=/opt/homebrew/share/android-commandlinetools
export ANDROID_SDK_ROOT="$ANDROID_HOME"
./gradlew -Pskip.supabase.check=true :shared:testAndroidHostTest --tests '*DWSMRoutineFlowTest*' --tests '*WarmupProgressionTest*' --tests '*SetReadyScreenScrollWiringTest*' --tests '*RestTimerProgressionWiringTest*'
```
Result: BUILD SUCCESSFUL. Parsed test reports: 60 tests, 0 failures, 0 errors, 0 skipped.

PASS:
```bash
git diff --check
```

INFO / pre-existing repo formatting gate:
```bash
./gradlew -Pskip.supabase.check=true spotlessCheck
```
Result: failed on existing formatting violations in unrelated files (first reported files under `shared/src/androidHostTest/...`; 62 other files). I did not run `spotlessApply` because that would rewrite unrelated files outside issue #604 scope.

## UI evidence
No emulator screenshots were captured from this headless Kanban worker environment. The PR includes source-level wiring/layout guards covering:
- Set Ready progression control tag/callback and Set Configuration before Equipment Rack/video.
- Rest Timer progression wiring through `WorkoutParameters.progressionRegressionKg`.
- Rest Timer live-region, +30s, pause/resume, reset, skip rest, and end-workout controls remain present.

Manual QA after build should validate:
1. Cable non-Echo Set Ready: compact header, Set Configuration visible earlier, `Weight Change / Rep` appears and changes the upcoming set.
2. Cable non-Echo Rest Timer: countdown remains primary, `Weight Change / Rep` appears in `NEXT SET CONFIGURATION`, and edits affect the next set.
3. Echo Set Ready/Rest Timer: Echo controls remain; `Weight Change / Rep` hidden.
4. Bodyweight Set Ready/Rest Timer: no cable progression control shown.
5. Saved routine defaults are unchanged by Set Ready or Rest Timer edits.
6. Warm-up packets still send zero progression; working set uses the Set Ready override.

## Scope notes
- No Phoenix Portal changes.
- No backend/API/Supabase/Edge Function changes.
- No SQLDelight schema migration.
- No cloud sync payload or backup/export changes.
- No BLE protocol/packet offset changes.
