### PR TITLE
feat(workout): prompt for session bodyweight

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/SessionBodyweightState.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/SessionBodyweightState.kt
@@ -1,0 +1,23 @@
+package com.devil.phoenixproject.domain.model
+
+/**
+ * Session-scoped bodyweight prompt state for bodyweight-containing workout sessions.
+ *
+ * A null [sessionBodyWeightKg] means the active session should fall back to the
+ * saved [UserPreferences.bodyWeightKg] value. A positive value is an explicit
+ * override for this loaded routine/session only unless the user also chose to
+ * save it to profile.
+ */
+data class SessionBodyweightState(
+    val routineHasBodyweight: Boolean = false,
+    val promptHandled: Boolean = false,
+    val sessionBodyWeightKg: Float? = null,
+    val lastAction: SessionBodyweightAction? = null,
+)
+
+enum class SessionBodyweightAction {
+    CONFIRMED_STORED,
+    EDITED_FOR_SESSION,
+    EDITED_AND_SAVED_TO_PROFILE,
+    SKIPPED,
+}

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -62,6 +62,8 @@ import com.devil.phoenixproject.util.Constants
 import com.devil.phoenixproject.util.DataBackupManager
 import com.devil.phoenixproject.util.KmpUtils
 import com.devil.phoenixproject.util.WorkoutCommandValidator
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.math.roundToInt
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -73,8 +75,6 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
-import kotlin.coroutines.cancellation.CancellationException
-import kotlin.math.roundToInt
 
 /**
  * Handles all workout lifecycle logic: start/stop, rep processing, auto-stop,
@@ -467,6 +467,9 @@ class ActiveSessionEngine(
 
     // ===== Calculation Helpers =====
 
+    private fun resolvedSessionBodyWeightKg(): Float = coordinator._sessionBodyweightState.value.sessionBodyWeightKg?.takeIf { it > 0f }
+        ?: settingsManager.userPreferences.value.bodyWeightKg
+
     private suspend fun resolveSelectedExercise(params: WorkoutParameters) = params.selectedExerciseId?.let { exerciseId -> exerciseRepository.getExerciseById(exerciseId) }
 
     private suspend fun captureRackLoadSnapshot(
@@ -838,7 +841,7 @@ class ActiveSessionEngine(
         )
 
         Logger.d("ActiveSessionEngine") {
-            "applyBodyweightVolume: exercise=$exerciseName, bodyWeight=${bodyWeightKg}kg, " +
+            "applyBodyweightVolume: exercise=$exerciseName, bodyWeightSet=${bodyWeightKg > 0f}, " +
                 "variant=${resolvedVariant?.label ?: "name-match"}, reps=$repCount, " +
                 "externalAddedLoad=${rackAdjustment.externalAddedLoadKg}kg, counterweight=${rackAdjustment.counterweightKg}kg, " +
                 "volume=${volume}kg, effectiveWeight=${effectiveWeight}kg"
@@ -901,7 +904,7 @@ class ActiveSessionEngine(
             plannedReps = plannedReps,
             currentSet = currentSetIndex + 1,
             totalSets = currentExercise.setReps.size.coerceAtLeast(1),
-            bodyWeightKg = settingsManager.userPreferences.value.bodyWeightKg,
+            bodyWeightKg = resolvedSessionBodyWeightKg(),
             variants = variants,
             selectedVariant = selectedVariant,
         )
@@ -2939,7 +2942,7 @@ class ActiveSessionEngine(
                 displayMultiplierHint = selectedExercise?.displayMultiplier,
             ).let { baseSummary ->
                 // Issue #229: Override volume for bodyweight exercises
-                val bodyWeightKg = settingsManager.userPreferences.value.bodyWeightKg
+                val bodyWeightKg = resolvedSessionBodyWeightKg()
                 applyBodyweightVolume(baseSummary, currentExercise, bodyWeightKg)
             }
             val rackAdjustment = coordinator._currentRackLoadAdjustment.value
@@ -3479,7 +3482,7 @@ class ActiveSessionEngine(
             displayMultiplierHint = selectedExercise?.displayMultiplier,
         ).let { baseSummary ->
             // Issue #229: Override volume for bodyweight exercises
-            val bodyWeightKg = settingsManager.userPreferences.value.bodyWeightKg
+            val bodyWeightKg = resolvedSessionBodyWeightKg()
             applyBodyweightVolume(baseSummary, currentExercise, bodyWeightKg, bodyweightVariant)
         }
         val savedWeightKg = if (isBodyweightExercise(currentExercise)) {
@@ -3849,7 +3852,7 @@ class ActiveSessionEngine(
                 displayMultiplierHint = selectedExercise?.displayMultiplier,
             ).let { raw ->
                 // Issue #229: Override volume for bodyweight exercises
-                val bodyWeightKg = settingsManager.userPreferences.value.bodyWeightKg
+                val bodyWeightKg = resolvedSessionBodyWeightKg()
                 applyBodyweightVolume(raw, currentExercise, bodyWeightKg, coordinator.bodyweightCompletionVariantOverride)
             }
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/DefaultWorkoutSessionManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/DefaultWorkoutSessionManager.kt
@@ -29,6 +29,8 @@ import com.devil.phoenixproject.domain.model.RepCountTiming
 import com.devil.phoenixproject.domain.model.Routine
 import com.devil.phoenixproject.domain.model.RoutineExercise
 import com.devil.phoenixproject.domain.model.RoutineFlowState
+import com.devil.phoenixproject.domain.model.SessionBodyweightAction
+import com.devil.phoenixproject.domain.model.SessionBodyweightState
 import com.devil.phoenixproject.domain.model.Superset
 import com.devil.phoenixproject.domain.model.WorkoutParameters
 import com.devil.phoenixproject.domain.model.WorkoutState
@@ -286,8 +288,7 @@ class DefaultWorkoutSessionManager(
             ): String? = routineFlowManager.calculateNextExerciseName(isSingleExercise, currentExercise, routine)
             override fun calculateIsLastExercise(isSingleExercise: Boolean, currentExercise: RoutineExercise?, routine: Routine?): Boolean = routineFlowManager.calculateIsLastExercise(isSingleExercise, currentExercise, routine)
             override fun clearCycleContext() = routineFlowManager.clearCycleContext()
-            override fun seedRackSelectionForExercise(exerciseIndex: Int) =
-                routineFlowManager.seedRackSelectionForExercise(exerciseIndex)
+            override fun seedRackSelectionForExercise(exerciseIndex: Int) = routineFlowManager.seedRackSelectionForExercise(exerciseIndex)
             override fun proceedFromSummary() = this@DefaultWorkoutSessionManager.proceedFromSummary()
         }
 
@@ -700,8 +701,7 @@ class DefaultWorkoutSessionManager(
     // ===== Training Cycles — delegated to ActiveSessionEngine =====
 
     fun loadRoutineFromCycle(routineId: String, cycleId: String, dayNumber: Int) = activeSessionEngine.loadRoutineFromCycle(routineId, cycleId, dayNumber)
-    suspend fun loadRoutineFromCycleAsync(routineId: String, cycleId: String, dayNumber: Int) =
-        activeSessionEngine.loadRoutineFromCycleAsync(routineId, cycleId, dayNumber)
+    suspend fun loadRoutineFromCycleAsync(routineId: String, cycleId: String, dayNumber: Int) = activeSessionEngine.loadRoutineFromCycleAsync(routineId, cycleId, dayNumber)
     fun clearCycleContext() = activeSessionEngine.clearCycleContext()
 
     // ===== Rest/Flow Control — delegated to ActiveSessionEngine =====
@@ -726,6 +726,49 @@ class DefaultWorkoutSessionManager(
     fun bodyweightVariantKey(exercise: RoutineExercise): String = activeSessionEngine.bodyweightVariantKey(exercise)
     fun selectBodyweightVariant(exerciseKey: String, variant: BodyweightVariantOption) = activeSessionEngine.selectBodyweightVariant(exerciseKey, variant)
     fun confirmBodyweightSetResult(reps: Int, variant: BodyweightVariantOption) = activeSessionEngine.confirmBodyweightSetResult(reps, variant)
+
+    // ===== Session bodyweight prompt (Issue #600) =====
+
+    val sessionBodyweightState: StateFlow<SessionBodyweightState>
+        get() = coordinator.sessionBodyweightState
+
+    fun resolvedBodyWeightKg(): Float = coordinator._sessionBodyweightState.value.sessionBodyWeightKg?.takeIf { it > 0f }
+        ?: settingsManager.userPreferences.value.bodyWeightKg
+
+    fun confirmSessionBodyWeight(weightKg: Float? = null, saveToProfile: Boolean = false) {
+        val current = coordinator._sessionBodyweightState.value
+        if (weightKg == null) {
+            coordinator._sessionBodyweightState.value = current.copy(
+                promptHandled = true,
+                sessionBodyWeightKg = null,
+                lastAction = SessionBodyweightAction.CONFIRMED_STORED,
+            )
+            return
+        }
+
+        val clamped = weightKg.coerceIn(20f, 300f)
+        coordinator._sessionBodyweightState.value = current.copy(
+            promptHandled = true,
+            sessionBodyWeightKg = clamped,
+            lastAction = if (saveToProfile) {
+                SessionBodyweightAction.EDITED_AND_SAVED_TO_PROFILE
+            } else {
+                SessionBodyweightAction.EDITED_FOR_SESSION
+            },
+        )
+        if (saveToProfile) {
+            settingsManager.setBodyWeightKg(clamped)
+        }
+    }
+
+    fun skipSessionBodyWeightPrompt() {
+        val current = coordinator._sessionBodyweightState.value
+        coordinator._sessionBodyweightState.value = current.copy(
+            promptHandled = true,
+            sessionBodyWeightKg = null,
+            lastAction = SessionBodyweightAction.SKIPPED,
+        )
+    }
 
     // ===== Orchestration: proceedFromSummary (cross-cutting, stays in DWSM) =====
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/RoutineFlowManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/RoutineFlowManager.kt
@@ -21,6 +21,7 @@ import com.devil.phoenixproject.domain.model.RoutineExercise
 import com.devil.phoenixproject.domain.model.RoutineFlowState
 import com.devil.phoenixproject.domain.model.RoutineGroup
 import com.devil.phoenixproject.domain.model.RoutineItem
+import com.devil.phoenixproject.domain.model.SessionBodyweightState
 import com.devil.phoenixproject.domain.model.Superset
 import com.devil.phoenixproject.domain.model.SupersetColors
 import com.devil.phoenixproject.domain.model.WorkoutParameters
@@ -767,9 +768,23 @@ class RoutineFlowManager(
     /**
      * Internal function to load a routine after weights have been resolved.
      */
+    private fun resetSessionBodyweightStateForRoutine(routine: Routine) {
+        coordinator._sessionBodyweightState.value = SessionBodyweightState(
+            routineHasBodyweight = routine.exercises.any { it.exercise.isBodyweight },
+            promptHandled = false,
+            sessionBodyWeightKg = null,
+            lastAction = null,
+        )
+    }
+
+    private fun clearSessionBodyweightState() {
+        coordinator._sessionBodyweightState.value = SessionBodyweightState()
+    }
+
     private fun loadRoutineInternal(routine: Routine) {
         val normalized = normalizeExerciseOrder(routine)
         coordinator.clearActiveRackSelection()
+        resetSessionBodyweightStateForRoutine(normalized)
         coordinator._loadedRoutine.value = normalized
         coordinator._currentExerciseIndex.value = 0
         coordinator._currentSetIndex.value = 0
@@ -950,6 +965,7 @@ class RoutineFlowManager(
 
     private fun enterRoutineOverviewInternal(routine: Routine) {
         val normalized = normalizeExerciseOrder(routine)
+        resetSessionBodyweightStateForRoutine(normalized)
         coordinator._loadedRoutine.value = normalized
         coordinator._currentExerciseIndex.value = 0
         coordinator._currentSetIndex.value = 0
@@ -1225,6 +1241,7 @@ class RoutineFlowManager(
     fun exitRoutineFlow() {
         coordinator._routineFlowState.value = RoutineFlowState.NotInRoutine
         coordinator._loadedRoutine.value = null
+        clearSessionBodyweightState()
         coordinator._workoutState.value = WorkoutState.Idle
         coordinator._weightAdjustmentRecommendation.value = null
         coordinator.clearActiveRackSelection()
@@ -1266,6 +1283,7 @@ class RoutineFlowManager(
             0L
         }
         coordinator._weightAdjustmentRecommendation.value = null
+        clearSessionBodyweightState()
         coordinator._routineFlowState.value = RoutineFlowState.Complete(
             routineName = routine.name,
             totalSets = completedSetCount,
@@ -1276,6 +1294,7 @@ class RoutineFlowManager(
 
     fun clearLoadedRoutine() {
         coordinator._loadedRoutine.value = null
+        clearSessionBodyweightState()
         coordinator.clearActiveRackSelection()
         clearCycleContext()
         coordinator._weightAdjustmentRecommendation.value = null

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutCoordinator.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutCoordinator.kt
@@ -14,6 +14,7 @@ import com.devil.phoenixproject.domain.model.RepQualityScore
 import com.devil.phoenixproject.domain.model.Routine
 import com.devil.phoenixproject.domain.model.RoutineFlowState
 import com.devil.phoenixproject.domain.model.RoutineGroup
+import com.devil.phoenixproject.domain.model.SessionBodyweightState
 import com.devil.phoenixproject.domain.model.WeightAdjustmentRecommendation
 import com.devil.phoenixproject.domain.model.WorkoutMetric
 import com.devil.phoenixproject.domain.model.WorkoutParameters
@@ -133,6 +134,10 @@ class WorkoutCoordinator(
 
     internal val _routineFlowState = MutableStateFlow<RoutineFlowState>(RoutineFlowState.NotInRoutine)
     val routineFlowState: StateFlow<RoutineFlowState> = _routineFlowState.asStateFlow()
+
+    // Issue #600: once-per-session bodyweight prompt and resolved session override.
+    internal val _sessionBodyweightState = MutableStateFlow(SessionBodyweightState())
+    val sessionBodyweightState: StateFlow<SessionBodyweightState> = _sessionBodyweightState.asStateFlow()
 
     /**
      * Issue #348: Session-scoped workout detection for wake lock.

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SetReadyScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SetReadyScreen.kt
@@ -16,8 +16,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.ui.platform.testTag
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
@@ -27,6 +27,7 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
@@ -50,13 +51,15 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -82,6 +85,7 @@ import com.devil.phoenixproject.presentation.navigation.NavigationRoutes
 import com.devil.phoenixproject.presentation.viewmodel.MainViewModel
 import com.devil.phoenixproject.ui.theme.Spacing
 import com.devil.phoenixproject.util.Constants
+import com.devil.phoenixproject.util.UnitConverter
 import org.jetbrains.compose.resources.stringResource
 import vitruvianprojectphoenix.shared.generated.resources.Res
 import vitruvianprojectphoenix.shared.generated.resources.action_cancel
@@ -149,6 +153,11 @@ fun SetReadyScreen(navController: NavController, viewModel: MainViewModel, exerc
 
     // Issue #266/#410: Use configured weight increment from user preferences
     val userPreferences by viewModel.userPreferences.collectAsState()
+    val sessionBodyweightState by viewModel.sessionBodyweightState.collectAsState()
+    val currentRackLoadAdjustment by viewModel.currentRackLoadAdjustment.collectAsState()
+    val resolvedBodyWeightKg = sessionBodyweightState.sessionBodyWeightKg ?: userPreferences.bodyWeightKg
+    val bodyweightPromptPending = sessionBodyweightState.routineHasBodyweight &&
+        !sessionBodyweightState.promptHandled
     val maxWeightKg = Constants.MAX_WEIGHT_PER_CABLE_KG
     val weightStepKg = userPreferences.effectiveWeightIncrementKg
 
@@ -164,6 +173,16 @@ fun SetReadyScreen(navController: NavController, viewModel: MainViewModel, exerc
     // and the reporter's request for "set selection in the middle of a workout"). Disabled when
     // there is only one set (no point picking).
     var setPickerExpanded by remember { mutableStateOf(false) }
+
+    var showSessionBodyweightEditor by remember { mutableStateOf(false) }
+    var sessionBodyweightInput by remember { mutableStateOf("") }
+    var saveSessionBodyweightToProfile by remember { mutableStateOf(false) }
+    fun openSessionBodyweightEditor() {
+        val initialKg = resolvedBodyWeightKg.takeIf { it > 0f }
+        sessionBodyweightInput = initialKg?.let { formatBodyWeightNumberForUnit(it, weightUnit) } ?: ""
+        saveSessionBodyweightToProfile = false
+        showSessionBodyweightEditor = true
+    }
 
     // Handle system back button
     BackHandler {
@@ -253,7 +272,7 @@ fun SetReadyScreen(navController: NavController, viewModel: MainViewModel, exerc
                         modifier = Modifier
                             .weight(1f)
                             .height(48.dp),
-                        enabled = connectionState is ConnectionState.Connected,
+                        enabled = connectionState is ConnectionState.Connected && !bodyweightPromptPending,
                         shape = RoundedCornerShape(12.dp),
                     ) {
                         Icon(
@@ -447,6 +466,20 @@ fun SetReadyScreen(navController: NavController, viewModel: MainViewModel, exerc
                 Spacer(Modifier.height(12.dp))
             }
 
+            // Issue #600: once-per-session Current bodyweight card for any routine
+            // containing a bodyweight exercise, even if the first Set Ready exercise is cable.
+            if (bodyweightPromptPending) {
+                CurrentBodyweightPromptCard(
+                    savedBodyWeightKg = userPreferences.bodyWeightKg,
+                    resolvedBodyWeightKg = resolvedBodyWeightKg,
+                    weightUnit = weightUnit,
+                    onConfirmStored = { viewModel.confirmSessionBodyWeight(null, saveToProfile = false) },
+                    onEdit = { openSessionBodyweightEditor() },
+                    onSkip = viewModel::skipSessionBodyWeightPrompt,
+                )
+                Spacer(Modifier.height(12.dp))
+            }
+
             // Issue #229/#427: Bodyweight variant picker (runtime state, carried across sets)
             if (isBodyweight) {
                 val variants = remember(currentExercise.exercise.name) {
@@ -514,15 +547,16 @@ fun SetReadyScreen(navController: NavController, viewModel: MainViewModel, exerc
                                     }
                                 }
                             }
-                            val userPrefs by viewModel.userPreferences.collectAsState()
-                            val currentRackLoadAdjustment by viewModel.currentRackLoadAdjustment.collectAsState()
-                            if (userPrefs.bodyWeightKg > 0f) {
+                            if (resolvedBodyWeightKg > 0f) {
                                 val effectiveKg = if (selectedVariant.percentage > 0f) {
-                                    (userPrefs.bodyWeightKg * selectedVariant.percentage +
-                                        currentRackLoadAdjustment.externalAddedLoadKg -
-                                        currentRackLoadAdjustment.counterweightKg
-                                    ).coerceAtLeast(0f)
-                                } else 0f
+                                    (
+                                        resolvedBodyWeightKg * selectedVariant.percentage +
+                                            currentRackLoadAdjustment.externalAddedLoadKg -
+                                            currentRackLoadAdjustment.counterweightKg
+                                        ).coerceAtLeast(0f)
+                                } else {
+                                    0f
+                                }
                                 val displayWeight = if (weightUnit == WeightUnit.KG) {
                                     "${com.devil.phoenixproject.util.UnitConverter.formatDecimal(effectiveKg)} kg"
                                 } else {
@@ -539,6 +573,15 @@ fun SetReadyScreen(navController: NavController, viewModel: MainViewModel, exerc
                     }
                     Spacer(Modifier.height(12.dp))
                 }
+            }
+
+            if (isBodyweight && sessionBodyweightState.promptHandled) {
+                HandledSessionBodyweightCard(
+                    resolvedBodyWeightKg = resolvedBodyWeightKg,
+                    weightUnit = weightUnit,
+                    onEdit = { openSessionBodyweightEditor() },
+                )
+                Spacer(Modifier.height(12.dp))
             }
 
             EquipmentRackSelectionCard(
@@ -703,6 +746,57 @@ fun SetReadyScreen(navController: NavController, viewModel: MainViewModel, exerc
         }
     }
 
+    val parsedSessionBodyWeightKg = parseBodyWeightInputKg(sessionBodyweightInput, weightUnit)
+    if (showSessionBodyweightEditor) {
+        AlertDialog(
+            onDismissRequest = { showSessionBodyweightEditor = false },
+            title = { Text("Edit current bodyweight") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(Spacing.small)) {
+                    Text("Used only for this workout unless saved to your profile.")
+                    OutlinedTextField(
+                        value = sessionBodyweightInput,
+                        onValueChange = { value ->
+                            sessionBodyweightInput = value.filter { it.isDigit() || it == '.' || it == ',' }
+                        },
+                        label = { Text("Current bodyweight (${if (weightUnit == WeightUnit.KG) "kg" else "lb"})") },
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Checkbox(
+                            checked = saveSessionBodyweightToProfile,
+                            onCheckedChange = { saveSessionBodyweightToProfile = it },
+                        )
+                        Text("Save to profile for next time")
+                    }
+                }
+            },
+            confirmButton = {
+                Button(
+                    enabled = parsedSessionBodyWeightKg != null && parsedSessionBodyWeightKg > 0f,
+                    onClick = {
+                        parsedSessionBodyWeightKg?.let { kg ->
+                            viewModel.confirmSessionBodyWeight(
+                                weightKg = kg,
+                                saveToProfile = saveSessionBodyweightToProfile,
+                            )
+                        }
+                        showSessionBodyweightEditor = false
+                    },
+                ) {
+                    Text("Save for session")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showSessionBodyweightEditor = false }) {
+                    Text("Cancel")
+                }
+            },
+        )
+    }
+
     // Stop confirmation dialog
     if (showStopConfirmation) {
         AlertDialog(
@@ -759,6 +853,150 @@ fun SetReadyScreen(navController: NavController, viewModel: MainViewModel, exerc
                 }
             },
         )
+    }
+}
+
+@Composable
+private fun CurrentBodyweightPromptCard(
+    savedBodyWeightKg: Float,
+    resolvedBodyWeightKg: Float,
+    weightUnit: WeightUnit,
+    onConfirmStored: () -> Unit,
+    onEdit: () -> Unit,
+    onSkip: () -> Unit,
+) {
+    val hasSavedBodyweight = savedBodyWeightKg > 0f
+    val displayBodyweight = (savedBodyWeightKg.takeIf { it > 0f } ?: resolvedBodyWeightKg)
+        .takeIf { it > 0f }
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag(SetReadyTestTags.SESSION_BODYWEIGHT_CARD),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+        ),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(Spacing.medium),
+            verticalArrangement = Arrangement.spacedBy(Spacing.small),
+        ) {
+            Text(
+                "Current bodyweight",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+            )
+            Text(
+                if (hasSavedBodyweight) {
+                    "Used for bodyweight effective load and volume in this session."
+                } else {
+                    "Add bodyweight to calculate bodyweight effective load and volume for this session."
+                },
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            if (displayBodyweight != null) {
+                Text(
+                    formatBodyWeightForUnit(displayBodyweight, weightUnit),
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.primary,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(Spacing.small),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                if (hasSavedBodyweight) {
+                    Button(onClick = onConfirmStored) {
+                        Text("Use for this session")
+                    }
+                    TextButton(onClick = onEdit) {
+                        Text("Edit")
+                    }
+                    TextButton(onClick = onConfirmStored) {
+                        Text("Use stored")
+                    }
+                } else {
+                    Button(onClick = onEdit) {
+                        Text("Save for session")
+                    }
+                    TextButton(onClick = onSkip) {
+                        Text("Not now")
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun HandledSessionBodyweightCard(
+    resolvedBodyWeightKg: Float,
+    weightUnit: WeightUnit,
+    onEdit: () -> Unit,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+        ),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(Spacing.medium),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    "Current bodyweight",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(
+                    if (resolvedBodyWeightKg > 0f) {
+                        formatBodyWeightForUnit(resolvedBodyWeightKg, weightUnit)
+                    } else {
+                        "Not set for this session"
+                    },
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+            TextButton(onClick = onEdit) {
+                Text("Edit current bodyweight")
+            }
+        }
+    }
+}
+
+private fun formatBodyWeightNumberForUnit(weightKg: Float, weightUnit: WeightUnit): String {
+    val displayValue = when (weightUnit) {
+        WeightUnit.KG -> weightKg
+        WeightUnit.LB -> UnitConverter.kgToLb(weightKg)
+    }
+    return UnitConverter.formatDecimal(displayValue)
+}
+
+private fun formatBodyWeightForUnit(weightKg: Float, weightUnit: WeightUnit): String {
+    val suffix = when (weightUnit) {
+        WeightUnit.KG -> "kg"
+        WeightUnit.LB -> "lb"
+    }
+    return "${formatBodyWeightNumberForUnit(weightKg, weightUnit)} $suffix"
+}
+
+private fun parseBodyWeightInputKg(input: String, weightUnit: WeightUnit): Float? {
+    val displayValue = input.trim().replace(',', '.').toFloatOrNull() ?: return null
+    return when (weightUnit) {
+        WeightUnit.KG -> displayValue
+        WeightUnit.LB -> UnitConverter.lbToKg(displayValue)
     }
 }
 
@@ -870,4 +1108,7 @@ private fun SetReadyEccentricLoadSlider(percent: Int, onPercentChange: (Int) -> 
 object SetReadyTestTags {
     /** EquipmentRackSelectionCard root inside SetReadyScreen. Issue #582. */
     const val RACK_CARD: String = "set_ready_rack_card"
+
+    /** Current bodyweight prompt card shown once per bodyweight-containing session. Issue #600. */
+    const val SESSION_BODYWEIGHT_CARD: String = "set_ready_session_bodyweight_card"
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SetReadyScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SetReadyScreen.kt
@@ -1,6 +1,7 @@
 package com.devil.phoenixproject.presentation.screen
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -764,7 +765,12 @@ fun SetReadyScreen(navController: NavController, viewModel: MainViewModel, exerc
                         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
                         modifier = Modifier.fillMaxWidth(),
                     )
-                    Row(verticalAlignment = Alignment.CenterVertically) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { saveSessionBodyweightToProfile = !saveSessionBodyweightToProfile },
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
                         Checkbox(
                             checked = saveSessionBodyweightToProfile,
                             onCheckedChange = { saveSessionBodyweightToProfile = it },
@@ -916,9 +922,6 @@ private fun CurrentBodyweightPromptCard(
                     }
                     TextButton(onClick = onEdit) {
                         Text("Edit")
-                    }
-                    TextButton(onClick = onConfirmStored) {
-                        Text("Use stored")
                     }
                 } else {
                     Button(onClick = onEdit) {

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SingleExerciseScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SingleExerciseScreen.kt
@@ -372,11 +372,22 @@ fun SingleExerciseScreen(
 
                                 viewModel.ensureConnection(
                                     onConnected = {
-                                        Logger.d { "SingleExercise: onConnected callback - starting workout" }
-                                        viewModel.startWorkout()
-                                        Logger.d { "SingleExercise: Navigating to ActiveWorkout" }
-                                        navController.navigate(NavigationRoutes.ActiveWorkout.route) {
-                                            popUpTo(NavigationRoutes.Home.route)
+                                        if (configuredExercise.exercise.isBodyweight) {
+                                            Logger.d {
+                                                "SingleExercise: onConnected callback - entering SetReady for bodyweight prompt"
+                                            }
+                                            viewModel.enterSetReady(0, 0)
+                                            Logger.d { "SingleExercise: Navigating to SetReady for bodyweight prompt" }
+                                            navController.navigate(NavigationRoutes.SetReady.route) {
+                                                popUpTo(NavigationRoutes.Home.route)
+                                            }
+                                        } else {
+                                            Logger.d { "SingleExercise: onConnected callback - starting workout" }
+                                            viewModel.startWorkout()
+                                            Logger.d { "SingleExercise: Navigating to ActiveWorkout" }
+                                            navController.navigate(NavigationRoutes.ActiveWorkout.route) {
+                                                popUpTo(NavigationRoutes.Home.route)
+                                            }
                                         }
                                     },
                                     onFailed = {

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
@@ -38,10 +38,11 @@ import com.devil.phoenixproject.domain.model.RackLoadAdjustment
 import com.devil.phoenixproject.domain.model.RepCount
 import com.devil.phoenixproject.domain.model.RepCountTiming
 import com.devil.phoenixproject.domain.model.Routine
-import com.devil.phoenixproject.domain.model.ScalingBasis
 import com.devil.phoenixproject.domain.model.RoutineExercise
 import com.devil.phoenixproject.domain.model.RoutineFlowState
 import com.devil.phoenixproject.domain.model.RoutineGroup
+import com.devil.phoenixproject.domain.model.ScalingBasis
+import com.devil.phoenixproject.domain.model.SessionBodyweightState
 import com.devil.phoenixproject.domain.model.Superset
 import com.devil.phoenixproject.domain.model.UserPreferences
 import com.devil.phoenixproject.domain.model.WeightUnit
@@ -243,6 +244,8 @@ class MainViewModel constructor(
     val currentSetRpe: StateFlow<Int?> get() = workoutSessionManager.coordinator.currentSetRpe
     val isCurrentExerciseBodyweight: StateFlow<Boolean> get() = workoutSessionManager.coordinator.isCurrentExerciseBodyweight
     val selectedBodyweightVariants: StateFlow<Map<String, BodyweightVariantOption>> get() = workoutSessionManager.selectedBodyweightVariants
+    val sessionBodyweightState: StateFlow<SessionBodyweightState> get() = workoutSessionManager.sessionBodyweightState
+    val resolvedBodyWeightKg: Float get() = workoutSessionManager.resolvedBodyWeightKg()
     val latestRepQuality get() = workoutSessionManager.coordinator.latestRepQuality
     val latestBiomechanicsResult get() = workoutSessionManager.coordinator.latestBiomechanicsResult
     val motionStartHoldProgress: StateFlow<Float?> get() = workoutSessionManager.coordinator.motionStartHoldProgress
@@ -346,6 +349,7 @@ class MainViewModel constructor(
     fun setVelocityLossThreshold(percent: Int) = settingsManager.setVelocityLossThreshold(percent)
     fun setAutoEndOnVelocityLoss(enabled: Boolean) = settingsManager.setAutoEndOnVelocityLoss(enabled)
     fun setWeightSuggestionsEnabled(enabled: Boolean) = settingsManager.setWeightSuggestionsEnabled(enabled)
+
     // Issue #517: system-wide default scaling basis
     fun setDefaultScalingBasis(basis: ScalingBasis) = settingsManager.setDefaultScalingBasis(basis)
 
@@ -524,6 +528,8 @@ class MainViewModel constructor(
     fun bodyweightVariantKey(exercise: RoutineExercise): String = workoutSessionManager.bodyweightVariantKey(exercise)
     fun selectBodyweightVariant(exerciseKey: String, variant: BodyweightVariantOption) = workoutSessionManager.selectBodyweightVariant(exerciseKey, variant)
     fun confirmBodyweightSetResult(reps: Int, variant: BodyweightVariantOption) = workoutSessionManager.confirmBodyweightSetResult(reps, variant)
+    fun confirmSessionBodyWeight(weightKg: Float?, saveToProfile: Boolean) = workoutSessionManager.confirmSessionBodyWeight(weightKg, saveToProfile)
+    fun skipSessionBodyWeightPrompt() = workoutSessionManager.skipSessionBodyWeightPrompt()
     fun returnToOverview() = workoutSessionManager.returnToOverview()
     fun exitRoutineFlow() = workoutSessionManager.exitRoutineFlow()
     fun showRoutineComplete() = workoutSessionManager.showRoutineComplete()
@@ -576,8 +582,7 @@ class MainViewModel constructor(
     // ===== Training Cycle Delegation =====
 
     fun loadRoutineFromCycle(routineId: String, cycleId: String, dayNumber: Int) = workoutSessionManager.loadRoutineFromCycle(routineId, cycleId, dayNumber)
-    suspend fun loadRoutineFromCycleAsync(routineId: String, cycleId: String, dayNumber: Int) =
-        workoutSessionManager.loadRoutineFromCycleAsync(routineId, cycleId, dayNumber)
+    suspend fun loadRoutineFromCycleAsync(routineId: String, cycleId: String, dayNumber: Int) = workoutSessionManager.loadRoutineFromCycleAsync(routineId, cycleId, dayNumber)
     fun clearCycleContext() = workoutSessionManager.clearCycleContext()
 
     // ===== Top Bar State (stays here - pure UI scaffolding) =====

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/SetReadySessionBodyweightPromptWiringTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/SetReadySessionBodyweightPromptWiringTest.kt
@@ -17,7 +17,6 @@ class SetReadySessionBodyweightPromptWiringTest {
             "Used for bodyweight effective load and volume in this session.",
             "Add bodyweight to calculate bodyweight effective load and volume for this session.",
             "Use for this session",
-            "Use stored",
             "Not now",
             "Save for session",
             "Save to profile for next time",
@@ -28,6 +27,38 @@ class SetReadySessionBodyweightPromptWiringTest {
                 "SetReadyScreen.kt must contain issue #600 prompt copy: $expected",
             )
         }
+        assertTrue(
+            "\"Use stored\"" !in src,
+            "SetReadyScreen.kt must not render a redundant Use stored action when Use for this session already confirms the saved value.",
+        )
+    }
+
+    @Test
+    fun saveToProfileCheckbox_usesClickableRowTouchTarget() {
+        val src = readSetReadyScreenSource()
+
+        assertTrue(
+            src.contains(".clickable { saveSessionBodyweightToProfile = !saveSessionBodyweightToProfile }"),
+            "The Save to profile row must be clickable so users do not have to precisely tap the checkbox.",
+        )
+    }
+
+    @Test
+    fun directBodyweightSingleExercise_routesThroughSetReadyPrompt() {
+        val src = readSingleExerciseScreenSource()
+
+        assertTrue(
+            src.contains("if (configuredExercise.exercise.isBodyweight)"),
+            "SingleExerciseScreen.kt must special-case direct bodyweight launches after loading the temp routine.",
+        )
+        assertTrue(
+            src.contains("viewModel.enterSetReady(0, 0)"),
+            "Direct bodyweight single-exercise launches must enter Set Ready so the current-bodyweight prompt can be handled before the set starts.",
+        )
+        assertTrue(
+            src.contains("navController.navigate(NavigationRoutes.SetReady.route)"),
+            "Direct bodyweight single-exercise launches must navigate to Set Ready instead of bypassing the prompt.",
+        )
     }
 
     @Test
@@ -87,6 +118,17 @@ class SetReadySessionBodyweightPromptWiringTest {
         assertNotNull(
             src,
             "Could not locate SetReadyScreen.kt on disk. Run from the shared/ module root or project root.",
+        )
+        return src
+    }
+
+    private fun readSingleExerciseScreenSource(): String {
+        val relativePath =
+            "src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SingleExerciseScreen.kt"
+        val src = readProjectFile(relativePath)
+        assertNotNull(
+            src,
+            "Could not locate SingleExerciseScreen.kt on disk. Run from the shared/ module root or project root.",
         )
         return src
     }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/SetReadySessionBodyweightPromptWiringTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/SetReadySessionBodyweightPromptWiringTest.kt
@@ -1,0 +1,93 @@
+package com.devil.phoenixproject.presentation
+
+import com.devil.phoenixproject.testutil.readProjectFile
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/** Source-level UI wiring guard for issue #600 session bodyweight prompt. */
+class SetReadySessionBodyweightPromptWiringTest {
+
+    @Test
+    fun promptCopy_isPresentInSetReadySource() {
+        val src = readSetReadyScreenSource()
+
+        listOf(
+            "Current bodyweight",
+            "Used for bodyweight effective load and volume in this session.",
+            "Add bodyweight to calculate bodyweight effective load and volume for this session.",
+            "Use for this session",
+            "Use stored",
+            "Not now",
+            "Save for session",
+            "Save to profile for next time",
+            "Edit current bodyweight",
+        ).forEach { expected ->
+            assertTrue(
+                expected in src,
+                "SetReadyScreen.kt must contain issue #600 prompt copy: $expected",
+            )
+        }
+    }
+
+    @Test
+    fun promptGate_usesRoutineLevelSessionState() {
+        val src = readSetReadyScreenSource()
+
+        assertTrue(
+            src.contains("val sessionBodyweightState by viewModel.sessionBodyweightState.collectAsState()"),
+            "SetReadyScreen.kt must collect sessionBodyweightState from MainViewModel.",
+        )
+        assertTrue(
+            src.contains("val bodyweightPromptPending = sessionBodyweightState.routineHasBodyweight &&\n        !sessionBodyweightState.promptHandled"),
+            "SetReadyScreen.kt must gate the prompt on routineHasBodyweight, not only current exercise bodyweight.",
+        )
+        assertTrue(
+            src.contains("enabled = connectionState is ConnectionState.Connected && !bodyweightPromptPending"),
+            "START must stay disabled until the current-bodyweight prompt is confirmed, edited, or skipped.",
+        )
+    }
+
+    @Test
+    fun promptCard_isTaggedForFutureComposeTests() {
+        val src = readSetReadyScreenSource()
+
+        assertTrue(
+            src.contains("testTag(SetReadyTestTags.SESSION_BODYWEIGHT_CARD)"),
+            "The issue #600 Current bodyweight card must have a stable test tag.",
+        )
+        assertTrue(
+            src.contains("\"set_ready_session_bodyweight_card\""),
+            "SetReadyTestTags.SESSION_BODYWEIGHT_CARD must keep a stable string value.",
+        )
+    }
+
+    @Test
+    fun effectiveLoadPreview_usesResolvedBodyweight() {
+        val src = readSetReadyScreenSource()
+
+        assertTrue(
+            src.contains("val resolvedBodyWeightKg = sessionBodyweightState.sessionBodyWeightKg ?: userPreferences.bodyWeightKg"),
+            "SetReadyScreen.kt must resolve session override before falling back to saved Settings bodyweight.",
+        )
+        assertTrue(
+            src.contains("resolvedBodyWeightKg * selectedVariant.percentage"),
+            "Bodyweight effective-load preview must use the resolved session bodyweight value.",
+        )
+        assertTrue(
+            src.contains("Text(\"Edit current bodyweight\")"),
+            "Handled bodyweight sessions must expose an edit affordance from the bodyweight setup area.",
+        )
+    }
+
+    private fun readSetReadyScreenSource(): String {
+        val relativePath =
+            "src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SetReadyScreen.kt"
+        val src = readProjectFile(relativePath)
+        assertNotNull(
+            src,
+            "Could not locate SetReadyScreen.kt on disk. Run from the shared/ module root or project root.",
+        )
+        return src
+    }
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMSessionBodyweightTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMSessionBodyweightTest.kt
@@ -1,0 +1,354 @@
+package com.devil.phoenixproject.presentation.manager
+
+import com.devil.phoenixproject.domain.model.Exercise
+import com.devil.phoenixproject.domain.model.RackItem
+import com.devil.phoenixproject.domain.model.RackItemBehavior
+import com.devil.phoenixproject.domain.model.RackItemCategory
+import com.devil.phoenixproject.domain.model.Routine
+import com.devil.phoenixproject.domain.model.RoutineExercise
+import com.devil.phoenixproject.domain.model.SessionBodyweightAction
+import com.devil.phoenixproject.domain.model.WorkoutState
+import com.devil.phoenixproject.testutil.DWSMTestHarness
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+
+/** Regression coverage for issue #600: session-scoped current bodyweight prompt. */
+class DWSMSessionBodyweightTest {
+
+    private val pushUp = Exercise(
+        name = "Push Up",
+        muscleGroup = "Chest",
+        muscleGroups = "Chest,Triceps,Shoulders",
+        equipment = "",
+        id = "push-up-issue-600",
+    )
+
+    private val cablePress = Exercise(
+        name = "Bench Press (cable)",
+        muscleGroup = "Chest",
+        muscleGroups = "Chest,Triceps,Shoulders",
+        equipment = "BAR",
+        id = "cable-bench-issue-600",
+    )
+
+    private fun bodyweightRoutine(id: String = "bodyweight-routine"): Routine = Routine(
+        id = id,
+        name = "Bodyweight Routine",
+        exercises = listOf(
+            RoutineExercise(
+                id = "$id-push-up",
+                exercise = pushUp,
+                orderIndex = 0,
+                setReps = listOf(10, 10),
+                weightPerCableKg = 0f,
+                duration = 1,
+                setRestSeconds = listOf(0, 0),
+            ),
+        ),
+    )
+
+    private fun mixedRoutineStartingWithCable(): Routine = Routine(
+        id = "mixed-routine",
+        name = "Mixed Routine",
+        exercises = listOf(
+            RoutineExercise(
+                id = "mixed-cable",
+                exercise = cablePress,
+                orderIndex = 0,
+                setReps = listOf(8),
+                weightPerCableKg = 40f,
+            ),
+            RoutineExercise(
+                id = "mixed-push-up",
+                exercise = pushUp,
+                orderIndex = 1,
+                setReps = listOf(10),
+                weightPerCableKg = 0f,
+                duration = 1,
+            ),
+        ),
+    )
+
+    private fun cableRoutine(): Routine = Routine(
+        id = "cable-routine",
+        name = "Cable Routine",
+        exercises = listOf(
+            RoutineExercise(
+                id = "cable-only",
+                exercise = cablePress,
+                orderIndex = 0,
+                setReps = listOf(8),
+                weightPerCableKg = 40f,
+            ),
+        ),
+    )
+
+    private fun vest(weightKg: Float = 3.62874f): RackItem = RackItem(
+        id = "vest-8lb-issue-600",
+        name = "Weighted Vest 8lb",
+        category = RackItemCategory.WEIGHTED_VEST,
+        weightKg = weightKg,
+        behavior = RackItemBehavior.ADDED_RESISTANCE,
+        enabled = true,
+        sortOrder = 1,
+    )
+
+    private fun assertFloatEquals(expected: Float, actual: Float, tolerance: Float = 0.5f) {
+        assertTrue(abs(expected - actual) < tolerance, "Expected $expected ± $tolerance, got $actual")
+    }
+
+    private fun seedExercises(harness: DWSMTestHarness) {
+        harness.fakeExerciseRepo.addExercise(pushUp)
+        harness.fakeExerciseRepo.addExercise(cablePress)
+    }
+
+    @Test
+    fun `bodyweight routine initializes prompt state`() = runTest {
+        val harness = DWSMTestHarness(this)
+        try {
+            seedExercises(harness)
+            harness.dwsm.loadRoutine(bodyweightRoutine())
+            advanceUntilIdle()
+
+            val state = harness.dwsm.sessionBodyweightState.value
+            assertTrue(state.routineHasBodyweight)
+            assertEquals(false, state.promptHandled)
+            assertNull(state.sessionBodyWeightKg)
+            assertNull(state.lastAction)
+        } finally {
+            harness.cleanup()
+        }
+    }
+
+    @Test
+    fun `mixed routine starting with cable still initializes bodyweight prompt`() = runTest {
+        val harness = DWSMTestHarness(this)
+        try {
+            seedExercises(harness)
+            harness.dwsm.loadRoutine(mixedRoutineStartingWithCable())
+            advanceUntilIdle()
+
+            val state = harness.dwsm.sessionBodyweightState.value
+            assertTrue(state.routineHasBodyweight)
+            assertEquals(false, state.promptHandled)
+            assertNull(state.sessionBodyWeightKg)
+        } finally {
+            harness.cleanup()
+        }
+    }
+
+    @Test
+    fun `cable routine does not initialize bodyweight prompt`() = runTest {
+        val harness = DWSMTestHarness(this)
+        try {
+            seedExercises(harness)
+            harness.dwsm.loadRoutine(cableRoutine())
+            advanceUntilIdle()
+
+            val state = harness.dwsm.sessionBodyweightState.value
+            assertEquals(false, state.routineHasBodyweight)
+            assertEquals(false, state.promptHandled)
+            assertNull(state.sessionBodyWeightKg)
+        } finally {
+            harness.cleanup()
+        }
+    }
+
+    @Test
+    fun `confirm stored uses saved preference`() = runTest {
+        val harness = DWSMTestHarness(this)
+        try {
+            seedExercises(harness)
+            harness.fakePrefsManager.setBodyWeightKg(82f)
+            harness.dwsm.loadRoutine(bodyweightRoutine())
+            advanceUntilIdle()
+
+            harness.dwsm.confirmSessionBodyWeight(weightKg = null, saveToProfile = false)
+
+            val state = harness.dwsm.sessionBodyweightState.value
+            assertEquals(true, state.promptHandled)
+            assertNull(state.sessionBodyWeightKg)
+            assertEquals(SessionBodyweightAction.CONFIRMED_STORED, state.lastAction)
+            assertFloatEquals(82f, harness.dwsm.resolvedBodyWeightKg())
+        } finally {
+            harness.cleanup()
+        }
+    }
+
+    @Test
+    fun `session edit clamps high values without changing saved preference`() = runTest {
+        val harness = DWSMTestHarness(this)
+        try {
+            seedExercises(harness)
+            harness.fakePrefsManager.setBodyWeightKg(75f)
+            harness.dwsm.loadRoutine(bodyweightRoutine())
+            advanceUntilIdle()
+
+            harness.dwsm.confirmSessionBodyWeight(weightKg = 350f, saveToProfile = false)
+            advanceUntilIdle()
+
+            val state = harness.dwsm.sessionBodyweightState.value
+            assertEquals(SessionBodyweightAction.EDITED_FOR_SESSION, state.lastAction)
+            assertFloatEquals(300f, state.sessionBodyWeightKg ?: 0f)
+            assertFloatEquals(300f, harness.dwsm.resolvedBodyWeightKg())
+            assertFloatEquals(75f, harness.fakePrefsManager.preferencesFlow.value.bodyWeightKg)
+        } finally {
+            harness.cleanup()
+        }
+    }
+
+    @Test
+    fun `session edit clamps low values without changing saved preference`() = runTest {
+        val harness = DWSMTestHarness(this)
+        try {
+            seedExercises(harness)
+            harness.fakePrefsManager.setBodyWeightKg(75f)
+            harness.dwsm.loadRoutine(bodyweightRoutine())
+            advanceUntilIdle()
+
+            harness.dwsm.confirmSessionBodyWeight(weightKg = 5f, saveToProfile = false)
+            advanceUntilIdle()
+
+            val state = harness.dwsm.sessionBodyweightState.value
+            assertEquals(SessionBodyweightAction.EDITED_FOR_SESSION, state.lastAction)
+            assertFloatEquals(20f, state.sessionBodyWeightKg ?: 0f)
+            assertFloatEquals(75f, harness.fakePrefsManager.preferencesFlow.value.bodyWeightKg)
+        } finally {
+            harness.cleanup()
+        }
+    }
+
+    @Test
+    fun `save to profile updates preference after session override`() = runTest {
+        val harness = DWSMTestHarness(this)
+        try {
+            seedExercises(harness)
+            harness.fakePrefsManager.setBodyWeightKg(75f)
+            harness.dwsm.loadRoutine(bodyweightRoutine())
+            advanceUntilIdle()
+
+            harness.dwsm.confirmSessionBodyWeight(weightKg = 91f, saveToProfile = true)
+            advanceUntilIdle()
+
+            val state = harness.dwsm.sessionBodyweightState.value
+            assertEquals(SessionBodyweightAction.EDITED_AND_SAVED_TO_PROFILE, state.lastAction)
+            assertFloatEquals(91f, state.sessionBodyWeightKg ?: 0f)
+            assertFloatEquals(91f, harness.fakePrefsManager.preferencesFlow.value.bodyWeightKg)
+            assertFloatEquals(91f, harness.dwsm.resolvedBodyWeightKg())
+        } finally {
+            harness.cleanup()
+        }
+    }
+
+    @Test
+    fun `skip preserves saved fallback semantics`() = runTest {
+        val harness = DWSMTestHarness(this)
+        try {
+            seedExercises(harness)
+            harness.fakePrefsManager.setBodyWeightKg(84f)
+            harness.dwsm.loadRoutine(bodyweightRoutine())
+            advanceUntilIdle()
+
+            harness.dwsm.skipSessionBodyWeightPrompt()
+
+            val state = harness.dwsm.sessionBodyweightState.value
+            assertEquals(true, state.promptHandled)
+            assertNull(state.sessionBodyWeightKg)
+            assertEquals(SessionBodyweightAction.SKIPPED, state.lastAction)
+            assertFloatEquals(84f, harness.dwsm.resolvedBodyWeightKg())
+        } finally {
+            harness.cleanup()
+        }
+    }
+
+    @Test
+    fun `new routine load clears previous session override`() = runTest {
+        val harness = DWSMTestHarness(this)
+        try {
+            seedExercises(harness)
+            harness.dwsm.loadRoutine(bodyweightRoutine("first-bodyweight"))
+            advanceUntilIdle()
+            harness.dwsm.confirmSessionBodyWeight(weightKg = 90f, saveToProfile = false)
+
+            harness.dwsm.loadRoutine(cableRoutine())
+            advanceUntilIdle()
+
+            val state = harness.dwsm.sessionBodyweightState.value
+            assertEquals(false, state.routineHasBodyweight)
+            assertEquals(false, state.promptHandled)
+            assertNull(state.sessionBodyWeightKg)
+            assertNull(state.lastAction)
+        } finally {
+            harness.cleanup()
+        }
+    }
+
+    @Test
+    fun `session override feeds bodyweight rep entry`() = runTest {
+        val harness = DWSMTestHarness(this)
+        try {
+            seedExercises(harness)
+            harness.fakeBleRepo.simulateConnect("Vee_Test")
+            harness.fakePrefsManager.setBodyWeightKg(80f)
+            harness.dwsm.loadRoutine(bodyweightRoutine())
+            advanceUntilIdle()
+            harness.dwsm.confirmSessionBodyWeight(weightKg = 90f, saveToProfile = false)
+            harness.dwsm.enterSetReady(0, 0)
+            advanceUntilIdle()
+
+            harness.dwsm.startWorkout(skipCountdown = true)
+            advanceTimeBy(1_100)
+            runCurrent()
+
+            val entry = assertIs<WorkoutState.BodyweightRepEntry>(harness.dwsm.coordinator.workoutState.value)
+            assertFloatEquals(90f, entry.bodyWeightKg)
+        } finally {
+            harness.cleanup()
+        }
+    }
+
+    @Test
+    fun `session override feeds persisted volume with weighted vest`() = runTest {
+        val harness = DWSMTestHarness(this)
+        try {
+            seedExercises(harness)
+            harness.fakeBleRepo.simulateConnect("Vee_Test")
+            harness.fakePrefsManager.setBodyWeightKg(80f)
+            val v = vest()
+            harness.fakeEquipmentRackRepo.upsert(v)
+            advanceUntilIdle()
+
+            harness.dwsm.loadRoutine(bodyweightRoutine())
+            advanceUntilIdle()
+            harness.dwsm.confirmSessionBodyWeight(weightKg = 90f, saveToProfile = false)
+            harness.dwsm.enterSetReady(0, 0)
+            advanceUntilIdle()
+            harness.dwsm.updateActiveRackSelection(listOf(v.id))
+
+            harness.dwsm.startWorkout(skipCountdown = true)
+            advanceTimeBy(1_100)
+            runCurrent()
+
+            val entry = assertIs<WorkoutState.BodyweightRepEntry>(harness.dwsm.coordinator.workoutState.value)
+            val decline18 = entry.variants.first { it.label == "Decline 18\"" }
+            harness.dwsm.confirmBodyweightSetResult(reps = 10, variant = decline18)
+            advanceTimeBy(1_000)
+            runCurrent()
+
+            val session = harness.fakeWorkoutRepo.getAllSessions("default").first().single()
+            assertFloatEquals(69.32874f, session.heaviestLiftKg ?: 0f)
+            assertFloatEquals(693.2874f, session.totalVolumeKg ?: 0f, tolerance = 1.0f)
+        } finally {
+            harness.cleanup()
+        }
+    }
+}


### PR DESCRIPTION
Fixes #600

## Summary
- Add a session-scoped `Current bodyweight` prompt to Set Ready for routines containing bodyweight exercises, including routines that start with a cable exercise but include bodyweight later.
- Add session bodyweight state/actions and resolver APIs so edited values are session-only by default, with `Save to profile for next time` as an explicit opt-in.
- Route the resolved bodyweight into Set Ready effective-load preview, `BodyweightRepEntry`, and `ActiveSessionEngine.applyBodyweightVolume(...)`; redact numeric bodyweight from the touched diagnostic log.
- Keep Settings -> Body Weight unchanged; no backend, API, schema, Supabase, portal, or historical recalculation changes.

## User-facing note
Bodyweight workouts now ask for your current bodyweight directly in Set Ready. Use the saved value, enter a session-only value, or optionally save the new value to your profile for next time.

## Tests
- PASS: `git diff --check`
- PASS: `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ANDROID_HOME=/opt/homebrew/share/android-commandlinetools ANDROID_SDK_ROOT=/opt/homebrew/share/android-commandlinetools ./gradlew :shared:testAndroidHostTest --tests '*DWSMSessionBodyweightTest*' --tests '*SetReadySessionBodyweightPromptWiringTest*' -Pskip.supabase.check=true`
- PASS: `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ANDROID_HOME=/opt/homebrew/share/android-commandlinetools ANDROID_SDK_ROOT=/opt/homebrew/share/android-commandlinetools ./gradlew :shared:testAndroidHostTest --tests '*BodyweightRackLoadTest*' --tests '*Issue593BodyweightRepEntryTest*' --tests '*BodyweightVolumeCalculatorTest*' -Pskip.supabase.check=true`
- PASS: `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ANDROID_HOME=/opt/homebrew/share/android-commandlinetools ANDROID_SDK_ROOT=/opt/homebrew/share/android-commandlinetools ./gradlew -q :shared:testAndroidHostTest --continue -Pskip.supabase.check=true`
- PASS: `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ANDROID_HOME=/opt/homebrew/share/android-commandlinetools ANDROID_SDK_ROOT=/opt/homebrew/share/android-commandlinetools ./gradlew -q :shared:compileKotlinMetadata :shared:validateSchemaManifest -Pskip.supabase.check=true`

## Notes
- `spotlessKotlinCheck` is still blocked by pre-existing formatting violations across unrelated files on main. I ran `spotlessKotlinApply` and restored unrelated files so this PR's touched files are formatter-normalized without broadening the diff.
