### PR TITLE
chore: bump app version to 0.9.3

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -196,7 +196,7 @@ android {
         targetSdk = 37
         // Fail fast if CI injects an invalid version code instead of silently shipping a default.
         versionCode = injectedVersionCode ?: 5
-        versionName = "0.9.2"
+        versionName = "0.9.3"
 
         // Supabase config injected from local.properties
         buildConfigField("String", "SUPABASE_URL", "\"$supabaseUrl\"")

--- a/iosApp/VitruvianPhoenix/VitruvianPhoenix.xcodeproj/project.pbxproj
+++ b/iosApp/VitruvianPhoenix/VitruvianPhoenix.xcodeproj/project.pbxproj
@@ -367,7 +367,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.9.2;
+				MARKETING_VERSION = 0.9.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.devil.phoenixproject.projectphoenix;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -412,7 +412,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.9.2;
+				MARKETING_VERSION = 0.9.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.devil.phoenixproject.projectphoenix;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/Constants.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/Constants.kt
@@ -5,7 +5,7 @@ package com.devil.phoenixproject.util
  */
 object Constants {
     // App version
-    const val APP_VERSION = "0.9.2"
+    const val APP_VERSION = "0.9.3"
 
     // EULA version - increment when EULA text changes materially
     // Users must re-accept when this version increases


### PR DESCRIPTION
## Summary
Bumps the app version from `0.9.2` to `0.9.3` across all platforms.

| File | Field | Change |
|------|-------|--------|
| `androidApp/build.gradle.kts` | `versionName` | `0.9.2` → `0.9.3` |
| `shared/.../util/Constants.kt` | `APP_VERSION` | `0.9.2` → `0.9.3` |
| `iosApp/.../project.pbxproj` | `MARKETING_VERSION` (Debug) | `0.9.2` → `0.9.3` |
| `iosApp/.../project.pbxproj` | `MARKETING_VERSION` (Release) | `0.9.2` → `0.9.3` |

Android `versionCode` left unchanged — bump separately for a new store release.

## Test plan
- [ ] Version displays correctly in Settings (Android reads `Constants.APP_VERSION`, iOS reads `CFBundleShortVersionString` from `MARKETING_VERSION`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)