### PR TITLE
feat(issue-584): show rack contributors in effective load

### DIFF
--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -671,4 +671,5 @@
     <string name="equipment_rack_save_override_confirm">Speichern</string>
     <string name="equipment_rack_save_override_dismiss">Nur dieses Mal</string>
     <string name="cd_equipment_rack">Equipment-Rack</string>
+    <string name="bodyweight_effective_load_includes">Includes: %1$s</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -671,5 +671,6 @@
     <string name="equipment_rack_save_override_confirm">Speichern</string>
     <string name="equipment_rack_save_override_dismiss">Nur dieses Mal</string>
     <string name="cd_equipment_rack">Equipment-Rack</string>
-    <string name="bodyweight_effective_load_includes">Includes: %1$s</string>
+    <string name="bodyweight_effective_load_includes">Inklusive: %1$s</string>
+    <string name="bodyweight_effective_load_more">+%1$d weitere</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-es/strings.xml
+++ b/shared/src/commonMain/composeResources/values-es/strings.xml
@@ -671,5 +671,6 @@
     <string name="equipment_rack_save_override_confirm">Guardar</string>
     <string name="equipment_rack_save_override_dismiss">Solo esta vez</string>
     <string name="cd_equipment_rack">Rack de equipamiento</string>
-    <string name="bodyweight_effective_load_includes">Includes: %1$s</string>
+    <string name="bodyweight_effective_load_includes">Incluye: %1$s</string>
+    <string name="bodyweight_effective_load_more">+%1$d más</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-es/strings.xml
+++ b/shared/src/commonMain/composeResources/values-es/strings.xml
@@ -671,4 +671,5 @@
     <string name="equipment_rack_save_override_confirm">Guardar</string>
     <string name="equipment_rack_save_override_dismiss">Solo esta vez</string>
     <string name="cd_equipment_rack">Rack de equipamiento</string>
+    <string name="bodyweight_effective_load_includes">Includes: %1$s</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-fr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fr/strings.xml
@@ -671,5 +671,6 @@
     <string name="equipment_rack_save_override_confirm">Enregistrer</string>
     <string name="equipment_rack_save_override_dismiss">Seulement cette fois</string>
     <string name="cd_equipment_rack">Rack d\'équipement</string>
-    <string name="bodyweight_effective_load_includes">Includes: %1$s</string>
+    <string name="bodyweight_effective_load_includes">Inclus : %1$s</string>
+    <string name="bodyweight_effective_load_more">+%1$d de plus</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-fr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fr/strings.xml
@@ -671,4 +671,5 @@
     <string name="equipment_rack_save_override_confirm">Enregistrer</string>
     <string name="equipment_rack_save_override_dismiss">Seulement cette fois</string>
     <string name="cd_equipment_rack">Rack d\'équipement</string>
+    <string name="bodyweight_effective_load_includes">Includes: %1$s</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-it/strings.xml
+++ b/shared/src/commonMain/composeResources/values-it/strings.xml
@@ -33,5 +33,6 @@
     <!-- ==================== Configuration ==================== -->
     <string name="config_echo_level">LIVELLO ECHO</string>
     <string name="progression_eccentric_load_increase_by">Aumenta il carico eccentrico di</string>
-    <string name="bodyweight_effective_load_includes">Includes: %1$s</string>
+    <string name="bodyweight_effective_load_includes">Incluso: %1$s</string>
+    <string name="bodyweight_effective_load_more">+%1$d in più</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-it/strings.xml
+++ b/shared/src/commonMain/composeResources/values-it/strings.xml
@@ -33,4 +33,5 @@
     <!-- ==================== Configuration ==================== -->
     <string name="config_echo_level">LIVELLO ECHO</string>
     <string name="progression_eccentric_load_increase_by">Aumenta il carico eccentrico di</string>
+    <string name="bodyweight_effective_load_includes">Includes: %1$s</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-nl/strings.xml
+++ b/shared/src/commonMain/composeResources/values-nl/strings.xml
@@ -650,5 +650,6 @@
     <string name="equipment_rack_save_override_confirm">Opslaan</string>
     <string name="equipment_rack_save_override_dismiss">Alleen deze keer</string>
     <string name="cd_equipment_rack">Equipment rack</string>
-    <string name="bodyweight_effective_load_includes">Includes: %1$s</string>
+    <string name="bodyweight_effective_load_includes">Inclusief: %1$s</string>
+    <string name="bodyweight_effective_load_more">+%1$d meer</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-nl/strings.xml
+++ b/shared/src/commonMain/composeResources/values-nl/strings.xml
@@ -650,4 +650,5 @@
     <string name="equipment_rack_save_override_confirm">Opslaan</string>
     <string name="equipment_rack_save_override_dismiss">Alleen deze keer</string>
     <string name="cd_equipment_rack">Equipment rack</string>
+    <string name="bodyweight_effective_load_includes">Includes: %1$s</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -83,6 +83,7 @@
     <string name="bodyweight_variant_percent">%1$s (%2$d%%)</string>
     <string name="bodyweight_effective_load">Effective load: %1$s</string>
     <string name="bodyweight_effective_load_includes">Includes: %1$s</string>
+    <string name="bodyweight_effective_load_more">+%1$d more</string>
     <string name="bodyweight_volume">Volume: %1$s</string>
     <string name="bodyweight_no_weight_volume">Body weight is not set, so volume will be saved as 0.</string>
     <string name="weight_recommendation_increase">Increase next set</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -82,6 +82,7 @@
     <string name="bodyweight_variant">Variant</string>
     <string name="bodyweight_variant_percent">%1$s (%2$d%%)</string>
     <string name="bodyweight_effective_load">Effective load: %1$s</string>
+    <string name="bodyweight_effective_load_includes">Includes: %1$s</string>
     <string name="bodyweight_volume">Volume: %1$s</string>
     <string name="bodyweight_no_weight_volume">Body weight is not set, so volume will be saved as 0.</string>
     <string name="weight_recommendation_increase">Increase next set</string>

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/EquipmentRack.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/EquipmentRack.kt
@@ -51,12 +51,21 @@ data class ActiveRackSelection(
 }
 
 @Serializable
+data class RackLoadContribution(
+    val itemId: String,
+    val itemName: String,
+    val behavior: RackItemBehavior,
+    val weightKg: Float,
+)
+
+@Serializable
 data class RackLoadAdjustment(
     val selectedItems: List<RackItem> = emptyList(),
     val externalAddedLoadKg: Float = 0f,
     val counterweightKg: Float = 0f,
     val displayLoadKg: Float = 0f,
     val adjustedMachineWeightPerCableKg: Float = 0f,
+    val loadContributions: List<RackLoadContribution> = emptyList(),
 ) {
     val hasLoadAdjustment: Boolean
         get() = externalAddedLoadKg > 0f || counterweightKg > 0f

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/ApplyEquipmentRackLoadUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/ApplyEquipmentRackLoadUseCase.kt
@@ -2,6 +2,7 @@ package com.devil.phoenixproject.domain.usecase
 
 import com.devil.phoenixproject.domain.model.RackItem
 import com.devil.phoenixproject.domain.model.RackItemBehavior
+import com.devil.phoenixproject.domain.model.RackLoadContribution
 import com.devil.phoenixproject.domain.model.RackLoadAdjustment
 import com.devil.phoenixproject.util.Constants
 
@@ -18,6 +19,7 @@ class ApplyEquipmentRackLoadUseCase {
         val uniqueItems = selectedItems.distinctBy { it.id }
         val externalAddedLoadKg = uniqueItems.loadFor(RackItemBehavior.ADDED_RESISTANCE, behaviorOverrides)
         val counterweightKg = uniqueItems.loadFor(RackItemBehavior.COUNTERWEIGHT, behaviorOverrides)
+        val loadContributions = uniqueItems.loadContributions(behaviorOverrides)
         val displayLoadKg = (
             programmedWeightPerCableKg.coerceAtLeast(0f) * cableCount +
                 externalAddedLoadKg -
@@ -42,6 +44,7 @@ class ApplyEquipmentRackLoadUseCase {
             counterweightKg = counterweightKg,
             displayLoadKg = displayLoadKg,
             adjustedMachineWeightPerCableKg = adjustedMachineWeightPerCableKg,
+            loadContributions = loadContributions,
         )
     }
 
@@ -70,4 +73,23 @@ class ApplyEquipmentRackLoadUseCase {
         val effectiveBehavior = overrides[item.id] ?: item.behavior
         item.enabled && effectiveBehavior == behavior
     }.sumOf { it.weightKg.toDouble() }.toFloat()
+
+    private fun List<RackItem>.loadContributions(
+        overrides: Map<String, RackItemBehavior> = emptyMap(),
+    ): List<RackLoadContribution> = mapNotNull { item ->
+        if (!item.enabled) return@mapNotNull null
+
+        val effectiveBehavior = overrides[item.id] ?: item.behavior
+        when (effectiveBehavior) {
+            RackItemBehavior.ADDED_RESISTANCE,
+            RackItemBehavior.COUNTERWEIGHT -> RackLoadContribution(
+                itemId = item.id,
+                itemName = item.name,
+                behavior = effectiveBehavior,
+                weightKg = item.weightKg,
+            )
+
+            RackItemBehavior.DISPLAY_ONLY -> null
+        }
+    }
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/RackLoadContributionFormatter.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/RackLoadContributionFormatter.kt
@@ -8,6 +8,7 @@ fun formatRackLoadContributionSummary(
     contributions: List<RackLoadContribution>,
     weightUnit: WeightUnit,
     formatWeight: (Float, WeightUnit) -> String,
+    moreTemplate: String = "+%d more",
     maxVisibleItems: Int = 2,
 ): String? {
     val loadAffectingContributions = contributions.filter { contribution ->
@@ -16,20 +17,23 @@ fun formatRackLoadContributionSummary(
     }
     if (loadAffectingContributions.isEmpty() || maxVisibleItems <= 0) return null
 
-    val visibleItems = loadAffectingContributions.take(maxVisibleItems).map { contribution ->
+    val visibleItems = loadAffectingContributions.take(maxVisibleItems).mapNotNull { contribution ->
         val sign = when (contribution.behavior) {
             RackItemBehavior.ADDED_RESISTANCE -> "+"
             RackItemBehavior.COUNTERWEIGHT -> "-"
-            RackItemBehavior.DISPLAY_ONLY -> return@map null
+            RackItemBehavior.DISPLAY_ONLY -> return@mapNotNull null
         }
         "${contribution.itemName} $sign${formatWeight(contribution.weightKg, weightUnit)}"
-    }.filterNotNull()
+    }
 
     if (visibleItems.isEmpty()) return null
 
     val hiddenCount = loadAffectingContributions.size - visibleItems.size
     val parts = if (hiddenCount > 0) {
-        visibleItems + "+$hiddenCount more"
+        val localizedMore = moreTemplate
+            .replace("%1\$d", hiddenCount.toString())
+            .replace("%d", hiddenCount.toString())
+        visibleItems + localizedMore
     } else {
         visibleItems
     }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/RackLoadContributionFormatter.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/RackLoadContributionFormatter.kt
@@ -1,0 +1,38 @@
+package com.devil.phoenixproject.presentation.components
+
+import com.devil.phoenixproject.domain.model.RackItemBehavior
+import com.devil.phoenixproject.domain.model.RackLoadContribution
+import com.devil.phoenixproject.domain.model.WeightUnit
+
+fun formatRackLoadContributionSummary(
+    contributions: List<RackLoadContribution>,
+    weightUnit: WeightUnit,
+    formatWeight: (Float, WeightUnit) -> String,
+    maxVisibleItems: Int = 2,
+): String? {
+    val loadAffectingContributions = contributions.filter { contribution ->
+        contribution.behavior == RackItemBehavior.ADDED_RESISTANCE ||
+            contribution.behavior == RackItemBehavior.COUNTERWEIGHT
+    }
+    if (loadAffectingContributions.isEmpty() || maxVisibleItems <= 0) return null
+
+    val visibleItems = loadAffectingContributions.take(maxVisibleItems).map { contribution ->
+        val sign = when (contribution.behavior) {
+            RackItemBehavior.ADDED_RESISTANCE -> "+"
+            RackItemBehavior.COUNTERWEIGHT -> "-"
+            RackItemBehavior.DISPLAY_ONLY -> return@map null
+        }
+        "${contribution.itemName} $sign${formatWeight(contribution.weightKg, weightUnit)}"
+    }.filterNotNull()
+
+    if (visibleItems.isEmpty()) return null
+
+    val hiddenCount = loadAffectingContributions.size - visibleItems.size
+    val parts = if (hiddenCount > 0) {
+        visibleItems + "+$hiddenCount more"
+    } else {
+        visibleItems
+    }
+
+    return parts.joinToString(separator = ", ")
+}

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SetReadyScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SetReadyScreen.kt
@@ -83,6 +83,7 @@ import com.devil.phoenixproject.presentation.components.SliderWithButtons
 import com.devil.phoenixproject.presentation.components.VideoPlayer
 import com.devil.phoenixproject.presentation.components.WeightRecommendationCard
 import com.devil.phoenixproject.presentation.components.WeightChangePerRepControl
+import com.devil.phoenixproject.presentation.components.formatRackLoadContributionSummary
 import com.devil.phoenixproject.presentation.navigation.NavigationRoutes
 import com.devil.phoenixproject.presentation.viewmodel.MainViewModel
 import com.devil.phoenixproject.ui.theme.Spacing
@@ -95,6 +96,7 @@ import vitruvianprojectphoenix.shared.generated.resources.action_exit
 import vitruvianprojectphoenix.shared.generated.resources.cd_next
 import vitruvianprojectphoenix.shared.generated.resources.cd_previous
 import vitruvianprojectphoenix.shared.generated.resources.cd_stop
+import vitruvianprojectphoenix.shared.generated.resources.bodyweight_effective_load_includes
 import vitruvianprojectphoenix.shared.generated.resources.equipment_rack_save_override_confirm
 import vitruvianprojectphoenix.shared.generated.resources.equipment_rack_save_override_dismiss
 import vitruvianprojectphoenix.shared.generated.resources.equipment_rack_save_override_message
@@ -539,12 +541,28 @@ fun SetReadyScreen(navController: NavController, viewModel: MainViewModel, exerc
                                 } else {
                                     "${com.devil.phoenixproject.util.UnitConverter.formatDecimal(com.devil.phoenixproject.util.UnitConverter.kgToLb(effectiveKg))} lb"
                                 }
+                                val rackLoadContributionSummary = formatRackLoadContributionSummary(
+                                    contributions = currentRackLoadAdjustment.loadContributions,
+                                    weightUnit = weightUnit,
+                                    formatWeight = viewModel::formatWeight,
+                                )
                                 Spacer(Modifier.height(4.dp))
                                 Text(
                                     "Effective load: $displayWeight",
                                     style = MaterialTheme.typography.bodySmall,
                                     color = MaterialTheme.colorScheme.primary,
                                 )
+                                if (rackLoadContributionSummary != null) {
+                                    Spacer(Modifier.height(2.dp))
+                                    Text(
+                                        stringResource(
+                                            Res.string.bodyweight_effective_load_includes,
+                                            rackLoadContributionSummary,
+                                        ),
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                }
                             }
                         }
                     }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SetReadyScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SetReadyScreen.kt
@@ -97,6 +97,7 @@ import vitruvianprojectphoenix.shared.generated.resources.cd_next
 import vitruvianprojectphoenix.shared.generated.resources.cd_previous
 import vitruvianprojectphoenix.shared.generated.resources.cd_stop
 import vitruvianprojectphoenix.shared.generated.resources.bodyweight_effective_load_includes
+import vitruvianprojectphoenix.shared.generated.resources.bodyweight_effective_load_more
 import vitruvianprojectphoenix.shared.generated.resources.equipment_rack_save_override_confirm
 import vitruvianprojectphoenix.shared.generated.resources.equipment_rack_save_override_dismiss
 import vitruvianprojectphoenix.shared.generated.resources.equipment_rack_save_override_message
@@ -545,6 +546,7 @@ fun SetReadyScreen(navController: NavController, viewModel: MainViewModel, exerc
                                     contributions = currentRackLoadAdjustment.loadContributions,
                                     weightUnit = weightUnit,
                                     formatWeight = viewModel::formatWeight,
+                                    moreTemplate = stringResource(Res.string.bodyweight_effective_load_more),
                                 )
                                 Spacer(Modifier.height(4.dp))
                                 Text(

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/WorkoutTab.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/WorkoutTab.kt
@@ -109,6 +109,7 @@ import vitruvianprojectphoenix.shared.generated.resources.action_skip
 import vitruvianprojectphoenix.shared.generated.resources.action_tag
 import vitruvianprojectphoenix.shared.generated.resources.bodyweight_effective_load
 import vitruvianprojectphoenix.shared.generated.resources.bodyweight_effective_load_includes
+import vitruvianprojectphoenix.shared.generated.resources.bodyweight_effective_load_more
 import vitruvianprojectphoenix.shared.generated.resources.bodyweight_no_weight_volume
 import vitruvianprojectphoenix.shared.generated.resources.bodyweight_reps_completed
 import vitruvianprojectphoenix.shared.generated.resources.bodyweight_reps_title
@@ -1230,6 +1231,7 @@ private fun BodyweightRepEntryDialog(
         contributions = rackLoadAdjustment.loadContributions,
         weightUnit = weightUnit,
         formatWeight = formatWeight,
+        moreTemplate = stringResource(Res.string.bodyweight_effective_load_more),
     )
 
     AlertDialog(

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/WorkoutTab.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/WorkoutTab.kt
@@ -95,6 +95,7 @@ import com.devil.phoenixproject.presentation.components.ExerciseNavigator
 import com.devil.phoenixproject.presentation.components.MiniExercisePickerDialog
 import com.devil.phoenixproject.presentation.components.RepQualityIndicator
 import com.devil.phoenixproject.presentation.components.VideoPlayer
+import com.devil.phoenixproject.presentation.components.formatRackLoadContributionSummary
 import com.devil.phoenixproject.presentation.util.LocalWindowSizeClass
 import com.devil.phoenixproject.presentation.util.WindowWidthSizeClass
 import com.devil.phoenixproject.ui.theme.Spacing
@@ -107,6 +108,7 @@ import vitruvianprojectphoenix.shared.generated.resources.action_cancel
 import vitruvianprojectphoenix.shared.generated.resources.action_skip
 import vitruvianprojectphoenix.shared.generated.resources.action_tag
 import vitruvianprojectphoenix.shared.generated.resources.bodyweight_effective_load
+import vitruvianprojectphoenix.shared.generated.resources.bodyweight_effective_load_includes
 import vitruvianprojectphoenix.shared.generated.resources.bodyweight_no_weight_volume
 import vitruvianprojectphoenix.shared.generated.resources.bodyweight_reps_completed
 import vitruvianprojectphoenix.shared.generated.resources.bodyweight_reps_title
@@ -1224,6 +1226,11 @@ private fun BodyweightRepEntryDialog(
         0f
     }
     val volumeKg = effectiveWeightKg * reps
+    val rackLoadContributionSummary = formatRackLoadContributionSummary(
+        contributions = rackLoadAdjustment.loadContributions,
+        weightUnit = weightUnit,
+        formatWeight = formatWeight,
+    )
 
     AlertDialog(
         onDismissRequest = {},
@@ -1300,6 +1307,16 @@ private fun BodyweightRepEntryDialog(
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.primary,
                     )
+                    if (rackLoadContributionSummary != null) {
+                        Text(
+                            stringResource(
+                                Res.string.bodyweight_effective_load_includes,
+                                rackLoadContributionSummary,
+                            ),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
                     Text(
                         stringResource(
                             Res.string.bodyweight_volume,

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/ApplyEquipmentRackLoadUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/ApplyEquipmentRackLoadUseCaseTest.kt
@@ -23,6 +23,11 @@ class ApplyEquipmentRackLoadUseCaseTest {
         assertEquals(0f, result.counterweightKg)
         assertEquals(30f, result.displayLoadKg)
         assertEquals(20f, result.adjustedMachineWeightPerCableKg)
+        assertEquals(1, result.loadContributions.size)
+        assertEquals("vest", result.loadContributions.single().itemId)
+        assertEquals("vest", result.loadContributions.single().itemName)
+        assertEquals(RackItemBehavior.ADDED_RESISTANCE, result.loadContributions.single().behavior)
+        assertEquals(10f, result.loadContributions.single().weightKg)
     }
 
     @Test
@@ -38,6 +43,7 @@ class ApplyEquipmentRackLoadUseCaseTest {
         assertEquals(0f, result.counterweightKg)
         assertEquals(20f, result.displayLoadKg)
         assertEquals(20f, result.adjustedMachineWeightPerCableKg)
+        assertEquals(0, result.loadContributions.size)
     }
 
     @Test
@@ -53,6 +59,10 @@ class ApplyEquipmentRackLoadUseCaseTest {
         assertEquals(12f, result.counterweightKg)
         assertEquals(68f, result.displayLoadKg)
         assertEquals(34f, result.adjustedMachineWeightPerCableKg)
+        assertEquals(1, result.loadContributions.size)
+        assertEquals("assist", result.loadContributions.single().itemId)
+        assertEquals(RackItemBehavior.COUNTERWEIGHT, result.loadContributions.single().behavior)
+        assertEquals(12f, result.loadContributions.single().weightKg)
     }
 
     @Test
@@ -107,6 +117,15 @@ class ApplyEquipmentRackLoadUseCaseTest {
         assertEquals(8f, result.counterweightKg)
         assertEquals(37f, result.displayLoadKg)
         assertEquals(22f, result.adjustedMachineWeightPerCableKg)
+        assertEquals(listOf("vest", "chain", "assist"), result.loadContributions.map { it.itemId })
+        assertEquals(
+            listOf(
+                RackItemBehavior.ADDED_RESISTANCE,
+                RackItemBehavior.ADDED_RESISTANCE,
+                RackItemBehavior.COUNTERWEIGHT,
+            ),
+            result.loadContributions.map { it.behavior },
+        )
     }
 
     @Test
@@ -165,6 +184,9 @@ class ApplyEquipmentRackLoadUseCaseTest {
         )
         assertEquals(0f, result.externalAddedLoadKg)
         assertEquals(5f, result.counterweightKg)
+        assertEquals(1, result.loadContributions.size)
+        assertEquals("vest-1", result.loadContributions.single().itemId)
+        assertEquals(RackItemBehavior.COUNTERWEIGHT, result.loadContributions.single().behavior)
     }
 
     @Test
@@ -182,6 +204,7 @@ class ApplyEquipmentRackLoadUseCaseTest {
         assertEquals(0f, result.counterweightKg)
         // displayLoadKg = (50 * 2 + 0 - 0).coerceAtLeast(0) = 100
         assertEquals(100f, result.displayLoadKg)
+        assertEquals(0, result.loadContributions.size)
     }
 
     @Test
@@ -199,6 +222,11 @@ class ApplyEquipmentRackLoadUseCaseTest {
         )
         assertEquals(2f, result.externalAddedLoadKg) // ankle only
         assertEquals(5f, result.counterweightKg) // vest only
+        assertEquals(listOf("vest-1", "ankle-1"), result.loadContributions.map { it.itemId })
+        assertEquals(
+            listOf(RackItemBehavior.COUNTERWEIGHT, RackItemBehavior.ADDED_RESISTANCE),
+            result.loadContributions.map { it.behavior },
+        )
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/components/RackLoadContributionFormatterTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/components/RackLoadContributionFormatterTest.kt
@@ -1,0 +1,124 @@
+package com.devil.phoenixproject.presentation.components
+
+import com.devil.phoenixproject.domain.model.RackItemBehavior
+import com.devil.phoenixproject.domain.model.RackLoadContribution
+import com.devil.phoenixproject.domain.model.WeightUnit
+import kotlin.math.round
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class RackLoadContributionFormatterTest {
+
+    @Test
+    fun `weighted vest added resistance uses plus sign`() {
+        val result = formatRackLoadContributionSummary(
+            contributions = listOf(contribution("vest", "Weighted Vest", RackItemBehavior.ADDED_RESISTANCE, 3.62874f)),
+            weightUnit = WeightUnit.KG,
+            formatWeight = ::formatWeight,
+        )
+
+        assertEquals("Weighted Vest +3.6 kg", result)
+    }
+
+    @Test
+    fun `counterweight uses minus sign`() {
+        val result = formatRackLoadContributionSummary(
+            contributions = listOf(contribution("band", "Assistance Band", RackItemBehavior.COUNTERWEIGHT, 10f)),
+            weightUnit = WeightUnit.KG,
+            formatWeight = ::formatWeight,
+        )
+
+        assertEquals("Assistance Band -10.0 kg", result)
+    }
+
+    @Test
+    fun `two contributors are shown in order`() {
+        val result = formatRackLoadContributionSummary(
+            contributions = listOf(
+                contribution("vest", "Weighted Vest", RackItemBehavior.ADDED_RESISTANCE, 3.62874f),
+                contribution("band", "Assistance Band", RackItemBehavior.COUNTERWEIGHT, 10f),
+            ),
+            weightUnit = WeightUnit.KG,
+            formatWeight = ::formatWeight,
+        )
+
+        assertEquals("Weighted Vest +3.6 kg, Assistance Band -10.0 kg", result)
+    }
+
+    @Test
+    fun `third contributor collapses to more count`() {
+        val result = formatRackLoadContributionSummary(
+            contributions = listOf(
+                contribution("vest", "Weighted Vest", RackItemBehavior.ADDED_RESISTANCE, 3.62874f),
+                contribution("band", "Assistance Band", RackItemBehavior.COUNTERWEIGHT, 10f),
+                contribution("chains", "Chains", RackItemBehavior.ADDED_RESISTANCE, 2f),
+            ),
+            weightUnit = WeightUnit.KG,
+            formatWeight = ::formatWeight,
+        )
+
+        assertEquals("Weighted Vest +3.6 kg, Assistance Band -10.0 kg, +1 more", result)
+    }
+
+    @Test
+    fun `empty contribution list returns null`() {
+        val result = formatRackLoadContributionSummary(
+            contributions = emptyList(),
+            weightUnit = WeightUnit.KG,
+            formatWeight = ::formatWeight,
+        )
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `display only contributions are defensively omitted`() {
+        val result = formatRackLoadContributionSummary(
+            contributions = listOf(contribution("note", "Phone", RackItemBehavior.DISPLAY_ONLY, 1f)),
+            weightUnit = WeightUnit.KG,
+            formatWeight = ::formatWeight,
+        )
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `display only contributions do not count toward more count`() {
+        val result = formatRackLoadContributionSummary(
+            contributions = listOf(
+                contribution("vest", "Weighted Vest", RackItemBehavior.ADDED_RESISTANCE, 3.62874f),
+                contribution("phone", "Phone", RackItemBehavior.DISPLAY_ONLY, 1f),
+                contribution("band", "Assistance Band", RackItemBehavior.COUNTERWEIGHT, 10f),
+                contribution("chains", "Chains", RackItemBehavior.ADDED_RESISTANCE, 2f),
+            ),
+            weightUnit = WeightUnit.KG,
+            formatWeight = ::formatWeight,
+        )
+
+        assertEquals("Weighted Vest +3.6 kg, Assistance Band -10.0 kg, +1 more", result)
+    }
+
+    private fun contribution(
+        id: String,
+        name: String,
+        behavior: RackItemBehavior,
+        weightKg: Float,
+    ): RackLoadContribution = RackLoadContribution(
+        itemId = id,
+        itemName = name,
+        behavior = behavior,
+        weightKg = weightKg,
+    )
+
+    private fun formatWeight(weight: Float, unit: WeightUnit): String {
+        val unitLabel = if (unit == WeightUnit.KG) "kg" else "lb"
+        val rounded = round(weight * 10f) / 10f
+        val valueText = if (rounded == rounded.toInt().toFloat()) {
+            "${rounded.toInt()}.0"
+        } else {
+            rounded.toString()
+        }
+        return "$valueText $unitLabel"
+    }
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/components/RackLoadContributionFormatterTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/components/RackLoadContributionFormatterTest.kt
@@ -62,6 +62,22 @@ class RackLoadContributionFormatterTest {
     }
 
     @Test
+    fun `more count uses localized template`() {
+        val result = formatRackLoadContributionSummary(
+            contributions = listOf(
+                contribution("vest", "Weighted Vest", RackItemBehavior.ADDED_RESISTANCE, 3.62874f),
+                contribution("band", "Assistance Band", RackItemBehavior.COUNTERWEIGHT, 10f),
+                contribution("chains", "Chains", RackItemBehavior.ADDED_RESISTANCE, 2f),
+            ),
+            weightUnit = WeightUnit.KG,
+            formatWeight = ::formatWeight,
+            moreTemplate = "+%1\$d más",
+        )
+
+        assertEquals("Weighted Vest +3.6 kg, Assistance Band -10.0 kg, +1 más", result)
+    }
+
+    @Test
     fun `empty contribution list returns null`() {
         val result = formatRackLoadContributionSummary(
             contributions = emptyList(),

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/BodyweightRackLoadTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/BodyweightRackLoadTest.kt
@@ -110,10 +110,15 @@ class BodyweightRackLoadTest {
         advanceTimeBy(1_000)
         runCurrent()
 
-        // The adjustment must reflect the vest mass.
+        // The adjustment must reflect the vest mass and expose the contributing item.
         assertFloatEquals(3.62874f, harness.dwsm.coordinator._currentRackLoadAdjustment.value.externalAddedLoadKg)
         assertEquals(0f, harness.dwsm.coordinator._currentRackLoadAdjustment.value.counterweightKg)
         assertEquals(listOf(v.id), harness.dwsm.coordinator._currentRackLoadAdjustment.value.selectedItems.map { it.id })
+        assertEquals(listOf(v.id), harness.dwsm.coordinator._currentRackLoadAdjustment.value.loadContributions.map { it.itemId })
+        val contribution = harness.dwsm.coordinator._currentRackLoadAdjustment.value.loadContributions.single()
+        assertEquals(v.name, contribution.itemName)
+        assertEquals(RackItemBehavior.ADDED_RESISTANCE, contribution.behavior)
+        assertFloatEquals(3.62874f, contribution.weightKg)
 
         // Effective per-rep weight: 80 * 0.73 + 3.62874 = 62.02874 kg
         // Volume for 10 reps: 620.2874 kg
@@ -166,7 +171,7 @@ class BodyweightRackLoadTest {
         // Capture the adjustment right after the toggle, before confirmBodyweightSetResult
         // triggers auto-advance to the next set (which would re-snapshot the empty
         // defaultRackItemIds via startWorkout → captureRackLoadSnapshot).
-        val capturedAdjustment = harness.dwsm.coordinator._currentRackLoadAdjustment.value.externalAddedLoadKg
+        val capturedAdjustment = harness.dwsm.coordinator._currentRackLoadAdjustment.value
 
         val entry = assertIs<WorkoutState.BodyweightRepEntry>(harness.dwsm.coordinator.workoutState.value)
         val decline18 = entry.variants.first { it.label == "Decline 18\"" }
@@ -175,7 +180,12 @@ class BodyweightRackLoadTest {
         advanceTimeBy(1_000)
         runCurrent()
 
-        assertFloatEquals(3.62874f, capturedAdjustment)
+        assertFloatEquals(3.62874f, capturedAdjustment.externalAddedLoadKg)
+        assertEquals(listOf(v.id), capturedAdjustment.loadContributions.map { it.itemId })
+        val contribution = capturedAdjustment.loadContributions.single()
+        assertEquals(v.name, contribution.itemName)
+        assertEquals(RackItemBehavior.ADDED_RESISTANCE, contribution.behavior)
+        assertFloatEquals(3.62874f, contribution.weightKg)
 
         val session = harness.fakeWorkoutRepo.getAllSessions("default").first().single()
         // If the body-weight fix regresses, this will be 584.0 (vest-less).
@@ -241,6 +251,11 @@ class BodyweightRackLoadTest {
         assertFloatEquals(3.62874f, harness.dwsm.coordinator._currentRackLoadAdjustment.value.externalAddedLoadKg)
         assertEquals(0f, harness.dwsm.coordinator._currentRackLoadAdjustment.value.counterweightKg)
         assertEquals(listOf(v.id), harness.dwsm.coordinator._currentRackLoadAdjustment.value.selectedItems.map { it.id })
+        assertEquals(listOf(v.id), harness.dwsm.coordinator._currentRackLoadAdjustment.value.loadContributions.map { it.itemId })
+        val contribution = harness.dwsm.coordinator._currentRackLoadAdjustment.value.loadContributions.single()
+        assertEquals(v.name, contribution.itemName)
+        assertEquals(RackItemBehavior.ADDED_RESISTANCE, contribution.behavior)
+        assertFloatEquals(3.62874f, contribution.weightKg)
 
         // Mirror fields on workout parameters must also be populated.
         assertFloatEquals(3.62874f, harness.dwsm.coordinator._workoutParameters.value.externalAddedLoadKg)


### PR DESCRIPTION
## Summary
- Adds override-aware rack load contribution details alongside existing body-weight effective-load math.
- Shows a compact `Includes: ...` line in Set Ready and the Bodyweight Rep Entry dialog when load-affecting rack items contribute.
- Excludes `DISPLAY_ONLY` rack items and preserves existing effective-load / volume calculations.

## Visual evidence
Final emulator/device visual evidence: https://gist.github.com/9thLevelSoftware/19fb3f945e3100a7ba678c8db3f0ce59

Visual evidence files in the linked gist:
- `burpee-config-final.png`
- `rack-expand-burpee.png`
- `weighted-vest-selected.png`

## Verification
- `git diff --check`
- `./gradlew :shared:allTests -Pskip.supabase.check=true --console=plain`

Closes #584
