### PR TITLE
feat(issue-595): seed routine exercises from PR defaults

### DIFF
--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/manager/SettingsManagerTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/manager/SettingsManagerTest.kt
@@ -89,6 +89,44 @@ class SettingsManagerTest {
     }
 
     @Test
+    fun `routine exercise percent defaults are off and eighty percent`() = runTest {
+        val managerScope = CoroutineScope(coroutineContext + SupervisorJob())
+        try {
+            val manager = SettingsManager(fakePreferencesManager, fakeBleRepository, managerScope)
+
+            assertFalse(manager.defaultRoutineExerciseUsePercentOfPR.value)
+            assertEquals(80, manager.defaultRoutineExerciseWeightPercentOfPR.value)
+        } finally {
+            managerScope.cancel()
+        }
+    }
+
+    @Test
+    fun `set routine exercise percent preferences persist and coerce range`() = runTest {
+        val managerScope = CoroutineScope(coroutineContext + SupervisorJob())
+        try {
+            val manager = SettingsManager(fakePreferencesManager, fakeBleRepository, managerScope)
+
+            manager.setDefaultRoutineExerciseUsePercentOfPR(true)
+            manager.setDefaultRoutineExerciseWeightPercentOfPR(135)
+            advanceUntilIdle()
+
+            assertTrue(fakePreferencesManager.preferencesFlow.value.defaultRoutineExerciseUsePercentOfPR)
+            assertEquals(120, fakePreferencesManager.preferencesFlow.value.defaultRoutineExerciseWeightPercentOfPR)
+            assertTrue(manager.defaultRoutineExerciseUsePercentOfPR.value)
+            assertEquals(120, manager.defaultRoutineExerciseWeightPercentOfPR.value)
+
+            manager.setDefaultRoutineExerciseWeightPercentOfPR(20)
+            advanceUntilIdle()
+
+            assertEquals(50, fakePreferencesManager.preferencesFlow.value.defaultRoutineExerciseWeightPercentOfPR)
+            assertEquals(50, manager.defaultRoutineExerciseWeightPercentOfPR.value)
+        } finally {
+            managerScope.cancel()
+        }
+    }
+
+    @Test
     fun `setVelocityOneRepMaxBackfillDone persists to preference-backed flow`() = runTest {
         val managerScope = CoroutineScope(coroutineContext + SupervisorJob())
         try {

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModelTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModelTest.kt
@@ -13,7 +13,9 @@ import com.devil.phoenixproject.domain.model.WeightUnit
 import com.devil.phoenixproject.domain.model.WorkoutPhase
 import com.devil.phoenixproject.presentation.screen.shouldShowCableOnlyExerciseControls
 import com.devil.phoenixproject.presentation.screen.shouldShowStopAtTopToggle
+import com.devil.phoenixproject.testutil.FakeExerciseRepository
 import com.devil.phoenixproject.testutil.FakePersonalRecordRepository
+import com.devil.phoenixproject.testutil.FakeVelocityOneRepMaxRepository
 import com.devil.phoenixproject.testutil.createTestDatabase
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -576,6 +578,62 @@ class ExerciseConfigViewModelTest {
         assertNotNull(saved)
         assertNull(saved.scalingBasis)
         assertEquals(ScalingBasis.MAX_WEIGHT_PR, saved.effectiveScalingBasis)
+    }
+
+    @Test
+    fun `editor preview uses same profile cross mode baseline when selected mode has none`() = runTest {
+        val prRepository = FakePersonalRecordRepository()
+        val velocityRepository = FakeVelocityOneRepMaxRepository()
+        val exerciseRepository = FakeExerciseRepository()
+        exerciseRepository.addExercise(
+            Exercise(
+                id = "bench-1",
+                name = "Bench Press",
+                muscleGroup = "Chest",
+                muscleGroups = "Chest",
+                equipment = "BAR",
+            ),
+        )
+        prRepository.addRecord(
+            PersonalRecord(
+                id = 595,
+                exerciseId = "bench-1",
+                exerciseName = "Bench Press",
+                weightPerCableKg = 60f,
+                reps = 5,
+                oneRepMax = 72f,
+                timestamp = 2_000L,
+                workoutMode = "Pump",
+                prType = PRType.MAX_WEIGHT,
+                volume = 300f,
+                profileId = "default",
+            ),
+        )
+
+        val viewModel = ExerciseConfigViewModel(prRepository, velocityRepository, exerciseRepository)
+        val exercise = benchRoutineExercise(
+            id = "rex-cross-mode-preview",
+            setReps = listOf(10),
+            weightPerCableKg = 5f,
+            setWeightsPerCableKg = listOf(5f),
+            usePercentOfPR = true,
+            weightPercentOfPR = 80,
+            scalingBasis = ScalingBasis.MAX_WEIGHT_PR,
+        )
+
+        viewModel.initialize(
+            exercise = exercise,
+            unit = WeightUnit.KG,
+            toDisplay = { value, _ -> value },
+            toKg = { value, _ -> value },
+            profileId = "default",
+        )
+        advanceUntilIdle()
+
+        assertNull(viewModel.currentExercisePR.value)
+        waitForCondition { viewModel.baselineKgForCurrentBasis() == 60f }
+        waitForCondition { viewModel.sets.value.first().weightPerCable == 48f }
+        assertEquals(48f, viewModel.calculateResolvedWeight())
     }
 
     private fun benchRoutineExercise(

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/preferences/PreferencesManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/preferences/PreferencesManager.kt
@@ -157,6 +157,10 @@ interface PreferencesManager {
     // Issue #517: Default scaling basis for % of 1RM routine weight resolution
     suspend fun setDefaultScalingBasis(basis: ScalingBasis)
 
+    // Issue #595: Routine-builder defaults for newly added exercises
+    suspend fun setDefaultRoutineExerciseUsePercentOfPR(enabled: Boolean)
+    suspend fun setDefaultRoutineExerciseWeightPercentOfPR(percent: Int)
+
     // Issue #517: Run-once flag for velocity 1RM backfill
     suspend fun setVelocityOneRepMaxBackfillDone(done: Boolean)
 
@@ -219,6 +223,8 @@ class SettingsPreferencesManager(private val settings: Settings) : PreferencesMa
         private const val KEY_AUTO_END_VELOCITY_LOSS = "auto_end_on_velocity_loss"
         private const val KEY_WEIGHT_SUGGESTIONS_ENABLED = "weight_suggestions_enabled"
         private const val KEY_DEFAULT_SCALING_BASIS = "default_scaling_basis"
+        private const val KEY_DEFAULT_ROUTINE_EXERCISE_USE_PERCENT_OF_PR = "default_routine_exercise_use_percent_of_pr"
+        private const val KEY_DEFAULT_ROUTINE_EXERCISE_WEIGHT_PERCENT_OF_PR = "default_routine_exercise_weight_percent_of_pr"
         private const val KEY_VELOCITY_1RM_BACKFILL_DONE = "velocity_1rm_backfill_done"
 
         // Permissions onboarding (health + microphone)
@@ -272,6 +278,11 @@ class SettingsPreferencesManager(private val settings: Settings) : PreferencesMa
             defaultScalingBasis = settings.getStringOrNull(KEY_DEFAULT_SCALING_BASIS)?.let {
                 runCatching { ScalingBasis.valueOf(it) }.getOrNull()
             } ?: ScalingBasis.MAX_WEIGHT_PR,
+            defaultRoutineExerciseUsePercentOfPR = settings.getBoolean(KEY_DEFAULT_ROUTINE_EXERCISE_USE_PERCENT_OF_PR, false),
+            defaultRoutineExerciseWeightPercentOfPR = settings.getInt(
+                KEY_DEFAULT_ROUTINE_EXERCISE_WEIGHT_PERCENT_OF_PR,
+                80,
+            ).coerceIn(50, 120),
             velocityOneRepMaxBackfillDone = settings.getBoolean(KEY_VELOCITY_1RM_BACKFILL_DONE, false),
         )
     }
@@ -541,6 +552,17 @@ class SettingsPreferencesManager(private val settings: Settings) : PreferencesMa
     override suspend fun setDefaultScalingBasis(basis: ScalingBasis) {
         settings.putString(KEY_DEFAULT_SCALING_BASIS, basis.name)
         updateAndEmit { copy(defaultScalingBasis = basis) }
+    }
+
+    override suspend fun setDefaultRoutineExerciseUsePercentOfPR(enabled: Boolean) {
+        settings.putBoolean(KEY_DEFAULT_ROUTINE_EXERCISE_USE_PERCENT_OF_PR, enabled)
+        updateAndEmit { copy(defaultRoutineExerciseUsePercentOfPR = enabled) }
+    }
+
+    override suspend fun setDefaultRoutineExerciseWeightPercentOfPR(percent: Int) {
+        val clamped = percent.coerceIn(50, 120)
+        settings.putInt(KEY_DEFAULT_ROUTINE_EXERCISE_WEIGHT_PERCENT_OF_PR, clamped)
+        updateAndEmit { copy(defaultRoutineExerciseWeightPercentOfPR = clamped) }
     }
 
     override suspend fun setVelocityOneRepMaxBackfillDone(done: Boolean) {

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/di/DomainModule.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/di/DomainModule.kt
@@ -22,6 +22,7 @@ import com.devil.phoenixproject.domain.usecase.ProgressionUseCase
 import com.devil.phoenixproject.domain.usecase.RecommendWeightAdjustmentUseCase
 import com.devil.phoenixproject.domain.usecase.RecordPersonalMvtSampleUseCase
 import com.devil.phoenixproject.domain.usecase.RepCounterFromMachine
+import com.devil.phoenixproject.domain.usecase.ResolveRoutineScalingBaselineUseCase
 import com.devil.phoenixproject.domain.usecase.ResolveRoutineWeightsUseCase
 import com.devil.phoenixproject.domain.usecase.RoutineTimeEstimator
 import com.devil.phoenixproject.domain.usecase.TemplateConverter
@@ -39,7 +40,8 @@ val domainModule = module {
     single { ProgressionUseCase(get(), get()) }
     single { RecommendWeightAdjustmentUseCase() }
     single { ApplyEquipmentRackLoadUseCase() }
-    factory { ResolveRoutineWeightsUseCase(get(), get(), get()) }
+    factory { ResolveRoutineScalingBaselineUseCase(get(), get(), get()) }
+    factory { ResolveRoutineWeightsUseCase(get(), get(), get(), get()) }
     factory { ApplyRoutineModifierUseCase(get(), get()) }
     factory { RoutineTimeEstimator(get()) }
     single { TemplateConverter(get()) }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/UserPreferences.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/UserPreferences.kt
@@ -49,6 +49,9 @@ data class UserPreferences(
     val weightSuggestionsEnabled: Boolean = true,
     // Issue #517: Default scaling basis for % of 1RM routine weight resolution
     val defaultScalingBasis: ScalingBasis = ScalingBasis.MAX_WEIGHT_PR,
+    // Issue #595: Opt-in routine-builder default for newly added cable exercises
+    val defaultRoutineExerciseUsePercentOfPR: Boolean = false,
+    val defaultRoutineExerciseWeightPercentOfPR: Int = 80,
     // Issue #517: Run-once flag — true after the velocity 1RM backfill has completed
     val velocityOneRepMaxBackfillDone: Boolean = false,
 ) {

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/ResolveRoutineScalingBaselineUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/ResolveRoutineScalingBaselineUseCase.kt
@@ -1,0 +1,180 @@
+package com.devil.phoenixproject.domain.usecase
+
+import com.devil.phoenixproject.data.repository.ExerciseRepository
+import com.devil.phoenixproject.data.repository.PersonalRecordRepository
+import com.devil.phoenixproject.data.repository.VelocityOneRepMaxRepository
+import com.devil.phoenixproject.data.repository.getBestVolumePRForWorkoutMode
+import com.devil.phoenixproject.data.repository.getBestWeightPRForWorkoutMode
+import com.devil.phoenixproject.data.repository.preferredPRPhaseForWorkoutMode
+import com.devil.phoenixproject.domain.model.PersonalRecord
+import com.devil.phoenixproject.domain.model.ProgramMode
+import com.devil.phoenixproject.domain.model.ScalingBasis
+import com.devil.phoenixproject.domain.model.WorkoutPhase
+
+/**
+ * Shared resolver for routine percent-of-PR baseline lookup.
+ *
+ * Keeps routine editor preview and workout-start resolution on the same order:
+ * current mode first, same-profile cross-mode fallback second, then no-baseline
+ * fallback handled by callers.
+ */
+class ResolveRoutineScalingBaselineUseCase(
+    private val prRepository: PersonalRecordRepository,
+    private val exerciseRepository: ExerciseRepository,
+    private val velocityOneRepMaxRepository: VelocityOneRepMaxRepository,
+) {
+    suspend operator fun invoke(
+        exerciseId: String,
+        mode: ProgramMode,
+        profileId: String = "default",
+        basis: ScalingBasis,
+    ): RoutineScalingBaseline? = when (basis) {
+        ScalingBasis.MAX_WEIGHT_PR -> resolveMaxWeight(exerciseId, mode, profileId, basis)
+        ScalingBasis.MAX_VOLUME_PR -> resolveMaxVolume(exerciseId, mode, profileId, basis)
+        ScalingBasis.ESTIMATED_1RM -> resolveEstimatedOneRepMax(exerciseId, mode, profileId, basis)
+    }
+
+    private suspend fun resolveMaxWeight(
+        exerciseId: String,
+        mode: ProgramMode,
+        profileId: String,
+        basis: ScalingBasis,
+    ): RoutineScalingBaseline? {
+        currentModeWeightPR(exerciseId, mode, profileId)?.let { record ->
+            return record.toBaseline(basis, RoutineScalingBaselineSource.CURRENT_MODE_PR)
+        }
+        crossModeWeightPR(exerciseId, mode, profileId)?.let { record ->
+            return record.toBaseline(basis, RoutineScalingBaselineSource.CROSS_MODE_PR)
+        }
+        return storedOneRepMaxBaseline(exerciseId, basis)
+    }
+
+    private suspend fun resolveMaxVolume(
+        exerciseId: String,
+        mode: ProgramMode,
+        profileId: String,
+        basis: ScalingBasis,
+    ): RoutineScalingBaseline? {
+        currentModeVolumePR(exerciseId, mode, profileId)?.let { record ->
+            return record.toBaseline(basis, RoutineScalingBaselineSource.CURRENT_MODE_PR)
+        }
+        crossModeVolumePR(exerciseId, mode, profileId)?.let { record ->
+            return record.toBaseline(basis, RoutineScalingBaselineSource.CROSS_MODE_PR)
+        }
+        return storedOneRepMaxBaseline(exerciseId, basis)
+    }
+
+    private suspend fun resolveEstimatedOneRepMax(
+        exerciseId: String,
+        mode: ProgramMode,
+        profileId: String,
+        basis: ScalingBasis,
+    ): RoutineScalingBaseline? {
+        velocityOneRepMaxRepository.getLatestPassing(exerciseId, profileId)
+            ?.estimatedPerCableKg
+            ?.takeIf { it > 0 }
+            ?.let { estimate ->
+                return RoutineScalingBaseline(
+                    weightPerCableKg = estimate,
+                    basis = basis,
+                    sourceMode = null,
+                    source = RoutineScalingBaselineSource.VELOCITY_ESTIMATE,
+                )
+            }
+
+        storedOneRepMaxBaseline(exerciseId, basis)?.let { return it }
+
+        currentModeWeightPR(exerciseId, mode, profileId)?.let { record ->
+            return record.toBaseline(basis, RoutineScalingBaselineSource.CURRENT_MODE_PR)
+        }
+        crossModeWeightPR(exerciseId, mode, profileId)?.let { record ->
+            return record.toBaseline(basis, RoutineScalingBaselineSource.CROSS_MODE_PR)
+        }
+        return null
+    }
+
+    private suspend fun currentModeWeightPR(
+        exerciseId: String,
+        mode: ProgramMode,
+        profileId: String,
+    ): PersonalRecord? = prRepository.getBestWeightPRForWorkoutMode(exerciseId, mode.displayName, profileId)
+        ?.takeIf { it.weightPerCableKg > 0 }
+
+    private suspend fun storedOneRepMaxBaseline(
+        exerciseId: String,
+        basis: ScalingBasis,
+    ): RoutineScalingBaseline? = exerciseRepository.getExerciseById(exerciseId)
+        ?.oneRepMaxKg
+        ?.takeIf { it > 0 }
+        ?.let { storedOneRepMax ->
+            RoutineScalingBaseline(
+                weightPerCableKg = storedOneRepMax,
+                basis = basis,
+                sourceMode = null,
+                source = RoutineScalingBaselineSource.STORED_ONE_REP_MAX,
+            )
+        }
+
+    private suspend fun currentModeVolumePR(
+        exerciseId: String,
+        mode: ProgramMode,
+        profileId: String,
+    ): PersonalRecord? = prRepository.getBestVolumePRForWorkoutMode(exerciseId, mode.displayName, profileId)
+        ?.takeIf { it.weightPerCableKg > 0 }
+
+    private suspend fun crossModeWeightPR(
+        exerciseId: String,
+        mode: ProgramMode,
+        profileId: String,
+    ): PersonalRecord? = bestCrossModeRecord(
+        preferredPhase = preferredPRPhaseForWorkoutMode(mode.displayName),
+        combinedLookup = { prRepository.getBestWeightPR(exerciseId, profileId, WorkoutPhase.COMBINED) },
+        phaseLookup = { phase -> prRepository.getBestWeightPR(exerciseId, profileId, phase) },
+    )
+
+    private suspend fun crossModeVolumePR(
+        exerciseId: String,
+        mode: ProgramMode,
+        profileId: String,
+    ): PersonalRecord? = bestCrossModeRecord(
+        preferredPhase = preferredPRPhaseForWorkoutMode(mode.displayName),
+        combinedLookup = { prRepository.getBestVolumePR(exerciseId, profileId, WorkoutPhase.COMBINED) },
+        phaseLookup = { phase -> prRepository.getBestVolumePR(exerciseId, profileId, phase) },
+    )
+
+    private suspend fun bestCrossModeRecord(
+        preferredPhase: WorkoutPhase,
+        phaseLookup: suspend (WorkoutPhase) -> PersonalRecord?,
+        combinedLookup: suspend () -> PersonalRecord?,
+    ): PersonalRecord? {
+        phaseLookup(preferredPhase)?.takeIf { it.weightPerCableKg > 0 }?.let { return it }
+        if (preferredPhase != WorkoutPhase.COMBINED) {
+            combinedLookup()?.takeIf { it.weightPerCableKg > 0 }?.let { return it }
+        }
+        return null
+    }
+
+    private fun PersonalRecord.toBaseline(
+        basis: ScalingBasis,
+        source: RoutineScalingBaselineSource,
+    ): RoutineScalingBaseline = RoutineScalingBaseline(
+        weightPerCableKg = weightPerCableKg,
+        basis = basis,
+        sourceMode = workoutMode,
+        source = source,
+    )
+}
+
+data class RoutineScalingBaseline(
+    val weightPerCableKg: Float,
+    val basis: ScalingBasis,
+    val sourceMode: String?,
+    val source: RoutineScalingBaselineSource,
+)
+
+enum class RoutineScalingBaselineSource {
+    CURRENT_MODE_PR,
+    CROSS_MODE_PR,
+    VELOCITY_ESTIMATE,
+    STORED_ONE_REP_MAX,
+}

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/ResolveRoutineWeightsUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/ResolveRoutineWeightsUseCase.kt
@@ -3,31 +3,33 @@ package com.devil.phoenixproject.domain.usecase
 import com.devil.phoenixproject.data.repository.ExerciseRepository
 import com.devil.phoenixproject.data.repository.PersonalRecordRepository
 import com.devil.phoenixproject.data.repository.VelocityOneRepMaxRepository
-import com.devil.phoenixproject.data.repository.getBestVolumePRForWorkoutMode
-import com.devil.phoenixproject.data.repository.getBestWeightPRForWorkoutMode
 import com.devil.phoenixproject.domain.model.ProgramMode
 import com.devil.phoenixproject.domain.model.RoutineExercise
-import com.devil.phoenixproject.domain.model.ScalingBasis
 
 /**
  * Use case for resolving PR percentage weights to absolute values at workout start time.
  *
  * When a routine exercise is configured to use a percentage of PR (usePercentOfPR = true),
- * this use case looks up the user's current PR for that exercise and calculates the
- * actual weight based on the configured percentage. When no PR exists, falls back to the
- * exercise's stored oneRepMaxKg (manual input or VBT assessment) before using absolute weights.
+ * this use case looks up the user's current baseline for that exercise and calculates the
+ * actual weight based on the configured percentage. When no baseline exists, it falls back
+ * to the exercise's saved absolute weights.
  */
 class ResolveRoutineWeightsUseCase(
     private val prRepository: PersonalRecordRepository,
     private val exerciseRepository: ExerciseRepository,
     private val velocityOneRepMaxRepository: VelocityOneRepMaxRepository,
+    private val scalingBaselineResolver: ResolveRoutineScalingBaselineUseCase = ResolveRoutineScalingBaselineUseCase(
+        prRepository,
+        exerciseRepository,
+        velocityOneRepMaxRepository,
+    ),
 ) {
     /**
      * Resolves RoutineExercise weights from PR percentages to absolute values.
-     * Call this at workout start time to get current weights based on latest PRs.
+     * Call this at workout start time to get current weights based on latest baselines.
      *
      * @param exercise The routine exercise to resolve weights for
-     * @param mode The program mode to use for PR lookup (defaults to exercise's programMode)
+     * @param mode The program mode to use for baseline lookup (defaults to exercise's programMode)
      * @return ResolvedExerciseWeights containing the absolute weight values
      */
     suspend operator fun invoke(
@@ -44,7 +46,6 @@ class ResolveRoutineWeightsUseCase(
             )
         }
 
-        // Get exercise ID from the nested Exercise object
         val exerciseId = exercise.exercise.id ?: return ResolvedExerciseWeights(
             baseWeight = exercise.weightPerCableKg,
             setWeights = exercise.setWeightsPerCableKg,
@@ -53,44 +54,18 @@ class ResolveRoutineWeightsUseCase(
             fallbackReason = "Exercise has no ID for PR lookup",
         )
 
-        // Lookup scaling baseline for this exercise filtered by mode and profile
-        val scalingWeight: Float? = when (exercise.effectiveScalingBasis) {
-            ScalingBasis.MAX_WEIGHT_PR -> prRepository.getBestWeightPRForWorkoutMode(
-                exerciseId,
-                mode.displayName,
-                profileId,
-            )?.weightPerCableKg?.takeIf { it > 0 }
+        val baseline = scalingBaselineResolver(
+            exerciseId = exerciseId,
+            mode = mode,
+            profileId = profileId,
+            basis = exercise.effectiveScalingBasis,
+        )
 
-            ScalingBasis.MAX_VOLUME_PR -> prRepository.getBestVolumePRForWorkoutMode(
-                exerciseId,
-                mode.displayName,
-                profileId,
-            )?.weightPerCableKg?.takeIf { it > 0 }
-
-            ScalingBasis.ESTIMATED_1RM -> velocityOneRepMaxRepository.getLatestPassing(
-                exerciseId,
-                profileId,
-            )?.estimatedPerCableKg?.takeIf { it > 0 }
-        } ?: exerciseRepository.getExerciseById(exerciseId)?.oneRepMaxKg?.takeIf { it > 0 }
-            // Last-resort baseline for ESTIMATED_1RM only: when there is no velocity estimate
-            // and no stored Exercise.oneRepMaxKg, fall back to the max-weight PR before going absolute.
-            ?: (
-                if (exercise.effectiveScalingBasis == ScalingBasis.ESTIMATED_1RM) {
-                    prRepository.getBestWeightPRForWorkoutMode(
-                        exerciseId,
-                        mode.displayName,
-                        profileId,
-                    )?.weightPerCableKg?.takeIf { it > 0 }
-                } else {
-                    null
-                }
-                )
-
-        return if (scalingWeight != null) {
+        return if (baseline != null) {
             ResolvedExerciseWeights(
-                baseWeight = exercise.resolveWeight(scalingWeight),
-                setWeights = exercise.resolveSetWeights(scalingWeight),
-                usedPR = scalingWeight,
+                baseWeight = exercise.resolveWeight(baseline.weightPerCableKg),
+                setWeights = exercise.resolveSetWeights(baseline.weightPerCableKg),
+                usedPR = baseline.weightPerCableKg,
                 percentOfPR = exercise.weightPercentOfPR,
             )
         } else {
@@ -110,7 +85,7 @@ class ResolveRoutineWeightsUseCase(
  *
  * @param baseWeight The resolved base weight per cable in kg
  * @param setWeights The resolved per-set weights in kg (may be empty if using baseWeight for all sets)
- * @param usedPR The PR weight value that was used for percentage calculation, or null if not applicable
+ * @param usedPR The baseline weight value that was used for percentage calculation, or null if not applicable
  * @param percentOfPR The percentage of PR that was applied, or null if not applicable
  * @param fallbackReason If weights fell back to absolute values, the reason why (e.g., no PR found)
  */

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/SettingsManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/SettingsManager.kt
@@ -44,6 +44,15 @@ class SettingsManager(
         .map { it.defaultScalingBasis }
         .stateIn(scope, SharingStarted.Eagerly, ScalingBasis.MAX_WEIGHT_PR)
 
+    // Issue #595: Routine-builder defaults for newly added cable exercises
+    val defaultRoutineExerciseUsePercentOfPR: StateFlow<Boolean> = userPreferences
+        .map { it.defaultRoutineExerciseUsePercentOfPR }
+        .stateIn(scope, SharingStarted.Eagerly, false)
+
+    val defaultRoutineExerciseWeightPercentOfPR: StateFlow<Int> = userPreferences
+        .map { it.defaultRoutineExerciseWeightPercentOfPR }
+        .stateIn(scope, SharingStarted.Eagerly, 80)
+
     // Issue #517: Run-once flag — true after the velocity 1RM backfill has completed
     val velocityOneRepMaxBackfillDone: StateFlow<Boolean> = userPreferences
         .map { it.velocityOneRepMaxBackfillDone }
@@ -159,6 +168,14 @@ class SettingsManager(
 
     fun setDefaultScalingBasis(basis: ScalingBasis) {
         scope.launch { preferencesManager.setDefaultScalingBasis(basis) }
+    }
+
+    fun setDefaultRoutineExerciseUsePercentOfPR(enabled: Boolean) {
+        scope.launch { preferencesManager.setDefaultRoutineExerciseUsePercentOfPR(enabled) }
+    }
+
+    fun setDefaultRoutineExerciseWeightPercentOfPR(percent: Int) {
+        scope.launch { preferencesManager.setDefaultRoutineExerciseWeightPercentOfPR(percent.coerceIn(50, 120)) }
     }
 
     fun setVelocityOneRepMaxBackfillDone(done: Boolean) {

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/navigation/NavGraph.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/navigation/NavGraph.kt
@@ -399,6 +399,11 @@ fun NavGraph(
                     // Issue #517: system-wide default scaling basis
                     defaultScalingBasis = userPreferences.defaultScalingBasis,
                     onDefaultScalingBasisChange = { viewModel.setDefaultScalingBasis(it) },
+                    // Issue #595: routine-builder defaults for newly added cable exercises
+                    defaultRoutineExerciseUsePercentOfPR = userPreferences.defaultRoutineExerciseUsePercentOfPR,
+                    defaultRoutineExerciseWeightPercentOfPR = userPreferences.defaultRoutineExerciseWeightPercentOfPR,
+                    onDefaultRoutineExerciseUsePercentOfPRChange = { viewModel.setDefaultRoutineExerciseUsePercentOfPR(it) },
+                    onDefaultRoutineExerciseWeightPercentOfPRChange = { viewModel.setDefaultRoutineExerciseWeightPercentOfPR(it) },
                 )
             }
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/routine/RoutineExerciseDefaults.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/routine/RoutineExerciseDefaults.kt
@@ -1,0 +1,48 @@
+package com.devil.phoenixproject.presentation.routine
+
+import com.devil.phoenixproject.domain.model.Exercise
+import com.devil.phoenixproject.domain.model.PRType
+import com.devil.phoenixproject.domain.model.RoutineExercise
+import com.devil.phoenixproject.domain.model.ScalingBasis
+import com.devil.phoenixproject.domain.model.UserPreferences
+
+private val DefaultRoutineSetReps: List<Int?> = listOf(10, 10, 10)
+
+fun buildDefaultRoutineExerciseForEditor(
+    id: String,
+    selectedExercise: Exercise,
+    orderIndex: Int,
+    userPreferences: UserPreferences,
+    supersetId: String? = null,
+    orderInSuperset: Int = 0,
+): RoutineExercise {
+    val shouldSeedPercent = userPreferences.defaultRoutineExerciseUsePercentOfPR && selectedExercise.hasCableAccessory
+    val defaultPercent = userPreferences.defaultRoutineExerciseWeightPercentOfPR.coerceIn(50, 120)
+    val defaultScalingBasis = userPreferences.defaultScalingBasis
+
+    return RoutineExercise(
+        id = id,
+        exercise = selectedExercise,
+        orderIndex = orderIndex,
+        setReps = DefaultRoutineSetReps,
+        weightPerCableKg = 5f,
+        usePercentOfPR = shouldSeedPercent,
+        weightPercentOfPR = defaultPercent,
+        setWeightsPercentOfPR = if (shouldSeedPercent) {
+            List(DefaultRoutineSetReps.size) { defaultPercent }
+        } else {
+            emptyList()
+        },
+        scalingBasis = defaultScalingBasis,
+        prTypeForScaling = defaultScalingBasis.toRoutineExercisePRType(),
+        supersetId = supersetId,
+        orderInSuperset = orderInSuperset,
+    )
+}
+
+fun ScalingBasis.toRoutineExercisePRType(): PRType = when (this) {
+    ScalingBasis.MAX_VOLUME_PR -> PRType.MAX_VOLUME
+    ScalingBasis.MAX_WEIGHT_PR,
+    ScalingBasis.ESTIMATED_1RM,
+    -> PRType.MAX_WEIGHT
+}

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseEditBottomSheet.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseEditBottomSheet.kt
@@ -79,6 +79,7 @@ import com.devil.phoenixproject.domain.model.WarmupSet
 import com.devil.phoenixproject.domain.model.WeightUnit
 import com.devil.phoenixproject.domain.model.WorkoutMode
 import com.devil.phoenixproject.domain.model.WorkoutPhase
+import com.devil.phoenixproject.domain.usecase.RoutineScalingBaselineSource
 import com.devil.phoenixproject.presentation.components.CompactNumberPicker
 import com.devil.phoenixproject.presentation.components.EquipmentRackSelectionCard
 import com.devil.phoenixproject.presentation.components.ExpressiveSlider
@@ -180,6 +181,7 @@ fun ExerciseEditBottomSheet(
     val currentMaxVolumePR by viewModel.currentMaxVolumePR.collectAsState()
     val velocityEstimateKg by viewModel.velocityEstimateKg.collectAsState()
     val storedOneRepMaxKg by viewModel.storedOneRepMaxKg.collectAsState()
+    val routineScalingBaseline by viewModel.routineScalingBaseline.collectAsState()
 
     // Resolved baseline weight for the currently-selected scaling basis, mirroring
     // ResolveRoutineWeightsUseCase so the editor preview matches workout-start resolution.
@@ -190,18 +192,34 @@ fun ExerciseEditBottomSheet(
     val maxVolumeBaselineKg = currentMaxVolumePR?.weightPerCableKg?.takeIf { it > 0 }
     val velocityBaselineKg = velocityEstimateKg?.takeIf { it > 0 }
     val storedBaselineKg = storedOneRepMaxKg?.takeIf { it > 0 }
-    val baselineWeightKg: Float? = when (effectiveScalingBasis) {
+    val sharedBaselineKg = routineScalingBaseline
+        ?.takeIf { it.basis == effectiveScalingBasis }
+        ?.weightPerCableKg
+        ?.takeIf { it > 0 }
+    val baselineWeightKg: Float? = sharedBaselineKg ?: when (effectiveScalingBasis) {
         ScalingBasis.MAX_WEIGHT_PR -> maxWeightBaselineKg
         ScalingBasis.MAX_VOLUME_PR -> maxVolumeBaselineKg
         ScalingBasis.ESTIMATED_1RM -> velocityBaselineKg ?: storedBaselineKg ?: maxWeightBaselineKg
     }
+    val baselineSourceMessage = routineScalingBaseline
+        ?.takeIf { it.source == RoutineScalingBaselineSource.CROSS_MODE_PR && it.basis == effectiveScalingBasis }
+        ?.sourceMode
+        ?.let { sourceMode ->
+            val basisLabel = when (effectiveScalingBasis) {
+                ScalingBasis.MAX_WEIGHT_PR -> "Max-weight PR"
+                ScalingBasis.MAX_VOLUME_PR -> "Max-volume PR"
+                ScalingBasis.ESTIMATED_1RM -> "Est. 1RM"
+            }
+            "No ${selectedMode.displayName} PR yet; using your best available $basisLabel from $sourceMode."
+        }
     // True if a baseline exists for AT LEAST ONE basis. Used to gate the % toggle and
     // warning so the user can enable scaling and switch to a basis that has data, rather
     // than being locked out when only the currently-selected basis lacks a baseline (#517).
     val hasAnyBaseline = maxWeightBaselineKg != null ||
         maxVolumeBaselineKg != null ||
         velocityBaselineKg != null ||
-        storedBaselineKg != null
+        storedBaselineKg != null ||
+        sharedBaselineKg != null
 
     val weightSuffix = if (weightUnit == WeightUnit.LB) "lbs" else "kg"
     val maxWeight = if (weightUnit == WeightUnit.LB) 242f else 110f // 110kg per cable max
@@ -377,6 +395,7 @@ fun ExerciseEditBottomSheet(
                         effectiveScalingBasis = effectiveScalingBasis,
                         baselineWeightKg = baselineWeightKg,
                         hasAnyBaseline = hasAnyBaseline,
+                        baselineSourceMessage = baselineSourceMessage,
                         weightUnit = weightUnit,
                         formatWeight = formatWeight,
                         onUsePercentOfPRChange = viewModel::onUsePercentOfPRChange,
@@ -1281,6 +1300,7 @@ fun WeightConfigurationCard(
      * even when the currently-selected basis lacks a baseline (Issue #517).
      */
     hasAnyBaseline: Boolean = baselineWeightKg != null,
+    baselineSourceMessage: String? = null,
     weightUnit: WeightUnit,
     formatWeight: (Float, WeightUnit) -> String,
     onUsePercentOfPRChange: (Boolean) -> Unit,
@@ -1328,6 +1348,8 @@ fun WeightConfigurationCard(
                                 "Scale weight based on your velocity 1RM estimate"
                             baselineWeightKg != null && effectiveScalingBasis == ScalingBasis.MAX_VOLUME_PR ->
                                 "Scale weight based on your max-volume personal record"
+                            baselineWeightKg != null && effectiveScalingBasis == ScalingBasis.MAX_WEIGHT_PR ->
+                                "Scale weight based on your max-weight personal record"
                             currentExercisePR != null ->
                                 "Scale weight based on your ${currentExercisePR.phase.displayLabel().lowercase()} personal record"
                             else ->
@@ -1336,6 +1358,14 @@ fun WeightConfigurationCard(
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
+                    baselineSourceMessage?.let { message ->
+                        Spacer(modifier = Modifier.height(Spacing.extraSmall))
+                        Text(
+                            text = message,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.primary,
+                        )
+                    }
                 }
                 Switch(
                     checked = usePercentOfPR,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseEditBottomSheet.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseEditBottomSheet.kt
@@ -1372,7 +1372,9 @@ fun WeightConfigurationCard(
                     onCheckedChange = onUsePercentOfPRChange,
                     // Enable the toggle whenever a baseline exists for ANY basis — the user
                     // can then switch to the basis that has data (fixes ESTIMATED_1RM lockout).
-                    enabled = hasAnyBaseline,
+                    // If scaling was seeded by routine defaults before a baseline exists,
+                    // keep the switch reversible so saving does not leave a latent % rule.
+                    enabled = hasAnyBaseline || usePercentOfPR,
                 )
             }
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RoutineEditorScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RoutineEditorScreen.kt
@@ -83,6 +83,7 @@ import com.devil.phoenixproject.presentation.components.SelectionActionBar
 import com.devil.phoenixproject.presentation.components.SupersetContainer
 import com.devil.phoenixproject.presentation.components.SupersetHeader
 import com.devil.phoenixproject.presentation.components.SupersetPickerDialog
+import com.devil.phoenixproject.presentation.routine.buildDefaultRoutineExerciseForEditor
 import com.devil.phoenixproject.ui.theme.SupersetTheme
 import com.devil.phoenixproject.util.UnitConverter
 import org.jetbrains.compose.resources.stringResource
@@ -786,16 +787,15 @@ fun RoutineEditorScreen(
                 supersetForAddExercise = null // Clear superset target on dismiss
             },
             onExerciseSelected = { selectedExercise ->
-                val newEx = RoutineExercise(
+                val targetSuperset = supersetForAddExercise
+                val newEx = buildDefaultRoutineExerciseForEditor(
                     id = generateUUID(),
-                    exercise = selectedExercise,
+                    selectedExercise = selectedExercise,
                     orderIndex = state.exercises.size,
-                    weightPerCableKg = 5f,
-                    // Issue #517: seed new exercises from the system-wide default scaling basis
-                    scalingBasis = userPreferences.defaultScalingBasis,
-                    // If adding to a superset, set the superset reference
-                    supersetId = supersetForAddExercise?.id,
-                    orderInSuperset = supersetForAddExercise?.let { ss ->
+                    userPreferences = userPreferences,
+                    // If adding to a superset, set the superset reference.
+                    supersetId = targetSuperset?.id,
+                    orderInSuperset = targetSuperset?.let { ss ->
                         state.exercises.filter { it.supersetId == ss.id }.size
                     } ?: 0,
                 )

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SettingsTab.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SettingsTab.kt
@@ -345,6 +345,11 @@ fun SettingsTab(
     // Issue #517: System-wide default scaling basis for % of 1RM
     defaultScalingBasis: ScalingBasis = ScalingBasis.MAX_WEIGHT_PR,
     onDefaultScalingBasisChange: (ScalingBasis) -> Unit = {},
+    // Issue #595: Routine-builder defaults for newly added cable exercises
+    defaultRoutineExerciseUsePercentOfPR: Boolean = false,
+    defaultRoutineExerciseWeightPercentOfPR: Int = 80,
+    onDefaultRoutineExerciseUsePercentOfPRChange: (Boolean) -> Unit = {},
+    onDefaultRoutineExerciseWeightPercentOfPRChange: (Int) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val focusManager = LocalFocusManager.current
@@ -1389,6 +1394,76 @@ fun SettingsTab(
                                 selected = defaultScalingBasis == basis,
                             ) {
                                 Text(label, maxLines = 1)
+                            }
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(Spacing.medium))
+
+                // Issue #595: Opt-in starting weights for newly added routine exercises.
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                "Routine starting weights",
+                                style = MaterialTheme.typography.bodyLarge,
+                                fontWeight = FontWeight.Medium,
+                                color = MaterialTheme.colorScheme.onSurface,
+                            )
+                            Spacer(modifier = Modifier.height(4.dp))
+                            Text(
+                                if (defaultRoutineExerciseUsePercentOfPR) {
+                                    "When a baseline exists, newly added routine exercises start at your chosen percentage. You can still edit each exercise before saving."
+                                } else {
+                                    "New routine exercises start from the normal manual weight."
+                                },
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                        Switch(
+                            checked = defaultRoutineExerciseUsePercentOfPR,
+                            onCheckedChange = onDefaultRoutineExerciseUsePercentOfPRChange,
+                        )
+                    }
+
+                    if (defaultRoutineExerciseUsePercentOfPR) {
+                        Spacer(modifier = Modifier.height(Spacing.small))
+                        val routineDefaultPercent = defaultRoutineExerciseWeightPercentOfPR.coerceIn(50, 120)
+                        Text(
+                            "$routineDefaultPercent% of selected baseline",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.primary,
+                        )
+                        Spacer(modifier = Modifier.height(Spacing.small))
+                        ExpressiveSlider(
+                            value = routineDefaultPercent.toFloat(),
+                            onValueChange = { value ->
+                                val roundedToFive = (value / 5f).roundToInt() * 5
+                                onDefaultRoutineExerciseWeightPercentOfPRChange(roundedToFive.coerceIn(50, 120))
+                            },
+                            valueRange = 50f..120f,
+                            steps = 13,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                        Spacer(modifier = Modifier.height(Spacing.small))
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(Spacing.small),
+                        ) {
+                            listOf(70, 80, 90, 100).forEach { percent ->
+                                FilterChip(
+                                    selected = routineDefaultPercent == percent,
+                                    onClick = { onDefaultRoutineExerciseWeightPercentOfPRChange(percent) },
+                                    label = { Text("$percent%") },
+                                    modifier = Modifier.weight(1f),
+                                )
                             }
                         }
                     }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModel.kt
@@ -20,6 +20,8 @@ import com.devil.phoenixproject.domain.model.WarmupSet
 import com.devil.phoenixproject.domain.model.WeightUnit
 import com.devil.phoenixproject.domain.model.WorkoutMode
 import com.devil.phoenixproject.domain.model.toWorkoutMode
+import com.devil.phoenixproject.domain.usecase.ResolveRoutineScalingBaselineUseCase
+import com.devil.phoenixproject.domain.usecase.RoutineScalingBaseline
 import com.devil.phoenixproject.util.KmpUtils
 import kotlin.math.roundToInt
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -54,6 +56,13 @@ class ExerciseConfigViewModel constructor(
     private val exerciseRepository: ExerciseRepository? = null,
 ) : ViewModel() {
 
+    private val scalingBaselineResolver: ResolveRoutineScalingBaselineUseCase? =
+        if (personalRecordRepository != null && velocityOneRepMaxRepository != null && exerciseRepository != null) {
+            ResolveRoutineScalingBaselineUseCase(personalRecordRepository, exerciseRepository, velocityOneRepMaxRepository)
+        } else {
+            null
+        }
+
     private val log = Logger.withTag("ExerciseConfigViewModel")
     private val _initialized = MutableStateFlow(false)
     private var activeProfileId: String = "default"
@@ -79,6 +88,10 @@ class ExerciseConfigViewModel constructor(
     // Stored Exercise.oneRepMaxKg (manual/VBT input) — fallback within ESTIMATED_1RM basis
     private val _storedOneRepMaxKg = MutableStateFlow<Float?>(null)
     val storedOneRepMaxKg: StateFlow<Float?> = _storedOneRepMaxKg.asStateFlow()
+
+    // Shared baseline resolver output, including same-profile cross-mode fallback metadata.
+    private val _routineScalingBaseline = MutableStateFlow<RoutineScalingBaseline?>(null)
+    val routineScalingBaseline: StateFlow<RoutineScalingBaseline?> = _routineScalingBaseline.asStateFlow()
 
     // Convenience accessor for just the PR weight (useful for PRIndicator component)
     val currentExercisePRWeight: Float?
@@ -265,6 +278,7 @@ class ExerciseConfigViewModel constructor(
         exercise.exercise.id?.let { exerciseId ->
             loadPRForExercise(exerciseId, _selectedMode.value.displayName)
             loadModeIndependentBaselines(exerciseId)
+            loadRoutineScalingBaseline(exerciseId, _selectedMode.value)
         }
 
         _initialized.value = true
@@ -321,6 +335,32 @@ class ExerciseConfigViewModel constructor(
             // The volume PR loads after the weight-PR sync above; re-sync so a MAX_VOLUME_PR
             // exercise picks up the just-loaded baseline instead of staying on stale weights.
             resyncSetWeightsIfBaselineReady()
+            loadRoutineScalingBaseline(exerciseId, _selectedMode.value)
+        }
+    }
+
+    private fun loadRoutineScalingBaselineForCurrentExercise() {
+        if (!::originalExercise.isInitialized) return
+        originalExercise.exercise.id?.let { exerciseId ->
+            loadRoutineScalingBaseline(exerciseId, _selectedMode.value)
+        }
+    }
+
+    private fun loadRoutineScalingBaseline(exerciseId: String, mode: WorkoutMode) {
+        val resolver = scalingBaselineResolver ?: return
+        viewModelScope.launch {
+            try {
+                _routineScalingBaseline.value = resolver(
+                    exerciseId = exerciseId,
+                    mode = mode.toProgramMode(),
+                    profileId = activeProfileId,
+                    basis = effectiveScalingBasis(),
+                )
+                resyncSetWeightsIfBaselineReady()
+            } catch (e: Exception) {
+                logWarning("Failed to resolve routine scaling baseline for exercise=$exerciseId, mode=${mode.displayName}, profile=$activeProfileId: ${e.message}")
+                _routineScalingBaseline.value = null
+            }
         }
     }
 
@@ -367,6 +407,7 @@ class ExerciseConfigViewModel constructor(
                 // Re-sync after the stored-1RM fallback lands.
                 resyncSetWeightsIfBaselineReady()
             }
+            loadRoutineScalingBaseline(exerciseId, _selectedMode.value)
         }
     }
 
@@ -390,6 +431,12 @@ class ExerciseConfigViewModel constructor(
      * Returns null when no data is available for the selected basis (controls preview and gating).
      */
     fun baselineKgForCurrentBasis(): Float? {
+        _routineScalingBaseline.value
+            ?.takeIf { it.basis == effectiveScalingBasis() }
+            ?.weightPerCableKg
+            ?.takeIf { it > 0 }
+            ?.let { return it }
+
         return when (effectiveScalingBasis()) {
             ScalingBasis.MAX_WEIGHT_PR ->
                 _currentExercisePR.value?.weightPerCableKg?.takeIf { it > 0 }
@@ -477,6 +524,7 @@ class ExerciseConfigViewModel constructor(
     // Issue #517: explicit 3-way scaling basis selector
     fun onScalingBasisChange(basis: ScalingBasis) {
         _scalingBasis.value = basis
+        loadRoutineScalingBaselineForCurrentExercise()
         // Re-resolve visible set weights against the newly-selected basis baseline
         // so the editor table matches what ResolveRoutineWeightsUseCase will use.
         if (_usePercentOfPR.value) {

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
@@ -353,6 +353,13 @@ class MainViewModel constructor(
     // Issue #517: system-wide default scaling basis
     fun setDefaultScalingBasis(basis: ScalingBasis) = settingsManager.setDefaultScalingBasis(basis)
 
+    // Issue #595: routine-builder defaults for newly added cable exercises
+    fun setDefaultRoutineExerciseUsePercentOfPR(enabled: Boolean) =
+        settingsManager.setDefaultRoutineExerciseUsePercentOfPR(enabled)
+
+    fun setDefaultRoutineExerciseWeightPercentOfPR(percent: Int) =
+        settingsManager.setDefaultRoutineExerciseWeightPercentOfPR(percent)
+
     // Backup stats for Settings UI
     private val _backupStats = kotlinx.coroutines.flow.MutableStateFlow<BackupStats?>(null)
     val backupStats: kotlinx.coroutines.flow.StateFlow<BackupStats?> = _backupStats

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/ResolveRoutineWeightsUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/ResolveRoutineWeightsUseCaseTest.kt
@@ -696,6 +696,94 @@ class ResolveRoutineWeightsUseCaseTest {
     }
 
     @Test
+    fun `max weight basis falls back to same profile cross mode PR when selected mode has none`() = runTest {
+        prRepository.addRecord(
+            PersonalRecord(
+                id = 10,
+                exerciseId = "bench-press",
+                exerciseName = "Bench Press",
+                weightPerCableKg = 62f,
+                reps = 5,
+                oneRepMax = 70f,
+                timestamp = 2_000L,
+                workoutMode = "Pump",
+                prType = PRType.MAX_WEIGHT,
+                volume = 310f,
+                profileId = "default",
+            ),
+        )
+        prRepository.addRecord(
+            PersonalRecord(
+                id = 11,
+                exerciseId = "bench-press",
+                exerciseName = "Bench Press",
+                weightPerCableKg = 90f,
+                reps = 5,
+                oneRepMax = 100f,
+                timestamp = 3_000L,
+                workoutMode = "Pump",
+                prType = PRType.MAX_WEIGHT,
+                volume = 450f,
+                profileId = "other-profile",
+            ),
+        )
+
+        val routineExercise = RoutineExercise(
+            id = "routine-ex-cross-mode",
+            exercise = testExercise,
+            orderIndex = 0,
+            weightPerCableKg = 5f,
+            usePercentOfPR = true,
+            weightPercentOfPR = 80,
+            scalingBasis = ScalingBasis.MAX_WEIGHT_PR,
+            programMode = ProgramMode.OldSchool,
+        )
+
+        val result = useCase(routineExercise, profileId = "default")
+
+        assertEquals(49.5f, result.baseWeight)
+        assertEquals(62f, result.usedPR)
+        assertTrue(result.isFromPR)
+        assertNull(result.fallbackReason)
+    }
+
+    @Test
+    fun `max volume basis falls back to same profile cross mode volume PR when selected mode has none`() = runTest {
+        prRepository.addRecord(
+            PersonalRecord(
+                id = 12,
+                exerciseId = "bench-press",
+                exerciseName = "Bench Press",
+                weightPerCableKg = 45f,
+                reps = 15,
+                oneRepMax = 65f,
+                timestamp = 2_000L,
+                workoutMode = "Pump",
+                prType = PRType.MAX_VOLUME,
+                volume = 675f,
+                profileId = "default",
+            ),
+        )
+
+        val routineExercise = RoutineExercise(
+            id = "routine-ex-cross-volume",
+            exercise = testExercise,
+            orderIndex = 0,
+            weightPerCableKg = 5f,
+            usePercentOfPR = true,
+            weightPercentOfPR = 100,
+            scalingBasis = ScalingBasis.MAX_VOLUME_PR,
+            programMode = ProgramMode.OldSchool,
+        )
+
+        val result = useCase(routineExercise, profileId = "default")
+
+        assertEquals(45f, result.baseWeight)
+        assertEquals(45f, result.usedPR)
+        assertTrue(result.isFromPR)
+    }
+
+    @Test
     fun `set weights default to base percentage when no per-set percentages defined`() = runTest {
         // Given: Exercise uses PR percentage for base weight, but no per-set percentages
         prRepository.addRecord(

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/routine/RoutineExerciseDefaultsTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/routine/RoutineExerciseDefaultsTest.kt
@@ -1,0 +1,118 @@
+package com.devil.phoenixproject.presentation.routine
+
+import com.devil.phoenixproject.domain.model.Exercise
+import com.devil.phoenixproject.domain.model.PRType
+import com.devil.phoenixproject.domain.model.ScalingBasis
+import com.devil.phoenixproject.domain.model.UserPreferences
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class RoutineExerciseDefaultsTest {
+
+    private val cableExercise = Exercise(
+        id = "squat",
+        name = "Squat",
+        muscleGroup = "Legs",
+        equipment = "BAR",
+    )
+
+    private val bodyweightExercise = Exercise(
+        id = "plank",
+        name = "Plank",
+        muscleGroup = "Core",
+        equipment = "",
+    )
+
+    @Test
+    fun `preference off preserves manual fallback for cable exercise`() {
+        val exercise = buildDefaultRoutineExerciseForEditor(
+            id = "routine-ex-1",
+            selectedExercise = cableExercise,
+            orderIndex = 0,
+            userPreferences = UserPreferences(
+                defaultRoutineExerciseUsePercentOfPR = false,
+                defaultRoutineExerciseWeightPercentOfPR = 90,
+                defaultScalingBasis = ScalingBasis.MAX_VOLUME_PR,
+            ),
+        )
+
+        assertFalse(exercise.usePercentOfPR)
+        assertEquals(5f, exercise.weightPerCableKg)
+        assertEquals(emptyList(), exercise.setWeightsPercentOfPR)
+        assertEquals(ScalingBasis.MAX_VOLUME_PR, exercise.scalingBasis)
+        assertEquals(PRType.MAX_VOLUME, exercise.prTypeForScaling)
+    }
+
+    @Test
+    fun `preference on seeds eligible cable exercise with percent fields`() {
+        val exercise = buildDefaultRoutineExerciseForEditor(
+            id = "routine-ex-2",
+            selectedExercise = cableExercise,
+            orderIndex = 1,
+            userPreferences = UserPreferences(
+                defaultRoutineExerciseUsePercentOfPR = true,
+                defaultRoutineExerciseWeightPercentOfPR = 80,
+                defaultScalingBasis = ScalingBasis.ESTIMATED_1RM,
+            ),
+            supersetId = "superset-1",
+            orderInSuperset = 2,
+        )
+
+        assertTrue(exercise.usePercentOfPR)
+        assertEquals(80, exercise.weightPercentOfPR)
+        assertEquals(listOf(80, 80, 80), exercise.setWeightsPercentOfPR)
+        assertEquals(5f, exercise.weightPerCableKg)
+        assertEquals(ScalingBasis.ESTIMATED_1RM, exercise.scalingBasis)
+        assertEquals(PRType.MAX_WEIGHT, exercise.prTypeForScaling)
+        assertEquals("superset-1", exercise.supersetId)
+        assertEquals(2, exercise.orderInSuperset)
+    }
+
+    @Test
+    fun `preference on does not seed bodyweight or non cable exercise`() {
+        val exercise = buildDefaultRoutineExerciseForEditor(
+            id = "routine-ex-3",
+            selectedExercise = bodyweightExercise,
+            orderIndex = 0,
+            userPreferences = UserPreferences(
+                defaultRoutineExerciseUsePercentOfPR = true,
+                defaultRoutineExerciseWeightPercentOfPR = 80,
+                defaultScalingBasis = ScalingBasis.MAX_WEIGHT_PR,
+            ),
+        )
+
+        assertFalse(exercise.usePercentOfPR)
+        assertEquals(80, exercise.weightPercentOfPR)
+        assertEquals(emptyList(), exercise.setWeightsPercentOfPR)
+        assertEquals(5f, exercise.weightPerCableKg)
+    }
+
+    @Test
+    fun `routine exercise default percent is coerced into supported range`() {
+        val low = buildDefaultRoutineExerciseForEditor(
+            id = "routine-ex-low",
+            selectedExercise = cableExercise,
+            orderIndex = 0,
+            userPreferences = UserPreferences(
+                defaultRoutineExerciseUsePercentOfPR = true,
+                defaultRoutineExerciseWeightPercentOfPR = 10,
+            ),
+        )
+        val high = buildDefaultRoutineExerciseForEditor(
+            id = "routine-ex-high",
+            selectedExercise = cableExercise,
+            orderIndex = 0,
+            userPreferences = UserPreferences(
+                defaultRoutineExerciseUsePercentOfPR = true,
+                defaultRoutineExerciseWeightPercentOfPR = 200,
+            ),
+        )
+
+        assertEquals(50, low.weightPercentOfPR)
+        assertEquals(listOf(50, 50, 50), low.setWeightsPercentOfPR)
+        assertEquals(120, high.weightPercentOfPR)
+        assertEquals(listOf(120, 120, 120), high.setWeightsPercentOfPR)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakePreferencesManager.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakePreferencesManager.kt
@@ -167,6 +167,14 @@ class FakePreferencesManager : PreferencesManager {
         _preferencesFlow.value = _preferencesFlow.value.copy(defaultScalingBasis = basis)
     }
 
+    override suspend fun setDefaultRoutineExerciseUsePercentOfPR(enabled: Boolean) {
+        _preferencesFlow.value = _preferencesFlow.value.copy(defaultRoutineExerciseUsePercentOfPR = enabled)
+    }
+
+    override suspend fun setDefaultRoutineExerciseWeightPercentOfPR(percent: Int) {
+        _preferencesFlow.value = _preferencesFlow.value.copy(defaultRoutineExerciseWeightPercentOfPR = percent.coerceIn(50, 120))
+    }
+
     override suspend fun setVelocityOneRepMaxBackfillDone(done: Boolean) {
         _preferencesFlow.value = _preferencesFlow.value.copy(velocityOneRepMaxBackfillDone = done)
     }


### PR DESCRIPTION
## Summary
- Adds an opt-in `Routine starting weights` preference for newly added routine exercises.
- Seeds eligible cable exercises from the configured % of PR/default scaling basis while preserving the existing 5 kg / ~11 lb fallback.
- Aligns editor preview and workout-start baseline resolution with current-mode first, same-profile cross-mode fallback, then safe fallback.
- Follow-up bbea651 keeps seeded `% of PR` defaults reversible when no baseline exists, so users can turn the switch off before saving.

## Visual evidence
Final emulator/device visual evidence: https://gist.github.com/9thLevelSoftware/bf7520958826d03465a46dd25bfa6ab3

Selected local evidence captured under `/Users/christopherwilloughby/.hermes/phoenix-enhancements/issue-595-github-issue-595/final-visuals/`:
- `settings-off-current-behavior.png`
- `settings-enabled-routine-starting-weights.png`
- `bottom-sheet-current-mode-baseline.png`
- `bottom-sheet-cross-mode-fallback.png`
- `bottom-sheet-no-baseline-reversible-on.png`
- `bottom-sheet-no-baseline-reversible-off.png`
- `bottom-sheet-non-cable-bodyweight-guard.png`

## Verification
- `git diff --check`
- `./gradlew :shared:testAndroidHostTest --tests 'com.devil.phoenixproject.presentation.manager.SettingsManagerTest' --tests 'com.devil.phoenixproject.presentation.viewmodel.ExerciseConfigViewModelTest' --tests 'com.devil.phoenixproject.domain.usecase.ResolveRoutineWeightsUseCaseTest' --tests 'com.devil.phoenixproject.presentation.routine.RoutineExerciseDefaultsTest' -Pskip.supabase.check=true --console=plain`
- `./gradlew :androidApp:installDebug -Pskip.supabase.check=true --console=plain`

Closes #595
