### PR TITLE
fix(theme): UX-audit Phase 0 — design-token foundations

### DIFF
--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/theme/DesignSystemRatchetTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/theme/DesignSystemRatchetTest.kt
@@ -37,11 +37,16 @@ class DesignSystemRatchetTest {
         )
     }
 
-    private fun countMatches(regex: Regex): Int =
-        presentationDir
+    private fun countMatches(regex: Regex): Int {
+        require(presentationDir.isDirectory) {
+            "Presentation directory not found at ${presentationDir.absolutePath}. " +
+                "Path resolution is broken — ratchet counts cannot be trusted."
+        }
+        return presentationDir
             .walkTopDown()
             .filter { it.extension == "kt" }
             .sumOf { f -> regex.findAll(f.readText()).count() }
+    }
 
     @Test
     fun presentationDir_exists() {

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/theme/DesignSystemRatchetTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/theme/DesignSystemRatchetTest.kt
@@ -1,0 +1,79 @@
+package com.devil.phoenixproject.presentation.theme
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Design-system ratchet: counts banned styling patterns in the shared presentation
+ * source tree and asserts they do NOT increase above the recorded baseline.
+ *
+ * Baselines measured 2026-07-04 on branch ux-audit/phase-0-tokens.
+ * Phase 2 sweep tasks will lower these numbers; each merge that lowers a baseline
+ * should also update the number and the comment below.
+ *
+ * Placement: androidHostTest — uses java.io.File which is JVM-only, consistent with
+ * ThemeModeUiContractGuardTest in the same package.
+ */
+class DesignSystemRatchetTest {
+
+    /**
+     * Resolve the repo root by walking up from user.dir until a directory containing
+     * settings.gradle.kts (or .git) is found. Fails loudly if not found so a broken
+     * path never silently counts 0 matches and passes.
+     */
+    private val presentationDir: File by lazy {
+        var dir = File(System.getProperty("user.dir") ?: ".")
+        while (
+            !File(dir, "settings.gradle.kts").exists() &&
+            !File(dir, ".git").exists() &&
+            dir.parentFile != null
+        ) {
+            dir = dir.parentFile!!
+        }
+        File(
+            dir,
+            "shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation",
+        )
+    }
+
+    private fun countMatches(regex: Regex): Int =
+        presentationDir
+            .walkTopDown()
+            .filter { it.extension == "kt" }
+            .sumOf { f -> regex.findAll(f.readText()).count() }
+
+    @Test
+    fun presentationDir_exists() {
+        assertTrue(
+            presentationDir.exists(),
+            "Presentation directory not found at ${presentationDir.absolutePath}. " +
+                "Path resolution may be broken — check user.dir root-walking logic.",
+        )
+    }
+
+    @Test
+    fun rawRoundedCornerShapes_doNotIncrease() {
+        // Baseline 2026-07-04: 449.
+        // Phase 2 (task 2.1) will drive this down to ~30 (component-shape tokens).
+        val count = countMatches(Regex("""RoundedCornerShape\(\d+\.dp"""))
+        assertTrue(
+            count <= 449,
+            "RoundedCornerShape(N.dp) usages increased: found $count, baseline ≤ 449. " +
+                "Use MaterialTheme.shapes or a named shape token instead.",
+        )
+    }
+
+    @Test
+    fun hardcodedBasicColors_doNotIncrease() {
+        // Baseline 2026-07-04: 66 (regex match count; grep wc -l gives 62 because
+        // multiple matches on the same line are collapsed by line counting).
+        // Phase 1 (task 1.1) will sweep semantic replacements to near 0.
+        val count = countMatches(Regex("""\bColor\.(White|Black|Red|Green|Gray|LightGray)\b"""))
+        assertTrue(
+            count <= 66,
+            "Hardcoded Color.(White|Black|Red|Green|Gray|LightGray) usages increased: " +
+                "found $count, baseline ≤ 66. Use MaterialTheme.colorScheme or Phoenix tokens instead.",
+        )
+    }
+}

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/testutil/SourceFileReader.android.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/testutil/SourceFileReader.android.kt
@@ -11,7 +11,7 @@ import java.io.File
 actual fun readProjectFile(relativePath: String): String? {
     val file = File(relativePath)
     if (file.exists() && file.isFile) {
-        return file.readText()
+        return file.readText().replace("\r\n", "\n")
     }
     // Walk up the directory tree looking for the project root.
     var dir: File? = File(".").absoluteFile
@@ -19,12 +19,12 @@ actual fun readProjectFile(relativePath: String): String? {
         if (dir == null) return@repeat
         val candidate = File(dir, "shared/$relativePath")
         if (candidate.exists() && candidate.isFile) {
-            return candidate.readText()
+            return candidate.readText().replace("\r\n", "\n")
         }
         if (File(dir, ".git").exists() || File(dir, "settings.gradle.kts").exists()) {
             val rootCandidate = File(dir, relativePath)
             if (rootCandidate.exists() && rootCandidate.isFile) {
-                return rootCandidate.readText()
+                return rootCandidate.readText().replace("\r\n", "\n")
             }
         }
         dir = dir.parentFile

--- a/shared/src/androidMain/kotlin/com/devil/phoenixproject/presentation/util/PlatformAccessibilitySettings.android.kt
+++ b/shared/src/androidMain/kotlin/com/devil/phoenixproject/presentation/util/PlatformAccessibilitySettings.android.kt
@@ -1,7 +1,26 @@
 package com.devil.phoenixproject.presentation.util
 
+import android.os.Build
+import android.provider.Settings
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 
 @Composable
-actual fun rememberPlatformAccessibilitySettings(): PlatformAccessibilitySettings = remember { PlatformAccessibilitySettings(boldTextEnabled = false) }
+actual fun rememberPlatformAccessibilitySettings(): PlatformAccessibilitySettings {
+    val context = LocalContext.current
+    val config = LocalConfiguration.current
+    return remember(config) {
+        val boldText = if (Build.VERSION.SDK_INT >= 31) {
+            context.resources.configuration.fontWeightAdjustment >= 300
+        } else false
+        val animScale = Settings.Global.getFloat(
+            context.contentResolver, Settings.Global.ANIMATOR_DURATION_SCALE, 1f
+        )
+        PlatformAccessibilitySettings(
+            boldTextEnabled = boldText,
+            reduceMotion = animScale == 0f,
+        )
+    }
+}

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/util/PlatformAccessibilitySettings.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/util/PlatformAccessibilitySettings.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.compositionLocalOf
 
 data class PlatformAccessibilitySettings(
     val boldTextEnabled: Boolean = false,
+    val reduceMotion: Boolean = false,
 )
 
 val LocalPlatformAccessibilitySettings = compositionLocalOf { PlatformAccessibilitySettings() }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/ui/theme/AccessibilityColors.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/ui/theme/AccessibilityColors.kt
@@ -55,10 +55,10 @@ data class AccessibilityColors(
  * Cyan=Explosive, Green=Fast, Amber=Moderate, Orange=Slow, Red=Grind.
  */
 val StandardPalette = AccessibilityColors(
-    // Semantic status (from Color.kt SignalSuccess/Error/Warning)
-    success = Color(0xFF22C55E),
-    error = Color(0xFFEF4444),
-    warning = Color(0xFFF59E0B),
+    // Semantic status (single source of truth: Color.kt)
+    success = SignalSuccess,
+    error = SignalError,
+    warning = SignalWarning,
     neutral = Color(0xFF9E9E9E),
 
     // Velocity zones (BiomechanicsHistoryCard canonical mapping)
@@ -68,14 +68,14 @@ val StandardPalette = AccessibilityColors(
     zoneSlow = Color(0xFFF97316), // Orange
     zoneGrind = Color(0xFFEF4444), // Red -- near failure
 
-    // Asymmetry severity
-    asymmetryGood = Color(0xFF4CAF50),
-    asymmetryCaution = Color(0xFFFFC107),
-    asymmetryBad = Color(0xFFF44336),
+    // Asymmetry severity — align to Signal family (was 4CAF50/FFC107/F44336)
+    asymmetryGood = SignalSuccess,
+    asymmetryCaution = SignalWarning,
+    asymmetryBad = SignalError,
 
     // Rep quality
-    qualityExcellent = Color(0xFF00E676),
-    qualityGood = Color(0xFF43A047),
+    qualityExcellent = Color(0xFF22C55E), // was 00E676 (poor dark-surface contrast)
+    qualityGood = Color(0xFF16A34A),      // was 43A047 — green-600, distinct from excellent
     qualityFair = Color(0xFFFDD835),
     qualityBelowAverage = Color(0xFFFF9800),
     qualityPoor = Color(0xFFE53935),

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/ui/theme/DataColors.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/ui/theme/DataColors.kt
@@ -11,11 +11,11 @@ object DataColors {
     /** Training volume trends - Blue */
     val Volume = Color(0xFF3B82F6)
 
-    /** Intensity/effort metrics - Amber */
-    val Intensity = Color(0xFFF59E0B)
+    /** Intensity/effort metrics - Yellow (distinct from SignalWarning amber) */
+    val Intensity = Color(0xFFEAB308)
 
-    /** Heart rate / cardio data - Red (use with icons for accessibility) */
-    val HeartRate = Color(0xFFEF4444)
+    /** Heart rate / cardio data - Rose (distinct from SignalError red) */
+    val HeartRate = Color(0xFFF43F5E)
 
     /** Time-based metrics - Emerald */
     val Duration = Color(0xFF10B981)
@@ -28,8 +28,8 @@ object DataColors {
 
     // Workout metrics chart colors (for WorkoutMetricsDetailChart)
 
-    /** Load A (left cable) - Blue */
-    val LoadA = Color(0xFF3B82F6)
+    /** Load A (left cable) - Indigo-blue (distinct from Volume blue) */
+    val LoadA = Color(0xFF2563EB)
 
     /** Load B (right cable) - Orange */
     val LoadB = Color(0xFFF97316)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/ui/theme/Material3Expressive.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/ui/theme/Material3Expressive.kt
@@ -3,7 +3,6 @@ package com.devil.phoenixproject.ui.theme
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -53,7 +52,7 @@ fun expressiveCardColors() = CardDefaults.cardColors(
  * Material 3 Expressive Card Shape
  * More rounded corners (20dp vs standard 16dp)
  */
-val expressiveCardShape = RoundedCornerShape(20.dp)
+val expressiveCardShape = ExpressiveShapeValues.Medium
 
 /**
  * Material 3 Expressive Card Elevation
@@ -78,7 +77,7 @@ fun expressiveCardBorder() = BorderStroke(
  * Material 3 Expressive Button Shape
  * More rounded corners
  */
-val expressiveButtonShape = RoundedCornerShape(16.dp)
+val expressiveButtonShape = ExpressiveShapeValues.Medium
 
 /**
  * Material 3 Expressive Button Elevation

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/ui/theme/Type.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/ui/theme/Type.kt
@@ -23,6 +23,12 @@ val Typography = Typography(
         lineHeight = 58.sp, // Expressive: Increased from 52sp
         letterSpacing = 0.sp,
     ),
+    displaySmall = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Bold,
+        fontSize = 40.sp,
+        lineHeight = 48.sp,
+    ),
 
     // Headline styles (screen titles) - Expressive: Larger and bolder
     headlineLarge = TextStyle(

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/ui/theme/DesignTokenConsistencyTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/ui/theme/DesignTokenConsistencyTest.kt
@@ -1,0 +1,21 @@
+package com.devil.phoenixproject.ui.theme
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class DesignTokenConsistencyTest {
+    @Test
+    fun standardPalette_references_signal_constants() {
+        assertEquals(SignalSuccess, StandardPalette.success)
+        assertEquals(SignalError, StandardPalette.error)
+        assertEquals(SignalWarning, StandardPalette.warning)
+    }
+
+    @Test
+    fun dataColors_are_pairwise_distinct_from_signals_and_each_other() {
+        assertNotEquals(DataColors.Volume, DataColors.LoadA, "Volume and LoadA must be distinguishable in combined charts")
+        assertNotEquals(SignalWarning, DataColors.Intensity, "warning signal and intensity series must be distinguishable")
+        assertNotEquals(SignalError, DataColors.HeartRate, "error signal and heart-rate series must be distinguishable")
+    }
+}

--- a/shared/src/iosMain/kotlin/com/devil/phoenixproject/presentation/util/PlatformAccessibilitySettings.ios.kt
+++ b/shared/src/iosMain/kotlin/com/devil/phoenixproject/presentation/util/PlatformAccessibilitySettings.ios.kt
@@ -10,15 +10,20 @@ import platform.Foundation.NSNotificationCenter
 import platform.Foundation.NSOperationQueue
 import platform.UIKit.UIAccessibilityBoldTextStatusDidChangeNotification
 import platform.UIKit.UIAccessibilityIsBoldTextEnabled
+import platform.UIKit.UIAccessibilityIsReduceMotionEnabled
+import platform.UIKit.UIAccessibilityReduceMotionStatusDidChangeNotification
 
 @Composable
 actual fun rememberPlatformAccessibilitySettings(): PlatformAccessibilitySettings {
     var boldTextEnabled by remember {
         mutableStateOf(UIAccessibilityIsBoldTextEnabled())
     }
+    var reduceMotion by remember {
+        mutableStateOf(UIAccessibilityIsReduceMotionEnabled())
+    }
 
     DisposableEffect(Unit) {
-        val observer = NSNotificationCenter.defaultCenter.addObserverForName(
+        val boldObserver = NSNotificationCenter.defaultCenter.addObserverForName(
             name = UIAccessibilityBoldTextStatusDidChangeNotification,
             `object` = null,
             queue = NSOperationQueue.mainQueue(),
@@ -26,11 +31,23 @@ actual fun rememberPlatformAccessibilitySettings(): PlatformAccessibilitySetting
                 boldTextEnabled = UIAccessibilityIsBoldTextEnabled()
             },
         )
+        val reduceMotionObserver = NSNotificationCenter.defaultCenter.addObserverForName(
+            name = UIAccessibilityReduceMotionStatusDidChangeNotification,
+            `object` = null,
+            queue = NSOperationQueue.mainQueue(),
+            usingBlock = {
+                reduceMotion = UIAccessibilityIsReduceMotionEnabled()
+            },
+        )
 
         onDispose {
-            NSNotificationCenter.defaultCenter.removeObserver(observer)
+            NSNotificationCenter.defaultCenter.removeObserver(boldObserver)
+            NSNotificationCenter.defaultCenter.removeObserver(reduceMotionObserver)
         }
     }
 
-    return PlatformAccessibilitySettings(boldTextEnabled = boldTextEnabled)
+    return PlatformAccessibilitySettings(
+        boldTextEnabled = boldTextEnabled,
+        reduceMotion = reduceMotion,
+    )
 }


### PR DESCRIPTION
## Summary

Phase 0 of the UX/UI audit remediation (`docs/ux-audit-2026-07-04.md`): fixes the design-token system itself so the Phase 1-2 sweeps have correct targets.

- **Color dedup:** `StandardPalette` now references `SignalSuccess/Error/Warning` (was 3 independent literals); colliding data-series hues separated (`Intensity`, `HeartRate`, `LoadA`); MD2-era asymmetry/rep-quality greens aligned to the signal family
- **Shape/type tokens:** `expressiveCardShape`/`expressiveButtonShape` route through `ExpressiveShapeValues.Medium` (16→20dp normalize decision); missing `displaySmall` added to the inflated type scale (40/48sp Bold)
- **Real accessibility settings:** Android `PlatformAccessibilitySettings` was a hardcoded stub — now reads `fontWeightAdjustment` (API 31+) and `ANIMATOR_DURATION_SCALE`; new `reduceMotion` flag on both platforms (iOS mirrors the existing bold-text observer pattern)
- **Ratchet test:** `DesignSystemRatchetTest` pins raw-shape (≤449) and hardcoded-color (≤66) counts in `presentation/` — counts can only go down; Phase 2 lowers the baselines
- **Bonus root-cause fix:** pre-existing `SetReadySessionBodyweightPromptWiringTest` failure — CRLF checkouts broke source-wiring assertions; `SourceFileReader.android.kt` now normalizes line endings

## Test plan

- [x] `./gradlew :shared:testAndroidHostTest` — 2296 tests, 0 failures (pre-existing failure root-caused and fixed)
- [x] `./gradlew :androidApp:assembleDebug` — clean
- [x] Ratchet loud-failure verified (bogus path → IllegalArgumentException, not silent pass)
- [x] Every task adversarially reviewed (1 Critical found and fixed pre-merge)

Phases 1-2 follow on separate branches per the approved plan.

https://claude.ai/code/session_013ZBMAvsvSxiCqpn8zQ7pvy