### PR TITLE
fix(#333): address PR #621 review comments

### DIFF
--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -631,6 +631,13 @@
     <string name="settings_adults_only_confirm">Ich bin 18+ und Oma hört mich nicht</string>
     <string name="settings_adults_only_decline">Sauber halten</string>
     <string name="settings_adults_only_compliance_footer">Apple 16+ / Google Play IARC: Starke Sprache + Anzügliche Themen</string>
+    <string name="settings_ble_compat_title">BLE-Kompatibilitätsmodus</string>
+    <string name="settings_ble_compat_description">Schreibpfad mit kleiner MTU, der Verbindungsabbrüche beim Trainingsstart auf Pixel 6/7 behebt. Auto aktiviert ihn nur auf diesen Geräten.</string>
+    <string name="settings_ble_compat_description_affected">Schreibpfad mit kleiner MTU, der Verbindungsabbrüche beim Trainingsstart auf Pixel 6/7 behebt. Auto aktiviert ihn nur auf diesen Geräten (dieses Gerät ist betroffen).</string>
+    <string name="settings_ble_compat_auto">Auto</string>
+    <string name="settings_ble_compat_on">Ein</string>
+    <string name="settings_ble_compat_off">Aus</string>
+    <string name="settings_ble_compat_reconnect_hint">Wird bei der nächsten Verbindung wirksam. Nach der Änderung erneut mit dem Trainer verbinden.</string>
 
     <!-- ==================== RPG Attributes ==================== -->
     <string name="rpg_no_data_yet">Schließe dein erstes Training ab, um RPG-Attribute freizuschalten</string>

--- a/shared/src/commonMain/composeResources/values-es/strings.xml
+++ b/shared/src/commonMain/composeResources/values-es/strings.xml
@@ -631,6 +631,13 @@
     <string name="settings_adults_only_confirm">Tengo 18+ y la abuela no me oye</string>
     <string name="settings_adults_only_decline">Mantenlo limpio</string>
     <string name="settings_adults_only_compliance_footer">Apple 16+ / Google Play IARC: Lenguaje fuerte + Temas sugerentes</string>
+    <string name="settings_ble_compat_title">Modo de compatibilidad BLE</string>
+    <string name="settings_ble_compat_description">Ruta de escritura con MTU pequeña que corrige las desconexiones al iniciar el entrenamiento en Pixel 6/7. Auto solo la activa en esos dispositivos.</string>
+    <string name="settings_ble_compat_description_affected">Ruta de escritura con MTU pequeña que corrige las desconexiones al iniciar el entrenamiento en Pixel 6/7. Auto solo la activa en esos dispositivos (este dispositivo está afectado).</string>
+    <string name="settings_ble_compat_auto">Auto</string>
+    <string name="settings_ble_compat_on">Activado</string>
+    <string name="settings_ble_compat_off">Desactivado</string>
+    <string name="settings_ble_compat_reconnect_hint">Se aplica en la próxima conexión. Vuelve a conectarte al trainer después de cambiarlo.</string>
 
     <!-- ==================== RPG Attributes ==================== -->
     <string name="rpg_no_data_yet">Completa tu primer entrenamiento para desbloquear atributos RPG</string>

--- a/shared/src/commonMain/composeResources/values-fr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fr/strings.xml
@@ -631,6 +631,13 @@
     <string name="settings_adults_only_confirm">J\'ai 18+ et mamie ne m\'entend pas</string>
     <string name="settings_adults_only_decline">Garder propre</string>
     <string name="settings_adults_only_compliance_footer">Apple 16+ / Google Play IARC : Langage grossier + Thèmes suggestifs</string>
+    <string name="settings_ble_compat_title">Mode de compatibilité BLE</string>
+    <string name="settings_ble_compat_description">Chemin d\'écriture à petite MTU qui corrige les déconnexions au démarrage de l\'entraînement sur Pixel 6/7. Auto ne l\'active que sur ces appareils.</string>
+    <string name="settings_ble_compat_description_affected">Chemin d\'écriture à petite MTU qui corrige les déconnexions au démarrage de l\'entraînement sur Pixel 6/7. Auto ne l\'active que sur ces appareils (cet appareil est concerné).</string>
+    <string name="settings_ble_compat_auto">Auto</string>
+    <string name="settings_ble_compat_on">Activé</string>
+    <string name="settings_ble_compat_off">Désactivé</string>
+    <string name="settings_ble_compat_reconnect_hint">Prend effet à la prochaine connexion. Reconnectez-vous au trainer après le changement.</string>
 
     <!-- ==================== RPG Attributes ==================== -->
     <string name="rpg_no_data_yet">Terminez votre premier entraînement pour débloquer les attributs RPG</string>

--- a/shared/src/commonMain/composeResources/values-it/strings.xml
+++ b/shared/src/commonMain/composeResources/values-it/strings.xml
@@ -60,4 +60,11 @@
     <string name="settings_adults_only_confirm">Ho 18+ e la nonna non mi sente</string>
     <string name="settings_adults_only_decline">Mantienilo pulito</string>
     <string name="settings_adults_only_compliance_footer">Apple 16+ / Google Play IARC: Linguaggio forte + Temi suggestivi</string>
+    <string name="settings_ble_compat_title">Modalità di compatibilità BLE</string>
+    <string name="settings_ble_compat_description">Percorso di scrittura con MTU ridotta che risolve le disconnessioni all\'avvio dell\'allenamento su Pixel 6/7. Auto la attiva solo su quei dispositivi.</string>
+    <string name="settings_ble_compat_description_affected">Percorso di scrittura con MTU ridotta che risolve le disconnessioni all\'avvio dell\'allenamento su Pixel 6/7. Auto la attiva solo su quei dispositivi (questo dispositivo è interessato).</string>
+    <string name="settings_ble_compat_auto">Auto</string>
+    <string name="settings_ble_compat_on">Attivato</string>
+    <string name="settings_ble_compat_off">Disattivato</string>
+    <string name="settings_ble_compat_reconnect_hint">Ha effetto alla prossima connessione. Riconnettiti al trainer dopo la modifica.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-nl/strings.xml
+++ b/shared/src/commonMain/composeResources/values-nl/strings.xml
@@ -610,6 +610,13 @@
     <string name="settings_adults_only_confirm">Ik ben 18+ en oma hoort me niet</string>
     <string name="settings_adults_only_decline">Houd het netjes</string>
     <string name="settings_adults_only_compliance_footer">Apple 16+ / Google Play IARC: Krachtige taal + Suggestieve thema\'s</string>
+    <string name="settings_ble_compat_title">BLE-compatibiliteitsmodus</string>
+    <string name="settings_ble_compat_description">Schrijfpad met kleine MTU dat verbroken verbindingen bij het starten van een workout op Pixel 6/7 verhelpt. Auto schakelt het alleen op die toestellen in.</string>
+    <string name="settings_ble_compat_description_affected">Schrijfpad met kleine MTU dat verbroken verbindingen bij het starten van een workout op Pixel 6/7 verhelpt. Auto schakelt het alleen op die toestellen in (dit toestel is getroffen).</string>
+    <string name="settings_ble_compat_auto">Auto</string>
+    <string name="settings_ble_compat_on">Aan</string>
+    <string name="settings_ble_compat_off">Uit</string>
+    <string name="settings_ble_compat_reconnect_hint">Wordt van kracht bij de volgende verbinding. Maak na het wijzigen opnieuw verbinding met de trainer.</string>
 
     <!-- ==================== RPG Attributes ==================== -->
     <string name="rpg_no_data_yet">Voltooi je eerste training om RPG-attributen te ontgrendelen</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -135,6 +135,13 @@
     <string name="settings_machine_diagnostics_description">View a redacted machine diagnostics snapshot: uptime, fault codes, temperatures, crash data, and warnings. This is not a full backup.</string>
     <string name="settings_weight_suggestions_title">Weight Suggestions</string>
     <string name="settings_weight_suggestions_description">Show Apply or Dismiss recommendations after completed sets</string>
+    <string name="settings_ble_compat_title">BLE Compatibility Mode</string>
+    <string name="settings_ble_compat_description">Small-MTU write path that fixes workout-start disconnects on Pixel 6/7. Auto enables it only on those devices.</string>
+    <string name="settings_ble_compat_description_affected">Small-MTU write path that fixes workout-start disconnects on Pixel 6/7. Auto enables it only on those devices (this device is affected).</string>
+    <string name="settings_ble_compat_auto">Auto</string>
+    <string name="settings_ble_compat_on">On</string>
+    <string name="settings_ble_compat_off">Off</string>
+    <string name="settings_ble_compat_reconnect_hint">Takes effect on the next connection. Reconnect to the trainer after changing.</string>
 
     <!-- Machine diagnostics -->
     <string name="diagnostics_title">Machine Diagnostics</string>

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/ble/KableBleConnectionManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/ble/KableBleConnectionManager.kt
@@ -147,7 +147,9 @@ class KableBleConnectionManager(
      * current connection attempt. @Volatile because the connect retry loop
      * reassigns it on the caller's dispatcher while the state observer
      * coroutine reads it on [scope] — a stale read would complete the previous
-     * attempt's gate and force a spurious initialization timeout.
+     * attempt's gate and force a spurious initialization timeout. The ready-up
+     * coroutine captures a snapshot of this field at launch so its completions
+     * always target the attempt it was started for, never a later reassignment.
      */
     @Volatile
     private var readyGate = CompletableDeferred<Unit>()
@@ -255,6 +257,7 @@ class KableBleConnectionManager(
         detectedFirmwareVersion = null
         negotiatedMtu = null
         wasEverConnected = false
+        compatibilityPathActive = false
         if (clearScannedDevices) {
             discoveredAdvertisements.clear()
             onScannedDevicesChanged(emptyList())
@@ -641,6 +644,13 @@ class KableBleConnectionManager(
                             // the saved LED color scheme, so publishing early injects a
                             // 34-byte write directly into the ready-up GATT sequence.
                             if (deviceReadyJob == null && !readyGate.isCompleted) {
+                                // Snapshot the gate for THIS attempt: the connect retry
+                                // loop reassigns [readyGate] on the caller's dispatcher,
+                                // so reading the field from inside the coroutine could
+                                // complete/cancel a LATER attempt's gate (PR #621 review).
+                                // complete/completeExceptionally/cancel are no-ops on an
+                                // already-completed deferred, so no isCompleted guards.
+                                val gate = readyGate
                                 deviceReadyJob = scope.launch {
                                     try {
                                         withTimeout(BleConstants.CONNECTION_TIMEOUT_MS) {
@@ -650,11 +660,9 @@ class KableBleConnectionManager(
                                         // connection down while ready-up was in flight —
                                         // don't resurrect Connected over a Disconnected UI.
                                         if (peripheral == null || isExplicitDisconnect) {
-                                            if (!readyGate.isCompleted) {
-                                                readyGate.completeExceptionally(
-                                                    BleDeviceInitializationException("Connection torn down during initialization"),
-                                                )
-                                            }
+                                            gate.completeExceptionally(
+                                                BleDeviceInitializationException("Connection torn down during initialization"),
+                                            )
                                             return@launch
                                         }
                                         reportConnectionState(
@@ -664,7 +672,7 @@ class KableBleConnectionManager(
                                                 hardwareModel = HardwareDetection.detectModel(device.name),
                                             ),
                                         )
-                                        readyGate.complete(Unit)
+                                        gate.complete(Unit)
                                     } catch (e: TimeoutCancellationException) {
                                         val failure = BleDeviceInitializationException(
                                             "Device initialization timeout after ${BleConstants.CONNECTION_TIMEOUT_MS}ms",
@@ -678,11 +686,9 @@ class KableBleConnectionManager(
                                             connectedDeviceAddress,
                                             failure.message,
                                         )
-                                        if (!readyGate.isCompleted) {
-                                            readyGate.completeExceptionally(failure)
-                                        }
+                                        gate.completeExceptionally(failure)
                                     } catch (e: CancellationException) {
-                                        readyGate.cancel(e)
+                                        gate.cancel(e)
                                         throw e
                                     } catch (e: Exception) {
                                         log.e(e) { "onDeviceReady failed: ${e.message}" }
@@ -693,14 +699,12 @@ class KableBleConnectionManager(
                                             connectedDeviceAddress,
                                             e.message,
                                         )
-                                        if (!readyGate.isCompleted) {
-                                            readyGate.completeExceptionally(
-                                                BleDeviceInitializationException(
-                                                    "Device initialization failed: ${e.message}",
-                                                    e,
-                                                ),
-                                            )
-                                        }
+                                        gate.completeExceptionally(
+                                            BleDeviceInitializationException(
+                                                "Device initialization failed: ${e.message}",
+                                                e,
+                                            ),
+                                        )
                                     }
                                 }
                             }
@@ -832,11 +836,10 @@ class KableBleConnectionManager(
                 }
             }
 
-            // All retries failed - cleanup and return to disconnected state
-            deviceReadyJob?.cancel()
-            deviceReadyJob = null
-            peripheral?.disconnect()
-            peripheral = null
+            // All retries failed - cleanup and return to disconnected state.
+            // cleanupExistingConnection() swallows disconnect errors, so peripheral
+            // is always released and Disconnected always reported (PR #621 review).
+            cleanupExistingConnection()
             reportConnectionState(ConnectionState.Disconnected)
             throw lastException ?: Exception("Connection failed after ${BleConstants.Timing.CONNECTION_RETRY_COUNT} attempts")
         } catch (e: Exception) {
@@ -1382,6 +1385,10 @@ class KableBleConnectionManager(
         }
 
         peripheral = null
+        // Connection-scoped snapshot — don't leak the previous connection's
+        // choreography into the next one (PR #621 review). onDeviceReady()
+        // re-resolves it for the new connection.
+        compatibilityPathActive = false
         // Note: Don't update _connectionState here - we're about to connect
         // and the Connecting state will be set by the caller
     }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SettingsTab.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SettingsTab.kt
@@ -185,6 +185,13 @@ import vitruvianprojectphoenix.shared.generated.resources.restore_description
 import vitruvianprojectphoenix.shared.generated.resources.restore_from_backup
 import vitruvianprojectphoenix.shared.generated.resources.select_file
 import vitruvianprojectphoenix.shared.generated.resources.settings_appearance
+import vitruvianprojectphoenix.shared.generated.resources.settings_ble_compat_auto
+import vitruvianprojectphoenix.shared.generated.resources.settings_ble_compat_description
+import vitruvianprojectphoenix.shared.generated.resources.settings_ble_compat_description_affected
+import vitruvianprojectphoenix.shared.generated.resources.settings_ble_compat_off
+import vitruvianprojectphoenix.shared.generated.resources.settings_ble_compat_on
+import vitruvianprojectphoenix.shared.generated.resources.settings_ble_compat_reconnect_hint
+import vitruvianprojectphoenix.shared.generated.resources.settings_ble_compat_title
 import vitruvianprojectphoenix.shared.generated.resources.settings_calibrate_button
 import vitruvianprojectphoenix.shared.generated.resources.settings_calibrate_first
 import vitruvianprojectphoenix.shared.generated.resources.settings_calibrated_badge
@@ -2836,16 +2843,20 @@ fun SettingsTab(
                 // Issue #333: BLE small-MTU compatibility path (fixes Pixel 6/7
                 // GATT_ERROR(133) disconnect at workout start)
                 Text(
-                    "BLE Compatibility Mode",
+                    stringResource(Res.string.settings_ble_compat_title),
                     style = MaterialTheme.typography.bodyLarge,
                     fontWeight = FontWeight.Medium,
                     color = MaterialTheme.colorScheme.onSurface,
                 )
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
-                    "Small-MTU write path that fixes workout-start disconnects on Pixel 6/7. " +
-                        "Auto enables it only on those devices" +
-                        if (DeviceInfo.isPixel6Or7()) " (this device is affected)." else ".",
+                    stringResource(
+                        if (DeviceInfo.isPixel6Or7()) {
+                            Res.string.settings_ble_compat_description_affected
+                        } else {
+                            Res.string.settings_ble_compat_description
+                        },
+                    ),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -2854,9 +2865,9 @@ fun SettingsTab(
                     modifier = Modifier.fillMaxWidth(),
                 ) {
                     val options = listOf(
-                        BleCompatibilitySetting.AUTO to "Auto",
-                        BleCompatibilitySetting.ON to "On",
-                        BleCompatibilitySetting.OFF to "Off",
+                        BleCompatibilitySetting.AUTO to stringResource(Res.string.settings_ble_compat_auto),
+                        BleCompatibilitySetting.ON to stringResource(Res.string.settings_ble_compat_on),
+                        BleCompatibilitySetting.OFF to stringResource(Res.string.settings_ble_compat_off),
                     )
                     options.forEachIndexed { index, (setting, label) ->
                         SegmentedButton(
@@ -2870,7 +2881,7 @@ fun SettingsTab(
                 }
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
-                    "Takes effect on the next connection. Reconnect to the trainer after changing.",
+                    stringResource(Res.string.settings_ble_compat_reconnect_hint),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )


### PR DESCRIPTION
Addresses the review comments on #621 (targets its head branch `pixel_test_moar`).

## Changes

**`KableBleConnectionManager.kt`**
- **Ready-gate snapshot** ([Gemini high](https://github.com/9thLevelSoftware/Project-Phoenix-MP/pull/621#discussion_r3525843995), [Kilo](https://github.com/9thLevelSoftware/Project-Phoenix-MP/pull/621#discussion_r3525858323)): the ready-up coroutine now captures `val gate = readyGate` before `scope.launch` and completes/fails/cancels only that instance, so a stale coroutine can never complete a later attempt's gate after the connect retry loop reassigns the `@Volatile` field. The `isCompleted` guards were dropped since completing an already-completed `CompletableDeferred` is a no-op.
- **`compatibilityPathActive` reset** ([Gemini medium](https://github.com/9thLevelSoftware/Project-Phoenix-MP/pull/621#discussion_r3525843998)): reset to `false` in `cleanupExistingConnection()` **and** `clearConnectionState()` — the latter is needed because `cleanupExistingConnection()` early-returns when `peripheral` is already null (e.g. after an explicit `disconnect()`), which would have left the stale snapshot in place.
- **Retry-exhaustion cleanup** ([Gemini medium](https://github.com/9thLevelSoftware/Project-Phoenix-MP/pull/621#discussion_r3525844001)): the manual `deviceReadyJob?.cancel()` / `peripheral?.disconnect()` / `peripheral = null` block in `connect()` is replaced with `cleanupExistingConnection()`, which swallows disconnect errors so the peripheral release and `Disconnected` report can't be skipped, and additionally cancels the lingering state observer.

**Settings i18n** ([Gemini medium](https://github.com/9thLevelSoftware/Project-Phoenix-MP/pull/621#discussion_r3525844005))
- The BLE Compatibility Mode strings in `SettingsTab.kt` now use compose resources (`settings_ble_compat_*`), following the existing `settings_*` convention, with translations added for de/fr/es/it/nl. The conditional "(this device is affected)" suffix became two full description variants to avoid concatenation grammar issues across languages.

## Not changed

- **Codex P1 (Parcelize plugin id)**: not applied — `org.jetbrains.kotlin.plugin.parcelize` is the official KGP plugin id and its `2.4.0` marker POM is live on both Maven Central and the Gradle Plugin Portal (both in `pluginManagement`), and CI on the reviewed commit (`d72674f`) configured and built green (Build Android, Unit Tests, iOS Test Target Compile). The resolution failure appears to be a sandbox-network artifact; replied on the thread.

## Testing

- All 6 `strings.xml` files validated well-formed.
- Full Gradle build not runnable in this sandbox (the Gradle 9.5.1 distribution download is blocked); changes are confined to reviewed patterns and repo CI will verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012MGLQ4j9mirmvXacjbG2rF

---
_Generated by [Claude Code](https://claude.ai/code/session_012MGLQ4j9mirmvXacjbG2rF)_