### PR TITLE
fix(#333): reset wasEverConnected in cleanupExistingConnection() (PR #622 follow-up)

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/ble/KableBleConnectionManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/ble/KableBleConnectionManager.kt
@@ -1385,6 +1385,12 @@ class KableBleConnectionManager(
         }
 
         peripheral = null
+        // The state observer was cancelled above, so the State.Disconnected
+        // handler that normally resets this flag never runs. Left true, the
+        // NEXT connect's observer would treat the new peripheral's initial
+        // Disconnected emission as a real drop and tear the attempt down
+        // before connect() is even called (PR #622 review).
+        wasEverConnected = false
         // Connection-scoped snapshot — don't leak the previous connection's
         // choreography into the next one (PR #621 review). onDeviceReady()
         // re-resolves it for the new connection.


### PR DESCRIPTION
Follow-up to #622, which merged before the fix for [Codex's P1](https://github.com/9thLevelSoftware/Project-Phoenix-MP/pull/622#discussion_r3525887147) could land.

## Problem

`cleanupExistingConnection()` cancels `stateObserverJob` as its first action, so the `State.Disconnected` handler that normally resets `wasEverConnected` never runs for that teardown. After #622 routed the connect-retry-exhaustion path through `cleanupExistingConnection()`, a connection that reached `State.Connected` but failed ready-up leaves `wasEverConnected` stale-true (the same leak already existed on the pre-connect device-switch call site).

On the next `connect()`, the fresh peripheral's initial `State.Disconnected` emission is then misread as a real drop: the handler fails the new ready gate, nulls the new peripheral before `connect()` is even called, and fires a spurious auto-reconnect request.

## Fix

Reset `wasEverConnected = false` in `cleanupExistingConnection()` alongside `peripheral = null`, with a comment explaining why the observer-based reset can't be relied on there. The early-return path (`peripheral == null`) is unaffected since every path that nulls the peripheral with a live observer already resets the flag.

## Testing

Sandbox cannot run Gradle (distribution download blocked); one-flag change confined to the reviewed cleanup path — repo CI will verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012MGLQ4j9mirmvXacjbG2rF