### PR TITLE
fix(#333): extend BLE compatibility mode auto-detect to Pixel Tablet and Pixel Fold

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -196,7 +196,7 @@ android {
         targetSdk = 37
         // Fail fast if CI injects an invalid version code instead of silently shipping a default.
         versionCode = injectedVersionCode ?: 5
-        versionName = "0.9.3"
+        versionName = "0.9.5"
 
         // Supabase config injected from local.properties
         buildConfigField("String", "SUPABASE_URL", "\"$supabaseUrl\"")

--- a/iosApp/VitruvianPhoenix/VitruvianPhoenix.xcodeproj/project.pbxproj
+++ b/iosApp/VitruvianPhoenix/VitruvianPhoenix.xcodeproj/project.pbxproj
@@ -367,7 +367,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.9.3;
+				MARKETING_VERSION = 0.9.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.devil.phoenixproject.projectphoenix;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -412,7 +412,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.9.3;
+				MARKETING_VERSION = 0.9.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.devil.phoenixproject.projectphoenix;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/shared/src/androidMain/kotlin/com/devil/phoenixproject/util/DeviceInfo.android.kt
+++ b/shared/src/androidMain/kotlin/com/devil/phoenixproject/util/DeviceInfo.android.kt
@@ -127,12 +127,14 @@ actual object DeviceInfo {
      * panther=Pixel 7, cheetah=Pixel 7 Pro, lynx=Pixel 7a,
      * felix=Pixel Fold, tangorpro=Pixel Tablet.
      */
-    actual fun isBcm4389Pixel(): Boolean =
+    private val isBcm4389: Boolean =
         isPixel() && device.lowercase() in setOf(
             "oriole", "raven", "bluejay",
             "panther", "cheetah", "lynx",
             "felix", "tangorpro",
         )
+
+    actual fun isBcm4389Pixel(): Boolean = isBcm4389
 
     /**
      * Check if running on Amazon Fire OS (Fire Tablets, Fire TV)

--- a/shared/src/androidMain/kotlin/com/devil/phoenixproject/util/DeviceInfo.android.kt
+++ b/shared/src/androidMain/kotlin/com/devil/phoenixproject/util/DeviceInfo.android.kt
@@ -119,14 +119,20 @@ actual object DeviceInfo {
     fun isPixel(): Boolean = manufacturer.equals("Google", ignoreCase = true)
 
     /**
-     * Issue #333: Pixel 6/7 family (Tensor G1/G2 + BCM4389 Bluetooth controller).
+     * Issue #333: Pixel devices with the Broadcom BCM4389 Bluetooth controller
+     * (Tensor G1/G2 generation), where large-MTU acknowledged writes wedge.
      * Matched by Build.DEVICE codename — the only reliable discriminator across
      * carrier/regional model numbers:
      * oriole=Pixel 6, raven=Pixel 6 Pro, bluejay=Pixel 6a,
-     * panther=Pixel 7, cheetah=Pixel 7 Pro, lynx=Pixel 7a.
+     * panther=Pixel 7, cheetah=Pixel 7 Pro, lynx=Pixel 7a,
+     * felix=Pixel Fold, tangorpro=Pixel Tablet.
      */
-    actual fun isPixel6Or7(): Boolean =
-        isPixel() && device.lowercase() in setOf("oriole", "raven", "bluejay", "panther", "cheetah", "lynx")
+    actual fun isBcm4389Pixel(): Boolean =
+        isPixel() && device.lowercase() in setOf(
+            "oriole", "raven", "bluejay",
+            "panther", "cheetah", "lynx",
+            "felix", "tangorpro",
+        )
 
     /**
      * Check if running on Amazon Fire OS (Fire Tablets, Fire TV)

--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -632,8 +632,8 @@
     <string name="settings_adults_only_decline">Sauber halten</string>
     <string name="settings_adults_only_compliance_footer">Apple 16+ / Google Play IARC: Starke Sprache + Anzügliche Themen</string>
     <string name="settings_ble_compat_title">BLE-Kompatibilitätsmodus</string>
-    <string name="settings_ble_compat_description">Schreibpfad mit kleiner MTU, der Verbindungsabbrüche beim Trainingsstart auf Pixel 6/7 behebt. Auto aktiviert ihn nur auf diesen Geräten.</string>
-    <string name="settings_ble_compat_description_affected">Schreibpfad mit kleiner MTU, der Verbindungsabbrüche beim Trainingsstart auf Pixel 6/7 behebt. Auto aktiviert ihn nur auf diesen Geräten (dieses Gerät ist betroffen).</string>
+    <string name="settings_ble_compat_description">Schreibpfad mit kleiner MTU, der Verbindungsabbrüche beim Trainingsstart auf Pixel 6/7, Fold und Tablet behebt. Auto aktiviert ihn nur auf diesen Geräten.</string>
+    <string name="settings_ble_compat_description_affected">Schreibpfad mit kleiner MTU, der Verbindungsabbrüche beim Trainingsstart auf Pixel 6/7, Fold und Tablet behebt. Auto aktiviert ihn nur auf diesen Geräten (dieses Gerät ist betroffen).</string>
     <string name="settings_ble_compat_auto">Auto</string>
     <string name="settings_ble_compat_on">Ein</string>
     <string name="settings_ble_compat_off">Aus</string>

--- a/shared/src/commonMain/composeResources/values-es/strings.xml
+++ b/shared/src/commonMain/composeResources/values-es/strings.xml
@@ -632,8 +632,8 @@
     <string name="settings_adults_only_decline">Mantenlo limpio</string>
     <string name="settings_adults_only_compliance_footer">Apple 16+ / Google Play IARC: Lenguaje fuerte + Temas sugerentes</string>
     <string name="settings_ble_compat_title">Modo de compatibilidad BLE</string>
-    <string name="settings_ble_compat_description">Ruta de escritura con MTU pequeña que corrige las desconexiones al iniciar el entrenamiento en Pixel 6/7. Auto solo la activa en esos dispositivos.</string>
-    <string name="settings_ble_compat_description_affected">Ruta de escritura con MTU pequeña que corrige las desconexiones al iniciar el entrenamiento en Pixel 6/7. Auto solo la activa en esos dispositivos (este dispositivo está afectado).</string>
+    <string name="settings_ble_compat_description">Ruta de escritura con MTU pequeña que corrige las desconexiones al iniciar el entrenamiento en Pixel 6/7, Fold y Tablet. Auto solo la activa en esos dispositivos.</string>
+    <string name="settings_ble_compat_description_affected">Ruta de escritura con MTU pequeña que corrige las desconexiones al iniciar el entrenamiento en Pixel 6/7, Fold y Tablet. Auto solo la activa en esos dispositivos (este dispositivo está afectado).</string>
     <string name="settings_ble_compat_auto">Auto</string>
     <string name="settings_ble_compat_on">Activado</string>
     <string name="settings_ble_compat_off">Desactivado</string>

--- a/shared/src/commonMain/composeResources/values-fr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fr/strings.xml
@@ -632,8 +632,8 @@
     <string name="settings_adults_only_decline">Garder propre</string>
     <string name="settings_adults_only_compliance_footer">Apple 16+ / Google Play IARC : Langage grossier + Thèmes suggestifs</string>
     <string name="settings_ble_compat_title">Mode de compatibilité BLE</string>
-    <string name="settings_ble_compat_description">Chemin d\'écriture à petite MTU qui corrige les déconnexions au démarrage de l\'entraînement sur Pixel 6/7. Auto ne l\'active que sur ces appareils.</string>
-    <string name="settings_ble_compat_description_affected">Chemin d\'écriture à petite MTU qui corrige les déconnexions au démarrage de l\'entraînement sur Pixel 6/7. Auto ne l\'active que sur ces appareils (cet appareil est concerné).</string>
+    <string name="settings_ble_compat_description">Chemin d\'écriture à petite MTU qui corrige les déconnexions au démarrage de l\'entraînement sur Pixel 6/7, Fold et Tablet. Auto ne l\'active que sur ces appareils.</string>
+    <string name="settings_ble_compat_description_affected">Chemin d\'écriture à petite MTU qui corrige les déconnexions au démarrage de l\'entraînement sur Pixel 6/7, Fold et Tablet. Auto ne l\'active que sur ces appareils (cet appareil est concerné).</string>
     <string name="settings_ble_compat_auto">Auto</string>
     <string name="settings_ble_compat_on">Activé</string>
     <string name="settings_ble_compat_off">Désactivé</string>

--- a/shared/src/commonMain/composeResources/values-it/strings.xml
+++ b/shared/src/commonMain/composeResources/values-it/strings.xml
@@ -61,8 +61,8 @@
     <string name="settings_adults_only_decline">Mantienilo pulito</string>
     <string name="settings_adults_only_compliance_footer">Apple 16+ / Google Play IARC: Linguaggio forte + Temi suggestivi</string>
     <string name="settings_ble_compat_title">Modalità di compatibilità BLE</string>
-    <string name="settings_ble_compat_description">Percorso di scrittura con MTU ridotta che risolve le disconnessioni all\'avvio dell\'allenamento su Pixel 6/7. Auto la attiva solo su quei dispositivi.</string>
-    <string name="settings_ble_compat_description_affected">Percorso di scrittura con MTU ridotta che risolve le disconnessioni all\'avvio dell\'allenamento su Pixel 6/7. Auto la attiva solo su quei dispositivi (questo dispositivo è interessato).</string>
+    <string name="settings_ble_compat_description">Percorso di scrittura con MTU ridotta che risolve le disconnessioni all\'avvio dell\'allenamento su Pixel 6/7, Fold e Tablet. Auto la attiva solo su quei dispositivi.</string>
+    <string name="settings_ble_compat_description_affected">Percorso di scrittura con MTU ridotta che risolve le disconnessioni all\'avvio dell\'allenamento su Pixel 6/7, Fold e Tablet. Auto la attiva solo su quei dispositivi (questo dispositivo è interessato).</string>
     <string name="settings_ble_compat_auto">Auto</string>
     <string name="settings_ble_compat_on">Attivato</string>
     <string name="settings_ble_compat_off">Disattivato</string>

--- a/shared/src/commonMain/composeResources/values-nl/strings.xml
+++ b/shared/src/commonMain/composeResources/values-nl/strings.xml
@@ -611,8 +611,8 @@
     <string name="settings_adults_only_decline">Houd het netjes</string>
     <string name="settings_adults_only_compliance_footer">Apple 16+ / Google Play IARC: Krachtige taal + Suggestieve thema\'s</string>
     <string name="settings_ble_compat_title">BLE-compatibiliteitsmodus</string>
-    <string name="settings_ble_compat_description">Schrijfpad met kleine MTU dat verbroken verbindingen bij het starten van een workout op Pixel 6/7 verhelpt. Auto schakelt het alleen op die toestellen in.</string>
-    <string name="settings_ble_compat_description_affected">Schrijfpad met kleine MTU dat verbroken verbindingen bij het starten van een workout op Pixel 6/7 verhelpt. Auto schakelt het alleen op die toestellen in (dit toestel is getroffen).</string>
+    <string name="settings_ble_compat_description">Schrijfpad met kleine MTU dat verbroken verbindingen bij het starten van een workout op Pixel 6/7, Fold en Tablet verhelpt. Auto schakelt het alleen op die toestellen in.</string>
+    <string name="settings_ble_compat_description_affected">Schrijfpad met kleine MTU dat verbroken verbindingen bij het starten van een workout op Pixel 6/7, Fold en Tablet verhelpt. Auto schakelt het alleen op die toestellen in (dit toestel is getroffen).</string>
     <string name="settings_ble_compat_auto">Auto</string>
     <string name="settings_ble_compat_on">Aan</string>
     <string name="settings_ble_compat_off">Uit</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -143,8 +143,8 @@
     <string name="settings_weight_suggestions_title">Weight Suggestions</string>
     <string name="settings_weight_suggestions_description">Show Apply or Dismiss recommendations after completed sets</string>
     <string name="settings_ble_compat_title">BLE Compatibility Mode</string>
-    <string name="settings_ble_compat_description">Small-MTU write path that fixes workout-start disconnects on Pixel 6/7. Auto enables it only on those devices.</string>
-    <string name="settings_ble_compat_description_affected">Small-MTU write path that fixes workout-start disconnects on Pixel 6/7. Auto enables it only on those devices (this device is affected).</string>
+    <string name="settings_ble_compat_description">Small-MTU write path that fixes workout-start disconnects on Pixel 6/7, Fold and Tablet. Auto enables it only on those devices.</string>
+    <string name="settings_ble_compat_description_affected">Small-MTU write path that fixes workout-start disconnects on Pixel 6/7, Fold and Tablet. Auto enables it only on those devices (this device is affected).</string>
     <string name="settings_ble_compat_auto">Auto</string>
     <string name="settings_ble_compat_on">On</string>
     <string name="settings_ble_compat_off">Off</string>

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/ble/BleCompatibilityMode.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/ble/BleCompatibilityMode.kt
@@ -7,7 +7,8 @@ import kotlin.concurrent.Volatile
 /**
  * Issue #333: BLE compatibility mode ("official small-MTU path").
  *
- * Root cause: on Pixel 6/7 (Tensor G1/G2 + Broadcom BCM4389 Bluetooth controller),
+ * Root cause: on BCM4389 Pixels (Tensor G1/G2 generation — Pixel 6/7 phones,
+ * Pixel Fold, Pixel Tablet — all with the Broadcom BCM4389 Bluetooth controller),
  * a 96-byte acknowledged write sent as a single large ATT PDU under the 517-byte
  * MTU that Android 14+ forces on the first requestMtu() call never completes —
  * the controller's write lane wedges (WriteRequestBusy forever), then surfaces
@@ -32,7 +33,7 @@ object BleCompatibilityMode {
     var setting: BleCompatibilitySetting = BleCompatibilitySetting.AUTO
 
     /** Resolved state: should the small-MTU compatibility path be used right now? */
-    fun isActive(isAffectedDevice: Boolean = DeviceInfo.isPixel6Or7()): Boolean =
+    fun isActive(isAffectedDevice: Boolean = DeviceInfo.isBcm4389Pixel()): Boolean =
         when (setting) {
             BleCompatibilitySetting.ON -> true
             BleCompatibilitySetting.OFF -> false
@@ -40,13 +41,13 @@ object BleCompatibilityMode {
         }
 
     /** The GATT heartbeat loop is suppressed on the compatibility path. */
-    fun includeHeartbeat(isAffectedDevice: Boolean = DeviceInfo.isPixel6Or7()): Boolean =
+    fun includeHeartbeat(isAffectedDevice: Boolean = DeviceInfo.isBcm4389Pixel()): Boolean =
         !isActive(isAffectedDevice)
 
     /** Best-effort pre-ready firmware/version reads are skipped on the compatibility path. */
-    fun includePreReadyDiagnosticReads(isAffectedDevice: Boolean = DeviceInfo.isPixel6Or7()): Boolean =
+    fun includePreReadyDiagnosticReads(isAffectedDevice: Boolean = DeviceInfo.isBcm4389Pixel()): Boolean =
         !isActive(isAffectedDevice)
 
-    fun summary(isAffectedDevice: Boolean = DeviceInfo.isPixel6Or7()): String =
+    fun summary(isAffectedDevice: Boolean = DeviceInfo.isBcm4389Pixel()): String =
         "setting=${setting.name}, affectedDevice=$isAffectedDevice, active=${isActive(isAffectedDevice)}"
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SettingsTab.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SettingsTab.kt
@@ -2853,7 +2853,7 @@ fun SettingsTab(
 
                 Spacer(modifier = Modifier.height(Spacing.medium))
 
-                // Issue #333: BLE small-MTU compatibility path (fixes Pixel 6/7
+                // Issue #333: BLE small-MTU compatibility path (fixes BCM4389 Pixel
                 // GATT_ERROR(133) disconnect at workout start)
                 Text(
                     stringResource(Res.string.settings_ble_compat_title),
@@ -2864,7 +2864,7 @@ fun SettingsTab(
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
                     stringResource(
-                        if (DeviceInfo.isPixel6Or7()) {
+                        if (DeviceInfo.isBcm4389Pixel()) {
                             Res.string.settings_ble_compat_description_affected
                         } else {
                             Res.string.settings_ble_compat_description

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/Constants.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/Constants.kt
@@ -5,7 +5,7 @@ package com.devil.phoenixproject.util
  */
 object Constants {
     // App version
-    const val APP_VERSION = "0.9.3"
+    const val APP_VERSION = "0.9.5"
 
     // EULA version - increment when EULA text changes materially
     // Users must re-accept when this version increases

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/DeviceInfo.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/DeviceInfo.kt
@@ -73,8 +73,9 @@ expect object DeviceInfo {
     fun toJson(): String
 
     /**
-     * Issue #333: true on the Pixel 6/7 family (Tensor G1/G2 + BCM4389 Bluetooth
-     * controller), the only devices where large-MTU acknowledged writes wedge.
+     * Issue #333: true on Pixel devices with the Broadcom BCM4389 Bluetooth
+     * controller (Tensor G1/G2 generation: Pixel 6/7 phones, Pixel Fold,
+     * Pixel Tablet), the only devices where large-MTU acknowledged writes wedge.
      */
-    fun isPixel6Or7(): Boolean
+    fun isBcm4389Pixel(): Boolean
 }

--- a/shared/src/iosMain/kotlin/com/devil/phoenixproject/util/DeviceInfo.ios.kt
+++ b/shared/src/iosMain/kotlin/com/devil/phoenixproject/util/DeviceInfo.ios.kt
@@ -83,5 +83,5 @@ actual object DeviceInfo {
     }
 
     /** Issue #333: Android-only concern; never a Pixel on iOS. */
-    actual fun isPixel6Or7(): Boolean = false
+    actual fun isBcm4389Pixel(): Boolean = false
 }


### PR DESCRIPTION
## RCA — why the Pixel Tablet still fails after the "permanent" #333 fix

[royalcrowncola77's Pixel Tablet logs](https://github.com/9thLevelSoftware/Project-Phoenix-MP/issues/333#issuecomment-4901229766) show the exact pre-fix failure signature:

- `MTU negotiated: 517` — the app-side `requestMtu()` still ran
- **No `[#333 compat]` log markers anywhere** — BLE Compatibility Mode never activated
- `GATT_ERROR(133)` on the first >20-byte command (the 34-byte `0x11` workout-start write), followed by the disconnect

The compatibility mode itself works (validated on Pixel 6/7 by four testers); the tablet simply never got it. `DeviceInfo.isPixel6Or7()` matched only the six **phone** codenames (`oriole`, `raven`, `bluejay`, `panther`, `cheetah`, `lynx`), so on the tablet `AUTO` resolved to off and the standard large-MTU path ran — and wedged the write lane exactly as on the phones.

The hardware says the tablet belongs on the allowlist:

- **Pixel Tablet (`tangorpro`)** runs Tensor G2 on the same **gs201** kernel platform as the Pixel 7 family ([LineageOS wiki](https://wiki.lineageos.org/devices/tangorpro/), [gs201 kernel](https://github.com/kerneltoast/android_kernel_google_gs201)) with the same **Broadcom BCM4389** Bluetooth controller — the chip whose write lane wedges on single large ATT PDUs.
- **Pixel Fold (`felix`)** is also Tensor G2 + BCM4389 — Google's own [bcmdhd_bcm4389 driver repo](https://github.com/GrapheneOS/kernel_google-modules_wlan_bcmdhd_bcm4389) is titled "Kernel Wi-Fi/Bluetooth driver for the Pixel 6, Pixel 6 Pro, Pixel 6a, Pixel 7, Pixel 7 Pro **and Pixel Fold**." Added proactively so Fold owners don't hit the same wall.

Pixel 8/9 (Tensor G3/G4) moved off the BCM4389 and have no reports in #333, so they stay on the standard path.

## Changes

- Add `tangorpro` (Pixel Tablet) and `felix` (Pixel Fold) to the affected-device codename allowlist
- Rename `DeviceInfo.isPixel6Or7()` → `isBcm4389Pixel()` — the set is no longer just Pixel 6/7, and the name now states the actual discriminating hardware (expect/actual + all call sites)
- Update the Settings → BLE Compatibility Mode description in all six locales to mention Fold and Tablet
- Update the #333 RCA doc comments to match

No behavior change on any device that isn't a BCM4389 Pixel; the ON/OFF manual override semantics are untouched.

## Testing

- `:shared:compileAndroidMain` and `:shared:testAndroidHostTest` pass (222 suites, incl. `BleCompatibilityModeTest` 7/7)
- Needs on-device validation from the Pixel Tablet reporter: with the new build on **Auto**, the Settings description should say "this device is affected," connection logs should show `[#333 compat] Skipping requestMtu()` instead of `MTU negotiated: 517`, and the workout-start write should survive

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WEQ8ZXWq8TBEEYcGzwhnPb

---
_Generated by [Claude Code](https://claude.ai/code/session_01WEQ8ZXWq8TBEEYcGzwhnPb)_