### PR TITLE
fix(#635): explicit isBodyweight flag — stop deriving from unreliable equipment metadata

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -209,8 +209,8 @@ sqldelight {
     databases {
         create("VitruvianDatabase") {
             packageName.set("com.devil.phoenixproject.database")
-            // Version 39 = initial schema (1) + 38 migrations (1.sqm through 38.sqm).
-            version = 39
+            // Version 40 = initial schema (1) + 39 migrations (1.sqm through 39.sqm).
+            version = 40
         }
     }
 }

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/local/SchemaParityTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/local/SchemaParityTest.kt
@@ -331,10 +331,93 @@ class SchemaParityTest {
         assertEquals("{}", rackBehaviorOverrides)
     }
 
+    @Test
+    fun `migration 39 adds isBodyweight columns and backfills catalog and sentinel rows`() {
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        buildSchemaAtVersion(driver, 39)
+
+        assertEquals(false, columnExistsInDriver(driver, "Exercise", "isBodyweight"))
+        assertEquals(false, columnExistsInDriver(driver, "RoutineExercise", "isBodyweight"))
+
+        // Squat: catalog cable lift shipping with empty equipment (#635)
+        driver.execute(
+            null,
+            """
+            INSERT INTO Exercise (
+                id, name, created, muscleGroup, muscleGroups, equipment,
+                popularity, archived, isFavorite, isCustom, timesPerformed, defaultCableConfig
+            ) VALUES (
+                'UjIGHxCav-lS9B2I', 'Squat', 0, 'LEGS', 'LEGS', '',
+                0, 0, 0, 0, 0, 'DOUBLE'
+            )
+            """.trimIndent(),
+            0,
+        )
+        // Genuinely bodyweight catalog entry with empty equipment — must stay NULL (derived)
+        driver.execute(
+            null,
+            """
+            INSERT INTO Exercise (
+                id, name, created, muscleGroup, muscleGroups, equipment,
+                popularity, archived, isFavorite, isCustom, timesPerformed, defaultCableConfig
+            ) VALUES (
+                'U9nn8f-vcAltrR-E', 'Plank', 0, 'CORE', 'CORE', '',
+                0, 0, 0, 0, 0, 'DOUBLE'
+            )
+            """.trimIndent(),
+            0,
+        )
+        driver.execute(
+            null,
+            "INSERT INTO Routine (id, name, createdAt) VALUES ('routine-635', 'BW Routine', 1)",
+            0,
+        )
+        // Row carrying the legacy pull-sync sentinel
+        driver.execute(
+            null,
+            """
+            INSERT INTO RoutineExercise (
+                id, routineId, exerciseName, exerciseMuscleGroup, exerciseEquipment, orderIndex, weightPerCableKg
+            ) VALUES (
+                'rex-sentinel', 'routine-635', 'Push Up', 'CHEST', 'Bodyweight', 0, 0.0
+            )
+            """.trimIndent(),
+            0,
+        )
+        // Row referencing a known misclassified cable lift
+        driver.execute(
+            null,
+            """
+            INSERT INTO RoutineExercise (
+                id, routineId, exerciseName, exerciseMuscleGroup, exerciseEquipment, exerciseId, orderIndex, weightPerCableKg
+            ) VALUES (
+                'rex-squat', 'routine-635', 'Squat', 'LEGS', '', 'UjIGHxCav-lS9B2I', 1, 40.0
+            )
+            """.trimIndent(),
+            0,
+        )
+
+        VitruvianDatabase.Schema.migrate(driver, 39, 40)
+
+        assertEquals(true, columnExistsInDriver(driver, "Exercise", "isBodyweight"))
+        assertEquals(true, columnExistsInDriver(driver, "RoutineExercise", "isBodyweight"))
+
+        // Squat backfilled to explicit cable (0); Plank untouched (NULL = derived)
+        assertEquals("0", queryScalar(driver, "SELECT CAST(isBodyweight AS TEXT) FROM Exercise WHERE id = 'UjIGHxCav-lS9B2I'"))
+        assertEquals(null, queryScalar(driver, "SELECT CAST(isBodyweight AS TEXT) FROM Exercise WHERE id = 'U9nn8f-vcAltrR-E'"))
+
+        // Sentinel converted to explicit flag and cleared from equipment
+        assertEquals("1", queryScalar(driver, "SELECT CAST(isBodyweight AS TEXT) FROM RoutineExercise WHERE id = 'rex-sentinel'"))
+        assertEquals("", queryScalar(driver, "SELECT exerciseEquipment FROM RoutineExercise WHERE id = 'rex-sentinel'"))
+
+        // Routine exercise referencing the misclassified cable lift force-corrected
+        assertEquals("0", queryScalar(driver, "SELECT CAST(isBodyweight AS TEXT) FROM RoutineExercise WHERE id = 'rex-squat'"))
+    }
+
     // ==================== HELPERS ====================
 
     companion object {
-        private const val CURRENT_VERSION = 39L
+        private const val CURRENT_VERSION = 40L
 
         /**
          * Transient tables are intermediate artifacts of table-rebuild migrations
@@ -610,6 +693,23 @@ class SchemaParityTest {
             parameters = 0,
         )
         return exists
+    }
+
+    /** Returns the first column of the first row as a String, or null when NULL / no row. */
+    private fun queryScalar(driver: SqlDriver, sql: String): String? {
+        var value: String? = null
+        driver.executeQuery(
+            identifier = null,
+            sql = sql,
+            mapper = { cursor ->
+                if (cursor.next().value) {
+                    value = cursor.getString(0)
+                }
+                QueryResult.Value(Unit)
+            },
+            parameters = 0,
+        )
+        return value
     }
 
     private fun countExerciseVideos(driver: SqlDriver, isTutorial: Boolean): Long {

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/local/SchemaParityTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/local/SchemaParityTest.kt
@@ -396,6 +396,31 @@ class SchemaParityTest {
             """.trimIndent(),
             0,
         )
+        // Legacy name-only row (NULL exerciseId) for a known cable lift — the
+        // loader heals these by name, so the backfill must catch them too
+        driver.execute(
+            null,
+            """
+            INSERT INTO RoutineExercise (
+                id, routineId, exerciseName, exerciseMuscleGroup, exerciseEquipment, orderIndex, weightPerCableKg
+            ) VALUES (
+                'rex-squat-name-only', 'routine-635', 'Squat', 'LEGS', '', 2, 40.0
+            )
+            """.trimIndent(),
+            0,
+        )
+        // Legacy name-only bodyweight row — must stay NULL (derived)
+        driver.execute(
+            null,
+            """
+            INSERT INTO RoutineExercise (
+                id, routineId, exerciseName, exerciseMuscleGroup, exerciseEquipment, orderIndex, weightPerCableKg
+            ) VALUES (
+                'rex-plank-name-only', 'routine-635', 'Plank', 'CORE', '', 3, 0.0
+            )
+            """.trimIndent(),
+            0,
+        )
 
         VitruvianDatabase.Schema.migrate(driver, 39, 40)
 
@@ -412,6 +437,11 @@ class SchemaParityTest {
 
         // Routine exercise referencing the misclassified cable lift force-corrected
         assertEquals("0", queryScalar(driver, "SELECT CAST(isBodyweight AS TEXT) FROM RoutineExercise WHERE id = 'rex-squat'"))
+
+        // Name-only legacy row (NULL exerciseId) force-corrected by name;
+        // name-only bodyweight row untouched (NULL = derived)
+        assertEquals("0", queryScalar(driver, "SELECT CAST(isBodyweight AS TEXT) FROM RoutineExercise WHERE id = 'rex-squat-name-only'"))
+        assertEquals(null, queryScalar(driver, "SELECT CAST(isBodyweight AS TEXT) FROM RoutineExercise WHERE id = 'rex-plank-name-only'"))
     }
 
     @Test

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/local/SchemaParityTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/local/SchemaParityTest.kt
@@ -414,6 +414,58 @@ class SchemaParityTest {
         assertEquals("0", queryScalar(driver, "SELECT CAST(isBodyweight AS TEXT) FROM RoutineExercise WHERE id = 'rex-squat'"))
     }
 
+    @Test
+    fun `migration 39 backfill runs via resilient fallback when a column already exists`() {
+        // #636 review (Codex P2): when Schema.migrate throws on a drifted DB
+        // (e.g. isBodyweight already added by a heal), the resilient fallback must
+        // still run 39.sqm's data backfills — reconciliation only adds columns,
+        // it never re-runs data fixes.
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        buildSchemaAtVersion(driver, 39)
+
+        // Simulate schema drift: the Exercise column already exists, so the
+        // standard migrate path aborts on 39.sqm's first statement.
+        driver.execute(null, "ALTER TABLE Exercise ADD COLUMN isBodyweight INTEGER", 0)
+
+        driver.execute(
+            null,
+            """
+            INSERT INTO Exercise (
+                id, name, created, muscleGroup, muscleGroups, equipment,
+                popularity, archived, isFavorite, isCustom, timesPerformed, defaultCableConfig
+            ) VALUES (
+                'UjIGHxCav-lS9B2I', 'Squat', 0, 'LEGS', 'LEGS', '',
+                0, 0, 0, 0, 0, 'DOUBLE'
+            )
+            """.trimIndent(),
+            0,
+        )
+        driver.execute(
+            null,
+            "INSERT INTO Routine (id, name, createdAt) VALUES ('routine-635-resilient', 'BW', 1)",
+            0,
+        )
+        driver.execute(
+            null,
+            """
+            INSERT INTO RoutineExercise (
+                id, routineId, exerciseName, exerciseMuscleGroup, exerciseEquipment, orderIndex, weightPerCableKg
+            ) VALUES (
+                'rex-sentinel-resilient', 'routine-635-resilient', 'Push Up', 'CHEST', 'Bodyweight', 0, 0.0
+            )
+            """.trimIndent(),
+            0,
+        )
+
+        // Same path production takes: migrate throws (duplicate column) -> fallback.
+        migrateWithResilience(driver, 39, 40)
+
+        assertEquals(true, columnExistsInDriver(driver, "RoutineExercise", "isBodyweight"))
+        assertEquals("0", queryScalar(driver, "SELECT CAST(isBodyweight AS TEXT) FROM Exercise WHERE id = 'UjIGHxCav-lS9B2I'"))
+        assertEquals("1", queryScalar(driver, "SELECT CAST(isBodyweight AS TEXT) FROM RoutineExercise WHERE id = 'rex-sentinel-resilient'"))
+        assertEquals("", queryScalar(driver, "SELECT exerciseEquipment FROM RoutineExercise WHERE id = 'rex-sentinel-resilient'"))
+    }
+
     // ==================== HELPERS ====================
 
     companion object {
@@ -619,7 +671,9 @@ class SchemaParityTest {
             try {
                 VitruvianDatabase.Schema.migrate(driver, v, v + 1)
             } catch (_: Exception) {
-                applyMigrationResilient(driver, (v + 1).toInt())
+                // Keyed by the .sqm file number (the version migrated FROM) — matches
+                // the production DriverFactory callers.
+                applyMigrationResilient(driver, v.toInt())
             }
         }
     }

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/migration/MigrationManagerTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/migration/MigrationManagerTest.kt
@@ -524,6 +524,7 @@ class MigrationManagerTest {
             defaultCableConfig = "DOUBLE",
             one_rep_max_kg = oneRepMaxKg,
             mvtOverrideMs = null,
+            isBodyweight = null,
         )
     }
 
@@ -564,6 +565,7 @@ class MigrationManagerTest {
             defaultRackItemIds = "[]",
             rackBehaviorOverrides = "{}",
             scalingBasis = null,
+            isBodyweight = null,
         )
     }
 

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightAssessmentRepositoryTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightAssessmentRepositoryTest.kt
@@ -83,6 +83,7 @@ class SqlDelightAssessmentRepositoryTest {
             defaultCableConfig = "DOUBLE",
             one_rep_max_kg = null,
             mvtOverrideMs = null,
+            isBodyweight = null,
         )
     }
 }

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightCompletedSetRepositoryTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightCompletedSetRepositoryTest.kt
@@ -152,6 +152,7 @@ class SqlDelightCompletedSetRepositoryTest {
             defaultRackItemIds = "[]",
             rackBehaviorOverrides = "{}",
             scalingBasis = null,
+            isBodyweight = null,
         )
     }
 

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightExerciseRepositoryTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightExerciseRepositoryTest.kt
@@ -271,6 +271,7 @@ class SqlDelightExerciseRepositoryTest {
             defaultCableConfig = defaultCableConfig,
             one_rep_max_kg = oneRepMaxKg,
             mvtOverrideMs = null,
+            isBodyweight = null,
         )
     }
 }

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightPersonalMvtRepositoryTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightPersonalMvtRepositoryTest.kt
@@ -37,6 +37,7 @@ class SqlDelightPersonalMvtRepositoryTest {
             defaultCableConfig = "DOUBLE",
             one_rep_max_kg = null,
             mvtOverrideMs = null,
+            isBodyweight = null,
         )
     }
 

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightPersonalRecordRepositoryTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightPersonalRecordRepositoryTest.kt
@@ -168,6 +168,7 @@ class SqlDelightPersonalRecordRepositoryTest {
             isFavorite = 0L, isCustom = 0L, timesPerformed = 0L,
             lastPerformed = null, aliases = null, defaultCableConfig = "DOUBLE",
             one_rep_max_kg = null, mvtOverrideMs = null,
+            isBodyweight = null,
         )
 
         // Trigger fires on the 1RM sync (third write in the transaction),
@@ -253,6 +254,7 @@ class SqlDelightPersonalRecordRepositoryTest {
             defaultCableConfig = "DOUBLE",
             one_rep_max_kg = null,
             mvtOverrideMs = null,
+            isBodyweight = null,
         )
     }
 }

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepositoryTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepositoryTest.kt
@@ -577,6 +577,18 @@ class SqlDelightSyncRepositoryTest {
                             weight = 40f,
                             isBodyweight = false,
                         ),
+                        // Older Edge Function payloads omit the field entirely — the
+                        // stored flag must stay NULL (derive from catalog equipment),
+                        // never explicit cable.
+                        PullRoutineExerciseDto(
+                            id = "rex-635-omitted",
+                            routineId = "routine-635",
+                            name = "Plank",
+                            muscleGroup = "Core",
+                            orderIndex = 2,
+                            reps = 1,
+                            weight = 0f,
+                        ),
                     ),
                 ),
             ),
@@ -597,6 +609,9 @@ class SqlDelightSyncRepositoryTest {
         val cableRow = exercises[1]
         assertEquals(0L, cableRow.isBodyweight)
         assertEquals("", cableRow.exerciseEquipment)
+
+        val omittedRow = exercises[2]
+        assertEquals(null, omittedRow.isBodyweight)
     }
 
     private fun insertHistoricalSession(

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepositoryTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepositoryTest.kt
@@ -549,6 +549,34 @@ class SqlDelightSyncRepositoryTest {
         // #635 regression: the pull path used to write a "Bodyweight" sentinel string
         // into exerciseEquipment, which permanently poisoned classification because
         // snapshot Exercises re-derived isBodyweight from the equipment string.
+        // Catalog cable lift with empty equipment and an explicit stored flag (Squat)
+        database.vitruvianDatabaseQueries.insertExercise(
+            id = "UjIGHxCav-lS9B2I",
+            name = "Squat",
+            displayName = "Squat",
+            description = null,
+            created = 0,
+            muscleGroup = "LEGS",
+            muscleGroups = "LEGS",
+            muscles = null,
+            equipment = "",
+            movement = null,
+            sidedness = null,
+            grip = null,
+            gripWidth = null,
+            minRepRange = null,
+            popularity = 0.0,
+            archived = 0,
+            isFavorite = 0,
+            isCustom = 0,
+            timesPerformed = 0,
+            lastPerformed = null,
+            aliases = null,
+            defaultCableConfig = "DOUBLE",
+            one_rep_max_kg = null,
+            mvtOverrideMs = null,
+            isBodyweight = 0,
+        )
         repository.mergePortalRoutines(
             routines = listOf(
                 PullRoutineDto(
@@ -589,6 +617,20 @@ class SqlDelightSyncRepositoryTest {
                             reps = 1,
                             weight = 0f,
                         ),
+                        // Omitted field + catalog exercise with an explicit stored flag:
+                        // must inherit the catalog classification (Squat = cable), or the
+                        // catalog-blind push snapshot re-derives bodyweight from the
+                        // empty equipment string and re-poisons the portal.
+                        PullRoutineExerciseDto(
+                            id = "rex-635-omitted-catalog",
+                            routineId = "routine-635",
+                            name = "Squat",
+                            muscleGroup = "LEGS",
+                            exerciseId = "UjIGHxCav-lS9B2I",
+                            orderIndex = 3,
+                            reps = 5,
+                            weight = 60f,
+                        ),
                     ),
                 ),
             ),
@@ -612,6 +654,9 @@ class SqlDelightSyncRepositoryTest {
 
         val omittedRow = exercises[2]
         assertEquals(null, omittedRow.isBodyweight)
+
+        val omittedCatalogRow = exercises[3]
+        assertEquals(0L, omittedCatalogRow.isBodyweight)
     }
 
     private fun insertHistoricalSession(

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepositoryTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepositoryTest.kt
@@ -199,6 +199,7 @@ class SqlDelightSyncRepositoryTest {
             "DUAL",
             null,
             null,
+            isBodyweight = null,
         )
 
         // Strategy 0: resolves by catalog id (unambiguous), ignoring name
@@ -427,6 +428,7 @@ class SqlDelightSyncRepositoryTest {
             defaultRackItemIds = """["vest"]""",
             rackBehaviorOverrides = "{}",
             scalingBasis = null,
+            isBodyweight = null,
         )
 
         repository.mergePortalRoutines(
@@ -508,6 +510,7 @@ class SqlDelightSyncRepositoryTest {
             defaultRackItemIds = "[]",
             rackBehaviorOverrides = "{}",
             scalingBasis = "ESTIMATED_1RM",
+            isBodyweight = null,
         )
 
         repository.mergePortalRoutines(
@@ -539,6 +542,61 @@ class SqlDelightSyncRepositoryTest {
             .executeAsList()
             .single()
         assertEquals("ESTIMATED_1RM", exercise.scalingBasis)
+    }
+
+    @Test
+    fun `mergePortalRoutines stores isBodyweight flag without corrupting equipment`() = runTest {
+        // #635 regression: the pull path used to write a "Bodyweight" sentinel string
+        // into exerciseEquipment, which permanently poisoned classification because
+        // snapshot Exercises re-derived isBodyweight from the equipment string.
+        repository.mergePortalRoutines(
+            routines = listOf(
+                PullRoutineDto(
+                    id = "routine-635",
+                    userId = "user",
+                    name = "Bodyweight Flag Routine",
+                    updatedAt = 1_700_000_000_200,
+                    exercises = listOf(
+                        PullRoutineExerciseDto(
+                            id = "rex-635-bw",
+                            routineId = "routine-635",
+                            name = "Push Up",
+                            muscleGroup = "Chest",
+                            orderIndex = 0,
+                            reps = 10,
+                            weight = 0f,
+                            isBodyweight = true,
+                        ),
+                        PullRoutineExerciseDto(
+                            id = "rex-635-cable",
+                            routineId = "routine-635",
+                            name = "Bench Press",
+                            muscleGroup = "Chest",
+                            orderIndex = 1,
+                            reps = 8,
+                            weight = 40f,
+                            isBodyweight = false,
+                        ),
+                    ),
+                ),
+            ),
+            lastSync = 1_700_000_000_100,
+            profileId = "active-profile",
+        )
+
+        val exercises = database.vitruvianDatabaseQueries
+            .selectExercisesByRoutine("routine-635")
+            .executeAsList()
+            .sortedBy { it.orderIndex }
+
+        val bodyweightRow = exercises[0]
+        assertEquals(1L, bodyweightRow.isBodyweight)
+        // Equipment must never carry the legacy sentinel
+        assertEquals("", bodyweightRow.exerciseEquipment)
+
+        val cableRow = exercises[1]
+        assertEquals(0L, cableRow.isBodyweight)
+        assertEquals("", cableRow.exerciseEquipment)
     }
 
     private fun insertHistoricalSession(

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightTrainingCycleRepositoryTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightTrainingCycleRepositoryTest.kt
@@ -240,6 +240,7 @@ class SqlDelightTrainingCycleRepositoryTest {
             defaultRackItemIds = "[]",
             rackBehaviorOverrides = "{}",
             scalingBasis = null,
+            isBodyweight = null,
         )
     }
 }

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightVelocityOneRepMaxRepositoryTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightVelocityOneRepMaxRepositoryTest.kt
@@ -40,6 +40,7 @@ class SqlDelightVelocityOneRepMaxRepositoryTest {
             defaultCableConfig = "DOUBLE",
             one_rep_max_kg = null,
             mvtOverrideMs = null,
+            isBodyweight = null,
         )
     }
 

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepositoryVelocityPointsTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepositoryVelocityPointsTest.kt
@@ -38,6 +38,7 @@ class SqlDelightWorkoutRepositoryVelocityPointsTest {
             defaultCableConfig = "DOUBLE",
             one_rep_max_kg = null,
             mvtOverrideMs = null,
+            isBodyweight = null,
         )
     }
 

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModelTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModelTest.kt
@@ -710,6 +710,7 @@ class ExerciseConfigViewModelTest {
             defaultCableConfig = "DOUBLE",
             one_rep_max_kg = null,
             mvtOverrideMs = null,
+            isBodyweight = null,
         )
     }
 

--- a/shared/src/androidMain/kotlin/com/devil/phoenixproject/data/local/DriverFactory.android.kt
+++ b/shared/src/androidMain/kotlin/com/devil/phoenixproject/data/local/DriverFactory.android.kt
@@ -64,7 +64,11 @@ actual class DriverFactory(private val context: Context) {
                         Log.i(TAG, "Migration ${version + 1} succeeded")
                     } catch (e: SQLiteException) {
                         Log.w(TAG, "Migration ${version + 1} failed, applying resilient fallback: ${e.message}")
-                        val results = applyMigrationResilient(callbackDriver(db), version + 1)
+                        // getMigrationStatements is keyed by the .sqm file number — the
+                        // version being migrated FROM (version), not the target. Passing
+                        // version + 1 replayed the NEXT migration's statements and skipped
+                        // the failed one's data fixes entirely (#636 review).
+                        val results = applyMigrationResilient(callbackDriver(db), version)
                         val failures = results.count { result -> !result.success && !result.recoverable }
                         if (failures > 0) {
                             Log.w(TAG, "Migration ${version + 1} had $failures non-recoverable statements")

--- a/shared/src/commonMain/composeResources/files/exercise_dump.json
+++ b/shared/src/commonMain/composeResources/files/exercise_dump.json
@@ -9640,6 +9640,7 @@
     {
         "id": "enuJ_FgAzXDLAweK",
         "name": "Good Morning",
+        "isBodyweight": false,
         "created": "2022-06-29T08:45:31.610Z",
         "description": "",
         "videos": [
@@ -11805,6 +11806,7 @@
     {
         "id": "fAglxv8VMaisUTyo",
         "name": "Just Lift exercise",
+        "isBodyweight": false,
         "created": "2023-06-14T02:04:31.780Z",
         "description": "",
         "videos": [],
@@ -11876,6 +11878,7 @@
     {
         "id": "2nTn2QR6MyezFYmK",
         "name": "Kneeling 45 Degree Kickback ",
+        "isBodyweight": false,
         "created": "2023-12-21T04:42:08.821Z",
         "description": "",
         "videos": [
@@ -13932,6 +13935,7 @@
     {
         "id": "KoL_gx00nuf2wncV",
         "name": "Medial Delt Twist",
+        "isBodyweight": false,
         "created": "2021-09-08T05:52:30.392Z",
         "description": "",
         "videos": [],
@@ -13964,6 +13968,7 @@
     {
         "id": "kSLyRg4bjLuzTeIM",
         "name": "Medial Delt Twist",
+        "isBodyweight": false,
         "created": "2021-08-26T08:37:32.901Z",
         "description": "",
         "videos": [
@@ -22205,6 +22210,7 @@
     {
         "id": "UjIGHxCav-lS9B2I",
         "name": "Squat",
+        "isBodyweight": false,
         "created": "2021-09-02T05:27:37.764Z",
         "description": "",
         "videos": [

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/ExerciseImporter.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/ExerciseImporter.kt
@@ -37,6 +37,7 @@ data class ExerciseJson(
     val archived: String? = null, // Date string when archived, null if active
     val range: RangeJson? = null,
     val popularity: Double? = null,
+    val isBodyweight: Boolean? = null, // Explicit classification (#635); null = derive from equipment
 )
 
 @Serializable
@@ -205,6 +206,7 @@ class ExerciseImporter(private val database: VitruvianDatabase) {
                             defaultCableConfig = cableConfig,
                             one_rep_max_kg = null,
                             mvtOverrideMs = null,
+                            isBodyweight = resolveIsBodyweightFlag(exerciseJson),
                         )
                         importedCount++
 
@@ -256,11 +258,39 @@ class ExerciseImporter(private val database: VitruvianDatabase) {
         }
     }
 
+    /**
+     * Resolve the explicit isBodyweight flag for an imported exercise (#635).
+     * Priority: explicit JSON field > known-cable override set > null (derive from equipment).
+     * The override set exists because the GitHub refresh source is the upstream Vitruvian
+     * repo, which does not carry the isBodyweight field — without it, a manual library
+     * refresh would revert the 6 known empty-equipment cable lifts to derived (wrong)
+     * classification.
+     */
+    private fun resolveIsBodyweightFlag(exercise: ExerciseJson): Long? = when {
+        exercise.isBodyweight != null -> if (exercise.isBodyweight) 1L else 0L
+        exercise.id in KNOWN_NON_BODYWEIGHT_IDS -> 0L
+        else -> null
+    }
+
     companion object {
         // GitHub raw content URL for exercise data
         // Update this to point to your actual exercise data repository
         private const val GITHUB_EXERCISES_URL =
             "https://raw.githubusercontent.com/VitruvianFitness/exercise-library/main/exercise_dump.json"
+
+        /**
+         * Catalog entries that ship with equipment=[] but are cable lifts (#635).
+         * Must stay in sync with the UPDATE statements in migration 39.sqm and the
+         * "isBodyweight": false tags in the bundled exercise_dump.json.
+         */
+        private val KNOWN_NON_BODYWEIGHT_IDS = setOf(
+            "UjIGHxCav-lS9B2I", // Squat
+            "enuJ_FgAzXDLAweK", // Good Morning
+            "KoL_gx00nuf2wncV", // Medial Delt Twist
+            "kSLyRg4bjLuzTeIM", // Medial Delt Twist (duplicate catalog entry)
+            "2nTn2QR6MyezFYmK", // Kneeling 45 Degree Kickback
+            "fAglxv8VMaisUTyo", // Just Lift exercise
+        )
 
         private val FORCED_SINGLE_CABLE_EXERCISE_NAMES = setOf(
             // Explicit single-cable variants (SC/SA suffix)
@@ -348,6 +378,7 @@ class ExerciseImporter(private val database: VitruvianDatabase) {
                         defaultCableConfig = mapSidednessToCableConfig(exercise.sidedness),
                         one_rep_max_kg = null,
                         mvtOverrideMs = null,
+                        isBodyweight = resolveIsBodyweightFlag(exercise),
                     )
 
                     // Insert videos

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/MigrationStatements.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/MigrationStatements.kt
@@ -927,6 +927,14 @@ WHERE gs.rowid = (
         '2nTn2QR6MyezFYmK',
         'fAglxv8VMaisUTyo'
     )""",
+        """UPDATE RoutineExercise SET isBodyweight = 0
+    WHERE isBodyweight IS NULL AND TRIM(exerciseName) IN (
+        'Squat',
+        'Good Morning',
+        'Medial Delt Twist',
+        'Kneeling 45 Degree Kickback',
+        'Just Lift exercise'
+    )""",
     )
 
     else -> emptyList()

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/MigrationStatements.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/MigrationStatements.kt
@@ -49,8 +49,10 @@ internal fun applyMigrationResilient(
  * Get the SQL statements for a specific migration version.
  *
  * These mirror the .sqm files exactly, split into individual statements so
- * the resilient executor can apply them one-by-one. Every version from 1-33
- * is covered. Version 18 is intentionally empty (NOOP).
+ * the resilient executor can apply them one-by-one. The key is the .sqm FILE
+ * NUMBER — the schema version being migrated FROM (N.sqm migrates N -> N+1).
+ * Callers falling back from a failed `Schema.migrate(v, v + 1)` must pass `v`,
+ * not `v + 1`. Version 18 is intentionally empty (NOOP).
  */
 internal fun getMigrationStatements(version: Int): List<String> = when (version) {
     // Migration 1: Add 1RM column to Exercise
@@ -898,6 +900,33 @@ WHERE gs.rowid = (
     // Migration 38: per-routine-exercise scaling basis (% of estimated 1RM) — issue #517 Phase 3.
     38 -> listOf(
         "ALTER TABLE RoutineExercise ADD COLUMN scalingBasis TEXT",
+    )
+
+    // Migration 39: explicit isBodyweight classification (issue #635).
+    // The UPDATE backfills MUST run even on the resilient path (duplicate-column
+    // fallback) — reconciliation can heal missing columns but never re-runs data
+    // fixes. All statements are idempotent, so partial replay is safe.
+    39 -> listOf(
+        "ALTER TABLE Exercise ADD COLUMN isBodyweight INTEGER",
+        "ALTER TABLE RoutineExercise ADD COLUMN isBodyweight INTEGER",
+        """UPDATE Exercise SET isBodyweight = 0 WHERE id IN (
+        'UjIGHxCav-lS9B2I',
+        'enuJ_FgAzXDLAweK',
+        'KoL_gx00nuf2wncV',
+        'kSLyRg4bjLuzTeIM',
+        '2nTn2QR6MyezFYmK',
+        'fAglxv8VMaisUTyo'
+    )""",
+        """UPDATE RoutineExercise SET isBodyweight = 1, exerciseEquipment = ''
+    WHERE exerciseEquipment = 'Bodyweight'""",
+        """UPDATE RoutineExercise SET isBodyweight = 0 WHERE exerciseId IN (
+        'UjIGHxCav-lS9B2I',
+        'enuJ_FgAzXDLAweK',
+        'KoL_gx00nuf2wncV',
+        'kSLyRg4bjLuzTeIM',
+        '2nTn2QR6MyezFYmK',
+        'fAglxv8VMaisUTyo'
+    )""",
     )
 
     else -> emptyList()

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/SchemaManifest.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/local/SchemaManifest.kt
@@ -712,7 +712,7 @@ internal val manifestTables: List<SchemaTableOperation> = listOf(
     // because applyColumnHeal handles "duplicate column" errors gracefully.
 
     // Exercise -- initial schema, full current shape
-    // Columns added by later migrations: one_rep_max_kg (m1), updatedAt/serverId/deletedAt (m11), displayName (m30), mvtOverrideMs (m37)
+    // Columns added by later migrations: one_rep_max_kg (m1), updatedAt/serverId/deletedAt (m11), displayName (m30), mvtOverrideMs (m37), isBodyweight (m39)
     SchemaTableOperation(
         table = "Exercise",
         createSql = """
@@ -743,7 +743,8 @@ internal val manifestTables: List<SchemaTableOperation> = listOf(
                 updatedAt INTEGER,
                 serverId TEXT,
                 deletedAt INTEGER,
-                mvtOverrideMs REAL
+                mvtOverrideMs REAL,
+                isBodyweight INTEGER
             )
         """.trimIndent(),
     ),
@@ -900,7 +901,7 @@ internal val manifestTables: List<SchemaTableOperation> = listOf(
 
     // RoutineExercise -- initial schema, full current shape
     // Columns added by later migrations: superset fields (m4), PR scaling (m7),
-    // routine programming (m18), behavior overrides (m20), scalingBasis (m38)
+    // routine programming (m18), behavior overrides (m20), scalingBasis (m38), isBodyweight (m39)
     SchemaTableOperation(
         table = "RoutineExercise",
         createSql = """
@@ -940,6 +941,7 @@ internal val manifestTables: List<SchemaTableOperation> = listOf(
                 warmupSets TEXT NOT NULL DEFAULT '',
                 defaultRackItemIds TEXT NOT NULL DEFAULT '[]',
                 rackBehaviorOverrides TEXT NOT NULL DEFAULT '{}',
+                isBodyweight INTEGER,
                 FOREIGN KEY (routineId) REFERENCES Routine(id) ON DELETE CASCADE,
                 FOREIGN KEY (exerciseId) REFERENCES Exercise(id) ON DELETE SET NULL,
                 FOREIGN KEY (supersetId) REFERENCES Superset(id) ON DELETE SET NULL
@@ -1186,7 +1188,7 @@ internal val manifestTables: List<SchemaTableOperation> = listOf(
 )
 
 // ============================================================
-// TASK 4: manifestColumns -- 71 column heal operations
+// TASK 4: manifestColumns -- column heal operations
 //
 // Every column added AFTER its table's initial creation. Each entry is a
 // complete ALTER TABLE ADD COLUMN statement. Comments trace provenance to
@@ -1195,7 +1197,7 @@ internal val manifestTables: List<SchemaTableOperation> = listOf(
 // ============================================================
 
 internal val manifestColumns: List<SchemaHealOperation> = listOf(
-    // ── Exercise (5 columns) ────────────────────────────────────────────
+    // ── Exercise (7 columns) ────────────────────────────────────────────
 
     // Migration 1: one_rep_max_kg
     SchemaHealOperation("Exercise", "one_rep_max_kg", "ALTER TABLE Exercise ADD COLUMN one_rep_max_kg REAL DEFAULT NULL"),
@@ -1207,6 +1209,8 @@ internal val manifestColumns: List<SchemaHealOperation> = listOf(
     SchemaHealOperation("Exercise", "displayName", "ALTER TABLE Exercise ADD COLUMN displayName TEXT"),
     // Migration 37: per-exercise MVT override for velocity 1RM (issue #517)
     SchemaHealOperation("Exercise", "mvtOverrideMs", "ALTER TABLE Exercise ADD COLUMN mvtOverrideMs REAL"),
+    // Migration 39: explicit bodyweight classification (issue #635)
+    SchemaHealOperation("Exercise", "isBodyweight", "ALTER TABLE Exercise ADD COLUMN isBodyweight INTEGER"),
 
     // ── WorkoutSession (31 columns) ─────────────────────────────────────
 
@@ -1277,7 +1281,7 @@ internal val manifestColumns: List<SchemaHealOperation> = listOf(
     // Migration 21: multi-profile support
     SchemaHealOperation("Routine", "profile_id", "ALTER TABLE Routine ADD COLUMN profile_id TEXT NOT NULL DEFAULT 'default'"),
 
-    // ── RoutineExercise (11 columns) ────────────────────────────────────
+    // ── RoutineExercise (15 columns) ────────────────────────────────────
 
     // Migration 4: superset container model
     SchemaHealOperation("RoutineExercise", "supersetId", "ALTER TABLE RoutineExercise ADD COLUMN supersetId TEXT"),
@@ -1296,6 +1300,8 @@ internal val manifestColumns: List<SchemaHealOperation> = listOf(
     SchemaHealOperation("RoutineExercise", "rackBehaviorOverrides", "ALTER TABLE RoutineExercise ADD COLUMN rackBehaviorOverrides TEXT NOT NULL DEFAULT '{}'"),
     // Migration 38: velocity-based 1RM scaling basis (issue #517 Phase 3)
     SchemaHealOperation("RoutineExercise", "scalingBasis", "ALTER TABLE RoutineExercise ADD COLUMN scalingBasis TEXT"),
+    // Migration 39: explicit bodyweight classification (issue #635)
+    SchemaHealOperation("RoutineExercise", "isBodyweight", "ALTER TABLE RoutineExercise ADD COLUMN isBodyweight INTEGER"),
     // Migration 20 (healed outside .sqm): rep detection behavior
     SchemaHealOperation("RoutineExercise", "stallDetectionEnabled", "ALTER TABLE RoutineExercise ADD COLUMN stallDetectionEnabled INTEGER NOT NULL DEFAULT 1"),
     SchemaHealOperation("RoutineExercise", "stopAtTop", "ALTER TABLE RoutineExercise ADD COLUMN stopAtTop INTEGER NOT NULL DEFAULT 0"),

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightExerciseRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightExerciseRepository.kt
@@ -49,6 +49,8 @@ class SqlDelightExerciseRepository(db: VitruvianDatabase, private val exerciseIm
         deletedAt: Long?,
         // Per-exercise MVT override (migration 37)
         mvtOverrideMs: Double?,
+        // Explicit bodyweight classification (migration 39, #635); null = derive from equipment
+        isBodyweight: Long?,
     ): Exercise = Exercise(
         id = id,
         name = name,
@@ -66,6 +68,7 @@ class SqlDelightExerciseRepository(db: VitruvianDatabase, private val exerciseIm
         ),
         displayName = displayName ?: name,
         mvtOverrideMs = mvtOverrideMs?.toFloat(),
+        isBodyweightOverride = isBodyweight?.let { it != 0L },
     )
 
     private fun resolveCableIntent(
@@ -221,6 +224,9 @@ class SqlDelightExerciseRepository(db: VitruvianDatabase, private val exerciseIm
                 defaultCableConfig = "DOUBLE", // Legacy field - no longer used
                 one_rep_max_kg = exercise.oneRepMaxKg?.toDouble(),
                 mvtOverrideMs = exercise.mvtOverrideMs?.toDouble(),
+                // Custom exercises carry no explicit flag; classification derives from
+                // their equipment token (HANDLES/BODYWEIGHT set by CreateExerciseDialog).
+                isBodyweight = null,
             )
 
             Logger.d { "Created custom exercise: ${exercise.name} with ID: $customId" }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt
@@ -2241,7 +2241,9 @@ class SqlDelightSyncRepository(
                     ?: localRackOverridesByExerciseId[exercise.id]
                     ?: "{}",
                 scalingBasis = localScalingBasisByExerciseId[exercise.id],
-                isBodyweight = if (exercise.isBodyweight) 1L else 0L,
+                // Explicit portal flag when present; NULL (derive from catalog equipment)
+                // when the payload omits the field — never coerce absence to cable (#635).
+                isBodyweight = exercise.isBodyweight?.let { if (it) 1L else 0L },
             )
         }
     }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt
@@ -440,6 +440,8 @@ class SqlDelightSyncRepository(
                         defaultCableConfig = dto.defaultCableConfig,
                         one_rep_max_kg = null,
                         mvtOverrideMs = null,
+                        // Custom exercises carry no explicit flag (#635); derive from equipment.
+                        isBodyweight = null,
                     )
 
                     if (dto.serverId != null) {
@@ -914,6 +916,7 @@ class SqlDelightSyncRepository(
                         muscleGroup = exRow.exerciseMuscleGroup,
                         muscleGroups = exRow.exerciseMuscleGroup,
                         equipment = exRow.exerciseEquipment,
+                        isBodyweightOverride = exRow.isBodyweight?.let { it != 0L },
                     )
 
                     val setReps: List<Int?> = try {
@@ -2194,11 +2197,11 @@ class SqlDelightSyncRepository(
                 queries.selectExerciseById(id).executeAsOneOrNull()
             } ?: queries.findExerciseByName(exercise.name).executeAsOneOrNull()
 
-            val resolvedEquipment = when {
-                exercise.isBodyweight -> "Bodyweight"
-                catalogExercise != null -> catalogExercise.equipment
-                else -> "Cable"
-            }
+            // #635: the explicit flag is stored in its own column — the portal's
+            // per-exercise toggle is honored directly. Equipment stays real catalog
+            // metadata (the old "Bodyweight"/"Cable" sentinel corrupted classification
+            // because reconstructed snapshot Exercises derived isBodyweight from it).
+            val resolvedEquipment = catalogExercise?.equipment ?: ""
 
             queries.insertRoutineExercise(
                 id = exercise.id,
@@ -2238,6 +2241,7 @@ class SqlDelightSyncRepository(
                     ?: localRackOverridesByExerciseId[exercise.id]
                     ?: "{}",
                 scalingBasis = localScalingBasisByExerciseId[exercise.id],
+                isBodyweight = if (exercise.isBodyweight) 1L else 0L,
             )
         }
     }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt
@@ -2241,9 +2241,13 @@ class SqlDelightSyncRepository(
                     ?: localRackOverridesByExerciseId[exercise.id]
                     ?: "{}",
                 scalingBasis = localScalingBasisByExerciseId[exercise.id],
-                // Explicit portal flag when present; NULL (derive from catalog equipment)
-                // when the payload omits the field — never coerce absence to cable (#635).
-                isBodyweight = exercise.isBodyweight?.let { if (it) 1L else 0L },
+                // Explicit portal flag when present; otherwise inherit the catalog's
+                // stored classification (e.g. Squat = cable despite empty equipment).
+                // Never coerce an omitted field to cable, and never leave a known
+                // catalog flag behind — the push snapshot builder reconstructs the
+                // Exercise from this row alone, without a catalog lookup (#635).
+                isBodyweight = exercise.isBodyweight?.let { if (it) 1L else 0L }
+                    ?: catalogExercise?.isBodyweight,
             )
         }
     }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepository.kt
@@ -268,6 +268,12 @@ class SqlDelightWorkoutRepository(private val db: VitruvianDatabase, private val
                     }
                 }
 
+                // #635: the per-routine-exercise flag (portal toggle / pull sync) overrides
+                // the catalog classification when explicitly stored on the row.
+                val exerciseWithBodyweightFlag = row.isBodyweight
+                    ?.let { exercise.copy(isBodyweightOverride = it != 0L) }
+                    ?: exercise
+
                 // Parse comma-separated setReps (supports "AMRAP" as null marker)
                 val setReps: List<Int?> = try {
                     row.setReps.split(",").map { value ->
@@ -381,7 +387,7 @@ class SqlDelightWorkoutRepository(private val db: VitruvianDatabase, private val
 
                 RoutineExercise(
                     id = row.id,
-                    exercise = exercise,
+                    exercise = exerciseWithBodyweightFlag,
                     orderIndex = row.orderIndex.toInt(),
                     setReps = setReps,
                     weightPerCableKg = row.weightPerCableKg.toFloat(),
@@ -741,6 +747,9 @@ class SqlDelightWorkoutRepository(private val db: VitruvianDatabase, private val
                 json.encodeToString(exercise.rackBehaviorOverrides)
             },
             scalingBasis = exercise.scalingBasis?.name,
+            // #635: persist the explicit flag so reloads and sync keep the exact
+            // classification (null = derive from equipment, pre-migration behavior)
+            isBodyweight = exercise.exercise.isBodyweightOverride?.let { if (it) 1L else 0L },
         )
     }
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapter.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapter.kt
@@ -554,7 +554,10 @@ object PortalSyncAdapter {
                 perSetReps = ex.setReps.takeIf { it.size > 1 || it.any { r -> r == null } }
                     ?.let { Json.encodeToString(ListSerializer(Int.serializer().nullable), it) },
                 isAmrap = ex.isAMRAP,
-                isBodyweight = !ex.exercise.hasCableAccessory,
+                // #635: stored flag (catalog/row) with equipment-derivation fallback —
+                // never derive directly from equipment, which is unreliable for
+                // empty-equipment catalog cable lifts.
+                isBodyweight = ex.exercise.isBodyweight,
                 prPercentage = if (ex.usePercentOfPR) ex.weightPercentOfPR.toFloat() else null,
                 repCountTiming = ex.repCountTiming.name,
                 stopAtPosition = if (ex.stopAtTop) "TOP" else null,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncDtos.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncDtos.kt
@@ -762,7 +762,9 @@ data class PullRoutineExerciseDto(
     val perSetRest: String? = null,
     val perSetReps: String? = null,
     val isAmrap: Boolean = false,
-    val isBodyweight: Boolean = false,
+    // Nullable so payloads that omit the field (older Edge Function versions)
+    // keep the derived/NULL classification instead of forcing explicit cable (#635).
+    val isBodyweight: Boolean? = null,
     val prPercentage: Float? = null,
     val repCountTiming: String? = null,
     val stopAtPosition: String? = null,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/Exercise.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/Exercise.kt
@@ -32,6 +32,13 @@ data class Exercise(
     val cableIntent: ExerciseCableIntent? = null, // Explicit single/dual cable metadata when known
     val displayName: String = name, // Disambiguated name from catalog; defaults to base name
     val mvtOverrideMs: Float? = null, // User-set Minimum Velocity Threshold override (m/s) for velocity-1RM
+    /**
+     * Explicit stored bodyweight classification (issue #635). Sourced from the catalog
+     * (Exercise.isBodyweight column / exercise_dump.json) or the RoutineExercise snapshot
+     * (portal per-exercise toggle). Null = no explicit flag; derive from [hasCableAccessory]
+     * (custom exercises and rows predating migration 39).
+     */
+    val isBodyweightOverride: Boolean? = null,
 ) {
     /**
      * Whether this exercise uses any cable accessory (handles, bar, rope, etc.).
@@ -41,11 +48,13 @@ data class Exercise(
         get() = equipment.split(",").any { it.trim().uppercase() in CABLE_ACCESSORIES }
 
     /**
-     * Whether this is a bodyweight exercise (no cable accessories attached).
-     * Inverse of [hasCableAccessory] for readability at call sites.
+     * Whether this is a bodyweight exercise.
+     * Uses the explicit stored flag when present ([isBodyweightOverride]); falls back to
+     * equipment derivation for custom exercises and pre-migration-39 rows. The derivation
+     * alone is unreliable: catalog cable lifts can ship with an empty equipment list (#635).
      */
     val isBodyweight: Boolean
-        get() = !hasCableAccessory
+        get() = isBodyweightOverride ?: !hasCableAccessory
 
     /**
      * Preferred cable count for summary calculations when the exercise metadata is explicit.

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/RoutineTimeEstimator.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/usecase/RoutineTimeEstimator.kt
@@ -169,7 +169,7 @@ class RoutineTimeEstimator(private val workoutRepository: WorkoutRepository) {
         includeRest: Boolean = true,
     ): ExerciseEstimateResult {
         val exerciseId = exercise.exercise.id
-        val isBodyweight = !exercise.exercise.hasCableAccessory
+        val isBodyweight = exercise.exercise.isBodyweight
 
         // Try to get historical average set duration
         var historicalAvgMs: Long? = null

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/CreateExerciseDialog.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/CreateExerciseDialog.kt
@@ -51,7 +51,9 @@ fun CreateExerciseDialog(
             } ?: ExerciseCategory.CHEST,
         )
     }
-    var usesCables by remember(existingExercise?.equipment) {
+    // Key on the whole exercise: classification now also depends on
+    // isBodyweightOverride, not just the equipment string (#635).
+    var usesCables by remember(existingExercise) {
         mutableStateOf(existingExercise?.let { !it.isBodyweight } ?: true)
     }
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/CreateExerciseDialog.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/CreateExerciseDialog.kt
@@ -52,7 +52,7 @@ fun CreateExerciseDialog(
         )
     }
     var usesCables by remember(existingExercise?.equipment) {
-        mutableStateOf(existingExercise?.hasCableAccessory ?: true)
+        mutableStateOf(existingExercise?.let { !it.isBodyweight } ?: true)
     }
 
     var showMuscleGroupDropdown by remember { mutableStateOf(false) }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/RoutineExerciseDetailText.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/RoutineExerciseDetailText.kt
@@ -19,8 +19,8 @@ fun routineExerciseDetailText(
     weightUnit: WeightUnit,
     kgToDisplay: (Float, WeightUnit) -> Float,
 ): String {
-    // Bodyweight = no cable accessories (handles, bar, rope, etc.) in equipment list
-    val isBodyweight = !exercise.exercise.hasCableAccessory
+    // #635: explicit stored flag with equipment-derivation fallback
+    val isBodyweight = exercise.exercise.isBodyweight
 
     return if (isBodyweight) {
         // Bodyweight exercise - always duration, never reps (no cables engaged)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/cycle/TemplatePreviewEditSheet.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/cycle/TemplatePreviewEditSheet.kt
@@ -213,14 +213,13 @@ fun TemplatePreviewEditSheet(
                             exerciseName = exercise.name,
                             sets = 3,
                             reps = 10,
-                            // Always stamp added exercises as cable (OldSchool). The catalog's
-                            // equipment metadata is unreliable for classification — Squat and
-                            // Good Morning ship with equipment=[] (isBodyweight=true!) while
-                            // Crunch ships with HANDLES — so trusting Exercise.isBodyweight
-                            // here silently disables live %-of-1RM scaling on major lifts.
-                            // Wrongly-cable is the safer failure: a visible, skippable 1RM
-                            // prompt and an editable weight, instead of silent no-scaling.
-                            suggestedMode = ProgramMode.OldSchool,
+                            // #635: Exercise.isBodyweight is now an explicit stored flag
+                            // (catalog column + migration 39), not an equipment-string
+                            // derivation, so it is safe to trust here. Bodyweight
+                            // exercises get suggestedMode = null (TemplateConverter's
+                            // bodyweight proxy); cable exercises get OldSchool with
+                            // %-of-1RM scaling.
+                            suggestedMode = if (exercise.isBodyweight) null else ProgramMode.OldSchool,
                             exerciseId = exercise.id,
                             percentOfOneRm = defaultPercentOfOneRmForReps(10),
                         )

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -817,7 +817,7 @@ class ActiveSessionEngine(
         selectedVariant: BodyweightVariantOption? = null,
     ): WorkoutState.SetSummary {
         if (currentExercise == null) return summary
-        if (currentExercise.exercise.hasCableAccessory) return summary
+        if (!currentExercise.exercise.isBodyweight) return summary
         if (bodyWeightKg <= 0f) return summary
 
         val exerciseName = currentExercise.exercise.name

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/RoutineFlowManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/RoutineFlowManager.kt
@@ -1806,9 +1806,12 @@ class RoutineFlowManager(
     replaceWith = ReplaceWith("exercise?.exercise?.isBodyweight ?: false"),
 )
 internal fun isBodyweightExercise(exercise: RoutineExercise?): Boolean = exercise?.let {
-    val isBodyweight = !it.exercise.hasCableAccessory
+    // #635: delegate to the property so the explicit stored flag is honored;
+    // never re-derive from the equipment string here.
+    val isBodyweight = it.exercise.isBodyweight
     Logger.d {
-        "isBodyweightExercise: exercise=${it.exercise.name}, equipment='${it.exercise.equipment}', hasCableAccessory=${it.exercise.hasCableAccessory}, result=$isBodyweight"
+        "isBodyweightExercise: exercise=${it.exercise.name}, equipment='${it.exercise.equipment}', " +
+            "override=${it.exercise.isBodyweightOverride}, result=$isBodyweight"
     }
     isBodyweight
 } ?: false

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/routine/RoutineExerciseDefaults.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/routine/RoutineExerciseDefaults.kt
@@ -16,7 +16,7 @@ fun buildDefaultRoutineExerciseForEditor(
     supersetId: String? = null,
     orderInSuperset: Int = 0,
 ): RoutineExercise {
-    val shouldSeedPercent = userPreferences.defaultRoutineExerciseUsePercentOfPR && selectedExercise.hasCableAccessory
+    val shouldSeedPercent = userPreferences.defaultRoutineExerciseUsePercentOfPR && !selectedExercise.isBodyweight
     val defaultPercent = userPreferences.defaultRoutineExerciseWeightPercentOfPR.coerceIn(50, 120)
     val defaultScalingBasis = userPreferences.defaultScalingBasis
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RoutineOverviewScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RoutineOverviewScreen.kt
@@ -563,8 +563,8 @@ private fun ExerciseOverviewCard(
 ) {
     val maxWeightKg = Constants.MAX_WEIGHT_PER_CABLE_KG
 
-    // Bodyweight = no cable accessories (handles, bar, rope, etc.) in equipment list
-    val isBodyweight = !exercise.exercise.hasCableAccessory
+    // #635: explicit stored flag with equipment-derivation fallback
+    val isBodyweight = exercise.exercise.isBodyweight
 
     Card(
         modifier = Modifier.fillMaxSize(),

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RoutinesTab.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RoutinesTab.kt
@@ -1510,7 +1510,7 @@ private fun formatEstimatedDuration(routine: Routine): String {
 private fun estimateSetWorkSeconds(exercise: com.devil.phoenixproject.domain.model.RoutineExercise, setIndex: Int): Int {
     val reps = exercise.setReps.getOrNull(setIndex)
     return when {
-        !exercise.exercise.hasCableAccessory -> (exercise.duration ?: 30).coerceAtLeast(0)
+        exercise.exercise.isBodyweight -> (exercise.duration ?: 30).coerceAtLeast(0)
 
         reps == null -> 30
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SetReadyScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SetReadyScreen.kt
@@ -150,8 +150,8 @@ fun SetReadyScreen(navController: NavController, viewModel: MainViewModel, exerc
     val isEchoMode = currentExercise.programMode is ProgramMode.Echo
     val isAMRAP = currentExercise.isAMRAP
 
-    // Bodyweight = no cable accessories (handles, bar, rope, etc.) in equipment list
-    val isBodyweight = !currentExercise.exercise.hasCableAccessory
+    // #635: explicit stored flag with equipment-derivation fallback
+    val isBodyweight = currentExercise.exercise.isBodyweight
     val matchingWeightRecommendation = weightRecommendation?.takeIf { recommendation ->
         !isBodyweight &&
             recommendation.targetExerciseId == currentExercise.exercise.id &&

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/WorkoutTab.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/WorkoutTab.kt
@@ -617,7 +617,7 @@ fun WorkoutTab(
                             nextExerciseName.startsWith(it.exercise.name) ||
                             nextExerciseName.startsWith(it.exercise.displayName)
                     }
-                    val isNextBodyweight = nextExercise?.exercise?.hasCableAccessory != true
+                    val isNextBodyweight = nextExercise?.exercise?.isBodyweight != false
                     val showNextProgression = !isNextBodyweight && workoutParameters.programMode != ProgramMode.Echo
 
                     RestTimerCard(

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModel.kt
@@ -179,7 +179,7 @@ class ExerciseConfigViewModel constructor(
         displayToKg = toKg
         activeProfileId = profileId
 
-        _exerciseType.value = if (!exercise.exercise.hasCableAccessory) {
+        _exerciseType.value = if (exercise.exercise.isBodyweight) {
             ExerciseType.BODYWEIGHT
         } else {
             ExerciseType.STANDARD

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/BackupModels.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/BackupModels.kt
@@ -174,6 +174,9 @@ data class RoutineExerciseBackup(
     // Velocity-based 1RM scaling basis (issue #517 Phase 3); enum name or null.
     // Default null keeps pre-existing backup files loadable.
     val scalingBasis: String? = null,
+    // Explicit bodyweight classification (issue #635); null = derive from equipment.
+    // Default null keeps pre-existing backup files loadable.
+    val isBodyweight: Boolean? = null,
 )
 
 /**

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/DataBackupManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/DataBackupManager.kt
@@ -166,6 +166,13 @@ abstract class BaseDataBackupManager(
         /** Batch size for metric sample transactions in streaming import. */
         const val IMPORT_BATCH_SIZE = 5_000
 
+        /**
+         * Legacy pull-sync sentinel written into RoutineExercise.exerciseEquipment before
+         * migration 39 (#635). Old backup files may still carry it; restore converts it
+         * to the explicit isBodyweight flag.
+         */
+        const val LEGACY_BODYWEIGHT_SENTINEL = "Bodyweight"
+
         /** Files at or above this size use streaming import to avoid OOM. */
         const val STREAMING_IMPORT_THRESHOLD = 50L * 1024 * 1024 // 50 MB
     }
@@ -581,7 +588,7 @@ abstract class BaseDataBackupManager(
                                 routineId = exercise.routineId,
                                 exerciseName = exercise.exerciseName,
                                 exerciseMuscleGroup = exercise.exerciseMuscleGroup,
-                                exerciseEquipment = exercise.exerciseEquipment,
+                                exerciseEquipment = resolveBackupEquipment(exercise),
                                 exerciseDefaultCableConfig = exercise.exerciseDefaultCableConfig,
                                 exerciseId = exercise.exerciseId,
                                 cableConfig = exercise.cableConfig,
@@ -614,6 +621,7 @@ abstract class BaseDataBackupManager(
                                 scalingBasis = exercise.scalingBasis?.let {
                                     runCatching { com.devil.phoenixproject.domain.model.ScalingBasis.valueOf(it) }.getOrNull()
                                 }?.name,
+                                isBodyweight = resolveBackupIsBodyweight(exercise),
                             )
                         }
                         if (inserted != null) routineExercisesImported++
@@ -1337,7 +1345,7 @@ abstract class BaseDataBackupManager(
                                                         routineId = exercise.routineId,
                                                         exerciseName = exercise.exerciseName,
                                                         exerciseMuscleGroup = exercise.exerciseMuscleGroup,
-                                                        exerciseEquipment = exercise.exerciseEquipment,
+                                                        exerciseEquipment = resolveBackupEquipment(exercise),
                                                         exerciseDefaultCableConfig = exercise.exerciseDefaultCableConfig,
                                                         exerciseId = exercise.exerciseId,
                                                         cableConfig = exercise.cableConfig,
@@ -1370,6 +1378,7 @@ abstract class BaseDataBackupManager(
                                                         scalingBasis = exercise.scalingBasis?.let {
                                                             runCatching { com.devil.phoenixproject.domain.model.ScalingBasis.valueOf(it) }.getOrNull()
                                                         }?.name,
+                                                        isBodyweight = resolveBackupIsBodyweight(exercise),
                                                     )
                                                 }
                                                 if (inserted != null) {
@@ -2368,7 +2377,24 @@ abstract class BaseDataBackupManager(
         rackBehaviorOverrides = exercise.rackBehaviorOverrides,
         // scalingBasis is stored as the enum name (TEXT) on the DB row; persist it verbatim.
         scalingBasis = exercise.scalingBasis,
+        // Explicit bodyweight flag (#635); null = derive from equipment.
+        isBodyweight = exercise.isBodyweight?.let { it != 0L },
     )
+
+    /**
+     * Resolve the explicit isBodyweight flag for a restored routine exercise (#635).
+     * Pre-migration-39 backups carried a 'Bodyweight' sentinel in exerciseEquipment
+     * instead of an explicit flag; convert it on restore just like migration 39 does.
+     */
+    private fun resolveBackupIsBodyweight(exercise: RoutineExerciseBackup): Long? = when {
+        exercise.isBodyweight != null -> if (exercise.isBodyweight) 1L else 0L
+        exercise.exerciseEquipment == LEGACY_BODYWEIGHT_SENTINEL -> 1L
+        else -> null
+    }
+
+    /** Strip the legacy 'Bodyweight' equipment sentinel from pre-migration-39 backups (#635). */
+    private fun resolveBackupEquipment(exercise: RoutineExerciseBackup): String =
+        if (exercise.exerciseEquipment == LEGACY_BODYWEIGHT_SENTINEL) "" else exercise.exerciseEquipment
 
     private fun decodeRackItemIds(encoded: String): List<String> = runCatching {
         if (encoded.isBlank()) {

--- a/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
+++ b/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
@@ -31,7 +31,10 @@ CREATE TABLE Exercise (
     serverId TEXT,
     deletedAt INTEGER,
     -- Per-exercise MVT override (added in migration 37, issue #517)
-    mvtOverrideMs REAL
+    mvtOverrideMs REAL,
+    -- Explicit bodyweight classification (added in migration 39, issue #635)
+    -- NULL = derive from equipment; 0 = cable; 1 = bodyweight
+    isBodyweight INTEGER
 );
 
 CREATE INDEX idx_exercise_popularity ON Exercise(popularity DESC, name ASC);
@@ -251,6 +254,10 @@ CREATE TABLE RoutineExercise (
     warmupSets TEXT NOT NULL DEFAULT '',
     defaultRackItemIds TEXT NOT NULL DEFAULT '[]',
     rackBehaviorOverrides TEXT NOT NULL DEFAULT '{}',
+    -- Explicit bodyweight classification (added in migration 39, issue #635)
+    -- NULL = derive from equipment; 0 = cable; 1 = bodyweight. Replaces the
+    -- legacy pull-sync 'Bodyweight' sentinel in exerciseEquipment.
+    isBodyweight INTEGER,
     FOREIGN KEY (routineId) REFERENCES Routine(id) ON DELETE CASCADE,
     FOREIGN KEY (exerciseId) REFERENCES Exercise(id) ON DELETE SET NULL,
     FOREIGN KEY (supersetId) REFERENCES Superset(id) ON DELETE SET NULL
@@ -550,9 +557,9 @@ INSERT OR REPLACE INTO Exercise (
     id, name, displayName, description, created, muscleGroup, muscleGroups, muscles,
     equipment, movement, sidedness, grip, gripWidth, minRepRange,
     popularity, archived, isFavorite, isCustom, timesPerformed, lastPerformed,
-    aliases, defaultCableConfig, one_rep_max_kg, mvtOverrideMs
+    aliases, defaultCableConfig, one_rep_max_kg, mvtOverrideMs, isBodyweight
 )
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 countExercises:
 SELECT COUNT(*) FROM Exercise;
@@ -1135,9 +1142,9 @@ INSERT INTO RoutineExercise (
     perSetRestTime, isAMRAP, supersetId, orderInSuperset,
     usePercentOfPR, weightPercentOfPR, prTypeForScaling, setWeightsPercentOfPR,
     stallDetectionEnabled, stopAtTop, repCountTiming, setEchoLevels, warmupSets, defaultRackItemIds,
-    rackBehaviorOverrides, scalingBasis
+    rackBehaviorOverrides, scalingBasis, isBodyweight
 )
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 -- Insert with IGNORE for import (won't overwrite existing)
 insertRoutineExerciseIgnore:
@@ -1148,9 +1155,9 @@ INSERT OR IGNORE INTO RoutineExercise (
     perSetRestTime, isAMRAP, supersetId, orderInSuperset,
     usePercentOfPR, weightPercentOfPR, prTypeForScaling, setWeightsPercentOfPR,
     stallDetectionEnabled, stopAtTop, repCountTiming, setEchoLevels, warmupSets, defaultRackItemIds,
-    rackBehaviorOverrides, scalingBasis
+    rackBehaviorOverrides, scalingBasis, isBodyweight
 )
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 deleteRoutineExercises:
 DELETE FROM RoutineExercise WHERE routineId = ?;

--- a/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/migrations/39.sqm
+++ b/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/migrations/39.sqm
@@ -32,3 +32,17 @@ UPDATE RoutineExercise SET isBodyweight = 0 WHERE exerciseId IN (
     '2nTn2QR6MyezFYmK',
     'fAglxv8VMaisUTyo'
 );
+
+-- Legacy rows can carry a NULL or stale exerciseId (the loader heals them by
+-- name at load time), so also match the known cable lifts by snapshot name.
+-- TRIM handles the catalog's trailing-space 'Kneeling 45 Degree Kickback '.
+-- The IS NULL guard preserves explicit flags set above (e.g. a portal
+-- bodyweight toggle converted from the sentinel).
+UPDATE RoutineExercise SET isBodyweight = 0
+WHERE isBodyweight IS NULL AND TRIM(exerciseName) IN (
+    'Squat',
+    'Good Morning',
+    'Medial Delt Twist',
+    'Kneeling 45 Degree Kickback',
+    'Just Lift exercise'
+);

--- a/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/migrations/39.sqm
+++ b/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/migrations/39.sqm
@@ -1,0 +1,34 @@
+-- Migration 39: explicit isBodyweight classification — issue #635.
+-- Exercise.isBodyweight was derived from the equipment string, misclassifying
+-- empty-equipment cable lifts as bodyweight. A dedicated nullable column now
+-- stores the explicit flag (NULL = derive from equipment; 0 = cable; 1 = bodyweight).
+-- Also retires the pull-sync 'Bodyweight' sentinel written into
+-- RoutineExercise.exerciseEquipment, which permanently corrupted classification.
+
+ALTER TABLE Exercise ADD COLUMN isBodyweight INTEGER;
+ALTER TABLE RoutineExercise ADD COLUMN isBodyweight INTEGER;
+
+-- Catalog fix: cable lifts that ship with equipment=[] in exercise_dump.json.
+UPDATE Exercise SET isBodyweight = 0 WHERE id IN (
+    'UjIGHxCav-lS9B2I',  -- Squat
+    'enuJ_FgAzXDLAweK',  -- Good Morning
+    'KoL_gx00nuf2wncV',  -- Medial Delt Twist
+    'kSLyRg4bjLuzTeIM',  -- Medial Delt Twist (duplicate catalog entry)
+    '2nTn2QR6MyezFYmK',  -- Kneeling 45 Degree Kickback
+    'fAglxv8VMaisUTyo'   -- Just Lift exercise
+);
+
+-- Convert the legacy pull-sync sentinel to the new column and clear the fake
+-- equipment value so classification no longer round-trips through equipment.
+UPDATE RoutineExercise SET isBodyweight = 1, exerciseEquipment = ''
+WHERE exerciseEquipment = 'Bodyweight';
+
+-- Force-correct routine exercises referencing the misclassified cable lifts.
+UPDATE RoutineExercise SET isBodyweight = 0 WHERE exerciseId IN (
+    'UjIGHxCav-lS9B2I',
+    'enuJ_FgAzXDLAweK',
+    'KoL_gx00nuf2wncV',
+    'kSLyRg4bjLuzTeIM',
+    '2nTn2QR6MyezFYmK',
+    'fAglxv8VMaisUTyo'
+);

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/ConflictResolutionTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/ConflictResolutionTest.kt
@@ -238,6 +238,7 @@ class ConflictResolutionTest {
             defaultRackItemIds = "[]",
             rackBehaviorOverrides = "{}",
             scalingBasis = null,
+            isBodyweight = null,
         )
 
         // Verify exercise exists

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/ExerciseTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/model/ExerciseTest.kt
@@ -52,6 +52,70 @@ class ExerciseTest {
     }
 
     @Test
+    fun `isBodyweight override wins over equipment derivation in both directions`() {
+        // #635: Squat ships with equipment=[] but is a cable lift — explicit flag wins
+        val emptyEquipmentCableLift = Exercise(
+            name = "Squat",
+            muscleGroup = "Legs",
+            equipment = "",
+            isBodyweightOverride = false,
+        )
+        assertEquals(false, emptyEquipmentCableLift.isBodyweight)
+
+        // Inverse direction: explicit bodyweight despite a cable-accessory tag
+        val taggedBodyweight = Exercise(
+            name = "Weighted-tag Bodyweight",
+            muscleGroup = "Core",
+            equipment = "HANDLES",
+            isBodyweightOverride = true,
+        )
+        assertEquals(true, taggedBodyweight.isBodyweight)
+    }
+
+    @Test
+    fun `isBodyweight falls back to equipment derivation when override is null`() {
+        val noEquipment = Exercise(
+            name = "Push Up",
+            muscleGroup = "Chest",
+            equipment = "",
+        )
+        assertEquals(true, noEquipment.isBodyweight)
+
+        val cableEquipment = Exercise(
+            name = "Bench Press",
+            muscleGroup = "Chest",
+            equipment = "BAR,BENCH",
+        )
+        assertEquals(false, cableEquipment.isBodyweight)
+
+        // BENCH alone is not a cable accessory
+        val benchOnly = Exercise(
+            name = "Tricep Dips",
+            muscleGroup = "Triceps",
+            equipment = "BENCH",
+        )
+        assertEquals(true, benchOnly.isBodyweight)
+    }
+
+    @Test
+    fun `isBodyweight override does not affect hasCableAccessory or display multiplier`() {
+        val exercise = Exercise(
+            name = "Squat",
+            muscleGroup = "Legs",
+            equipment = "",
+            cableIntent = ExerciseCableIntent.DUAL,
+            isBodyweightOverride = false,
+        )
+
+        // Equipment-based properties keep their original derivation semantics
+        assertEquals(false, exercise.hasCableAccessory)
+        assertEquals(false, exercise.usesUnifiedAttachment)
+        assertEquals(1, exercise.displayMultiplier)
+        // While classification honors the explicit flag
+        assertEquals(false, exercise.isBodyweight)
+    }
+
+    @Test
     fun `live unified accessory display multiplier doubles only dual bar or belt exercises`() {
         val dualBar = Exercise(
             name = "Bench Press",

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/RestTimerProgressionWiringTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/RestTimerProgressionWiringTest.kt
@@ -31,8 +31,9 @@ class RestTimerProgressionWiringTest {
             "WorkoutTab.kt must guard Rest Timer progression for non-Echo next sets only.",
         )
         assertTrue(
-            src.contains("nextExercise?.exercise?.hasCableAccessory != true"),
-            "WorkoutTab.kt must use the canonical Exercise.hasCableAccessory bodyweight guard before showing Rest Timer progression.",
+            src.contains("nextExercise?.exercise?.isBodyweight != false"),
+            "WorkoutTab.kt must use the canonical Exercise.isBodyweight guard (explicit stored flag, #635) " +
+                "before showing Rest Timer progression — never re-derive from hasCableAccessory/equipment.",
         )
         assertFalse(
             src.contains("nextEquipment.isEmpty()") || src.contains("nextEquipment.equals(\"bodyweight\""),

--- a/shared/src/iosMain/kotlin/com/devil/phoenixproject/data/local/DriverFactory.ios.kt
+++ b/shared/src/iosMain/kotlin/com/devil/phoenixproject/data/local/DriverFactory.ios.kt
@@ -140,7 +140,11 @@ private class ResilientMigratingSchema(
                 NSLog("iOS DB: Migration to version $stepTo succeeded")
             } catch (e: Exception) {
                 NSLog("iOS DB: Migration $stepTo failed (${e.message?.take(120)}), applying resilient fallback")
-                val results = applyMigrationResilient(driver, stepTo.toInt())
+                // getMigrationStatements is keyed by the .sqm file number — the version
+                // being migrated FROM ($version), not the target ($stepTo). Passing the
+                // target replayed the NEXT migration's statements and skipped the failed
+                // one's data fixes entirely (#636 review).
+                val results = applyMigrationResilient(driver, version.toInt())
                 val failures = results.count { !it.success && !it.recoverable }
                 if (failures > 0) {
                     NSLog("iOS DB: Migration $stepTo had $failures non-recoverable failures")


### PR DESCRIPTION
Closes #635.

## Problem
`Exercise.isBodyweight` was derived as `!hasCableAccessory` from the equipment string. Six catalog cable lifts ship with `equipment: []` (Squat, Good Morning, Medial Delt Twist ×2, Kneeling 45° Kickback, Just Lift exercise) and classified as bodyweight app-wide: warmup sets silently skipped, BLE start replaced by a countdown timer, DURATION mode forced, cable-only edit controls hidden, and `isBodyweight=true` shipped to the portal on every sync.

Two compounding defects found during implementation:
1. **Pull-sync corruption loop** — the pull path wrote a literal `"Bodyweight"` string into `RoutineExercise.exerciseEquipment`; snapshot Exercises re-derived bodyweight from it forever, and the next push re-sent the wrong flag.
2. **Catalog fixes don't propagate** — `importExercises()` is a no-op once seeded, so JSON edits alone never reach existing installs.

## Fix
- **Migration 39**: nullable `isBodyweight` column on `Exercise` + `RoutineExercise` (`NULL` = derive from equipment, `0` = cable, `1` = bodyweight). Backfills the 6 catalog IDs, converts `"Bodyweight"` sentinel rows to the explicit flag, and clears the fake equipment value.
- **Model**: `Exercise.isBodyweightOverride: Boolean?`; `isBodyweight` honors the stored flag with derivation fallback for custom exercises / pre-migration rows. `hasCableAccessory` / `usesUnifiedAttachment` / `displayMultiplier` semantics untouched.
- **Sync**: pull stores the portal's per-exercise toggle in the new column (portal user intent honored); push sends `ex.exercise.isBodyweight`. **Wire format unchanged — no portal changes required.**
- **Importer**: JSON `isBodyweight` field + `KNOWN_NON_BODYWEIGHT_IDS` override set, because `updateFromGitHub()` pulls from the upstream `VitruvianFitness/exercise-library` repo which will never carry the field — without the override set, a manual library refresh would revert the fix.
- **Backup/restore**: `RoutineExerciseBackup.isBodyweight` (default null, old files loadable); legacy sentinel backups converted on restore.
- **Consumers**: all 10 direct `!hasCableAccessory` bodyweight derivations now route through `Exercise.isBodyweight`.
- **#633 revert**: `TemplatePreviewEditSheet` derives `suggestedMode` from the now-reliable flag instead of force-stamping OldSchool.

## Catalog audit
All 111 empty-equipment entries reviewed; the 6 above are the complete correction set (the rest are push-up/plank/stretch/jump/burpee variants). Crunch (`HANDLES`) intentionally stays cable per issue triage.

## Verification
- `:shared:testAndroidHostTest` — 2339 tests green, including new migration-39 backfill/sentinel test, `Exercise` override-precedence tests, and a pull-sync equipment-corruption regression test
- `:androidApp:testDebugUnitTest` — green
- `:androidApp:assembleDebug` — builds

## Remaining risk
- Device validation pending: build a routine with Squat → warmup sets present, cable controls visible, BLE start path (not countdown timer); template preview adding Plank → bodyweight path.
- Pre-existing, out of scope: the picker's "Bodyweight" equipment filter (`ExercisePicker.kt:94`) only matches custom exercises with a literal `BODYWEIGHT` token — it never matched catalog entries. Worth a follow-up issue to filter on the new flag.

https://claude.ai/code/session_015hLWDq5QLjBpRwUYAec23o