### PR TITLE
feat(#646): label set types in workout UI

### DIFF
--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -700,5 +700,9 @@
     <string name="cd_equipment_rack">Equipment-Rack</string>
     <string name="bodyweight_effective_load_includes">Inklusive: %1$s</string>
     <string name="bodyweight_effective_load_more">+%1$d weitere</string>
+    <!-- ==================== Set type labels (Issue #646) ==================== -->
+    <string name="set_type_calibration">Calibration Reps</string>
+    <string name="set_type_warmup">Warm-up Set %1$d</string>
+    <string name="set_type_working">Working Set</string>
 
 </resources>

--- a/shared/src/commonMain/composeResources/values-es/strings.xml
+++ b/shared/src/commonMain/composeResources/values-es/strings.xml
@@ -700,5 +700,9 @@
     <string name="cd_equipment_rack">Rack de equipamiento</string>
     <string name="bodyweight_effective_load_includes">Incluye: %1$s</string>
     <string name="bodyweight_effective_load_more">+%1$d más</string>
+    <!-- ==================== Set type labels (Issue #646) ==================== -->
+    <string name="set_type_calibration">Calibration Reps</string>
+    <string name="set_type_warmup">Warm-up Set %1$d</string>
+    <string name="set_type_working">Working Set</string>
 
 </resources>

--- a/shared/src/commonMain/composeResources/values-fr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fr/strings.xml
@@ -700,5 +700,9 @@
     <string name="cd_equipment_rack">Rack d\'équipement</string>
     <string name="bodyweight_effective_load_includes">Inclus : %1$s</string>
     <string name="bodyweight_effective_load_more">+%1$d de plus</string>
+    <!-- ==================== Set type labels (Issue #646) ==================== -->
+    <string name="set_type_calibration">Calibration Reps</string>
+    <string name="set_type_warmup">Warm-up Set %1$d</string>
+    <string name="set_type_working">Working Set</string>
 
 </resources>

--- a/shared/src/commonMain/composeResources/values-it/strings.xml
+++ b/shared/src/commonMain/composeResources/values-it/strings.xml
@@ -67,5 +67,9 @@
     <string name="settings_ble_compat_on">Attivato</string>
     <string name="settings_ble_compat_off">Disattivato</string>
     <string name="settings_ble_compat_reconnect_hint">Ha effetto alla prossima connessione. Riconnettiti al trainer dopo la modifica.</string>
+    <!-- ==================== Set type labels (Issue #646) ==================== -->
+    <string name="set_type_calibration">Calibration Reps</string>
+    <string name="set_type_warmup">Warm-up Set %1$d</string>
+    <string name="set_type_working">Working Set</string>
 
 </resources>

--- a/shared/src/commonMain/composeResources/values-nl/strings.xml
+++ b/shared/src/commonMain/composeResources/values-nl/strings.xml
@@ -679,5 +679,9 @@
     <string name="cd_equipment_rack">Equipment rack</string>
     <string name="bodyweight_effective_load_includes">Inclusief: %1$s</string>
     <string name="bodyweight_effective_load_more">+%1$d meer</string>
+    <!-- ==================== Set type labels (Issue #646) ==================== -->
+    <string name="set_type_calibration">Calibration Reps</string>
+    <string name="set_type_warmup">Warm-up Set %1$d</string>
+    <string name="set_type_working">Working Set</string>
 
 </resources>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -765,6 +765,10 @@
     <string name="equipment_rack_selected_count">%1$d selected</string>
     <string name="equipment_rack_inline_context">Rack: %1$s</string>
     <string name="detailed_metrics_not_captured">Detailed metrics were not captured for this set</string>
+    <!-- ==================== Set type labels (Issue #646) ==================== -->
+    <string name="set_type_calibration">Calibration Reps</string>
+    <string name="set_type_warmup">Warm-up Set %1$d</string>
+    <string name="set_type_working">Working Set</string>
     <string name="equipment_rack_category_weighted_vest">Weighted vest</string>
     <string name="equipment_rack_category_dip_belt">Dip belt</string>
     <string name="equipment_rack_category_chains">Chains</string>

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SetReadyScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SetReadyScreen.kt
@@ -51,6 +51,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import com.devil.phoenixproject.domain.model.RepCount
+import com.devil.phoenixproject.presentation.util.SetTypeLabel
+import com.devil.phoenixproject.presentation.util.setTypeLabel
 import com.devil.phoenixproject.ui.theme.screenBackgroundBrush
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.Role
@@ -106,6 +109,8 @@ import vitruvianprojectphoenix.shared.generated.resources.equipment_rack_save_ov
 import vitruvianprojectphoenix.shared.generated.resources.equipment_rack_save_override_title
 import vitruvianprojectphoenix.shared.generated.resources.exit_routine_message
 import vitruvianprojectphoenix.shared.generated.resources.exit_routine_title
+import vitruvianprojectphoenix.shared.generated.resources.set_type_warmup
+import vitruvianprojectphoenix.shared.generated.resources.set_type_working
 import vitruvianprojectphoenix.shared.generated.resources.target_reps
 
 /**
@@ -124,6 +129,9 @@ fun SetReadyScreen(navController: NavController, viewModel: MainViewModel, exerc
     val weightRecommendation by viewModel.weightAdjustmentRecommendation.collectAsState()
     val rackItems by viewModel.rackItems.collectAsState()
     val activeRackItemIds by viewModel.activeRackItemIds.collectAsState()
+    // Issue #646: drive set-type badge in SetReady header
+    val currentWarmupSetIndex by viewModel.currentWarmupSetIndex.collectAsState()
+    val repCount by viewModel.repCount.collectAsState()
 
     // Get current state
     val setReadyState = routineFlowState as? RoutineFlowState.SetReady
@@ -435,6 +443,21 @@ fun SetReadyScreen(navController: NavController, viewModel: MainViewModel, exerc
                             style = MaterialTheme.typography.labelMedium,
                             color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.72f),
                         )
+                        // Issue #646: set-type badge — calibration label suppressed at SetReady
+                        // (calibration reps run during the active set, not at this screen)
+                        val setType = setTypeLabel(repCount, currentWarmupSetIndex, showCalibrationLabel = false)
+                        val setTypeText = when (setType) {
+                            is SetTypeLabel.Warmup -> stringResource(Res.string.set_type_warmup, setType.setNumber)
+                            SetTypeLabel.Working -> stringResource(Res.string.set_type_working)
+                            SetTypeLabel.Calibration -> "" // unreachable; showCalibrationLabel=false
+                        }
+                        if (setTypeText.isNotEmpty()) {
+                            Text(
+                                text = setTypeText,
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.72f),
+                            )
+                        }
                     }
                 }
             }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/WorkoutHud.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/WorkoutHud.kt
@@ -33,8 +33,10 @@ import com.devil.phoenixproject.presentation.components.ForceCurveMiniGraph
 import com.devil.phoenixproject.presentation.components.StableRepProgress
 import com.devil.phoenixproject.presentation.util.LocalWindowSizeClass
 import com.devil.phoenixproject.presentation.util.ResponsiveDimensions
+import com.devil.phoenixproject.presentation.util.SetTypeLabel
 import com.devil.phoenixproject.presentation.util.WindowWidthSizeClass
 import com.devil.phoenixproject.presentation.util.isCompactAccessibilityLayout
+import com.devil.phoenixproject.presentation.util.setTypeLabel
 import com.devil.phoenixproject.ui.theme.AccessibilityTheme
 import com.devil.phoenixproject.ui.theme.velocityZoneColor
 import com.devil.phoenixproject.ui.theme.velocityZoneLabel
@@ -82,6 +84,7 @@ fun WorkoutHud(
     onResetExerciseTimer: () -> Unit = {},
     velocityLossThresholdPercent: Int = 20,
     rackLoadAdjustment: RackLoadAdjustment = RackLoadAdjustment(),
+    currentWarmupSetIndex: Int = -1, // Issue #646: -1 = no warm-up phase
     modifier: Modifier = Modifier,
 ) {
     // Determine if we're in Echo mode
@@ -172,6 +175,7 @@ fun WorkoutHud(
                             onPauseExerciseTimer = onPauseExerciseTimer,
                             onResumeExerciseTimer = onResumeExerciseTimer,
                             onResetExerciseTimer = onResetExerciseTimer,
+                            currentWarmupSetIndex = currentWarmupSetIndex,
                         )
                     }
 
@@ -471,6 +475,7 @@ private fun ExecutionPage(
     onPauseExerciseTimer: () -> Unit = {},
     onResumeExerciseTimer: () -> Unit = {},
     onResetExerciseTimer: () -> Unit = {},
+    currentWarmupSetIndex: Int = -1, // Issue #646: -1 = no warm-up phase
 ) {
     // Issue #192: Check if this is a timed exercise
     val isTimedExercise = timedExerciseRemainingSeconds != null
@@ -505,6 +510,20 @@ private fun ExecutionPage(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
+
+            // Issue #646: set-type badge (Calibration Reps / Warm-up Set N / Working Set)
+            val setType = setTypeLabel(repCount, currentWarmupSetIndex, showCalibrationLabel = true)
+            val setTypeText = when (setType) {
+                SetTypeLabel.Calibration -> stringResource(Res.string.set_type_calibration)
+                is SetTypeLabel.Warmup -> stringResource(Res.string.set_type_warmup, setType.setNumber)
+                SetTypeLabel.Working -> stringResource(Res.string.set_type_working)
+            }
+            Text(
+                text = setTypeText,
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.85f),
+            )
 
             Spacer(modifier = Modifier.height(24.dp))
         }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/WorkoutTab.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/WorkoutTab.kt
@@ -224,6 +224,7 @@ fun WorkoutTab(
         velocityLossThresholdPercent = state.velocityLossThresholdPercent,
         weightStepKg = state.weightStepKg,
         rackLoadAdjustment = state.rackLoadAdjustment,
+        currentWarmupSetIndex = state.currentWarmupSetIndex,
     )
 }
 
@@ -305,6 +306,8 @@ fun WorkoutTab(
     // Issue #266/#410: Configurable weight step from user preferences (kg)
     weightStepKg: Float = 0.25f,
     rackLoadAdjustment: RackLoadAdjustment = RackLoadAdjustment(),
+    // Issue #646: -1 means not currently in variable warm-up phase
+    currentWarmupSetIndex: Int = -1,
 ) {
     // Note: HapticFeedbackEffect is now global in EnhancedMainScreen
     // No need for local haptic effect here
@@ -342,6 +345,7 @@ fun WorkoutTab(
                 onResetExerciseTimer = onResetExerciseTimer,
                 velocityLossThresholdPercent = velocityLossThresholdPercent,
                 rackLoadAdjustment = rackLoadAdjustment,
+                currentWarmupSetIndex = currentWarmupSetIndex,
                 modifier = Modifier.fillMaxSize(),
             )
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/util/SetTypeLabel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/util/SetTypeLabel.kt
@@ -1,0 +1,39 @@
+package com.devil.phoenixproject.presentation.util
+
+import com.devil.phoenixproject.domain.model.RepCount
+
+/**
+ * Issue #646: pure-Kotlin helper for the workout set-type badge.
+ *
+ * Decides whether the active workout header should read
+ * "Calibration Reps" / "Warm-up Set N" / "Working Set".
+ *
+ * Kept free of `@Composable` and string resources so it stays trivially
+ * testable as plain JVM code. Call sites resolve the sealed label to a
+ * locale string via [com.devil.phoenixproject.presentation.R] mappings.
+ *
+ * `showCalibrationLabel` is `false` at Set Ready because the firmware
+ * calibration buffer runs during the active set, not at Set Ready.
+ */
+sealed class SetTypeLabel {
+    data object Calibration : SetTypeLabel()
+    data class Warmup(val setNumber: Int) : SetTypeLabel()
+    data object Working : SetTypeLabel()
+}
+
+// ponytail: 3 mirrors Constants.DEFAULT_WARMUP_REPS; revisit if firmware
+// calibration buffer size ever changes.
+private const val CALIBRATION_BUFFER_REPS = 3
+
+fun setTypeLabel(
+    repCount: RepCount,
+    currentWarmupSetIndex: Int,
+    showCalibrationLabel: Boolean,
+): SetTypeLabel = when {
+    showCalibrationLabel && repCount.warmupReps < CALIBRATION_BUFFER_REPS && !repCount.isWarmupComplete ->
+        SetTypeLabel.Calibration
+    currentWarmupSetIndex >= 0 ->
+        SetTypeLabel.Warmup(currentWarmupSetIndex + 1)
+    else ->
+        SetTypeLabel.Working
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/SetTypeLabelTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/SetTypeLabelTest.kt
@@ -1,0 +1,42 @@
+package com.devil.phoenixproject.presentation
+
+import com.devil.phoenixproject.domain.model.RepCount
+import com.devil.phoenixproject.presentation.util.SetTypeLabel
+import com.devil.phoenixproject.presentation.util.setTypeLabel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Issue #646: pin the helper that drives the active-workout set-type badge.
+ * Pure Kotlin, no Compose runtime.
+ */
+class SetTypeLabelTest {
+
+    @Test
+    fun calibration_when_buffer_incomplete() {
+        val rc = RepCount(warmupReps = 0, isWarmupComplete = false)
+        val label = setTypeLabel(rc, currentWarmupSetIndex = -1, showCalibrationLabel = true)
+        assertEquals(SetTypeLabel.Calibration, label)
+    }
+
+    @Test
+    fun working_when_buffer_complete() {
+        val rc = RepCount(warmupReps = 3, isWarmupComplete = true)
+        val label = setTypeLabel(rc, currentWarmupSetIndex = -1, showCalibrationLabel = true)
+        assertEquals(SetTypeLabel.Working, label)
+    }
+
+    @Test
+    fun warmup_during_variable_warmup_set_1() {
+        val rc = RepCount(warmupReps = 0, isWarmupComplete = false)
+        val label = setTypeLabel(rc, currentWarmupSetIndex = 0, showCalibrationLabel = false)
+        assertEquals(SetTypeLabel.Warmup(setNumber = 1), label)
+    }
+
+    @Test
+    fun working_when_no_warmup_index_at_setready() {
+        val rc = RepCount(warmupReps = 0, isWarmupComplete = false)
+        val label = setTypeLabel(rc, currentWarmupSetIndex = -1, showCalibrationLabel = false)
+        assertEquals(SetTypeLabel.Working, label)
+    }
+}


### PR DESCRIPTION
## What
Labels each set in the workout UI as **Calibration Reps** (first 3 ROM/calibration reps), **Warm-up Set N** (variable warm-up phase), or **Working Set** (routine default). Visible on the active workout HUD below the existing "Set X / Y" text and inline in the Set Ready header. Just Lift is unchanged.

## Why
Issue #646 reporter frequently forgets they have Warm-up Sets enabled for some exercises because the UI doesn't currently distinguish the firmware 3-rep ROM buffer (labeled "REP" / "WARMUP" in the rep counter) from variable warm-up sets and from working sets.

## Scope (bounded)
- 1 pure-Kotlin helper `setTypeLabel(repCount, currentWarmupSetIndex, showCalibrationLabel)` returning sealed `Calibration | Warmup(n) | Working` — no Compose runtime, no string resources, trivially testable.
- 4-line label render in `ExecutionPage`'s existing `!isJustLift && exerciseName != null` block (reuses existing weight, color, and spacing).
- Inline label in `SetReadyScreen` header next to the existing set picker (reuses existing mode picker typography).
- 6 locale string resources (English-default fallback acceptable per project pattern).
- 1 new param `currentWarmupSetIndex: Int = -1` plumbed `WorkoutTab` → `WorkoutHud` → `ExecutionPage`. `SetReadyScreen` collects `viewModel.currentWarmupSetIndex` directly.
- 4 pure-Kotlin helper unit tests.
- New `showCalibrationLabel = false` flag at the SetReady call site (calibration reps run during the active set, not at SetReady).

## Not in scope (unchanged)
- No BLE / protocol / packet change
- No DB migration, no schema change
- No SetSummaryCard Echo phase breakdown change
- No rename of the existing "REP" / "WARMUP" rep-counter labels
- No new design tokens (color, typography, shape)
- No telemetry / analytics hooks
- `ActiveSessionEngine`, `RoutineFlowManager`, `WorkoutCoordinator` untouched

## Compatibility
- Additive i18n keys only — no existing strings change.
- No data shape change — the label is purely derived from existing state.
- Old routines, old logs, all render correctly without migration.

## Risks
- **Drift between label and engine behavior** — mitigated by wiring the helper off the same `currentWarmupSetIndex` and `repCount` fields the engine already uses for runtime behavior.
- **Locale gap** — non-English locales get English fallback; future i18n PRs can localize per project pattern.
- **Calibration label false-positive at SetReady** — fixed by the `showCalibrationLabel = false` flag at that call site.
- **Future firmware buffer change** — the literal `3` in the helper is tied to `Constants.DEFAULT_WARMUP_REPS`; `ponytail:` comment in code documents the coupling.

## Tests
- New `SetTypeLabelTest.kt` — 4 pure-Kotlin helper tests, all green.
- Existing `:shared:testAndroidHostTest` suite (2431 tests) — 0 failures.
- Manual smoke on AVD required: see Visual Evidence section.

## Visual Evidence
To be added as a PR comment once emulator captures are complete (`final-visuals/android/*.png`).

## References
- Architecture: `phoenix-enhancements/issue-646-1525152789725188258/architecture.md`
- Integration Model: `phoenix-enhancements/issue-646-1525152789725188258/integration-model.md`
- Implementation Spec: `phoenix-enhancements/issue-646-1525152789725188258/implementation-spec.md`
- Signoff (approved 2026-07-10 by 9thLevelSoftware): `phoenix-enhancements/issue-646-1525152789725188258/signoff.md`
- Prototype: https://gist.github.com/9thLevelSoftware/5bf123a90c87aef44337aaad58dfc6a7

Fixes #646
