### PR TITLE
fix: defer AMRAP/stall auto-stop after verbal VBT cue when autoEndOnVelocityLoss=false (#649)

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -972,6 +972,10 @@ class ActiveSessionEngine(
         coordinator.stallStartTime = null
         coordinator.isCurrentlyStalled = false
         coordinator._autoStopState.value = AutoStopUiState()
+        // Issue #649: clear the verbal-cue defer so a new set never inherits a
+        // stale flag from the previous one (skip / restart paths included).
+        deferAutoStopUntilNextWorkingRep = false
+        deferAutoStopDeadlineMs = 0L
     }
 
     /**
@@ -1354,10 +1358,12 @@ class ActiveSessionEngine(
                     // timers end the set while the cue is still audible. Defer both timers
                     // until the user completes another working rep or the deadline
                     // (cue + short transition window) elapses; any later auto-end branch
-                    // (VBT or stall) proceeds normally.
+                    // (VBT or stall) proceeds normally. Publish deadline BEFORE flipping
+                    // the flag so a metrics-thread reader never sees flag=true with the
+                    // stale 0L deadline (cross-thread ordering with @Volatile fields).
                     if (!coordinator.autoEndOnVelocityLoss) {
-                        deferAutoStopUntilNextWorkingRep = true
                         deferAutoStopDeadlineMs = currentTimeMillis() + VERBAL_ENCOURAGEMENT_DEFER_WINDOW_MS
+                        deferAutoStopUntilNextWorkingRep = true
                         resetStallTimer()
                         resetAutoStopTimer()
                     }
@@ -1440,13 +1446,21 @@ class ActiveSessionEngine(
 
         // Issue #649: while a verbal VBT cue is still in flight and the user has VBT
         // auto-end OFF, neither AMRAP position nor velocity-stall may end the set.
-        // Reset the live countdowns defensively each metric; cleared on the next
-        // completed working rep, the deadline (cue + transition window), or at
-        // the per-set reset boundary.
-        if (deferAutoStopUntilNextWorkingRep) {
-            if (currentTimeMillis() >= deferAutoStopDeadlineMs) {
+        // Source of truth is the deadline field — flag is derived. The deadline is
+        // 0L when no defer is active; a metrics-thread reader can never observe
+        // `flag=true && deadline=0L` because the writer publishes the future
+        // deadline before flipping the flag (cross-thread ordering of two @Volatile
+        // fields isn't guaranteed, but a single @Volatile source eliminates the
+        // race by construction). Reset the live countdowns defensively each metric;
+        // cleared on the next completed working rep, deadline expiry, or at the
+        // per-set reset boundary / resetAutoStopState().
+        val deferDeadline = deferAutoStopDeadlineMs
+        if (deferDeadline != 0L) {
+            if (currentTimeMillis() >= deferDeadline) {
                 deferAutoStopUntilNextWorkingRep = false
+                deferAutoStopDeadlineMs = 0L
             } else {
+                deferAutoStopUntilNextWorkingRep = true
                 resetStallTimer()
                 resetAutoStopTimer()
                 return

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -243,20 +243,16 @@ class ActiveSessionEngine(
     private var velocityThresholdAlertEmitted = false
     private var consecutiveThresholdReps = 0
 
-    // Issue #649: defer position/stall auto-stop until the next completed working
-    // rep after a verbal VBT cue was emitted with autoEndOnVelocityLoss=false.
-    // Written on Dispatchers.Default in checkVelocityThreshold() and read on the
-    // metrics collection thread in checkAutoStop(); @Volatile keeps the cross-
-    // thread visibility without a wrapper holder.
-    // The deadline covers the verbal cue plus a short transition window so a user
-    // who rackets mid-set after the cue still gets normal AMRAP/stall auto-stop.
-    // ponytail: single boolean + deadline; cleared on next completed working rep,
-    // expiry, or per-set reset. Add a tunable when legitimate pauses get ended.
-    @kotlin.concurrent.Volatile
-    private var deferAutoStopUntilNextWorkingRep = false
-    // @Volatile not strictly required for the deadline — both writes and reads
-    // happen on the metrics-collection thread — but reads after a metrics thread
-    // switch on arming can still race; mark volatile to match the flag's lifetime.
+    // Issue #649: defer position/stall auto-stop until the cue + short
+    // transition window elapses, or a completed working rep clears it. The
+    // deadline (@Volatile Long) is the single source of truth — 0L means no
+    // defer. checkVelocityThreshold() arms it on Dispatchers.Default;
+    // checkAutoStop() reads it on the metrics thread. @Volatile is required so
+    // the metrics thread never sees a stale old deadline across a thread switch.
+    // Resets: resetAutoStopState() (skip/restart/stop), per-set reset sites,
+    // and the next completed working rep all zero it.
+    // ponytail: one Long + one const ceiling; a tunable window is the only thing
+    // we'd add if users reported legitimate pauses being ended by this.
     @kotlin.concurrent.Volatile
     private var deferAutoStopDeadlineMs = 0L
 
@@ -972,9 +968,8 @@ class ActiveSessionEngine(
         coordinator.stallStartTime = null
         coordinator.isCurrentlyStalled = false
         coordinator._autoStopState.value = AutoStopUiState()
-        // Issue #649: clear the verbal-cue defer so a new set never inherits a
-        // stale flag from the previous one (skip / restart paths included).
-        deferAutoStopUntilNextWorkingRep = false
+        // Issue #649: zero the deadline so a new set never inherits a stale
+        // verbal-cue defer (skip / restart / startWorkout paths included).
         deferAutoStopDeadlineMs = 0L
     }
 
@@ -1101,9 +1096,10 @@ class ActiveSessionEngine(
         // Score the rep if rep count actually incremented
         val repCountAfter = repCounter.getRepCount().totalReps
         if (repCountAfter > repCountBefore) {
-            // Issue #649: a completed working rep proves the user is back in motion;
-            // let normal AMRAP / stall auto-stop resume.
-            deferAutoStopUntilNextWorkingRep = false
+            // Issue #649: a completed working rep proves the user is back in
+            // motion; let normal AMRAP / stall auto-stop resume by zeroing the
+            // deadline (the source-of-truth field).
+            deferAutoStopDeadlineMs = 0L
 
             // Capture rep boundary timestamp BEFORE scoring so scoreCurrentRep()
             // and processBiomechanicsForRep() both see the correct metric window.
@@ -1356,14 +1352,12 @@ class ActiveSessionEngine(
                     // Issue #649: when the user has VBT auto-end OFF, the verbal cue is
                     // the only velocity signal — don't let AMRAP position / velocity-stall
                     // timers end the set while the cue is still audible. Defer both timers
-                    // until the user completes another working rep or the deadline
-                    // (cue + short transition window) elapses; any later auto-end branch
-                    // (VBT or stall) proceeds normally. Publish deadline BEFORE flipping
-                    // the flag so a metrics-thread reader never sees flag=true with the
-                    // stale 0L deadline (cross-thread ordering with @Volatile fields).
+                    // until the deadline (cue + short transition window) elapses
+                    // or a completed working rep clears it. The deadline field
+                    // alone is the source of truth — no derived flag to keep in
+                    // sync.
                     if (!coordinator.autoEndOnVelocityLoss) {
                         deferAutoStopDeadlineMs = currentTimeMillis() + VERBAL_ENCOURAGEMENT_DEFER_WINDOW_MS
-                        deferAutoStopUntilNextWorkingRep = true
                         resetStallTimer()
                         resetAutoStopTimer()
                     }
@@ -1446,21 +1440,15 @@ class ActiveSessionEngine(
 
         // Issue #649: while a verbal VBT cue is still in flight and the user has VBT
         // auto-end OFF, neither AMRAP position nor velocity-stall may end the set.
-        // Source of truth is the deadline field — flag is derived. The deadline is
-        // 0L when no defer is active; a metrics-thread reader can never observe
-        // `flag=true && deadline=0L` because the writer publishes the future
-        // deadline before flipping the flag (cross-thread ordering of two @Volatile
-        // fields isn't guaranteed, but a single @Volatile source eliminates the
-        // race by construction). Reset the live countdowns defensively each metric;
-        // cleared on the next completed working rep, deadline expiry, or at the
-        // per-set reset boundary / resetAutoStopState().
+        // The deadline field is the only source of truth — 0L means no defer.
+        // Any reset path (next completed working rep, resetAutoStopState, per-set
+        // boundary, deadline expiry) zeros it; this predicate then falls through.
+        // Reset the live countdowns defensively each metric.
         val deferDeadline = deferAutoStopDeadlineMs
         if (deferDeadline != 0L) {
             if (currentTimeMillis() >= deferDeadline) {
-                deferAutoStopUntilNextWorkingRep = false
                 deferAutoStopDeadlineMs = 0L
             } else {
-                deferAutoStopUntilNextWorkingRep = true
                 resetStallTimer()
                 resetAutoStopTimer()
                 return
@@ -2070,7 +2058,7 @@ class ActiveSessionEngine(
         coordinator.biomechanicsEngine.reset()
         velocityThresholdAlertEmitted = false
         consecutiveThresholdReps = 0
-        deferAutoStopUntilNextWorkingRep = false
+        deferAutoStopDeadlineMs = 0L
         coordinator.repBoundaryTimestamps.value = emptyList()
         coordinator.warmupCompleteTimeMs = 0
         // Reset variable warm-up state
@@ -2493,7 +2481,7 @@ class ActiveSessionEngine(
         coordinator.biomechanicsEngine.reset()
         velocityThresholdAlertEmitted = false
         consecutiveThresholdReps = 0
-        deferAutoStopUntilNextWorkingRep = false
+        deferAutoStopDeadlineMs = 0L
         coordinator.repQualityScorer.reset()
         coordinator._latestRepQuality.value = null
         coordinator._loadBaselineA.value = 0f
@@ -4033,7 +4021,7 @@ class ActiveSessionEngine(
             coordinator.biomechanicsEngine.reset()
             velocityThresholdAlertEmitted = false
             consecutiveThresholdReps = 0
-            deferAutoStopUntilNextWorkingRep = false
+            deferAutoStopDeadlineMs = 0L
             coordinator.repBoundaryTimestamps.value = emptyList()
 
             val completedReps = coordinator._repCount.value.workingReps

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -1356,7 +1356,17 @@ class ActiveSessionEngine(
                     // or a completed working rep clears it. The deadline field
                     // alone is the source of truth — no derived flag to keep in
                     // sync.
-                    if (!coordinator.autoEndOnVelocityLoss) {
+                    //
+                    // Issue #649 (Codex P2, race-window): checkVelocityThreshold runs
+                    // on Dispatchers.Default; a stale callback resumed after a set
+                    // transition could publish a fresh deadline into the next set.
+                    // Same race characteristic as velocityThresholdAlertEmitted above.
+                    // Narrow the window for this fix by re-checking the active state
+                    // before writing; if the workout has already left Active (manual
+                    // stop / reset / next set started), drop the arm silently.
+                    if (!coordinator.autoEndOnVelocityLoss &&
+                        coordinator._workoutState.value is WorkoutState.Active
+                    ) {
                         deferAutoStopDeadlineMs = currentTimeMillis() + VERBAL_ENCOURAGEMENT_DEFER_WINDOW_MS
                         resetStallTimer()
                         resetAutoStopTimer()

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -243,6 +243,11 @@ class ActiveSessionEngine(
     private var velocityThresholdAlertEmitted = false
     private var consecutiveThresholdReps = 0
 
+    // Issue #649: defer position/stall auto-stop until the next completed working
+    // rep after a verbal VBT cue was emitted with autoEndOnVelocityLoss=false.
+    // ponytail: single boolean; cleared on next completed working rep + per-set reset.
+    private var deferAutoStopUntilNextWorkingRep = false
+
     // ===== Init Block: Workout-Related Collectors (moved from DWSM) =====
 
     init {
@@ -1080,6 +1085,10 @@ class ActiveSessionEngine(
         // Score the rep if rep count actually incremented
         val repCountAfter = repCounter.getRepCount().totalReps
         if (repCountAfter > repCountBefore) {
+            // Issue #649: a completed working rep proves the user is back in motion;
+            // let normal AMRAP / stall auto-stop resume.
+            deferAutoStopUntilNextWorkingRep = false
+
             // Capture rep boundary timestamp BEFORE scoring so scoreCurrentRep()
             // and processBiomechanicsForRep() both see the correct metric window.
             val now = KmpUtils.currentTimeMillis()
@@ -1327,6 +1336,17 @@ class ActiveSessionEngine(
                         ),
                     )
                     Logger.i { "VBT: VERBAL_ENCOURAGEMENT emitted (tier=${prefs.vulgarTier}, dominatrix=${prefs.dominatrixModeActive}, vulgar=${prefs.vulgarModeEnabled})" }
+
+                    // Issue #649: when the user has VBT auto-end OFF, the verbal cue is
+                    // the only velocity signal — don't let AMRAP position / velocity-stall
+                    // timers end the set while the cue is still audible. Defer both timers
+                    // until the user completes another working rep; any later auto-end
+                    // branch (VBT or stall) proceeds normally.
+                    if (!coordinator.autoEndOnVelocityLoss) {
+                        deferAutoStopUntilNextWorkingRep = true
+                        resetStallTimer()
+                        resetAutoStopTimer()
+                    }
                 }
             }
 
@@ -1401,6 +1421,16 @@ class ActiveSessionEngine(
         if (!isWarmupGateOpenForAutoStop()) {
             resetAutoStopTimer()
             resetStallTimer()
+            return
+        }
+
+        // Issue #649: while a verbal VBT cue is still in flight and the user has VBT
+        // auto-end OFF, neither AMRAP position nor velocity-stall may end the set.
+        // Reset the live countdowns defensively each metric; cleared on the next
+        // completed working rep or at the per-set reset boundary.
+        if (deferAutoStopUntilNextWorkingRep) {
+            resetStallTimer()
+            resetAutoStopTimer()
             return
         }
 
@@ -2007,6 +2037,7 @@ class ActiveSessionEngine(
         coordinator.biomechanicsEngine.reset()
         velocityThresholdAlertEmitted = false
         consecutiveThresholdReps = 0
+        deferAutoStopUntilNextWorkingRep = false
         coordinator.repBoundaryTimestamps.value = emptyList()
         coordinator.warmupCompleteTimeMs = 0
         // Reset variable warm-up state
@@ -2429,6 +2460,7 @@ class ActiveSessionEngine(
         coordinator.biomechanicsEngine.reset()
         velocityThresholdAlertEmitted = false
         consecutiveThresholdReps = 0
+        deferAutoStopUntilNextWorkingRep = false
         coordinator.repQualityScorer.reset()
         coordinator._latestRepQuality.value = null
         coordinator._loadBaselineA.value = 0f
@@ -3968,6 +4000,7 @@ class ActiveSessionEngine(
             coordinator.biomechanicsEngine.reset()
             velocityThresholdAlertEmitted = false
             consecutiveThresholdReps = 0
+            deferAutoStopUntilNextWorkingRep = false
             coordinator.repBoundaryTimestamps.value = emptyList()
 
             val completedReps = coordinator._repCount.value.workingReps

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -245,8 +245,20 @@ class ActiveSessionEngine(
 
     // Issue #649: defer position/stall auto-stop until the next completed working
     // rep after a verbal VBT cue was emitted with autoEndOnVelocityLoss=false.
-    // ponytail: single boolean; cleared on next completed working rep + per-set reset.
+    // Written on Dispatchers.Default in checkVelocityThreshold() and read on the
+    // metrics collection thread in checkAutoStop(); @Volatile keeps the cross-
+    // thread visibility without a wrapper holder.
+    // The deadline covers the verbal cue plus a short transition window so a user
+    // who rackets mid-set after the cue still gets normal AMRAP/stall auto-stop.
+    // ponytail: single boolean + deadline; cleared on next completed working rep,
+    // expiry, or per-set reset. Add a tunable when legitimate pauses get ended.
+    @kotlin.concurrent.Volatile
     private var deferAutoStopUntilNextWorkingRep = false
+    // @Volatile not strictly required for the deadline — both writes and reads
+    // happen on the metrics-collection thread — but reads after a metrics thread
+    // switch on arming can still race; mark volatile to match the flag's lifetime.
+    @kotlin.concurrent.Volatile
+    private var deferAutoStopDeadlineMs = 0L
 
     // ===== Init Block: Workout-Related Collectors (moved from DWSM) =====
 
@@ -1340,10 +1352,12 @@ class ActiveSessionEngine(
                     // Issue #649: when the user has VBT auto-end OFF, the verbal cue is
                     // the only velocity signal — don't let AMRAP position / velocity-stall
                     // timers end the set while the cue is still audible. Defer both timers
-                    // until the user completes another working rep; any later auto-end
-                    // branch (VBT or stall) proceeds normally.
+                    // until the user completes another working rep or the deadline
+                    // (cue + short transition window) elapses; any later auto-end branch
+                    // (VBT or stall) proceeds normally.
                     if (!coordinator.autoEndOnVelocityLoss) {
                         deferAutoStopUntilNextWorkingRep = true
+                        deferAutoStopDeadlineMs = currentTimeMillis() + VERBAL_ENCOURAGEMENT_DEFER_WINDOW_MS
                         resetStallTimer()
                         resetAutoStopTimer()
                     }
@@ -1427,11 +1441,16 @@ class ActiveSessionEngine(
         // Issue #649: while a verbal VBT cue is still in flight and the user has VBT
         // auto-end OFF, neither AMRAP position nor velocity-stall may end the set.
         // Reset the live countdowns defensively each metric; cleared on the next
-        // completed working rep or at the per-set reset boundary.
+        // completed working rep, the deadline (cue + transition window), or at
+        // the per-set reset boundary.
         if (deferAutoStopUntilNextWorkingRep) {
-            resetStallTimer()
-            resetAutoStopTimer()
-            return
+            if (currentTimeMillis() >= deferAutoStopDeadlineMs) {
+                deferAutoStopUntilNextWorkingRep = false
+            } else {
+                resetStallTimer()
+                resetAutoStopTimer()
+                return
+            }
         }
 
         val hasMeaningfulRange = repCounter.hasMeaningfulRange(WorkoutCoordinator.MIN_RANGE_THRESHOLD)
@@ -5038,5 +5057,9 @@ class ActiveSessionEngine(
 
     private companion object {
         const val TEMPLATE_531_ID = "template_531"
+        // Issue #649: verbal cues are typically <30s; this ceiling covers the cue
+        // plus a short post-cue transition window. Exceeding it releases the defer
+        // so a racked mid-set handle can end the set normally.
+        const val VERBAL_ENCOURAGEMENT_DEFER_WINDOW_MS = 30_000L
     }
 }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/VerbalEncouragementAutoStopDeferTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/VerbalEncouragementAutoStopDeferTest.kt
@@ -12,41 +12,29 @@ import kotlin.test.assertTrue
  * Mirrors the velocity-threshold state machine from VbtAutoEndTest / VerbalEncouragementGateTest.
  * Keeps the logic testable without spinning up the 17+ dependency ActiveSessionEngine.
  *
- * Cross-thread note: the production field is @Volatile. The tracker here doesn't
- * model the threading — it only mirrors the predicate (defer armed? deadline
- * passed?). The companion object constant is mirrored inline; production uses
- * ActiveSessionEngine.VERBAL_ENCOURAGEMENT_DEFER_WINDOW_MS.
+ * Single source of truth is a @Volatile Long deadline — 0L means no defer. The
+ * tracker mirrors that pattern: an `isDeferActive(nowMs)` predicate derived from
+ * the deadline only, with the flag computed lazily inside the predicate.
  */
 private const val VERBAL_ENCOURAGEMENT_DEFER_WINDOW_MS_TRACKER = 30_000L
 
 private class VerbalEncouragementAutoStopDeferTracker(
     private val autoEndOnVelocityLoss: Boolean,
 ) {
-    var alertEmitted = false
-        private set
-    var deferAutoStop = false
-        private set
     private var deferDeadlineMs: Long = 0L
 
     fun onRepCompleted(shouldStopSet: Boolean, nowMs: Long) {
         if (shouldStopSet) {
-            if (!alertEmitted) {
-                alertEmitted = true
-                // Verbal cue fired -> defer position/stall auto-stop until the next
-                // completed working rep or the cue-window deadline, but only if
-                // VBT auto-end is OFF.
-                if (!autoEndOnVelocityLoss) {
-                    deferAutoStop = true
-                    deferDeadlineMs = nowMs + VERBAL_ENCOURAGEMENT_DEFER_WINDOW_MS_TRACKER
-                }
+            if (deferDeadlineMs == 0L && !autoEndOnVelocityLoss) {
+                // Verbal cue fires once per set when VBT auto-end is OFF.
+                deferDeadlineMs = nowMs + VERBAL_ENCOURAGEMENT_DEFER_WINDOW_MS_TRACKER
             }
         }
     }
 
     fun onCompletedWorkingRep() {
-        // A completed working rep proves the user is back in motion;
-        // let normal AMRAP / stall auto-stop resume.
-        deferAutoStop = false
+        // A completed working rep proves the user is back in motion; let normal
+        // AMRAP / stall auto-stop resume by zeroing the deadline.
         deferDeadlineMs = 0L
     }
 
@@ -55,90 +43,90 @@ private class VerbalEncouragementAutoStopDeferTracker(
         val deadline = deferDeadlineMs
         if (deadline == 0L) return false
         if (nowMs >= deadline) {
-            deferAutoStop = false
             deferDeadlineMs = 0L
             return false
         }
-        deferAutoStop = true
         return true
     }
 
     /** Mirrors resetAutoStopState(): every new-set reset clears the defer. */
     fun onResetAutoStopState() {
-        deferAutoStop = false
         deferDeadlineMs = 0L
     }
 
     /** Test seam: read the published deadline (mirrors the @Volatile field). */
     fun deferDeadlineSnapshot(): Long = deferDeadlineMs
+
+    /** Test seam: true when no defer is armed (one-shot is fired unless VBT auto-end). */
+    fun armEligible(): Boolean = deferDeadlineMs == 0L && !autoEndOnVelocityLoss
 }
 
 class VerbalEncouragementAutoStopDeferTest {
 
     @Test
-    fun `autoEnd off - first velocity-threshold rep defers auto-stop`() {
+    fun `autoEnd off - first velocity-threshold rep arms the defer with a future deadline`() {
         val tracker = VerbalEncouragementAutoStopDeferTracker(autoEndOnVelocityLoss = false)
         tracker.onRepCompleted(shouldStopSet = true, nowMs = 0L)
 
-        assertTrue(tracker.alertEmitted, "Velocity threshold alert is one-shot per set")
-        assertTrue(tracker.deferAutoStop, "Defer must be active while verbal cue is in flight")
+        assertEquals(30_000L, tracker.deferDeadlineSnapshot())
+        assertTrue(tracker.isDeferActive(nowMs = 0L))
+        assertTrue(tracker.isDeferActive(nowMs = 29_999L))
     }
 
     @Test
-    fun `autoEnd on - first velocity-threshold rep does NOT defer auto-stop`() {
+    fun `autoEnd on - first velocity-threshold rep does NOT arm the defer`() {
         // With VBT auto-end ON, the existing two-consecutive-rep behavior decides set end;
         // the defer guard would only suppress that and must NOT be armed.
         val tracker = VerbalEncouragementAutoStopDeferTracker(autoEndOnVelocityLoss = true)
         tracker.onRepCompleted(shouldStopSet = true, nowMs = 0L)
 
-        assertTrue(tracker.alertEmitted)
-        assertFalse(
-            tracker.deferAutoStop,
-            "Defer must NOT arm when VBT auto-end is on — that branch handles set end itself",
-        )
+        assertEquals(0L, tracker.deferDeadlineSnapshot())
+        assertFalse(tracker.isDeferActive(nowMs = 0L))
     }
 
     @Test
-    fun `autoEnd off - next completed working rep clears the defer`() {
+    fun `next completed working rep clears the defer regardless of deadline remaining`() {
+        // Verbal cue armed at t=5s, user completes a working rep at t=10s.
+        // The defer must clear immediately, even though the 30s window hasn't expired,
+        // so AMRAP / stall auto-stop can fire normally on subsequent metrics.
         val tracker = VerbalEncouragementAutoStopDeferTracker(autoEndOnVelocityLoss = false)
-        tracker.onRepCompleted(shouldStopSet = true, nowMs = 0L)
-        assertTrue(tracker.deferAutoStop)
+        tracker.onRepCompleted(shouldStopSet = true, nowMs = 5_000L)
+        assertTrue(tracker.isDeferActive(nowMs = 10_000L))
 
         tracker.onCompletedWorkingRep()
 
+        assertEquals(0L, tracker.deferDeadlineSnapshot())
         assertFalse(
-            tracker.deferAutoStop,
+            tracker.isDeferActive(nowMs = 10_000L),
             "After a completed working rep the defer must clear so AMRAP/stall can fire again",
+        )
+        assertFalse(
+            tracker.isDeferActive(nowMs = 29_999L),
+            "Re-arm must require another velocity-threshold-triggered cue, not automatic re-derivation",
         )
     }
 
     @Test
     fun `autoEnd off - non-threshold reps do not arm the defer`() {
-        // ShouldStopSet=false never reaches the alert branch, so the defer never sets.
         val tracker = VerbalEncouragementAutoStopDeferTracker(autoEndOnVelocityLoss = false)
         tracker.onRepCompleted(shouldStopSet = false, nowMs = 0L)
         tracker.onRepCompleted(shouldStopSet = false, nowMs = 0L)
 
-        assertFalse(tracker.alertEmitted)
-        assertFalse(tracker.deferAutoStop)
+        assertEquals(0L, tracker.deferDeadlineSnapshot())
+        assertFalse(tracker.isDeferActive(nowMs = 0L))
+        assertTrue(tracker.armEligible(), "Cue hasn't fired yet, so arm remains eligible")
     }
 
     @Test
-    fun `autoEnd off - defer stays active within the cue window`() {
-        // Cue fires, user keeps exercising without a completed working rep, but the
-        // window hasn't elapsed — defer must stay armed so position/stall can't end the set.
+    fun `defer stays active within the cue window`() {
         val tracker = VerbalEncouragementAutoStopDeferTracker(autoEndOnVelocityLoss = false)
         tracker.onRepCompleted(shouldStopSet = true, nowMs = 10_000L)
 
         assertTrue(tracker.isDeferActive(nowMs = 20_000L))
-        assertTrue(
-            tracker.deferAutoStop,
-            "Within the cue window defer must remain active even without a completed rep",
-        )
     }
 
     @Test
-    fun `autoEnd off - defer expires at the cue window deadline`() {
+    fun `defer expires at the cue window deadline`() {
         // User rackets handles mid-set after the cue and never completes a working rep.
         // Once the deadline passes, the defer must release so AMRAP/stall auto-stop can fire.
         val tracker = VerbalEncouragementAutoStopDeferTracker(autoEndOnVelocityLoss = false)
@@ -149,11 +137,11 @@ class VerbalEncouragementAutoStopDeferTest {
             tracker.isDeferActive(nowMs = 30_001L),
             "Past the deadline the defer must clear so auto-stop can fire normally",
         )
-        assertFalse(tracker.deferAutoStop, "Expired defer must clear the flag")
+        assertEquals(0L, tracker.deferDeadlineSnapshot(), "Expiry must zero the deadline")
     }
 
     @Test
-    fun `autoEnd off - resetAutoStopState clears the defer for the next set`() {
+    fun `resetAutoStopState clears the defer for the next set`() {
         // Verbal cue armed the defer mid-set. Before the 30s deadline the user
         // skips / restarts. The next active set must not inherit the defer —
         // otherwise checkAutoStop() would suppress AMRAP/stall auto-stop there too.
@@ -163,11 +151,8 @@ class VerbalEncouragementAutoStopDeferTest {
 
         tracker.onResetAutoStopState()
 
-        assertFalse(tracker.deferAutoStop)
-        assertEquals(
-            0L, tracker.deferDeadlineSnapshot(),
-            "resetAutoStopState must zero the deadline so the source-of-truth predicate clears",
-        )
+        assertEquals(0L, tracker.deferDeadlineSnapshot())
+        assertTrue(tracker.armEligible(), "Next set must allow a fresh cue to arm again")
         assertFalse(
             tracker.isDeferActive(nowMs = 20_000L),
             "After resetAutoStopState() the new set must allow normal auto-stop behavior",
@@ -175,12 +160,10 @@ class VerbalEncouragementAutoStopDeferTest {
     }
 
     @Test
-    fun `arm publishes deadline before flag is observable to readers`() {
-        // Mirrors the production publish order: deadline first, flag second.
-        // The tracker mirrors the production single-source-of-truth pattern
-        // (deadline != 0L is the gate); this test pins the deadline value at
-        // arming time so a reader that arrives the instant the cue fires sees
-        // a future deadline and never the stale 0L value.
+    fun `arm publishes future deadline that a metrics-thread reader sees immediately`() {
+        // Single-source-of-truth guarantee: the deadline field is the gate.
+        // Even a reader that observes the field the instant the cue fires sees
+        // a future deadline, never the stale 0L value.
         val tracker = VerbalEncouragementAutoStopDeferTracker(autoEndOnVelocityLoss = false)
         tracker.onRepCompleted(shouldStopSet = true, nowMs = 5_000L)
         assertEquals(35_000L, tracker.deferDeadlineSnapshot())

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/VerbalEncouragementAutoStopDeferTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/VerbalEncouragementAutoStopDeferTest.kt
@@ -1,0 +1,91 @@
+package com.devil.phoenixproject.presentation.manager
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Issue #649: while a verbal VBT cue is playing and the user has VBT auto-end OFF,
+ * neither the AMRAP position-based nor the velocity-stall auto-stop may end the set.
+ *
+ * Mirrors the velocity-threshold state machine from VbtAutoEndTest / VerbalEncouragementGateTest.
+ * Keeps the logic testable without spinning up the 17+ dependency ActiveSessionEngine.
+ */
+private class VerbalEncouragementAutoStopDeferTracker(
+    private val autoEndOnVelocityLoss: Boolean,
+) {
+    var alertEmitted = false
+        private set
+    var deferAutoStop = false
+        private set
+
+    fun onRepCompleted(shouldStopSet: Boolean) {
+        if (shouldStopSet) {
+            if (!alertEmitted) {
+                alertEmitted = true
+                // Verbal cue fired -> defer position/stall auto-stop until the next
+                // completed working rep, but only if VBT auto-end is OFF.
+                if (!autoEndOnVelocityLoss) {
+                    deferAutoStop = true
+                }
+            }
+        }
+    }
+
+    fun onCompletedWorkingRep() {
+        // A completed working rep proves the user is back in motion;
+        // let normal AMRAP / stall auto-stop resume.
+        deferAutoStop = false
+    }
+}
+
+class VerbalEncouragementAutoStopDeferTest {
+
+    @Test
+    fun `autoEnd off - first velocity-threshold rep defers auto-stop`() {
+        val tracker = VerbalEncouragementAutoStopDeferTracker(autoEndOnVelocityLoss = false)
+        tracker.onRepCompleted(shouldStopSet = true)
+
+        assertTrue(tracker.alertEmitted, "Velocity threshold alert is one-shot per set")
+        assertTrue(tracker.deferAutoStop, "Defer must be active while verbal cue is in flight")
+    }
+
+    @Test
+    fun `autoEnd on - first velocity-threshold rep does NOT defer auto-stop`() {
+        // With VBT auto-end ON, the existing two-consecutive-rep behavior decides set end;
+        // the defer guard would only suppress that and must NOT be armed.
+        val tracker = VerbalEncouragementAutoStopDeferTracker(autoEndOnVelocityLoss = true)
+        tracker.onRepCompleted(shouldStopSet = true)
+
+        assertTrue(tracker.alertEmitted)
+        assertFalse(
+            tracker.deferAutoStop,
+            "Defer must NOT arm when VBT auto-end is on — that branch handles set end itself",
+        )
+    }
+
+    @Test
+    fun `autoEnd off - next completed working rep clears the defer`() {
+        val tracker = VerbalEncouragementAutoStopDeferTracker(autoEndOnVelocityLoss = false)
+        tracker.onRepCompleted(shouldStopSet = true)
+        assertTrue(tracker.deferAutoStop)
+
+        tracker.onCompletedWorkingRep()
+
+        assertFalse(
+            tracker.deferAutoStop,
+            "After a completed working rep the defer must clear so AMRAP/stall can fire again",
+        )
+    }
+
+    @Test
+    fun `autoEnd off - non-threshold reps do not arm the defer`() {
+        // ShouldStopSet=false never reaches the alert branch, so the defer never sets.
+        val tracker = VerbalEncouragementAutoStopDeferTracker(autoEndOnVelocityLoss = false)
+        tracker.onRepCompleted(shouldStopSet = false)
+        tracker.onRepCompleted(shouldStopSet = false)
+
+        assertFalse(tracker.alertEmitted)
+        assertFalse(tracker.deferAutoStop)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/VerbalEncouragementAutoStopDeferTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/VerbalEncouragementAutoStopDeferTest.kt
@@ -10,7 +10,14 @@ import kotlin.test.assertTrue
  *
  * Mirrors the velocity-threshold state machine from VbtAutoEndTest / VerbalEncouragementGateTest.
  * Keeps the logic testable without spinning up the 17+ dependency ActiveSessionEngine.
+ *
+ * Cross-thread note: the production field is @Volatile. The tracker here doesn't
+ * model the threading — it only mirrors the predicate (defer armed? deadline
+ * passed?). The companion object constant is mirrored inline; production uses
+ * ActiveSessionEngine.VERBAL_ENCOURAGEMENT_DEFER_WINDOW_MS.
  */
+private const val VERBAL_ENCOURAGEMENT_DEFER_WINDOW_MS_TRACKER = 30_000L
+
 private class VerbalEncouragementAutoStopDeferTracker(
     private val autoEndOnVelocityLoss: Boolean,
 ) {
@@ -18,15 +25,18 @@ private class VerbalEncouragementAutoStopDeferTracker(
         private set
     var deferAutoStop = false
         private set
+    private var deferDeadlineMs: Long = 0L
 
-    fun onRepCompleted(shouldStopSet: Boolean) {
+    fun onRepCompleted(shouldStopSet: Boolean, nowMs: Long) {
         if (shouldStopSet) {
             if (!alertEmitted) {
                 alertEmitted = true
                 // Verbal cue fired -> defer position/stall auto-stop until the next
-                // completed working rep, but only if VBT auto-end is OFF.
+                // completed working rep or the cue-window deadline, but only if
+                // VBT auto-end is OFF.
                 if (!autoEndOnVelocityLoss) {
                     deferAutoStop = true
+                    deferDeadlineMs = nowMs + VERBAL_ENCOURAGEMENT_DEFER_WINDOW_MS_TRACKER
                 }
             }
         }
@@ -36,6 +46,18 @@ private class VerbalEncouragementAutoStopDeferTracker(
         // A completed working rep proves the user is back in motion;
         // let normal AMRAP / stall auto-stop resume.
         deferAutoStop = false
+        deferDeadlineMs = 0L
+    }
+
+    /** Returns true if the defer is still active at `nowMs`. */
+    fun isDeferActive(nowMs: Long): Boolean {
+        if (!deferAutoStop) return false
+        if (nowMs >= deferDeadlineMs) {
+            deferAutoStop = false
+            deferDeadlineMs = 0L
+            return false
+        }
+        return true
     }
 }
 
@@ -44,7 +66,7 @@ class VerbalEncouragementAutoStopDeferTest {
     @Test
     fun `autoEnd off - first velocity-threshold rep defers auto-stop`() {
         val tracker = VerbalEncouragementAutoStopDeferTracker(autoEndOnVelocityLoss = false)
-        tracker.onRepCompleted(shouldStopSet = true)
+        tracker.onRepCompleted(shouldStopSet = true, nowMs = 0L)
 
         assertTrue(tracker.alertEmitted, "Velocity threshold alert is one-shot per set")
         assertTrue(tracker.deferAutoStop, "Defer must be active while verbal cue is in flight")
@@ -55,7 +77,7 @@ class VerbalEncouragementAutoStopDeferTest {
         // With VBT auto-end ON, the existing two-consecutive-rep behavior decides set end;
         // the defer guard would only suppress that and must NOT be armed.
         val tracker = VerbalEncouragementAutoStopDeferTracker(autoEndOnVelocityLoss = true)
-        tracker.onRepCompleted(shouldStopSet = true)
+        tracker.onRepCompleted(shouldStopSet = true, nowMs = 0L)
 
         assertTrue(tracker.alertEmitted)
         assertFalse(
@@ -67,7 +89,7 @@ class VerbalEncouragementAutoStopDeferTest {
     @Test
     fun `autoEnd off - next completed working rep clears the defer`() {
         val tracker = VerbalEncouragementAutoStopDeferTracker(autoEndOnVelocityLoss = false)
-        tracker.onRepCompleted(shouldStopSet = true)
+        tracker.onRepCompleted(shouldStopSet = true, nowMs = 0L)
         assertTrue(tracker.deferAutoStop)
 
         tracker.onCompletedWorkingRep()
@@ -82,10 +104,39 @@ class VerbalEncouragementAutoStopDeferTest {
     fun `autoEnd off - non-threshold reps do not arm the defer`() {
         // ShouldStopSet=false never reaches the alert branch, so the defer never sets.
         val tracker = VerbalEncouragementAutoStopDeferTracker(autoEndOnVelocityLoss = false)
-        tracker.onRepCompleted(shouldStopSet = false)
-        tracker.onRepCompleted(shouldStopSet = false)
+        tracker.onRepCompleted(shouldStopSet = false, nowMs = 0L)
+        tracker.onRepCompleted(shouldStopSet = false, nowMs = 0L)
 
         assertFalse(tracker.alertEmitted)
         assertFalse(tracker.deferAutoStop)
+    }
+
+    @Test
+    fun `autoEnd off - defer stays active within the cue window`() {
+        // Cue fires, user keeps exercising without a completed working rep, but the
+        // window hasn't elapsed — defer must stay armed so position/stall can't end the set.
+        val tracker = VerbalEncouragementAutoStopDeferTracker(autoEndOnVelocityLoss = false)
+        tracker.onRepCompleted(shouldStopSet = true, nowMs = 10_000L)
+
+        assertTrue(tracker.isDeferActive(nowMs = 20_000L))
+        assertTrue(
+            tracker.deferAutoStop,
+            "Within the cue window defer must remain active even without a completed rep",
+        )
+    }
+
+    @Test
+    fun `autoEnd off - defer expires at the cue window deadline`() {
+        // User rackets handles mid-set after the cue and never completes a working rep.
+        // Once the deadline passes, the defer must release so AMRAP/stall auto-stop can fire.
+        val tracker = VerbalEncouragementAutoStopDeferTracker(autoEndOnVelocityLoss = false)
+        tracker.onRepCompleted(shouldStopSet = true, nowMs = 0L)
+
+        assertTrue(tracker.isDeferActive(nowMs = 29_999L), "Just before deadline still defers")
+        assertFalse(
+            tracker.isDeferActive(nowMs = 30_001L),
+            "Past the deadline the defer must clear so auto-stop can fire normally",
+        )
+        assertFalse(tracker.deferAutoStop, "Expired defer must clear the flag")
     }
 }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/VerbalEncouragementAutoStopDeferTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/VerbalEncouragementAutoStopDeferTest.kt
@@ -1,6 +1,7 @@
 package com.devil.phoenixproject.presentation.manager
 
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -51,14 +52,25 @@ private class VerbalEncouragementAutoStopDeferTracker(
 
     /** Returns true if the defer is still active at `nowMs`. */
     fun isDeferActive(nowMs: Long): Boolean {
-        if (!deferAutoStop) return false
-        if (nowMs >= deferDeadlineMs) {
+        val deadline = deferDeadlineMs
+        if (deadline == 0L) return false
+        if (nowMs >= deadline) {
             deferAutoStop = false
             deferDeadlineMs = 0L
             return false
         }
+        deferAutoStop = true
         return true
     }
+
+    /** Mirrors resetAutoStopState(): every new-set reset clears the defer. */
+    fun onResetAutoStopState() {
+        deferAutoStop = false
+        deferDeadlineMs = 0L
+    }
+
+    /** Test seam: read the published deadline (mirrors the @Volatile field). */
+    fun deferDeadlineSnapshot(): Long = deferDeadlineMs
 }
 
 class VerbalEncouragementAutoStopDeferTest {
@@ -138,5 +150,40 @@ class VerbalEncouragementAutoStopDeferTest {
             "Past the deadline the defer must clear so auto-stop can fire normally",
         )
         assertFalse(tracker.deferAutoStop, "Expired defer must clear the flag")
+    }
+
+    @Test
+    fun `autoEnd off - resetAutoStopState clears the defer for the next set`() {
+        // Verbal cue armed the defer mid-set. Before the 30s deadline the user
+        // skips / restarts. The next active set must not inherit the defer —
+        // otherwise checkAutoStop() would suppress AMRAP/stall auto-stop there too.
+        val tracker = VerbalEncouragementAutoStopDeferTracker(autoEndOnVelocityLoss = false)
+        tracker.onRepCompleted(shouldStopSet = true, nowMs = 10_000L)
+        assertTrue(tracker.isDeferActive(nowMs = 20_000L))
+
+        tracker.onResetAutoStopState()
+
+        assertFalse(tracker.deferAutoStop)
+        assertEquals(
+            0L, tracker.deferDeadlineSnapshot(),
+            "resetAutoStopState must zero the deadline so the source-of-truth predicate clears",
+        )
+        assertFalse(
+            tracker.isDeferActive(nowMs = 20_000L),
+            "After resetAutoStopState() the new set must allow normal auto-stop behavior",
+        )
+    }
+
+    @Test
+    fun `arm publishes deadline before flag is observable to readers`() {
+        // Mirrors the production publish order: deadline first, flag second.
+        // The tracker mirrors the production single-source-of-truth pattern
+        // (deadline != 0L is the gate); this test pins the deadline value at
+        // arming time so a reader that arrives the instant the cue fires sees
+        // a future deadline and never the stale 0L value.
+        val tracker = VerbalEncouragementAutoStopDeferTracker(autoEndOnVelocityLoss = false)
+        tracker.onRepCompleted(shouldStopSet = true, nowMs = 5_000L)
+        assertEquals(35_000L, tracker.deferDeadlineSnapshot())
+        assertTrue(tracker.isDeferActive(nowMs = 5_000L))
     }
 }


### PR DESCRIPTION
## Summary

When the user has VBT **Auto-End on Velocity Loss** disabled but **verbal encouragement** enabled, the AMRAP position-based (2.5s) and velocity-stall (5s) auto-stop timers remained independent of the verbal VBT cue. After VBT triggered the verbal cue, the same cue's low-velocity window could start either timer; ~2.5–5s later the engine called `handleSetCompletion()`, cutting the verbal cue short and emitting `WORKOUT_END`. The user's AMRAP set ended mid-rep, with the set-completion audio cue firing right after the truncated encouragement.

This fix adds a per-set defer guard on the active session engine:

- When `checkVelocityThreshold()` emits `VERBAL_ENCOURAGEMENT` while `autoEndOnVelocityLoss=false`, set `deferAutoStopUntilNextWorkingRep = true` and reset both timers.
- `checkAutoStop()` early-returns (resetting both timers defensively) while the defer is active.
- Cleared by the next completed working rep and at the existing per-set reset boundaries.
- Enabled VBT auto-end (`autoEndOnVelocityLoss=true`) is untouched.

## Root cause

`ActiveSessionEngine.checkVelocityThreshold()` correctly gates the two-consecutive-rep auto-end on `coordinator.autoEndOnVelocityLoss`. AMRAP position auto-stop (`shouldRunPositionBasedAutoStop(params) → handlesCompletelyAtRest → requestAutoStop()` after 2.5s) and velocity-stall (`maxVelocity < STALL_VELOCITY_LOW → requestAutoStop()` after 5s when enabled) did **not** consult that preference or the verbal-cue one-shot, so any "verbal cue in flight + user pauses" window could end the set early. `handleSetCompletion()` then stops BLE and emits `WORKOUT_END`, producing the overlapping end cue the reporter observed.

## Fix direction (from GPT-5.5 RCA)

When `checkVelocityThreshold()` emits `VERBAL_ENCOURAGEMENT` while `autoEndOnVelocityLoss` is false, mark the current set as **auto-stop-deferred-until-next-completed-working-rep**. While that marker is set, `checkAutoStop()` must reset both position and velocity-stall countdown state and return before either can call `requestAutoStop()`. Clear the marker only after a later completed working rep, and reset it with the existing per-set reset path.

ponytail: single boolean + one early-return guard + three reset sites. Skipped: a tunable "encouragement duration" timeout (the next-rep boundary avoids guessing the cue's actual duration). Add when users report legitimate pauses being ended by this defer.

## Acceptance criteria coverage

- With `isAMRAP=true`, warmup complete, `autoEndOnVelocityLoss=false`, and a verbal VBT event, stationary metrics past both 2.5s and 5s stay Active with no BLE stop or `WORKOUT_END`.
- After the next completed working rep, normal AMRAP auto-stop can complete again.
- Enabled VBT auto-end (`autoEndOnVelocityLoss=true`) retains the two-consecutive-threshold-rep behavior (defer never arms).
- Both AMRAP position and enabled velocity-stall paths respect the defer guard.

## Tests

`./gradlew :shared:testAndroidHostTest -Pskip.supabase.check=true` — **2,424 tests pass, 0 failures, 0 errors** across 230 test classes.

New: `VerbalEncouragementAutoStopDeferTest` (4 tests) covers the guard logic in the same tracker-mirror style as `VbtAutoEndTest` and `VerbalEncouragementGateTest`. Existing `DWSMWorkoutLifecycleTest` (63), `VbtAutoEndTest` (9), and `VerbalEncouragementGateTest` (7) all still pass.

## Notes

- Coordinated with GPT-5.5 RCA at https://github.com/9thLevelSoftware/Project-Phoenix-MP/issues/649#issuecomment-4939731593.
- No public-surface changes — keeps the existing `autoEndOnVelocityLoss` setting semantically intact (still the user-controlled VBT switch) and adds no new preference.
- Maintainer hypothesis in the original Discord thread (stall detection and VBT may be conflicting) substantially confirmed: this fix is the coordination layer that was missing. Stall detection itself is preserved.

Fixes #649
