### PR TITLE
fix(#652): reset shared stall timer on completed working rep

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -1100,6 +1100,12 @@ class ActiveSessionEngine(
             // motion; let normal AMRAP / stall auto-stop resume by zeroing the
             // deadline (the source-of-truth field).
             deferAutoStopDeadlineMs = 0L
+            // Issue #652: the same completed-rep boundary is authoritative for
+            // the shared stall countdown (both DELOAD_OCCURRED and low-velocity
+            // arms write to coordinator.stallStartTime). Without this, a stale
+            // countdown started at a turnaround, brief pause, or firmware de-load
+            // can survive a subsequent valid rep and later auto-complete the set.
+            resetStallTimer()
 
             // Capture rep boundary timestamp BEFORE scoring so scoreCurrentRep()
             // and processBiomechanicsForRep() both see the correct metric window.

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMWorkoutLifecycleTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMWorkoutLifecycleTest.kt
@@ -1205,6 +1205,58 @@ class DWSMWorkoutLifecycleTest {
     }
 
     @Test
+    fun `Issue 652 - completed Echo rep cancels an armed stall timer`() = runTest {
+        val harness = DWSMTestHarness(this)
+        harness.fakeBleRepo.simulateConnect("Vee_Test")
+        harness.dwsm.updateWorkoutParameters(
+            WorkoutParameters(
+                programMode = ProgramMode.Echo,
+                echoLevel = EchoLevel.HARDER,
+                reps = 10,
+                warmupReps = 0,
+                stallDetectionEnabled = true,
+                isAMRAP = false,
+                isJustLift = false,
+            ),
+        )
+        harness.dwsm.startWorkout(skipCountdown = true)
+        advanceUntilIdle()
+        completeWarmupReps(harness, warmupTarget = 3, workingTarget = 10)
+        completeFirstWorkingRep(harness, warmupTarget = 3, workingTarget = 10)
+        advanceUntilIdle()
+
+        harness.fakeBleRepo.emitDeloadOccurred()
+        advanceUntilIdle()
+        assertNotNull(harness.dwsm.coordinator.stallStartTime)
+
+        harness.fakeBleRepo.emitRepNotification(
+            RepNotification(
+                topCounter = 5,
+                completeCounter = 5,
+                repsRomCount = 3,
+                repsRomTotal = 3,
+                repsSetCount = 2,
+                repsSetTotal = 10,
+                rangeTop = 800f,
+                rangeBottom = 0f,
+                rawData = ByteArray(24),
+                timestamp = 5L,
+            ),
+        )
+        advanceUntilIdle()
+
+        assertEquals(2, harness.dwsm.coordinator.repCount.value.workingReps)
+        assertEquals(
+            null,
+            harness.dwsm.coordinator.stallStartTime,
+            "A completed working rep proves motion resumed and must cancel the stale stall countdown",
+        )
+        assertFalse(harness.dwsm.coordinator.isCurrentlyStalled)
+        assertIs<WorkoutState.Active>(harness.dwsm.coordinator.workoutState.value)
+        harness.cleanup()
+    }
+
+    @Test
     fun `Issue 267 Just Lift warmup to working rep transitions without failed stall state`() = runTest {
         val harness = DWSMTestHarness(this)
         harness.fakeBleRepo.simulateConnect("Vee_Test")


### PR DESCRIPTION
Fixes #652

## Root cause

`ActiveSessionEngine.handleRepNotification` already treats a completed working rep as authoritative proof of resumed motion (PR #650) and zeroes `deferAutoStopDeadlineMs` at that boundary. The shared `WorkoutCoordinator.stallStartTime` countdown, armed by both low-velocity motion and firmware `DELOAD_OCCURRED`, was never reset at the same boundary. It was cancelled only when a later sample exceeded `STALL_VELOCITY_HIGH` (10 mm/s), so a countdown started at a turnaround, brief pause, or firmware de-load could survive a subsequent valid rep and later call `requestAutoStop()` -> `triggerAutoStop()` -> `handleSetCompletion()`, prematurely ending a set the athlete is still performing.

## Fix

In `ActiveSessionEngine.handleRepNotification()`, inside `if (repCountAfter > repCountBefore)`, call `resetStallTimer()` immediately alongside `deferAutoStopDeadlineMs = 0L`. One shared reset covers both stall arms because both write to the same `coordinator.stallStartTime`.

## TDD evidence

- RED on main@0f00f4b: new `Issue 652 - completed Echo rep cancels an armed stall timer` in `DWSMWorkoutLifecycleTest` failed with `expected:<null> but was:<1783989200633>`.
- GREEN after the one-line fix.
- Focused suite (DWSM + VbtAutoEnd + VerbalEncouragementAutoStopDefer): 81 tests, 0 failures.
- Full `:shared:testAndroidHostTest` suite: 2442 tests, 0 failures, 0 errors, 0 skipped.
- Issue #256 pending-first-rep stall tests (`deload starts stall timer even with pending rep`, `velocity stall auto-stops with pending rep after timer expires`) remain GREEN.

## What did NOT change

- Stall Detection thresholds (2.5 mm/s and 10 mm/s).
- Per-set reset, warm-up gating, or Echo level handling.
- AMRAP position auto-stop (`shouldRunPositionBasedAutoStop`).
- VBT Auto-End (still gated by `autoEndOnVelocityLoss`).
- Any other file outside `ActiveSessionEngine.kt` and `DWSMWorkoutLifecycleTest.kt`.

Issue #256 protection is preserved: a pending first working rep has not completed, so its timer remains armed and the existing 5-second stall guard still fires. Stall Detection remains independent from `autoEndOnVelocityLoss` - no new VBT/stall coupling introduced.

## Files

- `shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt` - production fix (one new `resetStallTimer()` call).
- `shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMWorkoutLifecycleTest.kt` - new regression test (RED characterization preserved from the RCA artifact).

Audited baseline: `origin/main@0f00f4b28856bfc3dd6536340390ec01b2c3ea03`
RCA: https://github.com/9thLevelSoftware/Project-Phoenix-MP/issues/652#issuecomment-4964220598
