### PR TITLE
fix(audio): align Test Sounds with rep-count setting

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -283,7 +283,7 @@ class ActiveSessionEngine(
                             // Issue #100: Check if this is the final working rep
                             val isFinalRep = !params.isJustLift && !params.isAMRAP &&
                                 params.reps > 0 && repNumber >= params.reps
-                            if (prefs.audioRepCountEnabled && repNumber in 1..25) {
+                            if (shouldEmitRepCountAnnouncement(prefs, repNumber)) {
                                 coordinator._hapticEvents.emit(HapticEvent.REP_COUNT_ANNOUNCED(repNumber))
                             }
                             if (isFinalRep && prefs.repSoundEnabled) {
@@ -302,7 +302,7 @@ class ActiveSessionEngine(
                             // Issue #100: Check if this is the final working rep
                             val isFinalRep = !params.isJustLift && !params.isAMRAP &&
                                 params.reps > 0 && event.workingCount >= params.reps
-                            if (prefs.audioRepCountEnabled && event.workingCount in 1..25) {
+                            if (shouldEmitRepCountAnnouncement(prefs, event.workingCount)) {
                                 coordinator._hapticEvents.emit(HapticEvent.REP_COUNT_ANNOUNCED(event.workingCount))
                             }
                             if (isFinalRep && prefs.repSoundEnabled) {

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutCuePolicy.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutCuePolicy.kt
@@ -1,0 +1,16 @@
+package com.devil.phoenixproject.presentation.manager
+
+import com.devil.phoenixproject.domain.model.HapticEvent
+import com.devil.phoenixproject.domain.model.UserPreferences
+
+internal fun shouldEmitRepCountAnnouncement(
+    prefs: UserPreferences,
+    repNumber: Int,
+): Boolean = prefs.audioRepCountEnabled && repNumber in 1..25
+
+internal fun currentProfileTestSoundEvents(prefs: UserPreferences): List<HapticEvent> = listOfNotNull(
+    HapticEvent.REP_COMPLETED,
+    HapticEvent.WARMUP_COMPLETE,
+    HapticEvent.REP_COUNT_ANNOUNCED(5).takeIf { shouldEmitRepCountAnnouncement(prefs, 5) },
+    HapticEvent.WORKOUT_COMPLETE,
+)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SettingsTab.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SettingsTab.kt
@@ -1244,7 +1244,7 @@ fun SettingsTab(
 
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
-                    "Play workout sounds to test audio configuration and volume",
+                    "Tests current workout sounds; numbered rep count requires Profile > Workout > Audio rep counter.",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
@@ -69,6 +69,7 @@ import com.devil.phoenixproject.presentation.manager.JustLiftDefaults
 import com.devil.phoenixproject.presentation.manager.ResumableProgressInfo
 import com.devil.phoenixproject.presentation.manager.SettingsManager
 import com.devil.phoenixproject.presentation.manager.WorkoutServiceController
+import com.devil.phoenixproject.presentation.manager.currentProfileTestSoundEvents
 import com.devil.phoenixproject.util.BackupDestination
 import com.devil.phoenixproject.util.BackupStats
 import com.devil.phoenixproject.util.DataBackupManager
@@ -684,13 +685,13 @@ class MainViewModel constructor(
 
     fun testSounds() {
         viewModelScope.launch {
-            _hapticEvents.emit(HapticEvent.REP_COMPLETED)
-            kotlinx.coroutines.delay(800)
-            _hapticEvents.emit(HapticEvent.WARMUP_COMPLETE)
-            kotlinx.coroutines.delay(1000)
-            _hapticEvents.emit(HapticEvent.REP_COUNT_ANNOUNCED(5))
-            kotlinx.coroutines.delay(1000)
-            _hapticEvents.emit(HapticEvent.WORKOUT_COMPLETE)
+            val events = currentProfileTestSoundEvents(settingsManager.userPreferences.value)
+            events.forEachIndexed { index, event ->
+                _hapticEvents.emit(event)
+                if (index < events.lastIndex) {
+                    kotlinx.coroutines.delay(if (event == HapticEvent.REP_COMPLETED) 800 else 1000)
+                }
+            }
         }
     }
 

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutCuePolicyTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutCuePolicyTest.kt
@@ -1,0 +1,118 @@
+package com.devil.phoenixproject.presentation.manager
+
+import com.devil.phoenixproject.domain.model.HapticEvent
+import com.devil.phoenixproject.domain.model.RepCountTiming
+import com.devil.phoenixproject.domain.model.RepEvent
+import com.devil.phoenixproject.domain.model.RepType
+import com.devil.phoenixproject.domain.model.UserPreferences
+import com.devil.phoenixproject.testutil.DWSMTestHarness
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+
+class WorkoutCuePolicyTest {
+    @Test
+    fun `test sounds omit numbered rep count when profile counter is off`() {
+        val events = currentProfileTestSoundEvents(UserPreferences(audioRepCountEnabled = false))
+
+        assertEquals(
+            listOf(
+                HapticEvent.REP_COMPLETED,
+                HapticEvent.WARMUP_COMPLETE,
+                HapticEvent.WORKOUT_COMPLETE,
+            ),
+            events,
+        )
+        assertFalse(events.any { it is HapticEvent.REP_COUNT_ANNOUNCED })
+    }
+
+    @Test
+    fun `test sounds include numbered rep count when profile counter is on`() {
+        assertEquals(
+            listOf(
+                HapticEvent.REP_COMPLETED,
+                HapticEvent.WARMUP_COMPLETE,
+                HapticEvent.REP_COUNT_ANNOUNCED(5),
+                HapticEvent.WORKOUT_COMPLETE,
+            ),
+            currentProfileTestSoundEvents(UserPreferences(audioRepCountEnabled = true)),
+        )
+    }
+
+    @Test
+    fun `rep count policy is bounded and independent of verbal encouragement`() {
+        assertFalse(shouldEmitRepCountAnnouncement(UserPreferences(), 1))
+        assertFalse(shouldEmitRepCountAnnouncement(UserPreferences(audioRepCountEnabled = true), 0))
+        assertTrue(
+            shouldEmitRepCountAnnouncement(
+                UserPreferences(audioRepCountEnabled = true, verbalEncouragementEnabled = false),
+                25,
+            ),
+        )
+        assertTrue(
+            shouldEmitRepCountAnnouncement(
+                UserPreferences(audioRepCountEnabled = true, verbalEncouragementEnabled = true),
+                25,
+            ),
+        )
+    }
+
+    @Test
+    fun `top and bottom workout events share the rep count gate`() = runTest {
+        val harness = DWSMTestHarness(this)
+        val events = mutableListOf<HapticEvent>()
+        val collector = launch(UnconfinedTestDispatcher(testScheduler)) {
+            harness.coordinator.hapticEvents.toList(events)
+        }
+
+        try {
+            advanceUntilIdle()
+            val paths = listOf(
+                Triple(
+                    RepCountTiming.TOP,
+                    RepEvent(type = RepType.WORKING_PENDING, warmupCount = 0, workingCount = 4),
+                    5,
+                ),
+                Triple(
+                    RepCountTiming.BOTTOM,
+                    RepEvent(type = RepType.WORKING_COMPLETED, warmupCount = 0, workingCount = 5),
+                    5,
+                ),
+            )
+
+            paths.forEach { (timing, event, repNumber) ->
+                harness.coordinator._workoutParameters.value = harness.coordinator._workoutParameters.value.copy(
+                    isJustLift = true,
+                    repCountTiming = timing,
+                    reps = 8,
+                )
+                harness.setActiveProfilePreferences(
+                    UserPreferences(audioRepCountEnabled = false, repSoundEnabled = true),
+                )
+                advanceUntilIdle()
+                events.clear()
+                harness.repCounter.onRepEvent?.invoke(event)
+                advanceUntilIdle()
+                assertEquals(listOf<HapticEvent>(HapticEvent.REP_COMPLETED), events)
+
+                harness.setActiveProfilePreferences(
+                    UserPreferences(audioRepCountEnabled = true, repSoundEnabled = true),
+                )
+                advanceUntilIdle()
+                events.clear()
+                harness.repCounter.onRepEvent?.invoke(event)
+                advanceUntilIdle()
+                assertEquals(listOf<HapticEvent>(HapticEvent.REP_COUNT_ANNOUNCED(repNumber)), events)
+            }
+        } finally {
+            collector.cancel()
+            harness.cleanup()
+        }
+    }
+}


### PR DESCRIPTION
## Bug Description

`Test Sounds` previewed a numbered rep-count cue even when the current profile had **Audio rep counter** disabled, while Single Exercise correctly suppressed numbered rep-count announcements.

Fixes #658

## Root Cause

The test-sound sequence emitted `REP_COUNT_ANNOUNCED(5)` unconditionally; the live TOP and BOTTOM rep paths had a separate `audioRepCountEnabled` gate.

## Fix

- Add one shared current-profile cue policy for the rep-count predicate and Test Sounds sequence.
- Route Test Sounds and both workout timing paths through that policy.
- Clarify that numbered rep count requires **Profile > Workout > Audio rep counter**.

## How to Verify

1. Disable **Profile > Workout > Audio rep counter**, run **Settings > Test Sounds**, and confirm no numbered rep-count sample plays.
2. Enable it, rerun **Test Sounds**, and confirm the rep-five sample plays between the warmup-complete and workout-complete cues.
3. In a Single Exercise session, verify TOP and BOTTOM timing announce reps 1–25 only when the profile setting is enabled; generic rep-completion/final-rep behavior remains otherwise.

## Test Plan

- [x] Added common cue-policy and TOP/BOTTOM runtime regression coverage.
- [x] `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ANDROID_HOME=/opt/homebrew/share/android-commandlinetools ./gradlew :shared:testAndroidHostTest -Pskip.supabase.check=true --no-daemon`
- [ ] Physical iPhone audio playback — not run; this PR intentionally makes no iOS audio-session claim.

## Risk Assessment

Low — the sequence only removes a sample that the active profile would suppress during a workout; shared TOP/BOTTOM behavior is otherwise preserved and covered by host tests.
