### PR TITLE
fix: keep timed bodyweight Stop Set in workout flow

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -3373,6 +3373,9 @@ class ActiveSessionEngine(
         coordinator._timedExerciseRemainingSeconds.value = null
         cancelJustLiftEggTimer()
 
+        // Leave this armed after a successful Stop Set so Idle routing cannot race the
+        // SetReady observer; startWorkout() releases it when the user retries the set.
+        var returnedToSetReady = false
         scope.launch {
             try {
                 bleRepository.stopWorkout()
@@ -3389,10 +3392,13 @@ class ActiveSessionEngine(
                     flowDelegate?.enterSetReady(coordinator._currentExerciseIndex.value, coordinator._currentSetIndex.value)
                 }
                 coordinator._workoutState.value = WorkoutState.Idle
+                returnedToSetReady = true
 
                 Logger.d { "stopAndReturnToSetReady: Reset to SetReady for exercise=${coordinator._currentExerciseIndex.value}, set=${coordinator._currentSetIndex.value}" }
             } finally {
-                coordinator.stopWorkoutInProgress.value = false
+                if (!returnedToSetReady) {
+                    coordinator.stopWorkoutInProgress.value = false
+                }
             }
         }
     }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -3382,12 +3382,13 @@ class ActiveSessionEngine(
                 coordinator._repRanges.value = null
                 coordinator.warmupCompleteTimeMs = 0
                 resetAutoStopState()
-                coordinator._workoutState.value = WorkoutState.Idle
 
                 val routine = coordinator._loadedRoutine.value
                 if (routine != null) {
+                    // Issue #660: publish SetReady before Idle so its observer owns navigation.
                     flowDelegate?.enterSetReady(coordinator._currentExerciseIndex.value, coordinator._currentSetIndex.value)
                 }
+                coordinator._workoutState.value = WorkoutState.Idle
 
                 Logger.d { "stopAndReturnToSetReady: Reset to SetReady for exercise=${coordinator._currentExerciseIndex.value}, set=${coordinator._currentSetIndex.value}" }
             } finally {

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/DefaultWorkoutSessionManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/DefaultWorkoutSessionManager.kt
@@ -702,16 +702,10 @@ class DefaultWorkoutSessionManager(
     fun skipCountdown() = activeSessionEngine.skipCountdown()
     fun stopWorkout(exitingWorkout: Boolean = false) = activeSessionEngine.stopWorkout(exitingWorkout)
 
-    // Issue #627: Read-only exposure of the in-flight stop guard. True from the moment
-    // stopWorkout() / stopAndReturnToSetReady() / stopAndSkipCurrentExercise() arm the
-    // compareAndSet. Reset to false at ALL of the following sites (zero writes from here):
-    //   - startWorkout()                       ActiveSessionEngine:2352  — primary; beginning of any new set
-    //   - stopAndReturnToSetReady()            ActiveSessionEngine:3145  — early release before delegating to handleSetCompletion
-    //   - stopAndReturnToSetReady() finally    ActiveSessionEngine:3178  — end of teardown coroutine
-    //   - stopAndSkipCurrentExercise() finally ActiveSessionEngine:3226  — end of skip coroutine
-    //   - warmup fast-path (next warmup set)   ActiveSessionEngine:3783  — before starting next warmup set
-    //   - warmup fast-path (to working sets)   ActiveSessionEngine:3801  — before transitioning to first working set
-    //   - resumeWorkout()                      ActiveSessionEngine:3253  — gate invariant: every resumable-state entry opens the guard
+    // Issue #627: Read-only exposure of the stop guard. It is armed by stop entry points.
+    // A successful Stop Set deliberately keeps it armed until startWorkout() begins the retry,
+    // preventing Idle navigation from racing SetReady. Failures, completed-rep delegation,
+    // skipped exercises, and warm-up transitions release it on their own paths.
     val isStoppingWorkout: Boolean get() = coordinator.stopWorkoutInProgress.value
 
     fun stopAndReturnToSetReady() = activeSessionEngine.stopAndReturnToSetReady()

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ActiveWorkoutScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ActiveWorkoutScreen.kt
@@ -258,12 +258,16 @@ fun ActiveWorkoutScreen(navController: NavController, viewModel: MainViewModel, 
             workoutState is WorkoutState.Idle &&
                 (
                     loadedRoutine == null ||
-                        loadedRoutine?.id?.startsWith(
-                            DefaultWorkoutSessionManager.TEMP_SINGLE_EXERCISE_PREFIX,
-                        ) ==
-                        true
+                        (
+                            loadedRoutine?.id?.startsWith(
+                                DefaultWorkoutSessionManager.TEMP_SINGLE_EXERCISE_PREFIX,
+                            ) ==
+                            true &&
+                                routineFlowState !is RoutineFlowState.SetReady
+                        )
                     ) -> {
-                // Single Exercise completed and reset to Idle - navigate back to SingleExerciseScreen
+                // Issue #660: a direct timed Stop Set returns a temp routine to SetReady.
+                // Let the routine-flow observer navigate there rather than tearing down to Home.
                 Logger.d { "ActiveWorkoutScreen: Single Exercise idle, navigating back" }
                 hasNavigatedAway = true
                 navController.navigateUp()

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ActiveWorkoutScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ActiveWorkoutScreen.kt
@@ -263,7 +263,7 @@ fun ActiveWorkoutScreen(navController: NavController, viewModel: MainViewModel, 
                                 DefaultWorkoutSessionManager.TEMP_SINGLE_EXERCISE_PREFIX,
                             ) ==
                             true &&
-                                routineFlowState !is RoutineFlowState.SetReady
+                                !viewModel.isStoppingWorkout()
                         )
                     ) -> {
                 // Issue #660: a direct timed Stop Set returns a temp routine to SetReady.

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/Issue660TempSingleStopSetNavigationTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/Issue660TempSingleStopSetNavigationTest.kt
@@ -9,8 +9,9 @@ import kotlin.test.assertTrue
  * Issue #660 regression guard for a direct timed bodyweight session.
  *
  * A SingleExerciseScreen launch uses a `temp_single_` routine. An early Stop Set
- * must publish SetReady before Idle so ActiveWorkoutScreen's Idle observer sees
- * that SetReady owns navigation, regardless of cross-flow observer scheduling.
+ * must retain the Stop Set guard until ActiveWorkoutScreen routes the idle state
+ * back to SetReady; normal temp-single completion must still navigate away. The
+ * two Compose observers otherwise race independently.
  *
  * This is source-level because this module has no Compose UI harness for the
  * two independent ActiveWorkoutScreen observers.
@@ -18,7 +19,7 @@ import kotlin.test.assertTrue
 class Issue660TempSingleStopSetNavigationTest {
 
     @Test
-    fun `early temp single Stop Set publishes SetReady before Idle navigation`() {
+    fun `early temp single Stop Set cannot teardown Idle during SetReady transition`() {
         val stopSet = between(
             readActiveSessionEngineSource(),
             "fun stopAndReturnToSetReady()",
@@ -26,22 +27,53 @@ class Issue660TempSingleStopSetNavigationTest {
         )
         val setReady = stopSet.indexOf("flowDelegate?.enterSetReady")
         val idle = stopSet.indexOf("coordinator._workoutState.value = WorkoutState.Idle")
+        val stopGuardRelease = stopSet.lastIndexOf("coordinator.stopWorkoutInProgress.value = false")
+        val returnedToSetReady = stopSet.indexOf("returnedToSetReady = true")
+        val releaseOnFailure = stopSet.indexOf("if (!returnedToSetReady)")
         assertTrue(
-            setReady >= 0 && idle >= 0 && setReady < idle,
-            "Issue #660: Stop Set must publish SetReady before Idle so no Idle observer can " +
-                "navigate a temp_single_ routine home first.",
+            setReady >= 0 &&
+                idle >= 0 &&
+                setReady < idle &&
+                returnedToSetReady > idle &&
+                releaseOnFailure > returnedToSetReady &&
+                stopGuardRelease > releaseOnFailure,
+            "Issue #660: only a failed Stop Set may release its guard; successful SetReady return must retain it.",
         )
 
+        val startWorkout = between(
+            readActiveSessionEngineSource(),
+            "fun startWorkout(",
+            "fun stopWorkout(",
+        )
+        assertTrue(
+            startWorkout.contains("coordinator.stopWorkoutInProgress.value = false"),
+            "Issue #660: the next SetReady start must release the preserved Stop Set guard.",
+        )
+
+        val activeWorkout = readActiveWorkoutScreenSource()
         val tempSingleIdleBranch = between(
-            readActiveWorkoutScreenSource(),
+            activeWorkout,
             "loadedRoutine == null ||",
             "workoutState is WorkoutState.Error",
         )
         val tempSingle = tempSingleIdleBranch.indexOf("DefaultWorkoutSessionManager.TEMP_SINGLE_EXERCISE_PREFIX")
-        val setReadyGuard = tempSingleIdleBranch.indexOf("routineFlowState !is RoutineFlowState.SetReady")
+        val stoppingGuard = tempSingleIdleBranch.indexOf("!viewModel.isStoppingWorkout()")
+        val staleSetReadyGuard = tempSingleIdleBranch.indexOf("routineFlowState !is RoutineFlowState.SetReady")
         assertTrue(
-            tempSingle >= 0 && setReadyGuard > tempSingle,
-            "Issue #660: the temp_single_ Idle completion branch must defer to the SetReady observer.",
+            tempSingle >= 0 && stoppingGuard > tempSingle && staleSetReadyGuard < 0,
+            "Issue #660: only an in-flight Stop Set may suppress temp_single_ Idle teardown; " +
+                "normal completion must retain its existing navigate-away behavior.",
+        )
+
+        val setReadyObserver = between(
+            activeWorkout,
+            "LaunchedEffect(routineFlowState, workoutState)",
+            "// Use the new state holder pattern",
+        )
+        assertTrue(
+            setReadyObserver.contains("is RoutineFlowState.SetReady") &&
+                setReadyObserver.contains("navController.navigate(NavigationRoutes.SetReady.route)"),
+            "Issue #660: the flow observer must own the deferred SetReady destination.",
         )
     }
 

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/Issue660TempSingleStopSetNavigationTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/Issue660TempSingleStopSetNavigationTest.kt
@@ -1,0 +1,46 @@
+package com.devil.phoenixproject.presentation
+
+import com.devil.phoenixproject.testutil.readProjectFile
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Issue #660 regression guard for a direct timed bodyweight session.
+ *
+ * A SingleExerciseScreen launch uses a `temp_single_` routine. An early Stop Set
+ * intentionally returns that routine to SetReady, but ActiveWorkoutScreen must
+ * not interpret the transient Idle state as completion and navigate home first.
+ *
+ * This is a source-level navigation test because the defect is a Compose
+ * navigation race/wiring invariant and this module has no Compose UI harness
+ * for ActiveWorkoutScreen.
+ */
+class Issue660TempSingleStopSetNavigationTest {
+
+    @Test
+    fun `early temp single Stop Set lets SetReady own Idle navigation`() {
+        val src = readActiveWorkoutScreenSource()
+        val tempSingleIdleBranch = src.substringAfter(
+            "loadedRoutine?.id?.startsWith(\n                            DefaultWorkoutSessionManager.TEMP_SINGLE_EXERCISE_PREFIX,",
+        ).substringBefore("workoutState is WorkoutState.Error")
+
+        assertTrue(
+            tempSingleIdleBranch.contains("routineFlowState !is RoutineFlowState.SetReady"),
+            "Issue #660: Idle temp_single_ Stop Set returning to SetReady must not call the " +
+                "single-exercise navigateUp() completion branch.",
+        )
+        assertTrue(
+            src.contains("RoutineFlowState.SetReady + Idle - navigating to SetReady"),
+            "Issue #660: the existing SetReady destination must own the early Stop Set transition.",
+        )
+    }
+
+    private fun readActiveWorkoutScreenSource(): String {
+        val src = readProjectFile(
+            "src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ActiveWorkoutScreen.kt",
+        )
+        assertNotNull(src, "Could not locate ActiveWorkoutScreen.kt")
+        return src
+    }
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/Issue660TempSingleStopSetNavigationTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/Issue660TempSingleStopSetNavigationTest.kt
@@ -18,20 +18,27 @@ import kotlin.test.assertTrue
  */
 class Issue660TempSingleStopSetNavigationTest {
 
+    private companion object {
+        val TEMP_SINGLE_SET_READY_GUARD = Regex(
+            """DefaultWorkoutSessionManager\.TEMP_SINGLE_EXERCISE_PREFIX.*?routineFlowState\s*!is\s+RoutineFlowState\.SetReady""",
+            RegexOption.DOT_MATCHES_ALL,
+        )
+        val SET_READY_NAVIGATION = Regex(
+            """is\s+RoutineFlowState\.SetReady\s*->\s*\{.*?navController\.navigate\(NavigationRoutes\.SetReady\.route\)""",
+            RegexOption.DOT_MATCHES_ALL,
+        )
+    }
+
     @Test
     fun `early temp single Stop Set lets SetReady own Idle navigation`() {
         val src = readActiveWorkoutScreenSource()
-        val tempSingleIdleBranch = src.substringAfter(
-            "loadedRoutine?.id?.startsWith(\n                            DefaultWorkoutSessionManager.TEMP_SINGLE_EXERCISE_PREFIX,",
-        ).substringBefore("workoutState is WorkoutState.Error")
-
         assertTrue(
-            tempSingleIdleBranch.contains("routineFlowState !is RoutineFlowState.SetReady"),
+            TEMP_SINGLE_SET_READY_GUARD.containsMatchIn(src),
             "Issue #660: Idle temp_single_ Stop Set returning to SetReady must not call the " +
                 "single-exercise navigateUp() completion branch.",
         )
         assertTrue(
-            src.contains("RoutineFlowState.SetReady + Idle - navigating to SetReady"),
+            SET_READY_NAVIGATION.containsMatchIn(src),
             "Issue #660: the existing SetReady destination must own the early Stop Set transition.",
         )
     }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/Issue660TempSingleStopSetNavigationTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/Issue660TempSingleStopSetNavigationTest.kt
@@ -9,45 +9,60 @@ import kotlin.test.assertTrue
  * Issue #660 regression guard for a direct timed bodyweight session.
  *
  * A SingleExerciseScreen launch uses a `temp_single_` routine. An early Stop Set
- * intentionally returns that routine to SetReady, but ActiveWorkoutScreen must
- * not interpret the transient Idle state as completion and navigate home first.
+ * must publish SetReady before Idle so ActiveWorkoutScreen's Idle observer sees
+ * that SetReady owns navigation, regardless of cross-flow observer scheduling.
  *
- * This is a source-level navigation test because the defect is a Compose
- * navigation race/wiring invariant and this module has no Compose UI harness
- * for ActiveWorkoutScreen.
+ * This is source-level because this module has no Compose UI harness for the
+ * two independent ActiveWorkoutScreen observers.
  */
 class Issue660TempSingleStopSetNavigationTest {
 
-    private companion object {
-        val TEMP_SINGLE_SET_READY_GUARD = Regex(
-            """DefaultWorkoutSessionManager\.TEMP_SINGLE_EXERCISE_PREFIX.*?routineFlowState\s*!is\s+RoutineFlowState\.SetReady""",
-            RegexOption.DOT_MATCHES_ALL,
-        )
-        val SET_READY_NAVIGATION = Regex(
-            """is\s+RoutineFlowState\.SetReady\s*->\s*\{.*?navController\.navigate\(NavigationRoutes\.SetReady\.route\)""",
-            RegexOption.DOT_MATCHES_ALL,
-        )
-    }
-
     @Test
-    fun `early temp single Stop Set lets SetReady own Idle navigation`() {
-        val src = readActiveWorkoutScreenSource()
-        assertTrue(
-            TEMP_SINGLE_SET_READY_GUARD.containsMatchIn(src),
-            "Issue #660: Idle temp_single_ Stop Set returning to SetReady must not call the " +
-                "single-exercise navigateUp() completion branch.",
+    fun `early temp single Stop Set publishes SetReady before Idle navigation`() {
+        val stopSet = between(
+            readActiveSessionEngineSource(),
+            "fun stopAndReturnToSetReady()",
+            "fun stopAndSkipCurrentExercise()",
         )
+        val setReady = stopSet.indexOf("flowDelegate?.enterSetReady")
+        val idle = stopSet.indexOf("coordinator._workoutState.value = WorkoutState.Idle")
         assertTrue(
-            SET_READY_NAVIGATION.containsMatchIn(src),
-            "Issue #660: the existing SetReady destination must own the early Stop Set transition.",
+            setReady >= 0 && idle >= 0 && setReady < idle,
+            "Issue #660: Stop Set must publish SetReady before Idle so no Idle observer can " +
+                "navigate a temp_single_ routine home first.",
+        )
+
+        val tempSingleIdleBranch = between(
+            readActiveWorkoutScreenSource(),
+            "loadedRoutine == null ||",
+            "workoutState is WorkoutState.Error",
+        )
+        val tempSingle = tempSingleIdleBranch.indexOf("DefaultWorkoutSessionManager.TEMP_SINGLE_EXERCISE_PREFIX")
+        val setReadyGuard = tempSingleIdleBranch.indexOf("routineFlowState !is RoutineFlowState.SetReady")
+        assertTrue(
+            tempSingle >= 0 && setReadyGuard > tempSingle,
+            "Issue #660: the temp_single_ Idle completion branch must defer to the SetReady observer.",
         )
     }
 
-    private fun readActiveWorkoutScreenSource(): String {
-        val src = readProjectFile(
-            "src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ActiveWorkoutScreen.kt",
-        )
-        assertNotNull(src, "Could not locate ActiveWorkoutScreen.kt")
+    private fun between(source: String, start: String, end: String): String {
+        val startIndex = source.indexOf(start)
+        val endIndex = source.indexOf(end, startIndex)
+        assertTrue(startIndex >= 0 && endIndex > startIndex, "Could not find $start bounded by $end")
+        return source.substring(startIndex, endIndex)
+    }
+
+    private fun readActiveSessionEngineSource(): String = readSource(
+        "src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt",
+    )
+
+    private fun readActiveWorkoutScreenSource(): String = readSource(
+        "src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ActiveWorkoutScreen.kt",
+    )
+
+    private fun readSource(path: String): String {
+        val src = readProjectFile(path)
+        assertNotNull(src, "Could not locate $path")
         return src
     }
 }


### PR DESCRIPTION
## Summary
- prevent the temp-single Idle completion branch from navigating Home when an early Stop Set has returned the flow to Set Ready
- add a regression guard for the direct timed bodyweight Stop Set navigation path

## Verification
- `:shared:testAndroidHostTest --tests Issue660TempSingleStopSetNavigationTest --tests *stopAndReturnToSetReady* --tests *stopAndSkipCurrentExercise* -Pskip.supabase.check=true` (4 tests passed)

## Scope
- preserves normal temp-single completion navigation and existing real-routine Stop Set / multi-exercise Skip Exercise behavior
- does not change standalone Skip Exercise final-screen semantics

Fixes #660