### PR TITLE
feat(analytics): delete personal records with sync tombstones

### DIFF
--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -372,6 +372,9 @@
     <string name="analytics_personal_records">Persönliche Rekorde</string>
     <string name="analytics_no_prs_title">Noch keine PRs</string>
     <string name="analytics_no_prs_message">Schließe Trainings ab, um persönliche Rekorde aufzustellen!</string>
+    <string name="analytics_delete_pr">Persönlichen Rekord löschen</string>
+    <string name="analytics_delete_pr_confirmation_title">Persönlichen Rekord löschen?</string>
+    <string name="analytics_delete_pr_confirmation_message">Dies entfernt diesen persönlichen Rekord von diesem und synchronisierten Geräten. Dies kann in dieser Version nicht rückgängig gemacht werden.</string>
     <string name="analytics_dashboard">Dashboard</string>
     <string name="analytics_history">Verlauf</string>
 

--- a/shared/src/commonMain/composeResources/values-es/strings.xml
+++ b/shared/src/commonMain/composeResources/values-es/strings.xml
@@ -372,6 +372,9 @@
     <string name="analytics_personal_records">Récords personales</string>
     <string name="analytics_no_prs_title">Sin RPs todavía</string>
     <string name="analytics_no_prs_message">Completa entrenamientos para establecer récords personales!</string>
+    <string name="analytics_delete_pr">Eliminar récord personal</string>
+    <string name="analytics_delete_pr_confirmation_title">¿Eliminar récord personal?</string>
+    <string name="analytics_delete_pr_confirmation_message">Esto elimina este récord personal de este dispositivo y de los dispositivos sincronizados. No se puede deshacer en esta versión.</string>
     <string name="analytics_dashboard">Dashboard</string>
     <string name="analytics_history">Historial</string>
 

--- a/shared/src/commonMain/composeResources/values-fr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fr/strings.xml
@@ -372,6 +372,9 @@
     <string name="analytics_personal_records">Records personnels</string>
     <string name="analytics_no_prs_title">Pas encore de RP</string>
     <string name="analytics_no_prs_message">Complete workouts to set personal records!</string>
+    <string name="analytics_delete_pr">Supprimer le record personnel</string>
+    <string name="analytics_delete_pr_confirmation_title">Supprimer ce record personnel ?</string>
+    <string name="analytics_delete_pr_confirmation_message">Cette action supprime ce record personnel de cet appareil et des appareils synchronisés. Elle est irréversible dans cette version.</string>
     <string name="analytics_dashboard">Dashboard</string>
     <string name="analytics_history">Historique</string>
 

--- a/shared/src/commonMain/composeResources/values-it/strings.xml
+++ b/shared/src/commonMain/composeResources/values-it/strings.xml
@@ -72,4 +72,7 @@
     <string name="set_type_warmup">Warm-up Set %1$d</string>
     <string name="set_type_working">Working Set</string>
 
+    <string name="analytics_delete_pr">Elimina record personale</string>
+    <string name="analytics_delete_pr_confirmation_title">Eliminare il record personale?</string>
+    <string name="analytics_delete_pr_confirmation_message">Questa azione rimuove questo record personale da questo dispositivo e dai dispositivi sincronizzati. Non può essere annullata in questa versione.</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-nl/strings.xml
+++ b/shared/src/commonMain/composeResources/values-nl/strings.xml
@@ -374,6 +374,9 @@
     <string name="analytics_personal_records">Persoonlijke records</string>
     <string name="analytics_no_prs_title">Nog geen PR\'s</string>
     <string name="analytics_no_prs_message">Voltooi trainingen om persoonlijke records te vestigen!</string>
+    <string name="analytics_delete_pr">Persoonlijk record verwijderen</string>
+    <string name="analytics_delete_pr_confirmation_title">Persoonlijk record verwijderen?</string>
+    <string name="analytics_delete_pr_confirmation_message">Dit verwijdert dit persoonlijke record van dit apparaat en gesynchroniseerde apparaten. Dit kan in deze versie niet ongedaan worden gemaakt.</string>
     <string name="analytics_dashboard">Dashboard</string>
     <string name="analytics_history">Geschiedenis</string>
 

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -453,6 +453,9 @@
     <string name="analytics_personal_records">Personal Records</string>
     <string name="analytics_no_prs_title">No PRs Yet</string>
     <string name="analytics_no_prs_message">Complete workouts to set personal records!</string>
+    <string name="analytics_delete_pr">Delete personal record</string>
+    <string name="analytics_delete_pr_confirmation_title">Delete personal record?</string>
+    <string name="analytics_delete_pr_confirmation_message">This removes this personal record from this device and synced devices. This can’t be undone in this release.</string>
     <string name="analytics_dashboard">Dashboard</string>
     <string name="analytics_history">History</string>
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/PersonalRecordRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/PersonalRecordRepository.kt
@@ -48,6 +48,9 @@ interface PersonalRecordRepository {
      */
     fun getAllPRsGrouped(profileId: String): Flow<List<PersonalRecord>>
 
+    /** Soft-delete one active-profile PR snapshot without changing workout history or exercise 1RM. */
+    suspend fun deletePR(prId: Long, profileId: String)
+
     /**
      * Update PR if the new performance is better
      * Compares the new weight and reps with the existing PR for the exercise/mode combination

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightPersonalRecordRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightPersonalRecordRepository.kt
@@ -7,6 +7,7 @@ import com.devil.phoenixproject.database.VitruvianDatabase
 import com.devil.phoenixproject.domain.model.PRType
 import com.devil.phoenixproject.domain.model.PersonalRecord
 import com.devil.phoenixproject.domain.model.WorkoutPhase
+import com.devil.phoenixproject.domain.model.currentTimeMillis
 import com.devil.phoenixproject.domain.model.generateUUID
 import com.devil.phoenixproject.util.OneRepMaxCalculator
 import kotlinx.coroutines.Dispatchers
@@ -63,6 +64,8 @@ class SqlDelightPersonalRecordRepository(private val db: VitruvianDatabase) : Pe
         profileId = profileId,
         cableCount = cableCount?.toInt(),
         uuid = uuid,
+        updatedAt = updatedAt ?: achievedAt,
+        deletedAt = deletedAt,
     )
 
     override suspend fun getLatestPR(exerciseId: String, workoutMode: String, profileId: String): PersonalRecord? = withContext(Dispatchers.IO) {
@@ -93,6 +96,18 @@ class SqlDelightPersonalRecordRepository(private val db: VitruvianDatabase) : Pe
                 // Return the best PR for each exercise (by weight, parity with parent repo)
                 prs.maxByOrNull { it.weightPerCableKg }
             }
+    }
+
+    override suspend fun deletePR(prId: Long, profileId: String) = withContext(Dispatchers.IO) {
+        val now = currentTimeMillis()
+        db.transaction {
+            queries.softDeletePR(
+                id = prId,
+                profileId = profileId,
+                deletedAt = now,
+                updatedAt = now,
+            )
+        }
     }
 
     override suspend fun updatePRIfBetter(
@@ -277,6 +292,7 @@ class SqlDelightPersonalRecordRepository(private val db: VitruvianDatabase) : Pe
         val volumeForVolumePR = volumePRWeightPerCableKg * reps
         val estimatedOneRepMax = OneRepMaxCalculator.estimate(weightPRWeightPerCableKg, reps)
         val phaseName = phase.name
+        val mutationTimestamp = currentTimeMillis()
 
         // Issue #319: Log the profile context being used
         Logger.d { "PR_SAVE: Checking for exercise=$exerciseId, mode=$canonicalWorkoutMode, phase=$phaseName, profile=$effectiveProfileId" }
@@ -347,6 +363,7 @@ class SqlDelightPersonalRecordRepository(private val db: VitruvianDatabase) : Pe
                     prType = PRType.MAX_WEIGHT.name,
                     volume = volumeForWeightPR.toDouble(),
                     phase = phaseName,
+                    updatedAt = mutationTimestamp,
                     profile_id = effectiveProfileId,
                     cable_count = cableCount?.toLong(),
                     uuid = currentWeightPR?.uuid ?: generateUUID(),
@@ -367,6 +384,7 @@ class SqlDelightPersonalRecordRepository(private val db: VitruvianDatabase) : Pe
                     prType = PRType.MAX_VOLUME.name,
                     volume = volumeForVolumePR.toDouble(),
                     phase = phaseName,
+                    updatedAt = mutationTimestamp,
                     profile_id = effectiveProfileId,
                     cable_count = cableCount?.toLong(),
                     uuid = currentVolumePR?.uuid ?: generateUUID(),

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightSyncRepository.kt
@@ -349,6 +349,7 @@ class SqlDelightSyncRepository(
                         profile_id = userProfileRepository.activeProfile.value?.id ?: "default",
                         cable_count = dto.cableCount?.toLong(),
                         uuid = dto.clientId.ifBlank { generateUUID() },
+                        updatedAt = dto.updatedAt,
                     )
                 }
             }
@@ -1348,6 +1349,8 @@ class SqlDelightSyncRepository(
                 profileId = row.profile_id,
                 cableCount = row.cable_count?.toInt(),
                 uuid = row.uuid,
+                updatedAt = row.updatedAt ?: row.achievedAt,
+                deletedAt = row.deletedAt,
             )
         }
     }
@@ -1455,12 +1458,9 @@ class SqlDelightSyncRepository(
     /**
      * Merge personal records from portal (pull-path).
      *
-     * CONFLICT RESOLUTION STRATEGY: LOCAL WINS (INSERT OR IGNORE)
-     * Reference: CONFLICT-RESOLUTION-DESIGN.md Task 2, Section 2 "Personal Records"
-     *
-     * PRs are computed from local workout sessions. Mobile computes PRs.
-     * If the same PR exists locally (same compound key: exerciseId, workoutMode, prType, phase),
-     * the local version is authoritative and the remote PR is silently dropped.
+     * CONFLICT RESOLUTION STRATEGY: stable UUID, timestamp last-write-wins;
+     * on equal timestamps a tombstone wins. This prevents an older active pull
+     * from resurrecting a PR a different device has deleted.
      *
      * Multi-device scenario: Both devices compute same PR from same session - no conflict
      * because the data is identical. Different PRs from different sessions both get inserted
@@ -1477,9 +1477,8 @@ class SqlDelightSyncRepository(
 
     private fun mergePersonalRecordRows(records: List<PersonalRecordSyncDto>, profileId: String) {
         records.forEach { dto ->
-            // INSERT OR IGNORE — local PRs win on conflict (same compound key)
             val effectiveVolume = if (dto.volume > 0f) dto.volume else dto.weight * dto.reps
-            val prUuid = dto.clientId.ifBlank { generateUUID() }
+            val prUuid = dto.clientId.takeIf { it.isNotBlank() } ?: return@forEach
             queries.adoptServerPrUuid(
                 uuid = prUuid,
                 exerciseId = dto.exerciseId,
@@ -1488,7 +1487,7 @@ class SqlDelightSyncRepository(
                 profileId = profileId,
                 achievedAt = dto.achievedAt,
             )
-            queries.insertPRIgnore(
+            queries.updatePRFromSyncIfNewer(
                 exerciseId = dto.exerciseId,
                 exerciseName = dto.exerciseName,
                 weight = dto.weight.toDouble(),
@@ -1499,6 +1498,25 @@ class SqlDelightSyncRepository(
                 prType = dto.prType,
                 volume = effectiveVolume.toDouble(),
                 phase = dto.phase,
+                updatedAt = dto.updatedAt,
+                deletedAt = dto.deletedAt,
+                profileId = profileId,
+                cable_count = dto.cableCount?.toLong(),
+                uuid = prUuid,
+            )
+            queries.insertPRFromSyncIgnore(
+                exerciseId = dto.exerciseId,
+                exerciseName = dto.exerciseName,
+                weight = dto.weight.toDouble(),
+                reps = dto.reps.toLong(),
+                oneRepMax = dto.oneRepMax.toDouble(),
+                achievedAt = dto.achievedAt,
+                workoutMode = dto.workoutMode,
+                prType = dto.prType,
+                volume = effectiveVolume.toDouble(),
+                phase = dto.phase,
+                updatedAt = dto.updatedAt,
+                deletedAt = dto.deletedAt,
                 profile_id = profileId,
                 cable_count = dto.cableCount?.toLong(),
                 uuid = prUuid,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/SqlDelightWorkoutRepository.kt
@@ -1011,6 +1011,7 @@ class SqlDelightWorkoutRepository(private val db: VitruvianDatabase, private val
                     profile_id = defaultProfileId,
                     cable_count = cableCount?.toLong(),
                     uuid = currentWeightPR?.uuid ?: generateUUID(),
+                    updatedAt = timestamp,
                 )
             }
 
@@ -1029,6 +1030,7 @@ class SqlDelightWorkoutRepository(private val db: VitruvianDatabase, private val
                     profile_id = defaultProfileId,
                     cable_count = cableCount?.toLong(),
                     uuid = currentVolumePR?.uuid ?: generateUUID(),
+                    updatedAt = timestamp,
                 )
             }
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalPullAdapter.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalPullAdapter.kt
@@ -354,6 +354,15 @@ object PortalPullAdapter {
         resolvedExerciseId: String? = null,
     ): PersonalRecordSyncDto {
         val now = currentTimeMillis()
+        fun parsePortalTimestamp(value: String?): Long? = value?.let {
+            try {
+                kotlinx.datetime.Instant.parse(it).toEpochMilliseconds()
+            } catch (_: Exception) {
+                null
+            }
+        }
+        val achievedAt = parsePortalTimestamp(pr.achievedAt) ?: now
+        val updatedAt = parsePortalTimestamp(pr.updatedAt) ?: achievedAt
         return PersonalRecordSyncDto(
             clientId = pr.id,
             serverId = pr.id,
@@ -369,20 +378,14 @@ object PortalPullAdapter {
             weight = pr.value.toFloat(),
             reps = pr.reps ?: 0,
             oneRepMax = 0f, // Portal doesn't send computed 1RM
-            achievedAt = pr.achievedAt?.let {
-                try {
-                    kotlinx.datetime.Instant.parse(it).toEpochMilliseconds()
-                } catch (_: Exception) {
-                    now
-                }
-            } ?: now,
+            achievedAt = achievedAt,
             workoutMode = pr.recordType,
             prType = pr.recordType,
             phase = pr.workoutPhase ?: "COMBINED",
             volume = pr.value.toFloat(),
-            deletedAt = null,
-            createdAt = now,
-            updatedAt = now,
+            deletedAt = parsePortalTimestamp(pr.deletedAt),
+            createdAt = achievedAt,
+            updatedAt = updatedAt,
         )
     }
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapter.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncAdapter.kt
@@ -360,7 +360,8 @@ object PortalSyncAdapter {
             workoutPhase = record.phase.name,
             sessionId = sessionId,
             achievedAt = epochToIso8601(record.timestamp),
-            updatedAt = epochToIso8601(currentTimeMillis()),
+            updatedAt = epochToIso8601(record.updatedAt),
+            deletedAt = record.deletedAt?.let(::epochToIso8601),
             localProfileId = record.profileId,
             workoutMode = PortalMappings.workoutModeToSync(record.workoutMode),
         )

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncDtos.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/PortalSyncDtos.kt
@@ -630,6 +630,7 @@ data class PortalPersonalRecordDto(
     val sessionId: String? = null,
     val achievedAt: String,
     val updatedAt: String? = null,
+    val deletedAt: String? = null,
     val localProfileId: String? = null,
     val workoutMode: String? = null,
 )
@@ -987,4 +988,5 @@ data class PullPersonalRecordDto(
     val sessionId: String? = null,
     val achievedAt: String? = null,
     val updatedAt: String? = null,
+    val deletedAt: String? = null,
 )

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/SyncManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/sync/SyncManager.kt
@@ -787,14 +787,18 @@ class SyncManager(
 
         // 2. Fetch full PRs with type/phase/volume metadata (GAP 2 fix), profile-scoped
         val recentPRs = syncRepository.getFullPRsModifiedSince(lastSync, activeProfileId)
-        val prBySessionKey = recentPRs.groupBy { pr ->
+        // Tombstones are dedicated PR payload rows only: they must be sent, but
+        // must not mark a workout session as a newly achieved PR or trigger an
+        // unnecessary historical-session lookup.
+        val activeRecentPRs = recentPRs.filter { it.deletedAt == null }
+        val prBySessionKey = activeRecentPRs.groupBy { pr ->
             personalRecordSessionKey(pr.exerciseId, pr.timestamp)
         }
         val sessionIdByDeltaPrKey = sessions.mapNotNull { session ->
             val exerciseId = session.exerciseId?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
             personalRecordSessionKey(exerciseId, session.timestamp) to session.id
         }.toMap()
-        val missingSessionRecords = recentPRs.filter { pr ->
+        val missingSessionRecords = activeRecentPRs.filter { pr ->
             personalRecordSessionKey(pr.exerciseId, pr.timestamp) !in sessionIdByDeltaPrKey
         }
         val historicalSessionIdByPrKey = if (missingSessionRecords.isEmpty()) {
@@ -1288,7 +1292,9 @@ class SyncManager(
         // server confirmed the push. This gives PersonalRecord rows the same
         // post-confirmation resend protection that WorkoutSession rows get from
         // the caller's post-push stamping block.
-        val pushedPrIds = recentPRs.map { it.id }.distinct()
+        // Active rows retain the legacy post-push stamp. Tombstones keep their
+        // deletion mutation timestamp so an older active payload cannot win LWW.
+        val pushedPrIds = activeRecentPRs.map { it.id }.distinct()
         if (pushedPrIds.isNotEmpty()) {
             val prStampTime = currentTimeMillis()
             syncRepository.updatePersonalRecordTimestamp(pushedPrIds, prStampTime)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/Models.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/Models.kt
@@ -51,6 +51,9 @@ data class PersonalRecord(
     val profileId: String = "default",
     val cableCount: Int? = null,
     val uuid: String? = null,
+    /** Sync-only mutation metadata. Product reads filter tombstones in SQL. */
+    val updatedAt: Long = timestamp,
+    val deletedAt: Long? = null,
 )
 
 /**

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/navigation/NavGraph.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/navigation/NavGraph.kt
@@ -331,6 +331,11 @@ fun NavGraph(
                             NavigationRoutes.StrengthAssessmentPicker.createRoute(profileId),
                         )
                     },
+                    onNavigateToExerciseDetail = { exerciseId ->
+                        navController.navigate(
+                            NavigationRoutes.ExerciseDetail.createRoute(exerciseId),
+                        )
+                    },
                 )
             }
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/AnalyticsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/AnalyticsScreen.kt
@@ -1,6 +1,7 @@
 package com.devil.phoenixproject.presentation.screen
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -55,8 +56,14 @@ fun ProgressTab(
     formatWeight: (Float, WeightUnit) -> String,
     assessmentEnabled: Boolean,
     onNavigateToStrengthAssessment: () -> Unit,
+    onNavigateToExerciseDetail: (String) -> Unit,
+    onDeletePersonalRecord: suspend (Long) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    var pendingDelete by remember { mutableStateOf<PersonalRecord?>(null) }
+    var isDeleting by remember { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
+
     LazyColumn(
         modifier = modifier
             .fillMaxSize()
@@ -193,7 +200,11 @@ fun ProgressTab(
                     }
 
                     Card(
-                        modifier = Modifier.fillMaxWidth(),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable(enabled = !isDeleting) {
+                                onNavigateToExerciseDetail(pr.exerciseId)
+                            },
                         colors = CardDefaults.cardColors(
                             containerColor = MaterialTheme.colorScheme.surfaceContainer,
                         ),
@@ -220,22 +231,33 @@ fun ProgressTab(
                                 )
                             }
 
-                            Column(horizontalAlignment = Alignment.End) {
-                                Text(
-                                    text = WeightDisplayFormatter.formatDisplayWeight(
-                                        pr.weightPerCableKg,
-                                        cableCount = null,
-                                        weightUnit,
-                                    ),
-                                    style = MaterialTheme.typography.headlineSmall,
-                                    fontWeight = FontWeight.Bold,
-                                    color = MaterialTheme.colorScheme.primary,
-                                )
-                                Text(
-                                    text = "${pr.reps} Reps",
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                )
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Column(horizontalAlignment = Alignment.End) {
+                                    Text(
+                                        text = WeightDisplayFormatter.formatDisplayWeight(
+                                            pr.weightPerCableKg,
+                                            cableCount = null,
+                                            weightUnit,
+                                        ),
+                                        style = MaterialTheme.typography.headlineSmall,
+                                        fontWeight = FontWeight.Bold,
+                                        color = MaterialTheme.colorScheme.primary,
+                                    )
+                                    Text(
+                                        text = "${pr.reps} Reps",
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                }
+                                IconButton(
+                                    enabled = !isDeleting,
+                                    onClick = { pendingDelete = pr },
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Default.Delete,
+                                        contentDescription = stringResource(Res.string.analytics_delete_pr),
+                                    )
+                                }
                             }
                         }
                     }
@@ -253,6 +275,33 @@ fun ProgressTab(
             Spacer(modifier = Modifier.height(80.dp))
         }
     }
+
+    pendingDelete?.let { pr ->
+        AlertDialog(
+            onDismissRequest = { if (!isDeleting) pendingDelete = null },
+            title = { Text(stringResource(Res.string.analytics_delete_pr_confirmation_title)) },
+            text = { Text(stringResource(Res.string.analytics_delete_pr_confirmation_message)) },
+            dismissButton = {
+                TextButton(
+                    enabled = !isDeleting,
+                    onClick = { pendingDelete = null },
+                ) { Text(stringResource(Res.string.action_cancel)) }
+            },
+            confirmButton = {
+                TextButton(
+                    enabled = !isDeleting,
+                    onClick = {
+                        scope.launch {
+                            isDeleting = true
+                            onDeletePersonalRecord(pr.id)
+                            isDeleting = false
+                            pendingDelete = null
+                        }
+                    },
+                ) { Text(stringResource(Res.string.action_delete)) }
+            },
+        )
+    }
 }
 
 /**
@@ -268,6 +317,7 @@ fun AnalyticsScreen(
     themeMode: com.devil.phoenixproject.ui.theme.ThemeMode,
     assessmentProfileId: String?,
     onNavigateToStrengthAssessment: (String) -> Unit,
+    onNavigateToExerciseDetail: (String) -> Unit,
 ) {
     val workoutHistory by viewModel.workoutHistory.collectAsState()
     val groupedWorkoutHistory by viewModel.groupedWorkoutHistory.collectAsState()
@@ -484,6 +534,10 @@ fun AnalyticsScreen(
                         assessmentEnabled = assessmentProfileId != null,
                         onNavigateToStrengthAssessment = {
                             assessmentProfileId?.let(onNavigateToStrengthAssessment)
+                        },
+                        onNavigateToExerciseDetail = onNavigateToExerciseDetail,
+                        onDeletePersonalRecord = { prId ->
+                            viewModel.personalRecordRepository.deletePR(prId, activeProfileId)
                         },
                         modifier = Modifier.fillMaxSize(),
                     )

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/DataBackupManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/util/DataBackupManager.kt
@@ -752,6 +752,7 @@ abstract class BaseDataBackupManager(
                             profile_id = pr.profileId ?: "default",
                             cable_count = pr.cableCount?.toLong(),
                             uuid = pr.uuid ?: generateUUID(),
+                            updatedAt = pr.achievedAt,
                         )
                         personalRecordsImported++
                     } catch (e: Exception) {
@@ -1585,6 +1586,7 @@ abstract class BaseDataBackupManager(
                                                     // non-streaming path already passes pr.cableCount).
                                                     cable_count = pr.cableCount?.toLong(),
                                                     uuid = pr.uuid ?: generateUUID(),
+                                                    updatedAt = pr.achievedAt,
                                                 )
                                                 personalRecordsImported++
                                             } catch (e: Exception) {

--- a/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
+++ b/shared/src/commonMain/sqldelight/com/devil/phoenixproject/database/VitruvianDatabase.sq
@@ -1000,17 +1000,18 @@ WHERE exerciseId = ?
 
 -- Get all PRs ordered by timestamp
 selectAllRecords:
-SELECT * FROM PersonalRecord WHERE profile_id = :profileId ORDER BY achievedAt DESC;
+SELECT * FROM PersonalRecord WHERE profile_id = :profileId AND deletedAt IS NULL ORDER BY achievedAt DESC;
 
 -- Get PRs for a specific exercise
 selectRecordsByExercise:
-SELECT * FROM PersonalRecord WHERE exerciseId = ? AND profile_id = :profileId ORDER BY oneRepMax DESC;
+SELECT * FROM PersonalRecord WHERE exerciseId = ? AND profile_id = :profileId AND deletedAt IS NULL ORDER BY oneRepMax DESC;
 
 -- Get PR by exercise, workout mode, PR type, and phase
 selectPR:
 SELECT * FROM PersonalRecord
 WHERE exerciseId = ? AND workoutMode = ? AND prType = ? AND phase = ?
 AND profile_id = :profileId
+AND deletedAt IS NULL
 LIMIT 1;
 
 -- Get both PRs (MAX_WEIGHT and MAX_VOLUME) for an exercise in a specific mode (COMBINED phase)
@@ -1018,6 +1019,7 @@ selectPRsForExerciseAndMode:
 SELECT * FROM PersonalRecord
 WHERE exerciseId = ? AND workoutMode = ?
 AND profile_id = :profileId
+AND deletedAt IS NULL
 ORDER BY prType;
 
 -- Get the best weight PR for an exercise across all modes
@@ -1025,6 +1027,7 @@ selectBestWeightPR:
 SELECT * FROM PersonalRecord
 WHERE exerciseId = ? AND prType = 'MAX_WEIGHT'
 AND profile_id = :profileId
+AND deletedAt IS NULL
 ORDER BY weight DESC
 LIMIT 1;
 
@@ -1033,6 +1036,7 @@ selectBestVolumePR:
 SELECT * FROM PersonalRecord
 WHERE exerciseId = ? AND prType = 'MAX_VOLUME'
 AND profile_id = :profileId
+AND deletedAt IS NULL
 ORDER BY volume DESC
 LIMIT 1;
 
@@ -1043,6 +1047,7 @@ WHERE exerciseId = :exerciseId
 AND prType = 'MAX_WEIGHT'
 AND workoutMode = :workoutMode
 AND profile_id = :profileId
+AND deletedAt IS NULL
 ORDER BY weight DESC
 LIMIT 1;
 
@@ -1053,6 +1058,7 @@ WHERE exerciseId = :exerciseId
 AND prType = 'MAX_VOLUME'
 AND workoutMode = :workoutMode
 AND profile_id = :profileId
+AND deletedAt IS NULL
 ORDER BY volume DESC
 LIMIT 1;
 
@@ -1061,6 +1067,7 @@ selectAllPRsForExercise:
 SELECT * FROM PersonalRecord
 WHERE exerciseId = :exerciseId
 AND profile_id = :profileId
+AND deletedAt IS NULL
 ORDER BY workoutMode, prType, achievedAt DESC;
 
 -- Get the best overall PR for an exercise (prefers weight, for backwards compatibility)
@@ -1068,6 +1075,7 @@ selectBestPR:
 SELECT * FROM PersonalRecord
 WHERE exerciseId = ?
 AND profile_id = :profileId
+AND deletedAt IS NULL
 ORDER BY weight DESC, volume DESC
 LIMIT 1;
 
@@ -1076,11 +1084,12 @@ selectLatestPR:
 SELECT * FROM PersonalRecord
 WHERE exerciseId = ? AND workoutMode = ? AND prType = 'MAX_WEIGHT'
 AND profile_id = :profileId
+AND deletedAt IS NULL
 LIMIT 1;
 
 -- Get all PRs grouped by exercise for analytics
 selectAllPRsGrouped:
-SELECT * FROM PersonalRecord WHERE profile_id = :profileId ORDER BY exerciseId, workoutMode, prType, achievedAt DESC;
+SELECT * FROM PersonalRecord WHERE profile_id = :profileId AND deletedAt IS NULL ORDER BY exerciseId, workoutMode, prType, achievedAt DESC;
 
 -- Insert a new PR (with prType, volume, and phase support)
 insertRecord:
@@ -1092,16 +1101,76 @@ upsertRecord:
 INSERT OR REPLACE INTO PersonalRecord (id, exerciseId, exerciseName, weight, reps, oneRepMax, achievedAt, workoutMode, prType, volume, phase, profile_id, cable_count, uuid)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
--- Upsert PR by unique key (exerciseId, workoutMode, prType, phase) - no ID required
--- Uses INSERT OR REPLACE which replaces on unique index conflict (idx_pr_unique)
+-- Upsert an active PR by business key while retaining its stable local/portal identity.
+-- The bundled SQLite 3.18 dialect lacks ON CONFLICT DO UPDATE; REPLACE therefore
+-- explicitly carries forward the matched row's id and UUID. A newer local PR can
+-- clear a tombstone, but no stale payload gets a new identity to bypass LWW.
 upsertPR:
-INSERT OR REPLACE INTO PersonalRecord (exerciseId, exerciseName, weight, reps, oneRepMax, achievedAt, workoutMode, prType, volume, phase, profile_id, cable_count, uuid)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+INSERT OR REPLACE INTO PersonalRecord (
+    id, exerciseId, exerciseName, weight, reps, oneRepMax, achievedAt,
+    workoutMode, prType, volume, phase, updatedAt, deletedAt,
+    profile_id, cable_count, uuid
+)
+VALUES (
+    (SELECT id FROM PersonalRecord
+     WHERE exerciseId = :exerciseId AND workoutMode = :workoutMode
+       AND prType = :prType AND phase = :phase AND profile_id = :profile_id
+     LIMIT 1),
+    :exerciseId, :exerciseName, :weight, :reps, :oneRepMax, :achievedAt,
+    :workoutMode, :prType, :volume, :phase, :updatedAt, NULL,
+    :profile_id, :cable_count,
+    COALESCE(
+        (SELECT uuid FROM PersonalRecord
+         WHERE exerciseId = :exerciseId AND workoutMode = :workoutMode
+           AND prType = :prType AND phase = :phase AND profile_id = :profile_id
+         LIMIT 1),
+        :uuid
+    )
+);
 
 -- Insert PR but ignore on conflict (local wins) - for portal pull merge
 insertPRIgnore:
 INSERT OR IGNORE INTO PersonalRecord (exerciseId, exerciseName, weight, reps, oneRepMax, achievedAt, workoutMode, prType, volume, phase, profile_id, cable_count, uuid)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+
+softDeletePR:
+UPDATE PersonalRecord
+SET deletedAt = :deletedAt, updatedAt = :updatedAt
+WHERE id = :id AND profile_id = :profileId AND deletedAt IS NULL;
+
+updatePRFromSyncIfNewer:
+UPDATE PersonalRecord
+SET exerciseId = :exerciseId,
+    exerciseName = :exerciseName,
+    weight = :weight,
+    reps = :reps,
+    oneRepMax = :oneRepMax,
+    achievedAt = :achievedAt,
+    workoutMode = :workoutMode,
+    prType = :prType,
+    volume = :volume,
+    phase = :phase,
+    updatedAt = :updatedAt,
+    deletedAt = :deletedAt,
+    cable_count = :cable_count
+WHERE uuid = :uuid
+  AND profile_id = :profileId
+  AND (
+    COALESCE(updatedAt, achievedAt) < :updatedAt
+    OR (
+      COALESCE(updatedAt, achievedAt) = :updatedAt
+      AND :deletedAt IS NOT NULL
+      AND deletedAt IS NULL
+    )
+  );
+
+insertPRFromSyncIgnore:
+INSERT OR IGNORE INTO PersonalRecord (
+    exerciseId, exerciseName, weight, reps, oneRepMax, achievedAt,
+    workoutMode, prType, volume, phase, updatedAt, deletedAt,
+    profile_id, cable_count, uuid
+)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 adoptServerPrUuid:
 UPDATE PersonalRecord
@@ -2655,7 +2724,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 
 -- Get PRs modified since last sync
 selectPRsModifiedSince:
 SELECT * FROM PersonalRecord
-WHERE (updatedAt > ? OR updatedAt IS NULL) AND deletedAt IS NULL
+WHERE (updatedAt > ? OR updatedAt IS NULL)
 AND profile_id = :profileId;
 
 -- Update PR server ID
@@ -2665,7 +2734,7 @@ UPDATE PersonalRecord SET serverId = ? WHERE id = ?;
 -- Stamp pushed PRs with current updatedAt so they aren't re-sent on next sync
 -- (Issue #528). Matches the WorkoutSession.updateSessionTimestamp pattern.
 updatePRTimestamp:
-UPDATE PersonalRecord SET updatedAt = ? WHERE id IN ?;
+UPDATE PersonalRecord SET updatedAt = ? WHERE id IN ? AND deletedAt IS NULL;
 
 -- Get routines modified since last sync
 selectRoutinesModifiedSince:

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/repository/PersonalRecordRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/repository/PersonalRecordRepositoryTest.kt
@@ -514,4 +514,43 @@ class PersonalRecordRepositoryTest {
         assertEquals(35f, oldSchoolPR?.weightPerCableKg)
         assertEquals(55f, echoPR?.weightPerCableKg)
     }
+
+    @Test
+    fun `deletePR removes only the requested active-profile record`() = runTest {
+        repository.addRecord(
+            PersonalRecord(
+                id = 1,
+                exerciseId = exerciseId,
+                exerciseName = exerciseName,
+                weightPerCableKg = 35f,
+                reps = 10,
+                oneRepMax = 45f,
+                timestamp = 1000L,
+                workoutMode = "OldSchool",
+                prType = PRType.MAX_WEIGHT,
+                volume = 350f,
+                profileId = profileId,
+            ),
+        )
+        repository.addRecord(
+            PersonalRecord(
+                id = 2,
+                exerciseId = exerciseId,
+                exerciseName = exerciseName,
+                weightPerCableKg = 55f,
+                reps = 8,
+                oneRepMax = 65f,
+                timestamp = 2000L,
+                workoutMode = "Echo",
+                prType = PRType.MAX_WEIGHT,
+                volume = 440f,
+                profileId = profileId,
+            ),
+        )
+
+        repository.deletePR(prId = 1, profileId = profileId)
+
+        assertNull(repository.getBestWeightPR(exerciseId, "OldSchool", profileId))
+        assertEquals(55f, repository.getBestWeightPR(exerciseId, "Echo", profileId)?.weightPerCableKg)
+    }
 }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/PortalPullAdapterTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/sync/PortalPullAdapterTest.kt
@@ -290,6 +290,19 @@ class PortalPullAdapterTest {
     }
 
     @Test
+    fun `toPersonalRecordSyncDto preserves portal tombstone and mutation timestamp`() {
+        val pr = makePullPersonalRecordDto(
+            updatedAt = "2026-01-03T04:05:06Z",
+            deletedAt = "2026-01-04T05:06:07Z",
+        )
+
+        val result = PortalPullAdapter.toPersonalRecordSyncDto(pr, resolvedExerciseId = "catalog-1")
+
+        assertEquals(1767413106000L, result.updatedAt)
+        assertEquals(1767503167000L, result.deletedAt)
+    }
+
+    @Test
     fun `toPersonalRecordSyncDto maps weight value and reps`() {
         val pr = makePullPersonalRecordDto(value = 102.5, reps = 5)
 
@@ -332,6 +345,8 @@ class PortalPullAdapterTest {
         exerciseName: String = "Bench Press",
         value: Double = 100.0,
         reps: Int? = 1,
+        updatedAt: String? = null,
+        deletedAt: String? = null,
     ) = PullPersonalRecordDto(
         id = id,
         userId = "user-1",
@@ -342,6 +357,8 @@ class PortalPullAdapterTest {
         reps = reps,
         workoutPhase = "COMBINED",
         achievedAt = "2026-01-01T00:00:00Z",
+        updatedAt = updatedAt,
+        deletedAt = deletedAt,
     )
 
     private fun makePullGamificationStatsDto(

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakePersonalRecordRepository.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakePersonalRecordRepository.kt
@@ -93,6 +93,14 @@ class FakePersonalRecordRepository : PersonalRecordRepository {
             .mapNotNull { (_, records) -> records.maxByOrNull { it.volume } }
     }
 
+    override suspend fun deletePR(prId: Long, profileId: String) {
+        val key = records.entries.firstOrNull { (_, record) ->
+            record.id == prId && record.profileId == profileId
+        }?.key ?: return
+        records.remove(key)
+        updateRecordsFlow()
+    }
+
     override suspend fun updatePRIfBetter(
         exerciseId: String,
         weightPerCableKg: Float,


### PR DESCRIPTION
## Summary
- Add a Progress-tab delete affordance and confirmation dialog for Personal Records; card taps now open the exercise detail route.
- Soft-delete profile-scoped PR rows locally and propagate stable-ID `deletedAt` / `updatedAt` tombstones through the portal sync DTOs.
- Reconcile pulled PR rows by stable UUID and LWW semantics, including tombstones.

## Validation
- `./gradlew :shared:testAndroidHostTest --tests ...PersonalRecordRepositoryTest --tests ...PortalPullAdapterTest`
- `./gradlew :androidApp:assembleDebug`
- Android emulator: confirmed Progress delete icon, confirmation copy (`Cancel` / `Delete`), and confirmation removes only the selected record from the list.

## Deployment dependency
Requires [portal PR #93](https://github.com/9thLevelSoftware/phoenix-portal/pull/93) to merge and deploy before production release of this destructive UI.

Refs #655