### PR TITLE
feat(#665): add Previously completed exercise filter to Single Exercise, Routine, and Profile

### DIFF
--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -796,4 +796,6 @@
     <string name="profile_disco_unlocked_body">Aktiviere den Disco-Modus in den LED-Einstellungen, damit dein Trainer Party macht.</string>
     <string name="profile_disco_unlocked_action">Party starten</string>
     <string name="profile_adult_enable_partial_failure">Die Altersbestätigung wurde gespeichert, aber der vulgäre Modus konnte nicht aktiviert werden. Versuche es erneut.</string>
+    <string name="label_previously_completed">Zuvor abgeschlossen</string>
+    <string name="cd_filter_previously_completed">Zuvor abgeschlossene Übungen filtern</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-es/strings.xml
+++ b/shared/src/commonMain/composeResources/values-es/strings.xml
@@ -796,4 +796,6 @@
     <string name="profile_disco_unlocked_body">Activa el modo disco en las preferencias LED para que tu entrenador se una a la fiesta.</string>
     <string name="profile_disco_unlocked_action">¡A bailar!</string>
     <string name="profile_adult_enable_partial_failure">La confirmación de edad se guardó, pero no se pudo activar el modo vulgar. Inténtalo de nuevo.</string>
+    <string name="label_previously_completed">Completado anteriormente</string>
+    <string name="cd_filter_previously_completed">Filtrar ejercicios completados anteriormente</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-fr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fr/strings.xml
@@ -796,4 +796,6 @@
     <string name="profile_disco_unlocked_body">Activez le mode disco dans les préférences LED pour faire danser votre machine.</string>
     <string name="profile_disco_unlocked_action">C\'est parti !</string>
     <string name="profile_adult_enable_partial_failure">La confirmation de l\'âge a été enregistrée, mais le mode vulgaire n\'a pas pu être activé. Réessayez.</string>
+    <string name="label_previously_completed">Déjà terminés</string>
+    <string name="cd_filter_previously_completed">Filtrer les exercices déjà terminés</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-it/strings.xml
+++ b/shared/src/commonMain/composeResources/values-it/strings.xml
@@ -74,4 +74,6 @@
     <string name="set_type_warmup">Warm-up Set %1$d</string>
     <string name="set_type_working">Working Set</string>
 
+    <string name="label_previously_completed">Completati in precedenza</string>
+    <string name="cd_filter_previously_completed">Filtra gli esercizi completati in precedenza</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-nl/strings.xml
+++ b/shared/src/commonMain/composeResources/values-nl/strings.xml
@@ -775,4 +775,6 @@
     <string name="profile_disco_unlocked_body">Schakel de discomodus in bij de LED-voorkeuren en laat je trainer feesten.</string>
     <string name="profile_disco_unlocked_action">Tijd voor een feestje</string>
     <string name="profile_adult_enable_partial_failure">De leeftijdsbevestiging is opgeslagen, maar de vulgaire modus kon niet worden ingeschakeld. Probeer het opnieuw.</string>
+    <string name="label_previously_completed">Eerder voltooid</string>
+    <string name="cd_filter_previously_completed">Eerder voltooide oefeningen filteren</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -931,4 +931,6 @@
     <string name="profile_disco_unlocked_body">Turn on Disco Mode in LED preferences to make your trainer party.</string>
     <string name="profile_disco_unlocked_action">Let\'s party</string>
     <string name="profile_adult_enable_partial_failure">Age confirmation was saved, but Vulgar Mode could not be enabled. Try again.</string>
+    <string name="label_previously_completed">Previously completed</string>
+    <string name="cd_filter_previously_completed">Filter exercises previously completed</string>
 </resources>

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/ExercisePicker.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/ExercisePicker.kt
@@ -47,7 +47,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalFocusManager
@@ -66,7 +65,9 @@ import com.devil.phoenixproject.data.repository.ExerciseVideoEntity
 import com.devil.phoenixproject.domain.model.Exercise
 import com.devil.phoenixproject.presentation.components.exercisepicker.ExerciseFilterShelf
 import com.devil.phoenixproject.presentation.components.exercisepicker.ExerciseListEmptyState
+import com.devil.phoenixproject.presentation.components.exercisepicker.ExercisePickerFilterState
 import com.devil.phoenixproject.presentation.components.exercisepicker.GroupedExerciseList
+import com.devil.phoenixproject.presentation.components.exercisepicker.filterExercisePickerCandidates
 import com.devil.phoenixproject.presentation.util.isCompactAccessibilityLayout
 import com.devil.phoenixproject.ui.theme.ThemeMode
 import kotlinx.coroutines.launch
@@ -110,6 +111,9 @@ fun ExercisePickerDialog(
     fullScreen: Boolean = false,
     themeMode: ThemeMode = ThemeMode.DARK,
     enableCustomExercises: Boolean = true,
+    enablePreviouslyCompletedFilter: Boolean = false,
+    completedExerciseIds: Set<String> = emptySet(),
+    completedExerciseIdsLoading: Boolean = false,
 ) {
     if (!showDialog) return
 
@@ -117,6 +121,10 @@ fun ExercisePickerDialog(
     var searchQuery by remember { mutableStateOf("") }
     var showFavoritesOnly by remember { mutableStateOf(false) }
     var showCustomOnly by remember { mutableStateOf(false) }
+    var showPreviouslyCompletedOnly by remember { mutableStateOf(false) }
+    LaunchedEffect(showDialog) {
+        if (showDialog) showPreviouslyCompletedOnly = false
+    }
     var selectedMuscles by remember { mutableStateOf(setOf<String>()) }
     var selectedEquipment by remember { mutableStateOf(setOf<String>()) }
     var showCreateDialog by remember { mutableStateOf(false) }
@@ -124,34 +132,48 @@ fun ExercisePickerDialog(
 
     val customExercises by exerciseRepository.getCustomExercises().collectAsState(initial = emptyList())
 
-    val allExercises by remember(searchQuery, showFavoritesOnly, showCustomOnly) {
+    val candidateExercises by remember(searchQuery) {
         when {
-            showCustomOnly -> exerciseRepository.getCustomExercises()
-            showFavoritesOnly -> exerciseRepository.getFavorites()
             searchQuery.isNotBlank() -> exerciseRepository.searchExercises(searchQuery)
             else -> exerciseRepository.getAllExercises()
         }
     }.collectAsState(initial = emptyList())
 
-    val exercises = remember(allExercises, selectedMuscles, selectedEquipment) {
-        allExercises.filter { exercise ->
-            val matchesMuscle = selectedMuscles.isEmpty() ||
-                selectedMuscles.any { muscle ->
-                    exercise.muscleGroups.contains(muscle, ignoreCase = true)
-                }
-            val matchesEquipment = selectedEquipment.isEmpty() ||
-                selectedEquipment.any { equipment ->
-                    val databaseValues = getEquipmentDatabaseValues(equipment)
-                    val equipmentList = exercise.equipment.uppercase().split(",").map { it.trim() }
-                    databaseValues.any { dbValue -> equipmentList.contains(dbValue.uppercase()) }
-                }
-            matchesMuscle && matchesEquipment
+    val isCompletedFilterLoading =
+        enablePreviouslyCompletedFilter && showPreviouslyCompletedOnly && completedExerciseIdsLoading
+    val exercises = remember(
+        candidateExercises,
+        showFavoritesOnly,
+        showCustomOnly,
+        selectedMuscles,
+        selectedEquipment,
+        showPreviouslyCompletedOnly,
+        completedExerciseIds,
+        isCompletedFilterLoading,
+    ) {
+        if (isCompletedFilterLoading) {
+            emptyList()
+        } else {
+            filterExercisePickerCandidates(
+                candidates = candidateExercises,
+                filters = ExercisePickerFilterState(
+                    showFavoritesOnly = showFavoritesOnly,
+                    showCustomOnly = showCustomOnly,
+                    selectedMuscles = selectedMuscles,
+                    selectedEquipment = selectedEquipment,
+                    showPreviouslyCompletedOnly =
+                        enablePreviouslyCompletedFilter && showPreviouslyCompletedOnly,
+                ),
+                completedExerciseIds = completedExerciseIds,
+            )
         }
     }
 
     fun clearAllFilters() {
+        searchQuery = ""
         showFavoritesOnly = false
         showCustomOnly = false
+        showPreviouslyCompletedOnly = false
         selectedMuscles = emptySet()
         selectedEquipment = emptySet()
     }
@@ -232,14 +254,13 @@ fun ExercisePickerDialog(
                         searchQuery = searchQuery,
                         onSearchQueryChange = { searchQuery = it },
                         showFavoritesOnly = showFavoritesOnly,
-                        onToggleFavorites = {
-                            showFavoritesOnly = !showFavoritesOnly
-                            if (showFavoritesOnly) showCustomOnly = false
-                        },
+                        onToggleFavorites = { showFavoritesOnly = !showFavoritesOnly },
                         showCustomOnly = showCustomOnly,
-                        onToggleCustom = {
-                            showCustomOnly = !showCustomOnly
-                            if (showCustomOnly) showFavoritesOnly = false
+                        onToggleCustom = { showCustomOnly = !showCustomOnly },
+                        enablePreviouslyCompletedFilter = enablePreviouslyCompletedFilter,
+                        showPreviouslyCompletedOnly = showPreviouslyCompletedOnly,
+                        onTogglePreviouslyCompleted = {
+                            showPreviouslyCompletedOnly = !showPreviouslyCompletedOnly
                         },
                         customExerciseCount = customExercises.size,
                         selectedMuscles = selectedMuscles,
@@ -275,6 +296,7 @@ fun ExercisePickerDialog(
                         enableCustomExercises = enableCustomExercises,
                         onCreateExercise = { showCreateDialog = true },
                         onEditExercise = { exercise -> exerciseToEdit = exercise },
+                        isLoading = isCompletedFilterLoading,
                         fullScreen = true,
                     )
                 }
@@ -295,14 +317,13 @@ fun ExercisePickerDialog(
                 searchQuery = searchQuery,
                 onSearchQueryChange = { searchQuery = it },
                 showFavoritesOnly = showFavoritesOnly,
-                onToggleFavorites = {
-                    showFavoritesOnly = !showFavoritesOnly
-                    if (showFavoritesOnly) showCustomOnly = false
-                },
+                onToggleFavorites = { showFavoritesOnly = !showFavoritesOnly },
                 showCustomOnly = showCustomOnly,
-                onToggleCustom = {
-                    showCustomOnly = !showCustomOnly
-                    if (showCustomOnly) showFavoritesOnly = false
+                onToggleCustom = { showCustomOnly = !showCustomOnly },
+                enablePreviouslyCompletedFilter = enablePreviouslyCompletedFilter,
+                showPreviouslyCompletedOnly = showPreviouslyCompletedOnly,
+                onTogglePreviouslyCompleted = {
+                    showPreviouslyCompletedOnly = !showPreviouslyCompletedOnly
                 },
                 customExerciseCount = customExercises.size,
                 selectedMuscles = selectedMuscles,
@@ -338,6 +359,7 @@ fun ExercisePickerDialog(
                 enableCustomExercises = enableCustomExercises,
                 onCreateExercise = { showCreateDialog = true },
                 onEditExercise = { exercise -> exerciseToEdit = exercise },
+                isLoading = isCompletedFilterLoading,
                 fullScreen = false,
             )
         }
@@ -361,6 +383,9 @@ fun ExercisePickerContent(
     onToggleFavorites: () -> Unit,
     showCustomOnly: Boolean,
     onToggleCustom: () -> Unit,
+    enablePreviouslyCompletedFilter: Boolean = false,
+    showPreviouslyCompletedOnly: Boolean = false,
+    onTogglePreviouslyCompleted: () -> Unit = {},
     customExerciseCount: Int,
     selectedMuscles: Set<String>,
     onToggleMuscle: (String) -> Unit,
@@ -389,6 +414,7 @@ fun ExercisePickerContent(
     val hasActiveFilters = searchQuery.isNotBlank() ||
         showFavoritesOnly ||
         showCustomOnly ||
+        showPreviouslyCompletedOnly ||
         selectedMuscles.isNotEmpty() ||
         selectedEquipment.isNotEmpty()
 
@@ -466,6 +492,9 @@ fun ExercisePickerContent(
                 onToggleFavorites = onToggleFavorites,
                 showCustomOnly = showCustomOnly,
                 onToggleCustom = onToggleCustom,
+                enablePreviouslyCompletedFilter = enablePreviouslyCompletedFilter,
+                showPreviouslyCompletedOnly = showPreviouslyCompletedOnly,
+                onTogglePreviouslyCompleted = onTogglePreviouslyCompleted,
                 selectedMuscles = selectedMuscles,
                 onToggleMuscle = onToggleMuscle,
                 selectedEquipment = selectedEquipment,

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/exercisepicker/CompletedExerciseIds.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/exercisepicker/CompletedExerciseIds.kt
@@ -1,0 +1,15 @@
+package com.devil.phoenixproject.presentation.components.exercisepicker
+
+import com.devil.phoenixproject.domain.model.WorkoutSession
+
+data class CompletedExerciseIdsState(
+    val profileId: String?,
+    val ids: Set<String> = emptySet(),
+    val isLoading: Boolean,
+)
+
+internal fun completedExerciseIdsFromHistory(
+    sessions: List<WorkoutSession>,
+): Set<String> = sessions.mapNotNullTo(linkedSetOf()) { session ->
+    session.exerciseId?.trim()?.takeIf(String::isNotEmpty)
+}

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/exercisepicker/ExerciseFilterShelf.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/exercisepicker/ExerciseFilterShelf.kt
@@ -22,6 +22,8 @@ import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.stringResource
 import vitruvianprojectphoenix.shared.generated.resources.*
@@ -37,6 +39,9 @@ fun ExerciseFilterShelf(
     onToggleFavorites: () -> Unit,
     showCustomOnly: Boolean,
     onToggleCustom: () -> Unit,
+    enablePreviouslyCompletedFilter: Boolean = false,
+    showPreviouslyCompletedOnly: Boolean = false,
+    onTogglePreviouslyCompleted: () -> Unit = {},
     selectedMuscles: Set<String>,
     onToggleMuscle: (String) -> Unit,
     selectedEquipment: Set<String>,
@@ -57,7 +62,9 @@ fun ExerciseFilterShelf(
             "Bodyweight",
         )
 
-    val hasActiveFilters = showFavoritesOnly || showCustomOnly ||
+    val previouslyCompletedDescription =
+        stringResource(Res.string.cd_filter_previously_completed)
+    val hasActiveFilters = showFavoritesOnly || showCustomOnly || showPreviouslyCompletedOnly ||
         selectedMuscles.isNotEmpty() || selectedEquipment.isNotEmpty()
 
     LazyRow(
@@ -126,6 +133,23 @@ fun ExerciseFilterShelf(
                     selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
                 ),
             )
+        }
+
+        if (enablePreviouslyCompletedFilter) {
+            item {
+                FilterChip(
+                    selected = showPreviouslyCompletedOnly,
+                    onClick = onTogglePreviouslyCompleted,
+                    label = { Text(stringResource(Res.string.label_previously_completed)) },
+                    modifier = Modifier.semantics {
+                        contentDescription = previouslyCompletedDescription
+                    },
+                    colors = FilterChipDefaults.filterChipColors(
+                        selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                        selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    ),
+                )
+            }
         }
 
         // Divider

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/exercisepicker/ExercisePickerFilters.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/components/exercisepicker/ExercisePickerFilters.kt
@@ -1,0 +1,41 @@
+package com.devil.phoenixproject.presentation.components.exercisepicker
+
+import com.devil.phoenixproject.domain.model.Exercise
+import com.devil.phoenixproject.presentation.components.getEquipmentDatabaseValues
+
+internal data class ExercisePickerFilterState(
+    val showFavoritesOnly: Boolean = false,
+    val showCustomOnly: Boolean = false,
+    val selectedMuscles: Set<String> = emptySet(),
+    val selectedEquipment: Set<String> = emptySet(),
+    val showPreviouslyCompletedOnly: Boolean = false,
+)
+
+/**
+ * Applies every exercise-picker narrowing predicate to the repository-selected candidates.
+ * The source list controls search semantics and ordering; this helper only removes entries.
+ */
+internal fun filterExercisePickerCandidates(
+    candidates: List<Exercise>,
+    filters: ExercisePickerFilterState,
+    completedExerciseIds: Set<String> = emptySet(),
+): List<Exercise> = candidates.filter { exercise ->
+    val matchesFavorites = !filters.showFavoritesOnly || exercise.isFavorite
+    val matchesCustom = !filters.showCustomOnly || exercise.isCustom
+    val matchesMuscle = filters.selectedMuscles.isEmpty() ||
+        filters.selectedMuscles.any { muscle ->
+            exercise.muscleGroups.contains(muscle, ignoreCase = true)
+        }
+    val matchesEquipment = filters.selectedEquipment.isEmpty() ||
+        filters.selectedEquipment.any { equipment ->
+            val databaseValues = getEquipmentDatabaseValues(equipment)
+            val exerciseEquipment = exercise.equipment.uppercase().split(",").map { it.trim() }
+            databaseValues.any { databaseValue ->
+                databaseValue.uppercase() in exerciseEquipment
+            }
+        }
+    val matchesPreviouslyCompleted = !filters.showPreviouslyCompletedOnly ||
+        (exercise.id?.trim()?.takeIf(String::isNotEmpty) in completedExerciseIds)
+
+    matchesFavorites && matchesCustom && matchesMuscle && matchesEquipment && matchesPreviouslyCompleted
+}

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ProfileScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ProfileScreen.kt
@@ -31,8 +31,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -48,10 +48,10 @@ import com.devil.phoenixproject.data.repository.ActiveProfileContext
 import com.devil.phoenixproject.data.repository.ExerciseRepository
 import com.devil.phoenixproject.data.repository.ProfileContextRecoveryException
 import com.devil.phoenixproject.data.repository.UserProfile
-import com.devil.phoenixproject.presentation.components.ExercisePickerDialog
 import com.devil.phoenixproject.presentation.components.AdultsOnlyConfirmDialog
 import com.devil.phoenixproject.presentation.components.DiscoModeUnlockDialog
 import com.devil.phoenixproject.presentation.components.DominatrixUnlockDialog
+import com.devil.phoenixproject.presentation.components.ExercisePickerDialog
 import com.devil.phoenixproject.presentation.components.LoadingIndicator
 import com.devil.phoenixproject.presentation.components.LoadingIndicatorSize
 import com.devil.phoenixproject.presentation.components.ProfileAvatar
@@ -144,8 +144,16 @@ fun ProfileScreen(
     exerciseRepository: ExerciseRepository = koinInject(),
 ) {
     val state by viewModel.uiState.collectAsState()
+    val completedExerciseIdsState by viewModel.completedExerciseIdsState.collectAsState()
     val ready = state.context as? ActiveProfileContext.Ready
     val readyProfileId = ready?.profile?.id
+    val pickerCompletedExerciseIds = if (completedExerciseIdsState.profileId == readyProfileId) {
+        completedExerciseIdsState.ids
+    } else {
+        emptySet()
+    }
+    val pickerCompletedExerciseIdsLoading =
+        completedExerciseIdsState.isLoading || completedExerciseIdsState.profileId != readyProfileId
     var pickerProfileId by rememberSaveable { mutableStateOf<String?>(null) }
     var editTargetProfileId by rememberSaveable { mutableStateOf<String?>(null) }
     var deleteTargetProfileId by rememberSaveable { mutableStateOf<String?>(null) }
@@ -218,6 +226,7 @@ fun ProfileScreen(
                     if (editTargetProfileId == event.profileId) editTargetProfileId = null
                     if (pendingIdentityProfileId == event.profileId) pendingIdentityProfileId = null
                 }
+
                 is ProfileUiEvent.IdentityUpdateFailed -> {
                     val failure = applyProfileIdentityFailure(
                         ownership = ProfileIdentityOverlayOwnership(
@@ -233,10 +242,12 @@ fun ProfileScreen(
                     pendingIdentityProfileId = failure.ownership.pendingIdentityProfileId
                     if (failure.showError) snackbarHostState.showSnackbar(updateFailedMessage)
                 }
+
                 is ProfileUiEvent.ProfileDeleted -> {
                     if (deleteTargetProfileId == event.profileId) deleteTargetProfileId = null
                     if (pendingIdentityProfileId == event.profileId) pendingIdentityProfileId = null
                 }
+
                 is ProfileUiEvent.ProfileRecoveryRequired -> {
                     if (pendingIdentityProfileId == event.profileId) {
                         editTargetProfileId = null
@@ -245,6 +256,7 @@ fun ProfileScreen(
                         currentOnProfileRecoveryRequired(event.cause)
                     }
                 }
+
                 is ProfileUiEvent.PreferenceMutationSucceeded -> {
                     if (trackedPreferenceTokens.containsKey(event.token)) {
                         val ownedProfileId = trackedPreferenceTokens[event.token]
@@ -256,17 +268,20 @@ fun ProfileScreen(
                         ) {
                             when (event.kind) {
                                 ProfilePreferenceMutationKind.UPDATE -> Unit
+
                                 ProfilePreferenceMutationKind.ADULT_ENABLE,
-                                ProfilePreferenceMutationKind.ADULT_DECLINE
+                                ProfilePreferenceMutationKind.ADULT_DECLINE,
                                 -> {
                                     showAdultsOnlyDialog = false
                                     adultTargetProfileId = null
                                     adultPreferenceError = null
                                 }
+
                                 ProfilePreferenceMutationKind.DISCO_UNLOCK -> {
                                     onPlayDiscoUnlockSound()
                                     showDiscoUnlockDialog = true
                                 }
+
                                 ProfilePreferenceMutationKind.DOMINATRIX_UNLOCK -> {
                                     onPlayDominatrixUnlockSound()
                                     showDominatrixUnlockDialog = true
@@ -275,6 +290,7 @@ fun ProfileScreen(
                         }
                     }
                 }
+
                 is ProfileUiEvent.PreferenceUpdateFailed -> {
                     if (trackedPreferenceTokens.containsKey(event.token)) {
                         val ownedProfileId = trackedPreferenceTokens[event.token]
@@ -286,7 +302,7 @@ fun ProfileScreen(
                         ) {
                             when (event.kind) {
                                 ProfilePreferenceMutationKind.ADULT_ENABLE,
-                                ProfilePreferenceMutationKind.ADULT_DECLINE
+                                ProfilePreferenceMutationKind.ADULT_DECLINE,
                                 -> {
                                     adultPreferenceError = if (
                                         ProfilePreferenceSection.LOCAL_SAFETY in event.committedSections
@@ -296,9 +312,10 @@ fun ProfileScreen(
                                         updateFailedMessage
                                     }
                                 }
+
                                 ProfilePreferenceMutationKind.UPDATE,
                                 ProfilePreferenceMutationKind.DISCO_UNLOCK,
-                                ProfilePreferenceMutationKind.DOMINATRIX_UNLOCK
+                                ProfilePreferenceMutationKind.DOMINATRIX_UNLOCK,
                                 -> snackbarHostState.showSnackbar(updateFailedMessage)
                             }
                         }
@@ -467,6 +484,9 @@ fun ProfileScreen(
         enableVideoPlayback = enableVideoPlayback,
         themeMode = themeMode,
         enableCustomExercises = false,
+        enablePreviouslyCompletedFilter = true,
+        completedExerciseIds = pickerCompletedExerciseIds,
+        completedExerciseIdsLoading = pickerCompletedExerciseIdsLoading,
     )
 
     if (showAdultsOnlyDialog && adultTargetProfileId == ready?.profile?.id) {

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RoutineEditorScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RoutineEditorScreen.kt
@@ -138,6 +138,13 @@ fun RoutineEditorScreen(
     // Issue #266/#410: Get user preferences for weight increment
     val userPreferences by viewModel.userPreferences.collectAsState()
     val rackItems by viewModel.rackItems.collectAsState()
+    val activeProfileId by viewModel.activeProfileId.collectAsState()
+    val completedExerciseIdsState by viewModel.completedExerciseIdsState.collectAsState()
+    val pickerCompletedExerciseIds = completedExerciseIdsState.ids.takeIf {
+        completedExerciseIdsState.profileId == activeProfileId
+    } ?: emptySet()
+    val pickerCompletedExerciseIdsLoading =
+        completedExerciseIdsState.isLoading || completedExerciseIdsState.profileId != activeProfileId
 
     // 1. Initialize State
     var state by remember { mutableStateOf(RoutineEditorState()) }
@@ -249,9 +256,9 @@ fun RoutineEditorScreen(
     // always false in state; collapse UI uses state.collapsedSupersets instead.
     val isDirty = hasSnapshot && (
         state.routineName != snapshotName ||
-        state.exercises != snapshotExercises ||
-        state.supersets != snapshotSupersets
-    )
+            state.exercises != snapshotExercises ||
+            state.supersets != snapshotSupersets
+        )
 
     // Drag and Drop State
     val lazyListState = rememberLazyListState()
@@ -848,6 +855,9 @@ fun RoutineEditorScreen(
             },
             exerciseRepository = exerciseRepository,
             enableVideoPlayback = false,
+            enablePreviouslyCompletedFilter = true,
+            completedExerciseIds = pickerCompletedExerciseIds,
+            completedExerciseIdsLoading = pickerCompletedExerciseIdsLoading,
         )
     }
 

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SingleExerciseScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/SingleExerciseScreen.kt
@@ -5,8 +5,6 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
-import com.devil.phoenixproject.presentation.components.LoadingIndicator
-import com.devil.phoenixproject.presentation.components.LoadingIndicatorSize
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
@@ -37,6 +35,10 @@ import com.devil.phoenixproject.presentation.components.ConnectionErrorDialog
 import com.devil.phoenixproject.presentation.components.CreateExerciseDialog
 import com.devil.phoenixproject.presentation.components.CustomExerciseSaveAction
 import com.devil.phoenixproject.presentation.components.ExercisePickerContent
+import com.devil.phoenixproject.presentation.components.LoadingIndicator
+import com.devil.phoenixproject.presentation.components.LoadingIndicatorSize
+import com.devil.phoenixproject.presentation.components.exercisepicker.ExercisePickerFilterState
+import com.devil.phoenixproject.presentation.components.exercisepicker.filterExercisePickerCandidates
 import com.devil.phoenixproject.presentation.components.resolveCustomExerciseDeleteTarget
 import com.devil.phoenixproject.presentation.components.resolveCustomExerciseSaveAction
 import com.devil.phoenixproject.presentation.manager.DefaultWorkoutSessionManager
@@ -66,6 +68,11 @@ fun SingleExerciseScreen(
     val enableVideoPlayback by viewModel.enableVideoPlayback.collectAsState()
     val userPreferences by viewModel.userPreferences.collectAsState()
     val rackItems by viewModel.rackItems.collectAsState()
+    val activeProfileId by viewModel.activeProfileId.collectAsState()
+    val completedExerciseIdsState by viewModel.completedExerciseIdsState.collectAsState()
+    val pickerCompletedExerciseIds = completedExerciseIdsState.ids.takeIf {
+        completedExerciseIdsState.profileId == activeProfileId
+    } ?: emptySet()
 
     val connectionError by viewModel.connectionError.collectAsState()
 
@@ -86,53 +93,47 @@ fun SingleExerciseScreen(
     var selectedEquipment by remember { mutableStateOf<Set<String>>(emptySet()) }
     var showFavoritesOnly by remember { mutableStateOf(false) }
     var showCustomOnly by remember { mutableStateOf(false) }
+    var showPreviouslyCompletedOnly by remember { mutableStateOf(false) }
     var showCreateDialog by remember { mutableStateOf(false) }
     var exerciseToEdit by remember { mutableStateOf<Exercise?>(null) }
 
     // Get exercises from repository
-    val allExercises by remember(searchQuery, selectedMuscles, showFavoritesOnly, showCustomOnly) {
+    val candidateExercises by remember(searchQuery) {
         when {
-            showFavoritesOnly -> exerciseRepository.getFavorites()
-
-            showCustomOnly -> exerciseRepository.getCustomExercises()
-
             searchQuery.isNotBlank() -> exerciseRepository.searchExercises(searchQuery)
-
-            selectedMuscles.isNotEmpty() -> {
-                // Get exercises for all selected muscle groups and combine
-                val flows = selectedMuscles.map { muscle ->
-                    exerciseRepository.filterByMuscleGroup(muscle)
-                }
-                // For now, just use the first one - ideally we'd combine all flows
-                flows.firstOrNull() ?: exerciseRepository.getAllExercises()
-            }
-
             else -> exerciseRepository.getAllExercises()
         }
     }.collectAsState(initial = emptyList())
 
-    // Apply equipment filter
-    val exercises = remember(allExercises, selectedEquipment) {
-        if (selectedEquipment.isNotEmpty()) {
-            allExercises.filter { exercise ->
-                selectedEquipment.any { selectedEq ->
-                    val databaseValues = when (selectedEq) {
-                        "Long Bar" -> listOf("BAR", "LONG_BAR", "BARBELL")
-                        "Short Bar" -> listOf("SHORT_BAR")
-                        "Ankle Strap" -> listOf("ANKLE_STRAP", "STRAPS")
-                        "Handles" -> listOf("HANDLES", "SINGLE_HANDLE", "BOTH_HANDLES")
-                        "Bench" -> listOf("BENCH")
-                        "Rope" -> listOf("ROPE")
-                        "Belt" -> listOf("BELT")
-                        "Bodyweight" -> listOf("BODYWEIGHT")
-                        else -> emptyList()
-                    }
-                    val equipmentList = exercise.equipment.uppercase().split(",").map { it.trim() }
-                    databaseValues.any { dbValue -> equipmentList.contains(dbValue.uppercase()) }
-                }
-            }
+    val isCompletedFilterLoading =
+        showPreviouslyCompletedOnly && (
+            completedExerciseIdsState.isLoading ||
+                completedExerciseIdsState.profileId != activeProfileId
+            )
+    val exercises = remember(
+        candidateExercises,
+        showFavoritesOnly,
+        showCustomOnly,
+        selectedMuscles,
+        selectedEquipment,
+        showPreviouslyCompletedOnly,
+        pickerCompletedExerciseIds,
+        isCompletedFilterLoading,
+    ) {
+        if (isCompletedFilterLoading) {
+            emptyList()
         } else {
-            allExercises
+            filterExercisePickerCandidates(
+                candidates = candidateExercises,
+                filters = ExercisePickerFilterState(
+                    showFavoritesOnly = showFavoritesOnly,
+                    showCustomOnly = showCustomOnly,
+                    selectedMuscles = selectedMuscles,
+                    selectedEquipment = selectedEquipment,
+                    showPreviouslyCompletedOnly = showPreviouslyCompletedOnly,
+                ),
+                completedExerciseIds = pickerCompletedExerciseIds,
+            )
         }
     }
 
@@ -262,24 +263,13 @@ fun SingleExerciseScreen(
                 searchQuery = searchQuery,
                 onSearchQueryChange = { searchQuery = it },
                 showFavoritesOnly = showFavoritesOnly,
-                onToggleFavorites = {
-                    showFavoritesOnly = !showFavoritesOnly
-                    if (showFavoritesOnly) {
-                        searchQuery = ""
-                        selectedMuscles = emptySet()
-                        selectedEquipment = emptySet()
-                        showCustomOnly = false
-                    }
-                },
+                onToggleFavorites = { showFavoritesOnly = !showFavoritesOnly },
                 showCustomOnly = showCustomOnly,
-                onToggleCustom = {
-                    showCustomOnly = !showCustomOnly
-                    if (showCustomOnly) {
-                        searchQuery = ""
-                        selectedMuscles = emptySet()
-                        selectedEquipment = emptySet()
-                        showFavoritesOnly = false
-                    }
+                onToggleCustom = { showCustomOnly = !showCustomOnly },
+                enablePreviouslyCompletedFilter = true,
+                showPreviouslyCompletedOnly = showPreviouslyCompletedOnly,
+                onTogglePreviouslyCompleted = {
+                    showPreviouslyCompletedOnly = !showPreviouslyCompletedOnly
                 },
                 customExerciseCount = customCount,
                 selectedMuscles = selectedMuscles,
@@ -304,6 +294,7 @@ fun SingleExerciseScreen(
                     selectedEquipment = emptySet()
                     showFavoritesOnly = false
                     showCustomOnly = false
+                    showPreviouslyCompletedOnly = false
                 },
                 onToggleFavorite = { exercise ->
                     exercise.id?.let { id ->
@@ -320,6 +311,7 @@ fun SingleExerciseScreen(
                 enableCustomExercises = true,
                 onCreateExercise = { showCreateDialog = true },
                 onEditExercise = { exercise -> exerciseToEdit = exercise },
+                isLoading = isCompletedFilterLoading,
                 onViewExerciseDetail = { exercise ->
                     exercise.id?.let { id ->
                         navController.navigate(NavigationRoutes.ExerciseDetail.createRoute(id))

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModel.kt
@@ -8,6 +8,7 @@ import com.devil.phoenixproject.data.integration.ExternalActivityRepository
 import com.devil.phoenixproject.data.integration.HealthIntegration
 import com.devil.phoenixproject.data.integration.IntegrationSyncCursorRepository
 import com.devil.phoenixproject.data.preferences.PreferencesManager
+import com.devil.phoenixproject.data.repository.ActiveProfileContext
 import com.devil.phoenixproject.data.repository.AutoStopUiState
 import com.devil.phoenixproject.data.repository.BiomechanicsRepository
 import com.devil.phoenixproject.data.repository.BleRepository
@@ -25,6 +26,7 @@ import com.devil.phoenixproject.data.repository.WorkoutRepository
 import com.devil.phoenixproject.data.sync.SyncTriggerManager
 import com.devil.phoenixproject.domain.model.AppliedRoutineModifier
 import com.devil.phoenixproject.domain.model.Badge
+import com.devil.phoenixproject.domain.model.BleCompatibilitySetting
 import com.devil.phoenixproject.domain.model.BodyweightVariantOption
 import com.devil.phoenixproject.domain.model.ConnectionState
 import com.devil.phoenixproject.domain.model.EchoLevel
@@ -36,13 +38,11 @@ import com.devil.phoenixproject.domain.model.RackItem
 import com.devil.phoenixproject.domain.model.RackItemBehavior
 import com.devil.phoenixproject.domain.model.RackLoadAdjustment
 import com.devil.phoenixproject.domain.model.RepCount
-import com.devil.phoenixproject.domain.model.BleCompatibilitySetting
 import com.devil.phoenixproject.domain.model.Routine
 import com.devil.phoenixproject.domain.model.RoutineExercise
 import com.devil.phoenixproject.domain.model.RoutineFlowState
-import com.devil.phoenixproject.domain.model.RoutineLaunchOrigin
-import com.devil.phoenixproject.presentation.navigation.NavigationRoutes
 import com.devil.phoenixproject.domain.model.RoutineGroup
+import com.devil.phoenixproject.domain.model.RoutineLaunchOrigin
 import com.devil.phoenixproject.domain.model.SessionBodyweightState
 import com.devil.phoenixproject.domain.model.Superset
 import com.devil.phoenixproject.domain.model.UserPreferences
@@ -60,6 +60,8 @@ import com.devil.phoenixproject.domain.usecase.RecommendWeightAdjustmentUseCase
 import com.devil.phoenixproject.domain.usecase.RecordPersonalMvtSampleUseCase
 import com.devil.phoenixproject.domain.usecase.RepCounterFromMachine
 import com.devil.phoenixproject.domain.usecase.ResolveRoutineWeightsUseCase
+import com.devil.phoenixproject.presentation.components.exercisepicker.CompletedExerciseIdsState
+import com.devil.phoenixproject.presentation.components.exercisepicker.completedExerciseIdsFromHistory
 import com.devil.phoenixproject.presentation.manager.BleConnectionManager
 import com.devil.phoenixproject.presentation.manager.DefaultWorkoutSessionManager
 import com.devil.phoenixproject.presentation.manager.GamificationManager
@@ -70,6 +72,7 @@ import com.devil.phoenixproject.presentation.manager.ResumableProgressInfo
 import com.devil.phoenixproject.presentation.manager.SettingsManager
 import com.devil.phoenixproject.presentation.manager.WorkoutServiceController
 import com.devil.phoenixproject.presentation.manager.currentProfileTestSoundEvents
+import com.devil.phoenixproject.presentation.navigation.NavigationRoutes
 import com.devil.phoenixproject.util.BackupDestination
 import com.devil.phoenixproject.util.BackupStats
 import com.devil.phoenixproject.util.DataBackupManager
@@ -82,7 +85,10 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -163,6 +169,46 @@ class MainViewModel constructor(
         userProfileRepository.activeProfile
             .map { it?.id ?: "default" }
             .stateIn(viewModelScope, SharingStarted.Eagerly, "default")
+
+    /**
+     * Picker-safe completed IDs.  The tag and loading sentinel prevent a picker from ever
+     * using a prior profile's history during an active-profile transition.
+     */
+    val completedExerciseIdsState: StateFlow<CompletedExerciseIdsState> =
+        userProfileRepository.activeProfileContext
+            .flatMapLatest { context ->
+                when (context) {
+                    is ActiveProfileContext.Switching -> flowOf(
+                        CompletedExerciseIdsState(
+                            profileId = context.targetProfileId,
+                            isLoading = true,
+                        ),
+                    )
+
+                    is ActiveProfileContext.Ready ->
+                        workoutRepository.getHistoryVisibleSessions(context.profile.id)
+                            .map { sessions ->
+                                CompletedExerciseIdsState(
+                                    profileId = context.profile.id,
+                                    ids = completedExerciseIdsFromHistory(sessions),
+                                    isLoading = false,
+                                )
+                            }
+                            .onStart {
+                                emit(
+                                    CompletedExerciseIdsState(
+                                        profileId = context.profile.id,
+                                        isLoading = true,
+                                    ),
+                                )
+                            }
+                }
+            }
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(5_000),
+                initialValue = CompletedExerciseIdsState(profileId = null, isLoading = true),
+            )
 
     // === Phase 2b: GamificationManager (extracted from this class) ===
     val gamificationManager: GamificationManager = GamificationManager(
@@ -444,9 +490,8 @@ class MainViewModel constructor(
      * back to the DB — the StateFlow intentionally filters out "cycle_routine_"-prefixed
      * template-cycle routines (issue #620), which must still be loadable for editing.
      */
-    suspend fun getRoutineById(routineId: String): Routine? =
-        workoutSessionManager.getRoutineById(routineId)
-            ?: workoutRepository.getRoutineById(routineId)
+    suspend fun getRoutineById(routineId: String): Routine? = workoutSessionManager.getRoutineById(routineId)
+        ?: workoutRepository.getRoutineById(routineId)
     fun saveRoutine(routine: Routine) = workoutSessionManager.saveRoutine(routine)
     fun updateRoutine(routine: Routine) = workoutSessionManager.updateRoutine(routine)
     fun saveRackBehaviorOverridesForExercise(
@@ -545,6 +590,7 @@ class MainViewModel constructor(
     fun confirmSessionBodyWeight(weightKg: Float?, saveToProfile: Boolean) = workoutSessionManager.confirmSessionBodyWeight(weightKg, saveToProfile)
     fun skipSessionBodyWeightPrompt() = workoutSessionManager.skipSessionBodyWeightPrompt()
     fun returnToOverview() = workoutSessionManager.returnToOverview()
+
     /**
      * Returns the navigation route to pop to when exiting the current routine flow.
      *
@@ -559,12 +605,11 @@ class MainViewModel constructor(
      *   viewModel.exitRoutineFlow()                     // 2. clears origin
      *   navController.popBackStack(dest, false)         // 3. navigate
      */
-    fun routineExitDestination(): String =
-        if (workoutSessionManager.coordinator.routineLaunchOrigin == RoutineLaunchOrigin.TRAINING_CYCLES) {
-            NavigationRoutes.TrainingCycles.route
-        } else {
-            NavigationRoutes.DailyRoutines.route
-        }
+    fun routineExitDestination(): String = if (workoutSessionManager.coordinator.routineLaunchOrigin == RoutineLaunchOrigin.TRAINING_CYCLES) {
+        NavigationRoutes.TrainingCycles.route
+    } else {
+        NavigationRoutes.DailyRoutines.route
+    }
 
     fun exitRoutineFlow() = workoutSessionManager.exitRoutineFlow()
     fun showRoutineComplete() = workoutSessionManager.showRoutineComplete()

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/ProfileViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/ProfileViewModel.kt
@@ -25,8 +25,10 @@ import com.devil.phoenixproject.domain.model.WorkoutPreferences
 import com.devil.phoenixproject.domain.model.WorkoutSession
 import com.devil.phoenixproject.domain.usecase.CurrentOneRepMax
 import com.devil.phoenixproject.domain.usecase.ResolveCurrentOneRepMaxUseCase
-import com.devil.phoenixproject.presentation.components.canDeleteProfile
 import com.devil.phoenixproject.presentation.components.ProfileMeasurementKey
+import com.devil.phoenixproject.presentation.components.canDeleteProfile
+import com.devil.phoenixproject.presentation.components.exercisepicker.CompletedExerciseIdsState
+import com.devil.phoenixproject.presentation.components.exercisepicker.completedExerciseIdsFromHistory
 import com.devil.phoenixproject.presentation.components.latestImportedBodyWeightMeasuredAt
 import com.devil.phoenixproject.presentation.components.normalizedProfileColorIndex
 import kotlin.coroutines.cancellation.CancellationException
@@ -35,11 +37,17 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
@@ -99,8 +107,7 @@ data class ProfileUiState(
     val prHighlights: ProfileLoadable<ProfilePrHighlights> = ProfileLoadable.Empty,
     val recentSessions: ProfileLoadable<List<WorkoutSession>> = ProfileLoadable.Empty,
     val identityMutation: ProfileIdentityMutation? = null,
-    val preferenceMutations:
-        Map<ProfilePreferenceSection, ProfilePreferenceMutation> = emptyMap(),
+    val preferenceMutations: Map<ProfilePreferenceSection, ProfilePreferenceMutation> = emptyMap(),
     val importedBodyWeightMeasuredAt: Long? = null,
 ) {
     val identityMutationInFlight: Boolean
@@ -150,6 +157,43 @@ class ProfileViewModel(
     val uiState: StateFlow<ProfileUiState> = _uiState.asStateFlow()
     private val _events = Channel<ProfileUiEvent>(Channel.BUFFERED)
     val events: Flow<ProfileUiEvent> = _events.receiveAsFlow()
+
+    /** Profile-tagged history IDs for the Profile exercise picker only. */
+    val completedExerciseIdsState: StateFlow<CompletedExerciseIdsState> =
+        profiles.activeProfileContext
+            .flatMapLatest { context ->
+                when (context) {
+                    is ActiveProfileContext.Switching -> flowOf(
+                        CompletedExerciseIdsState(
+                            profileId = context.targetProfileId,
+                            isLoading = true,
+                        ),
+                    )
+
+                    is ActiveProfileContext.Ready ->
+                        workouts.getHistoryVisibleSessions(context.profile.id)
+                            .map { sessions ->
+                                CompletedExerciseIdsState(
+                                    profileId = context.profile.id,
+                                    ids = completedExerciseIdsFromHistory(sessions),
+                                    isLoading = false,
+                                )
+                            }
+                            .onStart {
+                                emit(
+                                    CompletedExerciseIdsState(
+                                        profileId = context.profile.id,
+                                        isLoading = true,
+                                    ),
+                                )
+                            }
+                }
+            }
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(5_000),
+                initialValue = CompletedExerciseIdsState(profileId = null, isLoading = true),
+            )
 
     private val selectedExerciseIds = mutableMapOf<String, String>()
     private var resolvedSelectionProfileId: String? = null
@@ -240,12 +284,11 @@ class ProfileViewModel(
         profiles.updateVbt(profileId, value)
     }
 
-    fun updateLocalSafety(value: ProfileLocalSafetyPreferences): Long? =
-        startSinglePreferenceMutation(
-            section = ProfilePreferenceSection.LOCAL_SAFETY,
-        ) { profileId ->
-            profiles.updateLocalSafety(profileId, value)
-        }
+    fun updateLocalSafety(value: ProfileLocalSafetyPreferences): Long? = startSinglePreferenceMutation(
+        section = ProfilePreferenceSection.LOCAL_SAFETY,
+    ) { profileId ->
+        profiles.updateLocalSafety(profileId, value)
+    }
 
     fun confirmAdultsOnlyAndEnableVulgar(): Long? {
         val ready = currentReadyForPreferenceMutation() ?: return null
@@ -254,9 +297,11 @@ class ProfileViewModel(
                 ProfilePreferenceSection.LOCAL_SAFETY,
                 ProfilePreferenceSection.VBT,
             )
+
             !ready.preferences.vbt.value.vulgarModeEnabled -> setOf(
                 ProfilePreferenceSection.VBT,
             )
+
             else -> return null
         }
         return startPreferenceMutation(
@@ -536,16 +581,16 @@ class ProfileViewModel(
         }
     }
 
-    private fun requireAuthoritativeReady(profileId: String): ActiveProfileContext.Ready =
-        when (val context = profiles.activeProfileContext.value) {
-            is ActiveProfileContext.Switching -> throw ProfileContextUnavailableException()
-            is ActiveProfileContext.Ready -> {
-                if (context.profile.id != profileId) {
-                    throw StaleProfileContextException(profileId, context.profile.id)
-                }
-                context
+    private fun requireAuthoritativeReady(profileId: String): ActiveProfileContext.Ready = when (val context = profiles.activeProfileContext.value) {
+        is ActiveProfileContext.Switching -> throw ProfileContextUnavailableException()
+
+        is ActiveProfileContext.Ready -> {
+            if (context.profile.id != profileId) {
+                throw StaleProfileContextException(profileId, context.profile.id)
             }
+            context
         }
+    }
 
     private fun currentReadyForPreferenceMutation(): ActiveProfileContext.Ready? {
         val profileId = currentMutationProfileId() ?: return null
@@ -848,10 +893,9 @@ class ProfileViewModel(
         return repositoryReady.profile.id == profileId && uiReady.profile.id == profileId
     }
 
-    private fun isSelectionCurrent(profileId: String, exerciseId: String): Boolean =
-        isProfileCurrent(profileId) &&
-            uiState.value.selectedExercise?.id == exerciseId &&
-            selectedExerciseIds[profileId] == exerciseId
+    private fun isSelectionCurrent(profileId: String, exerciseId: String): Boolean = isProfileCurrent(profileId) &&
+        uiState.value.selectedExercise?.id == exerciseId &&
+        selectedExerciseIds[profileId] == exerciseId
 
     private inline fun updateIfProfileCurrent(
         profileId: String,

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/components/exercisepicker/ExercisePickerFiltersTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/components/exercisepicker/ExercisePickerFiltersTest.kt
@@ -1,0 +1,103 @@
+package com.devil.phoenixproject.presentation.components.exercisepicker
+
+import com.devil.phoenixproject.domain.model.Exercise
+import com.devil.phoenixproject.domain.model.WorkoutSession
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ExercisePickerFiltersTest {
+    private fun exercise(
+        id: String?,
+        name: String = id ?: "unnamed",
+        favorite: Boolean = false,
+        custom: Boolean = false,
+        muscleGroups: String = "Legs",
+        equipment: String = "BAR",
+    ) = Exercise(
+        id = id,
+        name = name,
+        muscleGroup = muscleGroups.substringBefore(','),
+        muscleGroups = muscleGroups,
+        equipment = equipment,
+        isFavorite = favorite,
+        isCustom = custom,
+    )
+
+    @Test
+    fun disabledPreviouslyCompletedFilterPreservesCandidateOrder() {
+        val candidates = listOf(
+            exercise("squat"),
+            exercise("bench"),
+            exercise("row"),
+        )
+
+        val result = filterExercisePickerCandidates(
+            candidates = candidates,
+            filters = ExercisePickerFilterState(),
+            completedExerciseIds = setOf("row"),
+        )
+
+        assertEquals(candidates, result)
+    }
+
+    @Test
+    fun allEnabledFiltersIntersectWithoutReorderingCandidates() {
+        val matching = exercise(
+            id = " squat ",
+            favorite = true,
+            custom = true,
+            muscleGroups = "Legs, Core",
+            equipment = "BAR, BENCH",
+        )
+        val wrongCompleted = exercise(
+            id = "bench",
+            favorite = true,
+            custom = true,
+            muscleGroups = "Legs",
+            equipment = "BAR",
+        )
+        val wrongFavorite = exercise(
+            id = "deadlift",
+            favorite = false,
+            custom = true,
+            muscleGroups = "Legs",
+            equipment = "BAR",
+        )
+        val blankId = exercise(
+            id = " ",
+            favorite = true,
+            custom = true,
+            muscleGroups = "Legs",
+            equipment = "BAR",
+        )
+
+        val result = filterExercisePickerCandidates(
+            candidates = listOf(wrongCompleted, matching, wrongFavorite, blankId),
+            filters = ExercisePickerFilterState(
+                showFavoritesOnly = true,
+                showCustomOnly = true,
+                selectedMuscles = setOf("Legs"),
+                selectedEquipment = setOf("Long Bar"),
+                showPreviouslyCompletedOnly = true,
+            ),
+            completedExerciseIds = setOf("squat"),
+        )
+
+        assertEquals(listOf(matching), result)
+    }
+
+    @Test
+    fun completedIdsTrimValuesAndIgnoreBlankOrMissingTags() {
+        val completedIds = completedExerciseIdsFromHistory(
+            listOf(
+                WorkoutSession(exerciseId = " squat "),
+                WorkoutSession(exerciseId = null),
+                WorkoutSession(exerciseId = ""),
+                WorkoutSession(exerciseId = "squat"),
+                WorkoutSession(exerciseId = "bench"),
+            ),
+        )
+
+        assertEquals(linkedSetOf("squat", "bench"), completedIds)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeWorkoutRepository.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeWorkoutRepository.kt
@@ -1,8 +1,8 @@
 package com.devil.phoenixproject.testutil
 
+import com.devil.phoenixproject.data.repository.MAX_RECENT_EXERCISE_SESSIONS
 import com.devil.phoenixproject.data.repository.PersonalRecordEntity
 import com.devil.phoenixproject.data.repository.PhaseStatisticsData
-import com.devil.phoenixproject.data.repository.MAX_RECENT_EXERCISE_SESSIONS
 import com.devil.phoenixproject.data.repository.WorkoutRepository
 import com.devil.phoenixproject.domain.model.HeuristicStatistics
 import com.devil.phoenixproject.domain.model.Routine
@@ -106,16 +106,16 @@ class FakeWorkoutRepository : WorkoutRepository {
     //   deletedAt IS NULL AND (workingReps > 0 OR totalReps > 0)
     // so unit tests using this fake exercise the same data the
     // production SqlDelightWorkoutRepository returns.
-    override fun getHistoryVisibleSessions(profileId: String): Flow<List<WorkoutSession>> =
-        _sessionsFlow.map { all ->
-            all.filter { session ->
-                // No deletedAt field on WorkoutSession today; when soft
-                // delete lands, gate on it here too. For now the in-memory
-                // fake never stores deleted rows, so only the rep guard is
-                // required to match the SQL behavior.
-                session.workingReps > 0 || session.totalReps > 0
-            }
+    override fun getHistoryVisibleSessions(profileId: String): Flow<List<WorkoutSession>> = _sessionsFlow.map { all ->
+        all.filter { session ->
+            // No deletedAt field on WorkoutSession today; when soft
+            // delete lands, gate on it here too. For now the in-memory
+            // fake never stores deleted rows, so only the profile and
+            // positive-rep guards are required to match the SQL behavior.
+            session.profileId == profileId &&
+                (session.workingReps > 0 || session.totalReps > 0)
         }
+    }
 
     override suspend fun getRecentCompletedSessionsForExercise(
         exerciseId: String,
@@ -335,14 +335,13 @@ class FakeWorkoutRepository : WorkoutRepository {
             )
         }
 
-    override suspend fun getExerciseIdsWithVelocityData(profileId: String): List<String> =
-        sessions.values
-            .filter { s ->
-                s.profileId == profileId &&
-                    s.avgMcvMmS != null &&
-                    s.workingReps > 0 &&
-                    s.exerciseId != null
-            }
-            .map { it.exerciseId!! }
-            .distinct()
+    override suspend fun getExerciseIdsWithVelocityData(profileId: String): List<String> = sessions.values
+        .filter { s ->
+            s.profileId == profileId &&
+                s.avgMcvMmS != null &&
+                s.workingReps > 0 &&
+                s.exerciseId != null
+        }
+        .map { it.exerciseId!! }
+        .distinct()
 }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeWorkoutRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeWorkoutRepositoryTest.kt
@@ -1,0 +1,39 @@
+package com.devil.phoenixproject.testutil
+
+import com.devil.phoenixproject.domain.model.WorkoutSession
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+
+class FakeWorkoutRepositoryTest {
+    @Test
+    fun historyVisibleSessionsUsesRequestedProfileAndPositiveRepContract() = runTest {
+        val repository = FakeWorkoutRepository()
+        repository.addSessions(
+            listOf(
+                WorkoutSession(
+                    id = "profile-a-completed",
+                    profileId = "profile-a",
+                    exerciseId = "squat",
+                    workingReps = 8,
+                ),
+                WorkoutSession(
+                    id = "profile-b-completed",
+                    profileId = "profile-b",
+                    exerciseId = "bench",
+                    totalReps = 8,
+                ),
+                WorkoutSession(
+                    id = "profile-a-ghost",
+                    profileId = "profile-a",
+                    exerciseId = "row",
+                ),
+            ),
+        )
+
+        val visible = repository.getHistoryVisibleSessions("profile-a").first()
+
+        assertEquals(listOf("squat"), visible.map { it.exerciseId })
+    }
+}


### PR DESCRIPTION
## Summary

Implements the signed-off enhancement for [Issue #665](https://github.com/9thLevelSoftware/Project-Phoenix-MP/issues/665): a shared, off-by-default **Previously completed** filter chip in the exercise picker, wired to exactly three callers.

## What this adds

A **Previously completed** filter chip in the exercise picker filter shelf (after Favorites/Custom, before the muscle/equipment divider). When selected, it narrows the exercise list to only exercises the active profile has actually completed in workout history.

### Affected flows
1. **Single Exercise** — exercise picker with the new filter
2. **Routine Editor → Add exercise** — exercise picker with the new filter
3. **Profile → Exercise Insights** — exercise picker with the new filter (no custom exercise creation)

### Key design decisions
- **Default off**: the chip is never selected when a picker opens
- **Profile-safe**: uses `flatMapLatest` on `activeProfileContext` to prevent cross-profile ID leaks during profile switches
- **Shared predicate**: one pure AND-composed filter helper (`filterExercisePickerCandidates`) for all narrowing filters
- **No backend changes**: reuses existing `getHistoryVisibleSessions` query
- **Qualifying criteria**: `profileId == active profile AND deletedAt IS NULL AND (workingReps > 0 OR totalReps > 0) AND exerciseId is not blank`

## Changes (18 files, +521/-148)

### New files
- `CompletedExerciseIds.kt` — profile-tagged state + history ID extraction
- `ExercisePickerFilters.kt` — pure AND-composed filter predicate
- `ExercisePickerFiltersTest.kt` — filter contract tests
- `FakeWorkoutRepositoryTest.kt` — profile-scoped fake coverage

### Modified files
- `ExercisePicker.kt` — opt-in params, loading state, shared filter wiring
- `ExerciseFilterShelf.kt` — Previously completed chip
- `MainViewModel.kt` / `ProfileViewModel.kt` — profile-safe completed-history state
- `SingleExerciseScreen.kt` / `RoutineEditorScreen.kt` / `ProfileScreen.kt` — caller opt-ins
- `FakeWorkoutRepository.kt` — profile-scoped + positive-rep filtering
- 6 locale string bundles (en, de, es, fr, it, nl)

## Testing

```
JAVA_HOME=/opt/homebrew/opt/openjdk@17 ANDROID_HOME=/opt/homebrew/share/android-commandlinetools ./gradlew spotlessCheck :shared:testAndroidHostTest :androidApp:assembleDebug   -Pskip.supabase.check=true --console=plain
```

**Result: BUILD SUCCESSFUL** — all tests pass, spotless check passes, debug APK assembles.

## Visual Evidence

Final emulator screenshots captured on `phoenix_phantom_api36` (API 36):
- `01-single-exercise-default-off.png` — default state, chip unselected
- `02-single-exercise-filtered.png` — chip selected, empty state with Clear recovery
- `03-routine-add-exercise-default.png` — Routine Editor picker, chip visible
- `04-routine-add-exercise-filtered.png` — chip selected, empty state
- `05-profile-insights-default.png` — Profile Insights picker, no custom exercise button
- `06-profile-insights-filtered.png` — chip selected, empty state with Clear recovery

Evidence stored in pipeline artifact directory: `~/.hermes/phoenix-enhancements/issue-665-1527694753049874593/final-visuals/`

## Release Notes

**Previously completed exercise filter** — A new filter chip in the exercise picker lets you quickly find exercises you have actually done before. Available in Single Exercise, Routine Editor, and Profile Exercise Insights. Off by default; tap the chip to activate.

Closes #665