### PR TITLE
feat(routines): add set repetition with expand-at-save model (#667)

### DIFF
--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModelTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModelTest.kt
@@ -995,4 +995,62 @@ class ExerciseConfigViewModelTest {
         assertEquals(listOf(20f, 25f, 30f), saved!!.setWeightsPerCableKg)
         assertEquals(listOf(60, 90, 120), saved!!.setRestSeconds)
     }
+
+    @Test
+    fun `onSave preserves per-set echo overrides through expansion`() = runTest {
+        val viewModel = ExerciseConfigViewModel()
+        val exercise = RoutineExercise(
+            id = "rex-667-echo",
+            exercise = Exercise(id = "bench-1", name = "Bench Press", muscleGroup = "Chest", muscleGroups = "Chest", equipment = "BAR"),
+            orderIndex = 0,
+            setReps = listOf(10, 8),
+            weightPerCableKg = 20f,
+            setWeightsPerCableKg = listOf(20f, 25f),
+            programMode = ProgramMode.OldSchool,
+            eccentricLoad = EccentricLoad.LOAD_100,
+            echoLevel = EchoLevel.HARDER,
+            setEchoLevels = listOf(EchoLevel.EASIER, EchoLevel.HARDER), // Per-set overrides
+            setRestSeconds = listOf(60, 90),
+            perSetRestTime = true,
+        )
+        viewModel.initialize(exercise = exercise, unit = WeightUnit.KG, toDisplay = { v, _ -> v }, toKg = { v, _ -> v })
+
+        // Set 2 has repeatCount=3
+        val setIds = viewModel.sets.value.map { it.id }
+        viewModel.onRepeatCountChange(setIds[1], 3)
+
+        // Verify SetConfiguration carries echo override
+        assertEquals(EchoLevel.EASIER, viewModel.sets.value[0].echoLevel, "Set 1 should carry EASIER echo override")
+        assertEquals(EchoLevel.HARDER, viewModel.sets.value[1].echoLevel, "Set 2 should carry HARDER echo override")
+
+        var saved: RoutineExercise? = null
+        viewModel.onSave { updated -> saved = updated }
+
+        assertNotNull(saved)
+        // Expanded: set1 (EASIER) + set2×3 (HARDER each)
+        assertEquals(listOf(EchoLevel.EASIER, EchoLevel.HARDER, EchoLevel.HARDER, EchoLevel.HARDER), saved!!.setEchoLevels,
+            "Per-set Echo overrides should be preserved through expansion")
+    }
+
+    @Test
+    fun `initialize loads per-set echo overrides into SetConfiguration`() = runTest {
+        val viewModel = ExerciseConfigViewModel()
+        val exercise = RoutineExercise(
+            id = "rex-667-echo-init",
+            exercise = Exercise(id = "squat-1", name = "Squat", muscleGroup = "Legs", muscleGroups = "Legs", equipment = "BAR"),
+            orderIndex = 0,
+            setReps = listOf(10, 10, 10),
+            weightPerCableKg = 50f,
+            programMode = ProgramMode.OldSchool,
+            eccentricLoad = EccentricLoad.LOAD_100,
+            echoLevel = EchoLevel.HARDER,
+            setEchoLevels = listOf(EchoLevel.EASIER, null, EchoLevel.HARDER), // Mixed overrides
+        )
+        viewModel.initialize(exercise = exercise, unit = WeightUnit.KG, toDisplay = { v, _ -> v }, toKg = { v, _ -> v })
+
+        val sets = viewModel.sets.value
+        assertEquals(EchoLevel.EASIER, sets[0].echoLevel, "Set 1 echo should be EASIER")
+        assertNull(sets[1].echoLevel, "Set 2 echo should be null (no override)")
+        assertEquals(EchoLevel.HARDER, sets[2].echoLevel, "Set 3 echo should be HARDER")
+    }
 }

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModelTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModelTest.kt
@@ -1009,7 +1009,7 @@ class ExerciseConfigViewModelTest {
             programMode = ProgramMode.OldSchool,
             eccentricLoad = EccentricLoad.LOAD_100,
             echoLevel = EchoLevel.HARDER,
-            setEchoLevels = listOf(EchoLevel.EASIER, EchoLevel.HARDER), // Per-set overrides
+            setEchoLevels = listOf(EchoLevel.HARD, EchoLevel.HARDER), // Per-set overrides
             setRestSeconds = listOf(60, 90),
             perSetRestTime = true,
         )
@@ -1020,15 +1020,15 @@ class ExerciseConfigViewModelTest {
         viewModel.onRepeatCountChange(setIds[1], 3)
 
         // Verify SetConfiguration carries echo override
-        assertEquals(EchoLevel.EASIER, viewModel.sets.value[0].echoLevel, "Set 1 should carry EASIER echo override")
+        assertEquals(EchoLevel.HARD, viewModel.sets.value[0].echoLevel, "Set 1 should carry HARD echo override")
         assertEquals(EchoLevel.HARDER, viewModel.sets.value[1].echoLevel, "Set 2 should carry HARDER echo override")
 
         var saved: RoutineExercise? = null
         viewModel.onSave { updated -> saved = updated }
 
         assertNotNull(saved)
-        // Expanded: set1 (EASIER) + set2×3 (HARDER each)
-        assertEquals(listOf(EchoLevel.EASIER, EchoLevel.HARDER, EchoLevel.HARDER, EchoLevel.HARDER), saved!!.setEchoLevels,
+        // Expanded: set1 (HARD) + set2×3 (HARDER each)
+        assertEquals(listOf(EchoLevel.HARD, EchoLevel.HARDER, EchoLevel.HARDER, EchoLevel.HARDER), saved!!.setEchoLevels,
             "Per-set Echo overrides should be preserved through expansion")
     }
 
@@ -1044,12 +1044,12 @@ class ExerciseConfigViewModelTest {
             programMode = ProgramMode.OldSchool,
             eccentricLoad = EccentricLoad.LOAD_100,
             echoLevel = EchoLevel.HARDER,
-            setEchoLevels = listOf(EchoLevel.EASIER, null, EchoLevel.HARDER), // Mixed overrides
+            setEchoLevels = listOf(EchoLevel.HARD, null, EchoLevel.HARDER), // Mixed overrides
         )
         viewModel.initialize(exercise = exercise, unit = WeightUnit.KG, toDisplay = { v, _ -> v }, toKg = { v, _ -> v })
 
         val sets = viewModel.sets.value
-        assertEquals(EchoLevel.EASIER, sets[0].echoLevel, "Set 1 echo should be EASIER")
+        assertEquals(EchoLevel.HARD, sets[0].echoLevel, "Set 1 echo should be HARD")
         assertNull(sets[1].echoLevel, "Set 2 echo should be null (no override)")
         assertEquals(EchoLevel.HARDER, sets[2].echoLevel, "Set 3 echo should be HARDER")
     }

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModelTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModelTest.kt
@@ -747,4 +747,252 @@ class ExerciseConfigViewModelTest {
         }
         assertTrue(condition(), "Timed out waiting for view model state update")
     }
+
+    // ──────────────────────────────────────────────────────────────────
+    // Issue #667: Set repetition tests
+    // ──────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `onRepeatCountChange updates correct set`() = runTest {
+        val viewModel = ExerciseConfigViewModel()
+        val exercise = RoutineExercise(
+            id = "rex-667-1",
+            exercise = Exercise(id = "bench-1", name = "Bench Press", muscleGroup = "Chest", muscleGroups = "Chest", equipment = "BAR"),
+            orderIndex = 0,
+            setReps = listOf(10, 10, 10),
+            weightPerCableKg = 20f,
+            setWeightsPerCableKg = listOf(20f, 20f, 20f),
+        )
+        viewModel.initialize(exercise = exercise, unit = WeightUnit.KG, toDisplay = { v, _ -> v }, toKg = { v, _ -> v })
+
+        val secondSetId = viewModel.sets.value[1].id
+        viewModel.onRepeatCountChange(secondSetId, 4)
+
+        assertEquals(1, viewModel.sets.value[0].repeatCount)
+        assertEquals(4, viewModel.sets.value[1].repeatCount)
+        assertEquals(1, viewModel.sets.value[2].repeatCount)
+    }
+
+    @Test
+    fun `onRepeatCountChange coerces to 1-20 range`() = runTest {
+        val viewModel = ExerciseConfigViewModel()
+        val exercise = RoutineExercise(
+            id = "rex-667-2",
+            exercise = Exercise(id = "bench-1", name = "Bench Press", muscleGroup = "Chest", muscleGroups = "Chest", equipment = "BAR"),
+            orderIndex = 0,
+            setReps = listOf(10),
+            weightPerCableKg = 20f,
+            setWeightsPerCableKg = listOf(20f),
+        )
+        viewModel.initialize(exercise = exercise, unit = WeightUnit.KG, toDisplay = { v, _ -> v }, toKg = { v, _ -> v })
+
+        val setId = viewModel.sets.value[0].id
+
+        viewModel.onRepeatCountChange(setId, 0)
+        assertEquals(1, viewModel.sets.value[0].repeatCount, "0 should coerce to 1")
+
+        viewModel.onRepeatCountChange(setId, 25)
+        assertEquals(20, viewModel.sets.value[0].repeatCount, "25 should coerce to 20")
+    }
+
+    @Test
+    fun `totalExpandedSetCount sums repeatCounts`() = runTest {
+        val viewModel = ExerciseConfigViewModel()
+        val exercise = RoutineExercise(
+            id = "rex-667-3",
+            exercise = Exercise(id = "bench-1", name = "Bench Press", muscleGroup = "Chest", muscleGroups = "Chest", equipment = "BAR"),
+            orderIndex = 0,
+            setReps = listOf(10, 10, 10),
+            weightPerCableKg = 20f,
+            setWeightsPerCableKg = listOf(20f, 20f, 20f),
+        )
+        viewModel.initialize(exercise = exercise, unit = WeightUnit.KG, toDisplay = { v, _ -> v }, toKg = { v, _ -> v })
+
+        assertEquals(3, viewModel.totalExpandedSetCount, "All repeatCount=1 → 3")
+
+        val setIds = viewModel.sets.value.map { it.id }
+        viewModel.onRepeatCountChange(setIds[1], 3)
+        viewModel.onRepeatCountChange(setIds[2], 2)
+        assertEquals(6, viewModel.totalExpandedSetCount, "[1,3,2] → 6")
+    }
+
+    @Test
+    fun `onSave with repeatCount produces expanded arrays`() = runTest {
+        val viewModel = ExerciseConfigViewModel()
+        val exercise = RoutineExercise(
+            id = "rex-667-4",
+            exercise = Exercise(id = "bench-1", name = "Bench Press", muscleGroup = "Chest", muscleGroups = "Chest", equipment = "BAR"),
+            orderIndex = 0,
+            setReps = listOf(10, 8, 10),
+            weightPerCableKg = 20f,
+            setWeightsPerCableKg = listOf(20f, 25f, 20f),
+            programMode = ProgramMode.OldSchool,
+            eccentricLoad = EccentricLoad.LOAD_100,
+            echoLevel = EchoLevel.HARDER,
+            setRestSeconds = listOf(60, 60, 60),
+        )
+        viewModel.initialize(exercise = exercise, unit = WeightUnit.KG, toDisplay = { v, _ -> v }, toKg = { v, _ -> v })
+
+        // Set 2 has repeatCount=3
+        val setIds = viewModel.sets.value.map { it.id }
+        viewModel.onRepeatCountChange(setIds[1], 3)
+
+        var saved: RoutineExercise? = null
+        viewModel.onSave { updated -> saved = updated }
+
+        assertNotNull(saved)
+        // 1 + 3 + 1 = 5 expanded sets
+        assertEquals(5, saved!!.setReps.size, "setReps should have 5 entries")
+        assertEquals(5, saved!!.setWeightsPerCableKg.size, "setWeights should have 5 entries")
+        assertEquals(5, saved!!.setRestSeconds.size, "setRestSeconds should have 5 entries")
+        // Check values: [10, 8, 8, 8, 10]
+        assertEquals(listOf(10, 8, 8, 8, 10), saved!!.setReps)
+        // Check weights: [20, 25, 25, 25, 20]
+        assertEquals(listOf(20f, 25f, 25f, 25f, 20f), saved!!.setWeightsPerCableKg)
+    }
+
+    @Test
+    fun `onSave with repeatCount and AMRAP sets`() = runTest {
+        val viewModel = ExerciseConfigViewModel()
+        val exercise = RoutineExercise(
+            id = "rex-667-5",
+            exercise = Exercise(id = "bench-1", name = "Bench Press", muscleGroup = "Chest", muscleGroups = "Chest", equipment = "BAR"),
+            orderIndex = 0,
+            setReps = listOf(null, null),
+            weightPerCableKg = 20f,
+            setWeightsPerCableKg = listOf(20f, 20f),
+            programMode = ProgramMode.OldSchool,
+            eccentricLoad = EccentricLoad.LOAD_100,
+            echoLevel = EchoLevel.HARDER,
+            isAMRAP = true,
+        )
+        viewModel.initialize(exercise = exercise, unit = WeightUnit.KG, toDisplay = { v, _ -> v }, toKg = { v, _ -> v })
+
+        val setIds = viewModel.sets.value.map { it.id }
+        viewModel.onRepeatCountChange(setIds[0], 2)
+
+        var saved: RoutineExercise? = null
+        viewModel.onSave { updated -> saved = updated }
+
+        assertNotNull(saved)
+        assertTrue(saved!!.isAMRAP, "AMRAP should be preserved")
+        assertEquals(3, saved!!.setReps.size, "2+1=3 expanded sets")
+        assertTrue(saved!!.setReps.all { it == null }, "All reps should be null (AMRAP)")
+    }
+
+    @Test
+    fun `onSave with repeatCount and uniform rest`() = runTest {
+        val viewModel = ExerciseConfigViewModel()
+        val exercise = RoutineExercise(
+            id = "rex-667-6",
+            exercise = Exercise(id = "bench-1", name = "Bench Press", muscleGroup = "Chest", muscleGroups = "Chest", equipment = "BAR"),
+            orderIndex = 0,
+            setReps = listOf(10, 10),
+            weightPerCableKg = 20f,
+            setWeightsPerCableKg = listOf(20f, 20f),
+            programMode = ProgramMode.OldSchool,
+            eccentricLoad = EccentricLoad.LOAD_100,
+            echoLevel = EchoLevel.HARDER,
+            perSetRestTime = false,
+        )
+        viewModel.initialize(exercise = exercise, unit = WeightUnit.KG, toDisplay = { v, _ -> v }, toKg = { v, _ -> v })
+        viewModel.onRestChange(90)
+        viewModel.onPerSetRestTimeChange(false)
+
+        val setIds = viewModel.sets.value.map { it.id }
+        viewModel.onRepeatCountChange(setIds[0], 3)
+
+        var saved: RoutineExercise? = null
+        viewModel.onSave { updated -> saved = updated }
+
+        assertNotNull(saved)
+        assertEquals(4, saved!!.setRestSeconds.size, "3+1=4 expanded rest entries")
+        assertTrue(saved!!.setRestSeconds.all { it == 90 }, "Uniform rest applied to all expanded sets")
+    }
+
+    @Test
+    fun `initialize sets all repeatCount to 1`() = runTest {
+        val viewModel = ExerciseConfigViewModel()
+        val exercise = RoutineExercise(
+            id = "rex-667-7",
+            exercise = Exercise(id = "bench-1", name = "Bench Press", muscleGroup = "Chest", muscleGroups = "Chest", equipment = "BAR"),
+            orderIndex = 0,
+            setReps = listOf(10, 8, 6),
+            weightPerCableKg = 20f,
+            setWeightsPerCableKg = listOf(20f, 25f, 30f),
+        )
+        viewModel.initialize(exercise = exercise, unit = WeightUnit.KG, toDisplay = { v, _ -> v }, toKg = { v, _ -> v })
+
+        assertEquals(3, viewModel.sets.value.size)
+        assertTrue(viewModel.sets.value.all { it.repeatCount == 1 }, "All sets should have repeatCount=1 after init")
+    }
+
+    @Test
+    fun `addSet creates set with repeatCount 1`() = runTest {
+        val viewModel = ExerciseConfigViewModel()
+        val exercise = RoutineExercise(
+            id = "rex-667-8",
+            exercise = Exercise(id = "bench-1", name = "Bench Press", muscleGroup = "Chest", muscleGroups = "Chest", equipment = "BAR"),
+            orderIndex = 0,
+            setReps = listOf(10, 10),
+            weightPerCableKg = 20f,
+            setWeightsPerCableKg = listOf(20f, 20f),
+        )
+        viewModel.initialize(exercise = exercise, unit = WeightUnit.KG, toDisplay = { v, _ -> v }, toKg = { v, _ -> v })
+
+        viewModel.addSet()
+        assertEquals(3, viewModel.sets.value.size)
+        assertEquals(1, viewModel.sets.value.last().repeatCount, "New set should have repeatCount=1")
+    }
+
+    @Test
+    fun `deleteSet preserves repeatCount on remaining sets`() = runTest {
+        val viewModel = ExerciseConfigViewModel()
+        val exercise = RoutineExercise(
+            id = "rex-667-9",
+            exercise = Exercise(id = "bench-1", name = "Bench Press", muscleGroup = "Chest", muscleGroups = "Chest", equipment = "BAR"),
+            orderIndex = 0,
+            setReps = listOf(10, 10, 10),
+            weightPerCableKg = 20f,
+            setWeightsPerCableKg = listOf(20f, 20f, 20f),
+        )
+        viewModel.initialize(exercise = exercise, unit = WeightUnit.KG, toDisplay = { v, _ -> v }, toKg = { v, _ -> v })
+
+        val setIds = viewModel.sets.value.map { it.id }
+        viewModel.onRepeatCountChange(setIds[0], 1)
+        viewModel.onRepeatCountChange(setIds[1], 3)
+        viewModel.onRepeatCountChange(setIds[2], 1)
+
+        viewModel.deleteSet(0) // Remove first set
+        assertEquals(2, viewModel.sets.value.size)
+        assertEquals(3, viewModel.sets.value[0].repeatCount, "Second set's repeatCount should survive reindex")
+        assertEquals(1, viewModel.sets.value[1].repeatCount)
+    }
+
+    @Test
+    fun `onSave backward compat - all repeatCount 1 produces identical output`() = runTest {
+        val viewModel = ExerciseConfigViewModel()
+        val exercise = RoutineExercise(
+            id = "rex-667-10",
+            exercise = Exercise(id = "bench-1", name = "Bench Press", muscleGroup = "Chest", muscleGroups = "Chest", equipment = "BAR"),
+            orderIndex = 0,
+            setReps = listOf(10, 8, 6),
+            weightPerCableKg = 20f,
+            setWeightsPerCableKg = listOf(20f, 25f, 30f),
+            programMode = ProgramMode.OldSchool,
+            eccentricLoad = EccentricLoad.LOAD_100,
+            echoLevel = EchoLevel.HARDER,
+            setRestSeconds = listOf(60, 90, 120),
+            perSetRestTime = true,
+        )
+        viewModel.initialize(exercise = exercise, unit = WeightUnit.KG, toDisplay = { v, _ -> v }, toKg = { v, _ -> v })
+
+        var saved: RoutineExercise? = null
+        viewModel.onSave { updated -> saved = updated }
+
+        assertNotNull(saved)
+        assertEquals(listOf(10, 8, 6), saved!!.setReps)
+        assertEquals(listOf(20f, 25f, 30f), saved!!.setWeightsPerCableKg)
+        assertEquals(listOf(60, 90, 120), saved!!.setRestSeconds)
+    }
 }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseEditBottomSheet.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/ExerciseEditBottomSheet.kt
@@ -452,6 +452,7 @@ fun ExerciseEditBottomSheet(
                     onRestChange = viewModel::updateRestTime,
                     onAddSet = viewModel::addSet,
                     onDeleteSet = viewModel::deleteSet,
+                    onRepeatCountChange = viewModel::onRepeatCountChange, // Issue #667
                 )
 
                 // Per Set Rest Time toggle — immediately follows SetsConfiguration so rest
@@ -818,6 +819,7 @@ fun SetsConfiguration(
     onRestChange: (String, Int) -> Unit,
     onAddSet: () -> Unit,
     onDeleteSet: (Int) -> Unit,
+    onRepeatCountChange: (String, Int) -> Unit = { _, _ -> }, // Issue #667
 ) {
     Column(
         modifier = Modifier.fillMaxWidth(),
@@ -847,8 +849,22 @@ fun SetsConfiguration(
                     onRestChange = { newRest -> onRestChange(setConfig.id, newRest) },
                     onDelete = { onDeleteSet(index) },
                     perSetRestTime = perSetRestTime,
+                    repeatCount = setConfig.repeatCount, // Issue #667
+                    onRepeatCountChange = { newCount -> onRepeatCountChange(setConfig.id, newCount) }, // Issue #667
                 )
             }
+        }
+
+        // Issue #667: Total expanded sets preview
+        if (sets.any { it.repeatCount > 1 }) {
+            val total = sets.sumOf { it.repeatCount.coerceIn(1, 20) }
+            Text(
+                "Total sets after expansion: $total",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.primary,
+                fontWeight = FontWeight.Medium,
+                modifier = Modifier.padding(vertical = Spacing.extraSmall),
+            )
         }
 
         // Add Set button
@@ -890,6 +906,8 @@ fun SetRow(
     onRestChange: (Int) -> Unit,
     onDelete: () -> Unit,
     perSetRestTime: Boolean = false,
+    repeatCount: Int = 1, // Issue #667
+    onRepeatCountChange: (Int) -> Unit = {}, // Issue #667
 ) {
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -914,6 +932,15 @@ fun SetRow(
                     style = MaterialTheme.typography.bodyMedium,
                     fontWeight = FontWeight.Bold,
                 )
+                // Issue #667: ×N badge for repeated sets
+                if (repeatCount > 1) {
+                    Text(
+                        " ×$repeatCount",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.primary,
+                        fontWeight = FontWeight.Bold,
+                    )
+                }
                 IconButton(
                     onClick = onDelete,
                     enabled = canDelete,
@@ -950,6 +977,28 @@ fun SetRow(
                 }
                 Spacer(modifier = Modifier.height(Spacing.small))
             }
+
+            // Issue #667: Repeat counter
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(Spacing.small),
+            ) {
+                Text(
+                    "Repeat:",
+                    style = MaterialTheme.typography.bodySmall,
+                    fontWeight = FontWeight.Medium,
+                )
+                CompactNumberPicker(
+                    value = repeatCount,
+                    onValueChange = onRepeatCountChange,
+                    range = 1..20,
+                    label = "",
+                    suffix = "x",
+                )
+            }
+
+            Spacer(modifier = Modifier.height(Spacing.small))
 
             // Reps/Duration and Weight side-by-side
             Row(

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModel.kt
@@ -50,6 +50,7 @@ data class SetConfiguration(
     val duration: Int = 30,
     val restSeconds: Int = 60, // Add this
     val repeatCount: Int = 1, // 1 = no repeat, 2-20 = repeat N times (Issue #667)
+    val echoLevel: EchoLevel? = null, // Per-set echo override (Issue #667 review fix)
 )
 
 class ExerciseConfigViewModel constructor(
@@ -211,6 +212,7 @@ class ExerciseConfigViewModel constructor(
         val initialSets = exercise.setReps.mapIndexed { index, reps ->
             val perSetWeightKg = exercise.setWeightsPerCableKg.getOrNull(index) ?: exercise.weightPerCableKg
             val perSetRest = exercise.setRestSeconds.getOrNull(index) ?: 60
+            val perSetEcho = exercise.setEchoLevels.getOrNull(index) // Preserve per-set Echo overrides
             SetConfiguration(
                 id = generateUUID(),
                 setNumber = index + 1,
@@ -218,6 +220,7 @@ class ExerciseConfigViewModel constructor(
                 weightPerCable = kgToDisplay(perSetWeightKg, weightUnit),
                 duration = defaultDuration,
                 restSeconds = perSetRest,
+                echoLevel = perSetEcho,
             )
         }.ifEmpty {
             listOf(
@@ -786,7 +789,7 @@ class ExerciseConfigViewModel constructor(
                 expandedReps.add(set.reps)
                 expandedWeights.add(resolvedWeightsKg[index])
                 expandedRest.add(set.restSeconds)
-                expandedEcho.add(null) // null = fallback to exercise-level echoLevel
+                expandedEcho.add(set.echoLevel) // Preserve per-set Echo override (Issue #667 review fix)
             }
         }
         return ExpandedSets(expandedReps, expandedWeights, expandedRest, expandedEcho)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/viewmodel/ExerciseConfigViewModel.kt
@@ -49,6 +49,7 @@ data class SetConfiguration(
     val weightPerCable: Float = 15.0f,
     val duration: Int = 30,
     val restSeconds: Int = 60, // Add this
+    val repeatCount: Int = 1, // 1 = no repeat, 2-20 = repeat N times (Issue #667)
 )
 
 class ExerciseConfigViewModel constructor(
@@ -765,33 +766,55 @@ class ExerciseConfigViewModel constructor(
         }
     }
 
+    // Issue #667: Set repetition support
+    private data class ExpandedSets(
+        val reps: List<Int?>,
+        val weights: List<Float>,
+        val rest: List<Int>,
+        val echo: List<EchoLevel?>,
+    )
+
+    private fun expandSets(sets: List<SetConfiguration>, resolvedWeightsKg: List<Float>): ExpandedSets {
+        val expandedReps = mutableListOf<Int?>()
+        val expandedWeights = mutableListOf<Float>()
+        val expandedRest = mutableListOf<Int>()
+        val expandedEcho = mutableListOf<EchoLevel?>()
+
+        for ((index, set) in sets.withIndex()) {
+            val count = set.repeatCount.coerceIn(1, 20)
+            repeat(count) {
+                expandedReps.add(set.reps)
+                expandedWeights.add(resolvedWeightsKg[index])
+                expandedRest.add(set.restSeconds)
+                expandedEcho.add(null) // null = fallback to exercise-level echoLevel
+            }
+        }
+        return ExpandedSets(expandedReps, expandedWeights, expandedRest, expandedEcho)
+    }
+
+    fun onRepeatCountChange(setId: String, count: Int) {
+        val coerced = count.coerceIn(1, 20)
+        _sets.value = _sets.value.map { set ->
+            if (set.id == setId) set.copy(repeatCount = coerced) else set
+        }
+    }
+
+    val totalExpandedSetCount: Int
+        get() = _sets.value.sumOf { it.repeatCount.coerceIn(1, 20) }
+
     fun onSave(onSaveCallback: (RoutineExercise) -> Unit) {
         if (_sets.value.isEmpty()) return
-
-        // Determine rest times based on perSetRestTime toggle
-        val restTimes = if (_perSetRestTime.value) {
-            // Per-set rest times: use each set's rest time
-            _sets.value.map { it.restSeconds }
-        } else {
-            // Single rest time: use the bottom rest time picker value for all sets
-            List(_sets.value.size) { _rest.value }
-        }
-
-        // Determine if exercise is AMRAP (all sets have null reps)
-        val isAMRAP = _sets.value.all { it.reps == null }
 
         // Debug logging for AMRAP exercise data saving
         logDebug("━━━━━ ExerciseConfigViewModel.onSave() ━━━━━")
         logDebug("Exercise: ${originalExercise.exercise.name}")
-        logDebug("isAMRAP computed: $isAMRAP")
         logDebug("perSetRestTime toggle: ${_perSetRestTime.value}")
-        logDebug("Current sets before save:")
+        logDebug("Current sets before expansion:")
         _sets.value.forEach { set ->
-            logDebug("  Set ${set.setNumber}: reps=${set.reps}, weight=${set.weightPerCable}, rest=${set.restSeconds}")
+            logDebug("  Set ${set.setNumber}: reps=${set.reps}, weight=${set.weightPerCable}, rest=${set.restSeconds}, repeat=${set.repeatCount}")
         }
-        logDebug("Rest times to save: $restTimes")
-        logDebug("Weights to save: ${_sets.value.map { displayToKg(it.weightPerCable, weightUnit) }}")
 
+        // Resolve weights BEFORE expansion (Issue #667)
         val resolvedSetWeightsKg = resolvedSetWeightsKgFromCurrentBasis()
             ?: _sets.value.map { displayToKg(it.weightPerCable, weightUnit) }
         val resolvedSetWeightsPercentOfPR = if (_usePercentOfPR.value) {
@@ -804,15 +827,48 @@ class ExerciseConfigViewModel constructor(
             emptyList()
         }
 
+        // Expand repeated sets into flat arrays (Issue #667)
+        val expanded = expandSets(_sets.value, resolvedSetWeightsKg)
+
+        // Expand rest times: after per-set/uniform decision
+        val expandedRestTimes = if (_perSetRestTime.value) {
+            expanded.rest // per-set rest already expanded
+        } else {
+            List(expanded.reps.size) { _rest.value }
+        }
+
+        // Expand PR percentage weights in parallel
+        val expandedPercentOfPR = if (_usePercentOfPR.value && resolvedSetWeightsPercentOfPR.isNotEmpty()) {
+            val expandedPercent = mutableListOf<Int>()
+            for ((index, set) in _sets.value.withIndex()) {
+                val count = set.repeatCount.coerceIn(1, 20)
+                val percent = resolvedSetWeightsPercentOfPR.getOrElse(index) { _weightPercentOfPR.value.coerceIn(50, 120) }
+                repeat(count) { expandedPercent.add(percent) }
+            }
+            expandedPercent
+        } else {
+            resolvedSetWeightsPercentOfPR
+        }
+
+        // Determine if exercise is AMRAP (all expanded reps are null)
+        val isAMRAP = expanded.reps.all { it == null }
+
+        logDebug("Expanded sets: ${expanded.reps.size} (from ${_sets.value.size} editor sets)")
+        logDebug("Expanded reps: ${expanded.reps}")
+        logDebug("Expanded weights: ${expanded.weights}")
+        logDebug("Expanded rest: $expandedRestTimes")
+        logDebug("isAMRAP computed: $isAMRAP")
+
         val updatedExercise = originalExercise.copy(
-            setReps = _sets.value.map { it.reps },
-            weightPerCableKg = resolvedSetWeightsKg.first(),
-            setWeightsPerCableKg = resolvedSetWeightsKg,
+            setReps = expanded.reps,
+            weightPerCableKg = expanded.weights.first(),
+            setWeightsPerCableKg = expanded.weights,
             programMode = _selectedMode.value.toProgramMode(),
             eccentricLoad = _eccentricLoad.value,
             echoLevel = _echoLevel.value,
             progressionKg = displayToKg(_weightChange.value.toFloat(), weightUnit),
-            setRestSeconds = restTimes,
+            setRestSeconds = expandedRestTimes,
+            setEchoLevels = expanded.echo,
             duration = if (_setMode.value == SetMode.DURATION) {
                 _sets.value.firstOrNull()?.duration ?: 30 // Default to 30 seconds if not set
             } else {
@@ -827,7 +883,7 @@ class ExerciseConfigViewModel constructor(
             usePercentOfPR = _usePercentOfPR.value,
             weightPercentOfPR = _weightPercentOfPR.value,
             prTypeForScaling = _prTypeForScaling.value,
-            setWeightsPercentOfPR = resolvedSetWeightsPercentOfPR,
+            setWeightsPercentOfPR = expandedPercentOfPR,
             // Issue #517: persist explicit scaling basis (null = back-compat derivation from prTypeForScaling)
             scalingBasis = _scalingBasis.value,
             // Warm-up sets (Issue #30)


### PR DESCRIPTION
## Summary

Adds set repetition to the routine editor. Users can specify a repeat count (1-20) for any set, and on save the repeated sets expand into flat arrays — zero schema changes, full backward compatibility.

Fixes #667

## Changes

### Production files (2)
- **`ExerciseConfigViewModel.kt`**: Added `repeatCount` field to `SetConfiguration`, `expandSets()` for single-loop array expansion, `onRepeatCountChange()` handler, `totalExpandedSetCount` computed property, and modified `onSave()` to expand before persisting.
- **`ExerciseEditBottomSheet.kt`**: Added repeat counter (`CompactNumberPicker`, range 1-20) to each `SetRow`, `×N` badge on sets with repeatCount > 1, total expanded sets preview text, and wired `onRepeatCountChange` through `SetsConfiguration`.

### Test file (1)
- **`ExerciseConfigViewModelTest.kt`**: 10 new unit tests covering:
  - `onRepeatCountChange` updates correct set and coerces range (0→1, 25→20)
  - `totalExpandedSetCount` sums correctly
  - `onSave` with repeat produces expanded arrays (reps, weights, rest)
  - AMRAP preservation through expansion
  - Uniform rest time applied to all expanded sets
  - Backward compatibility (all repeatCount=1 produces identical output)
  - `initialize`/`addSet`/`deleteSet` preserve repeatCount defaults

## Design: Expand-at-Save

The repeat metadata is **editor-local only** (not persisted). On save:
1. Resolve weights first (before expansion)
2. Expand all parallel arrays in lockstep via `expandSets()`
3. Expand rest times after per-set/uniform decision
4. Expand PR percentage weights in parallel
5. Pass expanded arrays to `RoutineExercise.copy()`

This means zero schema changes — the existing `setReps TEXT`, `setWeights TEXT`, `setRestSeconds TEXT`, `setEchoLevels TEXT` columns simply contain longer comma-separated/JSON strings.

## How to test

1. Open routine editor → add/edit an exercise
2. Use the "Repeat: Nx" picker on any set (default 1x)
3. Verify `×N` badge appears on sets with repeat > 1
4. Verify "Total sets after expansion: N" preview updates
5. Save and verify the workout HUD shows the expanded set count
6. Verify old routines (no repeat) load and save identically

## Out of scope (Phase 2)
- Progression factors (static/percentage weight increase per set)
- Nesting (repeat groups within repeat groups)
- Portal/web changes