### PR TITLE
fix: dark mode color scheme sporadic switch (#677)

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -98,7 +98,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize|density|uiMode"
+            android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize|density"
             android:theme="@style/Theme.VitruvianProjectPhoenix">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/shared/src/androidMain/kotlin/com/devil/phoenixproject/ui/theme/StatusBarAppearance.android.kt
+++ b/shared/src/androidMain/kotlin/com/devil/phoenixproject/ui/theme/StatusBarAppearance.android.kt
@@ -1,0 +1,22 @@
+package com.devil.phoenixproject.ui.theme
+
+import android.app.Activity
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.WindowCompat
+
+/**
+ * Android actual: applies status bar icon appearance based on dark/light theme.
+ * Called inside a Composable scope where LocalView is available.
+ */
+@Composable
+actual fun ApplyStatusBarAppearance(isDark: Boolean) {
+    val view = LocalView.current
+    if (!view.isInEditMode) {
+        SideEffect {
+            val window = (view.context as Activity).window
+            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = !isDark
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/ui/theme/StatusBarAppearance.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/ui/theme/StatusBarAppearance.kt
@@ -1,8 +1,11 @@
 package com.devil.phoenixproject.ui.theme
 
+import androidx.compose.runtime.Composable
+
 /**
  * Platform hook to apply status bar icon appearance after a theme change.
  * On Android, this sets `isAppearanceLightStatusBars` based on [isDark].
  * On iOS, this is a no-op.
  */
+@Composable
 expect fun ApplyStatusBarAppearance(isDark: Boolean)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/ui/theme/StatusBarAppearance.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/ui/theme/StatusBarAppearance.kt
@@ -1,0 +1,8 @@
+package com.devil.phoenixproject.ui.theme
+
+/**
+ * Platform hook to apply status bar icon appearance after a theme change.
+ * On Android, this sets `isAppearanceLightStatusBars` based on [isDark].
+ * On iOS, this is a no-op.
+ */
+expect fun ApplyStatusBarAppearance(isDark: Boolean)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/ui/theme/Theme.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/ui/theme/Theme.kt
@@ -128,6 +128,8 @@ fun VitruvianTheme(
         LightColorScheme
     }
 
+    ApplyStatusBarAppearance(isDark = useDarkColors)
+
     MaterialTheme(
         colorScheme = colorScheme,
         typography = Typography,

--- a/shared/src/iosMain/kotlin/com/devil/phoenixproject/ui/theme/StatusBarAppearance.ios.kt
+++ b/shared/src/iosMain/kotlin/com/devil/phoenixproject/ui/theme/StatusBarAppearance.ios.kt
@@ -1,0 +1,11 @@
+package com.devil.phoenixproject.ui.theme
+
+import androidx.compose.runtime.Composable
+
+/**
+ * iOS actual: no-op. iOS manages status bar appearance per-ViewController.
+ */
+@Composable
+actual fun ApplyStatusBarAppearance(isDark: Boolean) {
+    // No-op on iOS
+}


### PR DESCRIPTION
## Fix: Dark mode color scheme sporadic switch

### Problem
When Dark mode is selected with Material You colors enabled on Pixel 10 Pro XL (v0.9.6), the color scheme sporadically switches to light mode. After the phone times out and locks, unlocking shows the correct dark theme again.

### Root Cause
`android:configChanges` in `AndroidManifest.xml` includes `uiMode`, which tells Android "I handle uiMode changes myself." However, `MainActivity` does not override `onConfigurationChanged()`. When the system dark mode changes (e.g., due to scheduling, ambient light sensor, or other triggers), Android does not recreate the Activity. Compose recomposition occurs but becomes stale — some Material You surfaces resolve to light colors while the app's theme state remains dark.

This produces the mixed-surface rendering reported in the issue: light-colored Scaffold/headers with dark exercise cards.

### Fix
1. **Remove `uiMode` from `configChanges`** — When system dark mode changes, Android now properly destroys and recreates `MainActivity`. The `ThemeViewModel` re-reads the persisted theme preference from SharedPreferences, and the correct theme is applied cleanly.

2. **Add `ApplyStatusBarAppearance` SideEffect** — Status bar icon appearance (light/dark icons) now updates correctly on theme changes via an expect/actual pattern: Android uses `WindowCompat.getInsetsController`, iOS is a no-op.

### Files Changed
- `androidApp/src/main/AndroidManifest.xml` — Remove `uiMode` from `configChanges`
- `shared/src/commonMain/.../StatusBarAppearance.kt` — expect declaration
- `shared/src/androidMain/.../StatusBarAppearance.android.kt` — Android actual (SideEffect)
- `shared/src/iosMain/.../StatusBarAppearance.ios.kt` — iOS actual (no-op)
- `shared/src/commonMain/.../Theme.kt` — Call `ApplyStatusBarAppearance` in `VitruvianTheme`

### Verification
- When system dark mode toggles, the Activity now recreates cleanly
- Material You dynamic dark scheme remains clamped (existing #640 fix preserved)
- Status bar icons correctly reflect the active theme
- No behavior change for explicit Light/DARK mode selections

Fixes #677
