### PR TITLE
fix: propagate stopAtTop and repCountTiming across exercise transitions (#689)

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -4444,6 +4444,8 @@ class ActiveSessionEngine(
                         isAMRAP = nextIsAMRAP,
                         stallDetectionEnabled = exerciseForNextSet.stallDetectionEnabled,
                         warmupReps = if (nextExerciseIsBodyweight) 0 else Constants.DEFAULT_WARMUP_REPS,
+                        stopAtTop = exerciseForNextSet.stopAtTop,
+                        repCountTiming = exerciseForNextSet.repCountTiming,
                     )
                     Logger.d { "startRestTimer: Issue #203 - Updated params for next set: ${exerciseForNextSet.exercise.name}, setIdx=$nextSetIdx, isAMRAP=$nextIsAMRAP, nextSetReps=$nextSetReps" }
                 }
@@ -4850,6 +4852,8 @@ class ActiveSessionEngine(
                 isAMRAP = nextIsAMRAP,
                 stallDetectionEnabled = nextExercise.stallDetectionEnabled,
                 warmupReps = if (nextIsBodyweight) 0 else Constants.DEFAULT_WARMUP_REPS,
+                stopAtTop = nextExercise.stopAtTop,
+                repCountTiming = nextExercise.repCountTiming,
             )
             Logger.d {
                 "startNextSetOrExercise: Issue #203 - progressionKg=${nextExercise.progressionKg}kg for " +

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/DefaultWorkoutSessionManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/DefaultWorkoutSessionManager.kt
@@ -937,6 +937,8 @@ class DefaultWorkoutSessionManager(
                             selectedExerciseId = nextExercise.exercise.id,
                             isAMRAP = nextIsAMRAP,
                             stallDetectionEnabled = nextExercise.stallDetectionEnabled,
+                            stopAtTop = nextExercise.stopAtTop,
+                            repCountTiming = nextExercise.repCountTiming,
                         )
                         Logger.d {
                             "proceedFromSummary: Issue #203 - Updated params for next set: ${nextExercise.exercise.name}, setIdx=$nextSetIdx, isAMRAP=$nextIsAMRAP"

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMRoutineFlowTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMRoutineFlowTest.kt
@@ -3,6 +3,7 @@ package com.devil.phoenixproject.presentation.manager
 import com.devil.phoenixproject.domain.model.AppliedRoutineModifier
 import com.devil.phoenixproject.domain.model.PRType
 import com.devil.phoenixproject.domain.model.PersonalRecord
+import com.devil.phoenixproject.domain.model.RepCountTiming
 import com.devil.phoenixproject.domain.model.ProgramMode
 import com.devil.phoenixproject.domain.model.Routine
 import com.devil.phoenixproject.domain.model.RoutineExercise
@@ -853,6 +854,87 @@ class DWSMRoutineFlowTest {
         )
         val complete = assertIs<RoutineFlowState.Complete>(harness.dwsm.coordinator.routineFlowState.value)
         assertEquals(0, complete.totalExercises, "Warmup-only completion should not count as a completed exercise")
+        harness.cleanup()
+    }
+
+    /**
+     * Issue #689: Regression test for per-exercise stopAtTop/repCountTiming propagation.
+     *
+     * Before the fix, WorkoutParameters.copy() at the proceedFromSummary transition
+     * omitted stopAtTop and repCountTiming, so the first exercise's values leaked
+     * to all subsequent exercises during autoplay-off routines.
+     */
+    @Test
+    fun proceedFromSummary_propagatesPerExerciseStopAtTopAndRepCountTiming() = runTest {
+        val harness = DWSMTestHarness(this)
+        val exercise0 = TestFixtures.allExercises[0]
+        val exercise1 = TestFixtures.allExercises[1]
+        val routine = Routine(
+            id = "test-689-stopAtTop-repCountTiming",
+            name = "Issue689 Regression",
+            exercises = listOf(
+                RoutineExercise(
+                    id = "re-0-stopAtTop-false",
+                    exercise = exercise0,
+                    orderIndex = 0,
+                    setReps = listOf(10, 10, 10),
+                    weightPerCableKg = 25f,
+                    stopAtTop = false,
+                    repCountTiming = RepCountTiming.BOTTOM,
+                ),
+                RoutineExercise(
+                    id = "re-1-stopAtTop-true",
+                    exercise = exercise1,
+                    orderIndex = 1,
+                    setReps = listOf(12, 12, 12),
+                    weightPerCableKg = 15f,
+                    stopAtTop = true,
+                    repCountTiming = RepCountTiming.TOP,
+                ),
+            ),
+        )
+        routine.exercises.forEach { harness.fakeExerciseRepo.addExercise(it.exercise) }
+        advanceUntilIdle()
+
+        harness.dwsm.loadRoutine(routine)
+        advanceUntilIdle()
+
+        // Verify initial state: exercise 0's values seeded
+        assertEquals(false, harness.dwsm.coordinator.workoutParameters.value.stopAtTop)
+        assertEquals(RepCountTiming.BOTTOM, harness.dwsm.coordinator.workoutParameters.value.repCountTiming)
+
+        // Simulate finishing the last set of exercise 0 (autoplay OFF path)
+        harness.dwsm.coordinator._currentExerciseIndex.value = 0
+        harness.dwsm.coordinator._currentSetIndex.value = 2 // last of 3 sets
+        harness.dwsm.coordinator._workoutState.value = WorkoutState.SetSummary(
+            metrics = emptyList(),
+            peakLoadKgPerCable = 20f,
+            avgLoadKgPerCable = 18f,
+            repCount = 10,
+            workingReps = 10,
+            warmupReps = 0,
+        )
+
+        harness.dwsm.proceedFromSummary()
+        advanceUntilIdle()
+
+        // Assert: exercise 1's stopAtTop and repCountTiming propagated
+        val params = harness.dwsm.coordinator.workoutParameters.value
+        assertEquals(
+            true,
+            params.stopAtTop,
+            "stopAtTop must propagate from exercise 1 after proceedFromSummary (Issue #689 regression)",
+        )
+        assertEquals(
+            RepCountTiming.TOP,
+            params.repCountTiming,
+            "repCountTiming must propagate from exercise 1 after proceedFromSummary (Issue #689 regression)",
+        )
+        assertEquals(
+            exercise1.id,
+            params.selectedExerciseId,
+            "Selected exercise should advance to exercise 1",
+        )
         harness.cleanup()
     }
 

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMRoutineFlowTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMRoutineFlowTest.kt
@@ -858,38 +858,37 @@ class DWSMRoutineFlowTest {
     }
 
     /**
-     * Issue #689: Regression test for per-exercise stopAtTop/repCountTiming propagation.
+     * Issue #689: Regression test for the autoplay exercise-boundary transition.
      *
-     * Before the fix, WorkoutParameters.copy() at the proceedFromSummary transition
-     * omitted stopAtTop and repCountTiming, so the first exercise's values leaked
-     * to all subsequent exercises during autoplay-off routines.
+     * ActiveSessionEngine.startNextSetOrExercise must replace the preceding exercise's
+     * stopAtTop and repCountTiming values with the next RoutineExercise's values.
      */
     @Test
-    fun proceedFromSummary_propagatesPerExerciseStopAtTopAndRepCountTiming() = runTest {
+    fun startNextSet_propagatesPerExerciseStopAtTopAndRepCountTiming() = runTest {
         val harness = DWSMTestHarness(this)
         val exercise0 = TestFixtures.allExercises[0]
         val exercise1 = TestFixtures.allExercises[1]
         val routine = Routine(
-            id = "test-689-stopAtTop-repCountTiming",
-            name = "Issue689 Regression",
+            id = "test-689-autoplay-stopAtTop-repCountTiming",
+            name = "Issue689 Autoplay Regression",
             exercises = listOf(
                 RoutineExercise(
-                    id = "re-0-stopAtTop-false",
+                    id = "re-0-stopAtTop-true",
                     exercise = exercise0,
                     orderIndex = 0,
-                    setReps = listOf(10, 10, 10),
+                    setReps = listOf(10),
                     weightPerCableKg = 25f,
-                    stopAtTop = false,
-                    repCountTiming = RepCountTiming.BOTTOM,
-                ),
-                RoutineExercise(
-                    id = "re-1-stopAtTop-true",
-                    exercise = exercise1,
-                    orderIndex = 1,
-                    setReps = listOf(12, 12, 12),
-                    weightPerCableKg = 15f,
                     stopAtTop = true,
                     repCountTiming = RepCountTiming.TOP,
+                ),
+                RoutineExercise(
+                    id = "re-1-stopAtTop-false",
+                    exercise = exercise1,
+                    orderIndex = 1,
+                    setReps = listOf(12),
+                    weightPerCableKg = 15f,
+                    stopAtTop = false,
+                    repCountTiming = RepCountTiming.BOTTOM,
                 ),
             ),
         )
@@ -899,36 +898,35 @@ class DWSMRoutineFlowTest {
         harness.dwsm.loadRoutine(routine)
         advanceUntilIdle()
 
-        // Verify initial state: exercise 0's values seeded
-        assertEquals(false, harness.dwsm.coordinator.workoutParameters.value.stopAtTop)
-        assertEquals(RepCountTiming.BOTTOM, harness.dwsm.coordinator.workoutParameters.value.repCountTiming)
+        // Exercise 0 has the values that the report says leaked into later exercises.
+        assertEquals(true, harness.dwsm.coordinator.workoutParameters.value.stopAtTop)
+        assertEquals(RepCountTiming.TOP, harness.dwsm.coordinator.workoutParameters.value.repCountTiming)
 
-        // Simulate finishing the last set of exercise 0 (autoplay OFF path)
+        // Simulate a completed rest countdown advancing from exercise 0 to exercise 1.
+        harness.setActiveSummaryCountdownSeconds(0)
         harness.dwsm.coordinator._currentExerciseIndex.value = 0
-        harness.dwsm.coordinator._currentSetIndex.value = 2 // last of 3 sets
-        harness.dwsm.coordinator._workoutState.value = WorkoutState.SetSummary(
-            metrics = emptyList(),
-            peakLoadKgPerCable = 20f,
-            avgLoadKgPerCable = 18f,
-            repCount = 10,
-            workingReps = 10,
-            warmupReps = 0,
+        harness.dwsm.coordinator._currentSetIndex.value = 0
+        harness.dwsm.coordinator._workoutState.value = WorkoutState.Resting(
+            restSecondsRemaining = 0,
+            nextExerciseName = exercise1.displayName,
+            isLastExercise = false,
+            currentSet = 1,
+            totalSets = 1,
         )
 
-        harness.dwsm.proceedFromSummary()
+        harness.dwsm.startNextSet()
         advanceUntilIdle()
 
-        // Assert: exercise 1's stopAtTop and repCountTiming propagated
         val params = harness.dwsm.coordinator.workoutParameters.value
         assertEquals(
-            true,
+            false,
             params.stopAtTop,
-            "stopAtTop must propagate from exercise 1 after proceedFromSummary (Issue #689 regression)",
+            "stopAtTop must not leak from exercise 0 to exercise 1 (Issue #689 regression)",
         )
         assertEquals(
-            RepCountTiming.TOP,
+            RepCountTiming.BOTTOM,
             params.repCountTiming,
-            "repCountTiming must propagate from exercise 1 after proceedFromSummary (Issue #689 regression)",
+            "repCountTiming must not leak from exercise 0 to exercise 1 (Issue #689 regression)",
         )
         assertEquals(
             exercise1.id,


### PR DESCRIPTION
## Summary

Fixes per-exercise `stopAtTop` and `repCountTiming` settings leaking across exercise boundaries during autoplay routines. Previously, only the first exercise's values were preserved; all subsequent exercises inherited them.

## Root Cause

Three `WorkoutParameters.copy()` transition sites during autoplay omitted `stopAtTop` and `repCountTiming`, causing the Kotlin `copy()` default behavior (retain previous value) to persist stale per-exercise settings across exercise boundaries.

## Changes

Added explicit propagation of `stopAtTop` and `repCountTiming` from the next `RoutineExercise` at all three cross-exercise transition sites:

1. **`DefaultWorkoutSessionManager.proceedFromSummary`** — autoplay OFF path, transitions from summary to next exercise's set-ready
2. **`ActiveSessionEngine.startRestTimer`** — rest timer path, seeds params for the next set/exercise during rest
3. **`ActiveSessionEngine.startNextSetOrExercise`** — autoplay ON path, advances to next set or exercise after rest

## Verification

- `RoutineExercise` data class (line 79 of `Routine.kt`) has both `stopAtTop: Boolean` and `repCountTiming: RepCountTiming` fields
- Seeding paths in `RoutineFlowManager.kt` (lines 845/850, 1107-1108, 1182-1183, 1427-1428) already correctly set these from `RoutineExercise` on initial workout setup — the bug was only in transition copy sites
- No schema, sync, portal, UI, or migration impact

Fixes #689