### PR TITLE
fix: use Android-owned Configuration.uiMode for SYSTEM dark mode (#677)

### DIFF
--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/theme/ThemeModeUiContractGuardTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/theme/ThemeModeUiContractGuardTest.kt
@@ -75,4 +75,22 @@ class ThemeModeUiContractGuardTest {
         )
     }
 
+    @Test
+    fun androidSystemDarkDiagnostic_readsTheLatestComposeSignalOnResume() {
+        val source = read("shared/src/androidMain/kotlin/com/devil/phoenixproject/ui/theme/PlatformSystemDark.android.kt")
+
+        assertTrue(
+            source.contains("Lifecycle.Event.ON_RESUME") && source.contains("isDark = refreshed"),
+            "The Android-owned theme source must reconcile its state from Configuration.uiMode on every lifecycle resume so lock/unlock can repair a stale system appearance.",
+        )
+        assertTrue(
+            source.contains("val currentComposeSignal by rememberUpdatedState(composeSignal)"),
+            "The lifecycle observer must bridge a recomposed isSystemInDarkTheme() value with rememberUpdatedState so ON_RESUME does not compare Configuration.uiMode with the first composition's stale Compose signal.",
+        )
+        assertTrue(
+            source.contains("currentComposeSignal != refreshed"),
+            "The resume mismatch diagnostic must compare Configuration.uiMode with the current Compose signal rather than the observer's initial captured value.",
+        )
+    }
+
 }

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/theme/ThemeModeUiContractGuardTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/theme/ThemeModeUiContractGuardTest.kt
@@ -62,12 +62,16 @@ class ThemeModeUiContractGuardTest {
     }
 
     @Test
-    fun commonTheme_mapsSystemToSystemDarkTheme() {
+    fun commonTheme_mapsSystemToLifecycleSafePlatformDark() {
         val source = read("shared/src/commonMain/kotlin/com/devil/phoenixproject/ui/theme/Theme.kt")
 
         assertTrue(
-            source.contains("ThemeMode.SYSTEM -> isSystemInDarkTheme()"),
-            "System theme mode must continue to follow the platform system dark-theme signal.",
+            source.contains("ThemeMode.SYSTEM -> rememberPlatformSystemDark()"),
+            "System theme mode must use the lifecycle-safe platform dark signal (Configuration.uiMode on Android) rather than the transient isSystemInDarkTheme().",
+        )
+        assertFalse(
+            source.contains("isSystemInDarkTheme()"),
+            "Theme.kt must not directly call isSystemInDarkTheme(); use rememberPlatformSystemDark() for lifecycle-safe resume reconciliation.",
         )
     }
 

--- a/shared/src/androidMain/kotlin/com/devil/phoenixproject/ui/theme/PlatformSystemDark.android.kt
+++ b/shared/src/androidMain/kotlin/com/devil/phoenixproject/ui/theme/PlatformSystemDark.android.kt
@@ -37,6 +37,10 @@ actual fun rememberPlatformSystemDark(): Boolean {
 
     var isDark by remember { mutableStateOf(readUiModeDark()) }
 
+    // Capture the Compose system-dark signal during composition so we can compare
+    // it against the authoritative Configuration.uiMode value on resume.
+    val composeSignal = isSystemInDarkTheme()
+
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_RESUME) {
@@ -46,19 +50,14 @@ actual fun rememberPlatformSystemDark(): Boolean {
                 }
                 isDark = refreshed
 
-                // Diagnostic: log mismatch between Android-owned value and Compose signal
-                val composeSignal = try {
-                    // Evaluate the Compose system-dark signal outside of composition
-                    // so we can compare it against our authoritative source.
-                    (context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) ==
-                        Configuration.UI_MODE_NIGHT_YES
-                } catch (_: Throwable) {
-                    null
-                }
-                if (composeSignal != null && composeSignal != refreshed) {
+                // Diagnostic: log mismatch between Android-owned value and Compose signal.
+                // composeSignal is captured during composition; refreshed comes from
+                // Configuration.uiMode on this resume event.  A drift between them means
+                // the Compose ambient and the OS night-mode flag disagree.
+                if (composeSignal != refreshed) {
                     log.w {
                         "MISMATCH: Configuration.uiMode says dark=$refreshed " +
-                            "but Compose signal says dark=$composeSignal"
+                            "but Compose isSystemInDarkTheme() says dark=$composeSignal"
                     }
                 }
             }

--- a/shared/src/androidMain/kotlin/com/devil/phoenixproject/ui/theme/PlatformSystemDark.android.kt
+++ b/shared/src/androidMain/kotlin/com/devil/phoenixproject/ui/theme/PlatformSystemDark.android.kt
@@ -1,0 +1,73 @@
+package com.devil.phoenixproject.ui.theme
+
+import android.content.res.Configuration
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import co.touchlab.kermit.Logger
+
+private val log = Logger.withTag("PlatformSystemDark")
+
+/**
+ * Android-owned lifecycle-safe system appearance source.
+ *
+ * Seeds from `Configuration.uiMode` on first composition and refreshes on every
+ * `ON_RESUME` event so lock/unlock, display-mode changes, and other configuration
+ * transitions are captured.  Logs a mismatch when the Compose
+ * `isSystemInDarkTheme()` signal disagrees with the Android-owned value — this
+ * telemetry is the first diagnostic that would have caught issue #677.
+ */
+@Composable
+actual fun rememberPlatformSystemDark(): Boolean {
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    fun readUiModeDark(): Boolean {
+        val nightMask = context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
+        return nightMask == Configuration.UI_MODE_NIGHT_YES
+    }
+
+    var isDark by remember { mutableStateOf(readUiModeDark()) }
+
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                val refreshed = readUiModeDark()
+                if (refreshed != isDark) {
+                    log.i { "System dark mode changed on resume: $isDark -> $refreshed" }
+                }
+                isDark = refreshed
+
+                // Diagnostic: log mismatch between Android-owned value and Compose signal
+                val composeSignal = try {
+                    // Evaluate the Compose system-dark signal outside of composition
+                    // so we can compare it against our authoritative source.
+                    (context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) ==
+                        Configuration.UI_MODE_NIGHT_YES
+                } catch (_: Throwable) {
+                    null
+                }
+                if (composeSignal != null && composeSignal != refreshed) {
+                    log.w {
+                        "MISMATCH: Configuration.uiMode says dark=$refreshed " +
+                            "but Compose signal says dark=$composeSignal"
+                    }
+                }
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
+
+    return isDark
+}

--- a/shared/src/androidMain/kotlin/com/devil/phoenixproject/ui/theme/PlatformSystemDark.android.kt
+++ b/shared/src/androidMain/kotlin/com/devil/phoenixproject/ui/theme/PlatformSystemDark.android.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.Lifecycle
@@ -37,9 +38,10 @@ actual fun rememberPlatformSystemDark(): Boolean {
 
     var isDark by remember { mutableStateOf(readUiModeDark()) }
 
-    // Capture the Compose system-dark signal during composition so we can compare
-    // it against the authoritative Configuration.uiMode value on resume.
+    // Capture the Compose system-dark signal during composition and bridge its latest
+    // value into the long-lived lifecycle observer for each resume diagnostic.
     val composeSignal = isSystemInDarkTheme()
+    val currentComposeSignal by rememberUpdatedState(composeSignal)
 
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
@@ -50,14 +52,13 @@ actual fun rememberPlatformSystemDark(): Boolean {
                 }
                 isDark = refreshed
 
-                // Diagnostic: log mismatch between Android-owned value and Compose signal.
-                // composeSignal is captured during composition; refreshed comes from
-                // Configuration.uiMode on this resume event.  A drift between them means
-                // the Compose ambient and the OS night-mode flag disagree.
-                if (composeSignal != refreshed) {
+                // Diagnostic: log mismatch between Android-owned value and the latest
+                // recomposed Compose signal. `rememberUpdatedState` keeps this observer
+                // current without re-registering it on every recomposition.
+                if (currentComposeSignal != refreshed) {
                     log.w {
                         "MISMATCH: Configuration.uiMode says dark=$refreshed " +
-                            "but Compose isSystemInDarkTheme() says dark=$composeSignal"
+                            "but Compose isSystemInDarkTheme() says dark=$currentComposeSignal"
                     }
                 }
             }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/ui/theme/PlatformSystemDark.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/ui/theme/PlatformSystemDark.kt
@@ -1,0 +1,17 @@
+package com.devil.phoenixproject.ui.theme
+
+import androidx.compose.runtime.Composable
+
+/**
+ * Returns the platform-owned system dark-mode state, refreshed on lifecycle resume.
+ *
+ * On Android this reads `Configuration.uiMode` (the OS-owned source of truth) and
+ * is refreshed on `ON_RESUME` so lock/unlock and other configuration changes are
+ * captured without relying on the transient Compose `isSystemInDarkTheme()` signal.
+ *
+ * On iOS this delegates to `isSystemInDarkTheme()` which is already lifecycle-stable.
+ *
+ * Use this instead of `isSystemInDarkTheme()` when resolving `ThemeMode.SYSTEM`.
+ */
+@Composable
+expect fun rememberPlatformSystemDark(): Boolean

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/ui/theme/Theme.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/ui/theme/Theme.kt
@@ -1,6 +1,5 @@
 package com.devil.phoenixproject.ui.theme
 
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
@@ -107,7 +106,7 @@ fun VitruvianTheme(
     content: @Composable () -> Unit,
 ) {
     val useDarkColors = when (themeMode) {
-        ThemeMode.SYSTEM -> isSystemInDarkTheme()
+        ThemeMode.SYSTEM -> rememberPlatformSystemDark()
         ThemeMode.LIGHT -> false
         ThemeMode.DARK -> true
     }

--- a/shared/src/iosMain/kotlin/com/devil/phoenixproject/ui/theme/PlatformSystemDark.ios.kt
+++ b/shared/src/iosMain/kotlin/com/devil/phoenixproject/ui/theme/PlatformSystemDark.ios.kt
@@ -1,0 +1,12 @@
+package com.devil.phoenixproject.ui.theme
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.Composable
+
+/**
+ * iOS: delegate to the platform `isSystemInDarkTheme()` signal.
+ * iOS does not have the same transient-signal issue as Android's Compose bridge;
+ * the SwiftUI/UIViewController lifecycle keeps the appearance stable.
+ */
+@Composable
+actual fun rememberPlatformSystemDark(): Boolean = isSystemInDarkTheme()


### PR DESCRIPTION
## Summary

Fixes the sporadic light-mode surface appearance when Android night mode is active and the user has selected `ThemeMode.SYSTEM`. The root cause (per GPT-5.6 Terra RCA) is that `Theme.kt` delegated the SYSTEM-mode dark/light decision to the transient Compose `isSystemInDarkTheme()` signal with no app-owned lifecycle reconciliation. A stale or false Compose signal deterministically selected the light dynamic/static branch.

## Root Cause

In `Theme.kt:110`, `ThemeMode.SYSTEM -> isSystemInDarkTheme()` depends on a transient Compose signal. Phoenix had:
- No app-owned `Configuration.uiMode` state
- No ON_RESUME reconciliation after lock/unlock or configuration changes
- No mismatch telemetry between the Compose signal and the Android-owned value

PR #678 correctly removed `uiMode` from `configChanges` in the manifest, but the underlying signal boundary was never addressed.

## Fix

Introduces `rememberPlatformSystemDark()` — an Android-owned lifecycle-safe system appearance source:

1. **`PlatformSystemDark.kt`** (commonMain) — `expect` declaration for the lifecycle-safe platform dark signal
2. **`PlatformSystemDark.android.kt`** (androidMain) — Reads `Configuration.uiMode & UI_MODE_NIGHT_MASK`, registers `LifecycleEventObserver` to refresh on `ON_RESUME`, logs Compose-vs-Configuration mismatches
3. **`PlatformSystemDark.ios.kt`** (iosMain) — Delegates to `isSystemInDarkTheme()` (iOS does not have the transient-signal issue)
4. **`Theme.kt`** — `ThemeMode.SYSTEM -> rememberPlatformSystemDark()` replaces `isSystemInDarkTheme()`
5. **`ThemeModeUiContractGuardTest.kt`** — Updated contract test to assert the new lifecycle-safe source

## Non-Goals (per RCA)

- No theme-system rewrite
- No Material You removal
- No speculative clamp expansion
- Permission-gated roots (`BlePermissionHandler`, `OptionalPermissionsHandler`) have their own `isSystemInDarkTheme()` calls — outside this fix scope

## Acceptance Criteria

- SYSTEM + dynamic colors renders dark normal-root bg/surface when Android night mode is dark after foreground/resume
- DARK remains dark and LIGHT remains light across foreground/resume
- Existing dark Material You clamp contract preserved
- Pixel lock/unlock diagnostic trace captured before issue closure (requires device testing)

## RCA Contract

- RCA: [GPT-5.6 Terra xhigh RCA comment](https://github.com/9thLevelSoftware/Project-Phoenix-MP/issues/677#issuecomment-5172396115)
- Architecture review: [approved](https://github.com/9thLevelSoftware/Project-Phoenix-MP/issues/677#issuecomment-5172423762)
- Fix driver: `gpt56_terra_rca`

Fixes #677
