### PR TITLE
feat: suppress connection alerts for bodyweight-only workouts (#693)

### DIFF
--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/manager/BleConnectionManagerTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/manager/BleConnectionManagerTest.kt
@@ -228,16 +228,49 @@ class BleConnectionManagerTest {
         }
     }
 
-    private class FakeWorkoutStateProvider(var active: Boolean, var midSet: Boolean = false) : WorkoutStateProvider {
+    private class FakeWorkoutStateProvider(
+        var active: Boolean,
+        var midSet: Boolean = false,
+        var allBodyweight: Boolean = false, // Issue #693
+    ) : WorkoutStateProvider {
         var connectionLostCallbacks = 0
 
         override val isWorkoutActiveForConnectionAlert: Boolean
-            get() = active
+            get() = active && !allBodyweight
         override val isWorkoutMidSet: Boolean
             get() = midSet
 
         override fun onWorkoutConnectionLost() {
             connectionLostCallbacks++
+        }
+    }
+
+    @Test
+    fun `disconnect during bodyweight-only workout does not set connection lost alert`() = runTest {
+        val managerScope = CoroutineScope(coroutineContext + SupervisorJob())
+        try {
+            val workoutStateProvider = FakeWorkoutStateProvider(active = true, allBodyweight = true)
+            val settingsManager =
+                SettingsManager(fakePreferencesManager, fakeProfileRepository, managerScope)
+            val manager =
+                BleConnectionManager(
+                    fakeBleRepository,
+                    settingsManager,
+                    workoutStateProvider,
+                    MutableSharedFlow(),
+                    managerScope,
+                )
+            advanceUntilIdle()
+
+            fakeBleRepository.simulateConnect("Vee_Test")
+            advanceUntilIdle()
+            fakeBleRepository.simulateDisconnect()
+            advanceUntilIdle()
+
+            assertFalse(manager.connectionLostDuringWorkout.value)
+            assertEquals(0, workoutStateProvider.connectionLostCallbacks)
+        } finally {
+            managerScope.cancel()
         }
     }
 }

--- a/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModelTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/devil/phoenixproject/presentation/viewmodel/MainViewModelTest.kt
@@ -602,6 +602,44 @@ class MainViewModelTest {
     }
 
     @Test
+    fun `disconnect during bodyweight-only workout does not show connection lost alert`() = runTest(testCoroutineRule.dispatcher) {
+        fakeBleRepository.simulateConnect("Vee_Test", "AA:BB:CC:DD:EE:FF")
+        advanceUntilIdle()
+
+        val bodyweightRoutine = Routine(
+            id = "routine-bodyweight-test",
+            name = "Bodyweight Test",
+            exercises = listOf(
+                RoutineExercise(
+                    id = "routine-ex-bw-1",
+                    exercise = Exercise(
+                        id = "pullup",
+                        name = "Pull-Up",
+                        muscleGroup = "Back",
+                        equipment = "",
+                        isBodyweightOverride = true,
+                    ),
+                    orderIndex = 0,
+                    setReps = listOf(10),
+                    weightPerCableKg = 0f,
+                    warmupSets = emptyList(),
+                ),
+            ),
+        )
+        viewModel.loadRoutine(bodyweightRoutine)
+        advanceUntilIdle()
+        viewModel.enterSetReady(0, 0)
+        advanceUntilIdle()
+        viewModel.startWorkout(skipCountdown = true)
+        advanceUntilIdle()
+
+        fakeBleRepository.simulateDisconnect()
+        advanceUntilIdle()
+
+        assertFalse(viewModel.connectionLostDuringWorkout.value)
+    }
+
+    @Test
     fun `disconnect during workout sets connection lost flag`() = runTest(testCoroutineRule.dispatcher) {
         fakeBleRepository.simulateConnect("Vee_Test", "AA:BB:CC:DD:EE:FF")
         advanceUntilIdle()

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/DefaultWorkoutSessionManager.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/DefaultWorkoutSessionManager.kt
@@ -472,9 +472,24 @@ class DefaultWorkoutSessionManager(
     // ===== WorkoutStateProvider Implementation =====
 
     override val isWorkoutActiveForConnectionAlert: Boolean
-        get() = when (coordinator._workoutState.value) {
-            is WorkoutState.Active, is WorkoutState.Countdown, is WorkoutState.Resting -> true
-            else -> false
+        get() {
+            val state = coordinator._workoutState.value
+            if (state !is WorkoutState.Active &&
+                state !is WorkoutState.Countdown &&
+                state !is WorkoutState.Resting
+            ) {
+                return false
+            }
+            // Issue #693: Suppress connection alerts for bodyweight-only workouts.
+            // When all exercises in the loaded routine are bodyweight, the Vitruvian
+            // trainer is not needed and its auto-power-off should not interrupt the user.
+            val routine = coordinator._loadedRoutine.value
+            if (routine != null && routine.exercises.isNotEmpty() &&
+                routine.exercises.all { it.exercise.isBodyweight }
+            ) {
+                return false
+            }
+            return true
         }
 
     override val isWorkoutMidSet: Boolean


### PR DESCRIPTION
## Summary

Suppresses the `ConnectionLostDialog` and BLE auto-reconnect when the loaded workout routine contains **only** bodyweight exercises. This prevents spurious interruptions during bodyweight-only sessions (e.g. pull-up EMOM workouts) when the Vitruvian trainer auto-powers-off after 15 minutes of inactivity.

Fixes #693

## Changes

**Single chokepoint:** `DefaultWorkoutSessionManager.isWorkoutActiveForConnectionAlert`

| File | Change |
|------|--------|
| `DefaultWorkoutSessionManager.kt` | Modified `isWorkoutActiveForConnectionAlert` to return `false` when all routine exercises are bodyweight |
| `BleConnectionManagerTest.kt` | Extended `FakeWorkoutStateProvider` with `allBodyweight` flag; added bodyweight disconnect test |
| `MainViewModelTest.kt` | Added integration test: bodyweight routine disconnect does not trigger alert |

**~91 LOC across 3 files.** No UI/schema/API/interface changes.

## Behavior Matrix

| Workout Type | Connection Alert on Disconnect |
|---|---|
| Routine with all bodyweight exercises | **Suppressed** |
| Routine with mixed cable + bodyweight | Alert appears |
| Routine with all cable exercises | Alert appears |
| Single bodyweight exercise | **Suppressed** |
| Single cable exercise | Alert appears |
| Just Lift mode | Alert appears |
| Routine not loaded (race) | Alert appears (safe fallback) |

## Test Results

- ✅ `BleConnectionManagerTest` — all tests pass (including new bodyweight test)
- ✅ `MainViewModelTest` — all tests pass (including new bodyweight integration test)
- ✅ Full `shared:testAndroidHostTest` — regression suite green

## Release Note

**Enhancement: Suppress connection alerts during bodyweight-only workouts**

The Phoenix app no longer shows a "Connection Lost" notification or attempts to auto-reconnect when the Vitruvian trainer disconnects during a bodyweight-only workout. Connection monitoring remains fully active for routines that include any cable-based exercise, Just Lift mode, and single cable exercises.