### PR TITLE
feat(#673): MachineStatusEvent flow and ROM-fraction stall detection

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/ble/MonitorDataProcessor.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/ble/MonitorDataProcessor.kt
@@ -1,12 +1,14 @@
 package com.devil.phoenixproject.data.ble
 
 import co.touchlab.kermit.Logger
+import com.devil.phoenixproject.domain.model.MachineStatusEvent
 import com.devil.phoenixproject.domain.model.SampleStatus
 import com.devil.phoenixproject.domain.model.WorkoutMetric
 import com.devil.phoenixproject.domain.model.currentTimeMillis
 import com.devil.phoenixproject.util.BleConstants
 import com.devil.phoenixproject.util.Constants
 import kotlin.math.abs
+import kotlin.math.max
 
 /**
  * Synchronous processing pipeline for BLE monitor packets.
@@ -42,6 +44,7 @@ import kotlin.math.abs
 class MonitorDataProcessor(
     private val onDeloadOccurred: () -> Unit = {},
     private val onRomViolation: (RomViolationType) -> Unit = {},
+    private val onStatusEvent: (MachineStatusEvent) -> Unit = {},
     private val timeProvider: () -> Long = { currentTimeMillis() },
 ) {
     private val log = Logger.withTag("MonitorDataProcessor")
@@ -219,6 +222,21 @@ class MonitorDataProcessor(
 
         // Update timestamp for poll rate diagnostics
         lastTimestamp = currentTime
+
+        // ===== STAGE 6B: STATUS EVENT EMISSION =====
+        // Issue #673 PR 2: emit MachineStatusEvent carrying the full SampleStatus +
+        // position + velocity for downstream ROM-fraction stall detection.
+        // Only fires on packets that carry a non-zero status word.
+        if (packet.status != 0) {
+            onStatusEvent(
+                MachineStatusEvent(
+                    timestamp = currentTime,
+                    sampleStatus = SampleStatus(packet.status),
+                    position = max(posA, posB),
+                    velocity = max(smoothedVelocityA, smoothedVelocityB).toFloat(),
+                ),
+            )
+        }
 
         // ===== STAGE 7: BUILD METRIC =====
         return WorkoutMetric(

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/ble/MonitorDataProcessor.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/ble/MonitorDataProcessor.kt
@@ -226,17 +226,16 @@ class MonitorDataProcessor(
         // ===== STAGE 6B: STATUS EVENT EMISSION =====
         // Issue #673 PR 2: emit MachineStatusEvent carrying the full SampleStatus +
         // position + velocity for downstream ROM-fraction stall detection.
-        // Only fires on packets that carry a non-zero status word.
-        if (packet.status != 0) {
-            onStatusEvent(
-                MachineStatusEvent(
-                    timestamp = currentTime,
-                    sampleStatus = SampleStatus(packet.status),
-                    position = max(posA, posB),
-                    velocity = max(smoothedVelocityA, smoothedVelocityB).toFloat(),
-                ),
-            )
-        }
+        // Fires on EVERY processed packet (including status=0) so the ROM-fraction
+        // collector gets continuous position/velocity data, not just edge events.
+        onStatusEvent(
+            MachineStatusEvent(
+                timestamp = currentTime,
+                sampleStatus = SampleStatus(packet.status),
+                position = max(posA, posB),
+                velocity = max(abs(smoothedVelocityA), abs(smoothedVelocityB)).toFloat(),
+            ),
+        )
 
         // ===== STAGE 7: BUILD METRIC =====
         return WorkoutMetric(

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/BleRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/BleRepository.kt
@@ -2,6 +2,7 @@ package com.devil.phoenixproject.data.repository
 
 import com.devil.phoenixproject.data.ble.DiagnosticPacket
 import com.devil.phoenixproject.domain.model.ConnectionState
+import com.devil.phoenixproject.domain.model.MachineStatusEvent
 import com.devil.phoenixproject.domain.model.WorkoutMetric
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
@@ -141,6 +142,9 @@ interface BleRepository {
 
     // Deload safety event (for Just Lift mode safety recovery)
     val deloadOccurredEvents: Flow<Unit>
+
+    // Full machine status-word events (Issue #673 PR 2: ROM-fraction stall detection)
+    val machineStatusEvents: Flow<MachineStatusEvent>
 
     // Reconnection request (for auto-recovery on connection loss)
     val reconnectionRequested: Flow<ReconnectionRequest>

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/KableBleRepository.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/data/repository/KableBleRepository.kt
@@ -18,6 +18,7 @@ import com.devil.phoenixproject.data.ble.parseRepPacket
 import com.devil.phoenixproject.data.ble.toVitruvianHex
 import com.devil.phoenixproject.domain.model.ConnectionState
 import com.devil.phoenixproject.domain.model.HeuristicStatistics
+import com.devil.phoenixproject.domain.model.MachineStatusEvent
 import com.devil.phoenixproject.domain.model.WorkoutMetric
 import com.devil.phoenixproject.domain.model.WorkoutParameters
 import com.devil.phoenixproject.util.BlePacketFactory
@@ -83,6 +84,12 @@ class KableBleRepository : BleRepository {
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
     )
     override val deloadOccurredEvents: Flow<Unit> = _deloadOccurredEvents.asSharedFlow()
+    private val _machineStatusEvents = MutableSharedFlow<MachineStatusEvent>(
+        replay = 0,
+        extraBufferCapacity = 64,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+    override val machineStatusEvents: Flow<MachineStatusEvent> = _machineStatusEvents.asSharedFlow()
     enum class RomViolationType { OUTSIDE_HIGH, OUTSIDE_LOW }
     private val _romViolationEvents = MutableSharedFlow<RomViolationType>(
         replay = 0,
@@ -118,6 +125,9 @@ class KableBleRepository : BleRepository {
                 MonitorDataProcessor.RomViolationType.OUTSIDE_LOW -> RomViolationType.OUTSIDE_LOW
             }
             publishSafetyEvent(_romViolationEvents, mapped, BleCriticalEventType.ROM_VIOLATION)
+        },
+        onStatusEvent = { event ->
+            _machineStatusEvents.tryEmit(event)
         },
     )
 
@@ -510,6 +520,10 @@ class KableBleRepository : BleRepository {
 
     internal suspend fun publishDeloadOccurredForTest() {
         _deloadOccurredEvents.emit(Unit)
+    }
+
+    internal suspend fun publishMachineStatusEventForTest(event: MachineStatusEvent) {
+        _machineStatusEvents.emit(event)
     }
 
     internal suspend fun publishRomViolationForTest(type: RomViolationType) {

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/MachineStatusEvent.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/MachineStatusEvent.kt
@@ -1,0 +1,19 @@
+package com.devil.phoenixproject.domain.model
+
+/**
+ * Carries the full machine status-word, position, and velocity from every BLE monitor
+ * sample that has a non-zero status word. Supersedes the narrow [Unit]-typed
+ * `deloadOccurredEvents` flow for downstream consumers that need richer context
+ * (e.g. ROM-fraction stall detection in Issue #673 PR 2).
+ *
+ * @param timestamp Epoch-ms when the sample was received
+ * @param sampleStatus Parsed status-word flags from the monitor packet
+ * @param position Cable position in mm (max of A/B at time of status sample)
+ * @param velocity Cable velocity in mm/s (max of A/B, EMA-smoothed, at time of status sample)
+ */
+data class MachineStatusEvent(
+    val timestamp: Long,
+    val sampleStatus: SampleStatus,
+    val position: Float,
+    val velocity: Float,
+)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/MachineStatusEvent.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/domain/model/MachineStatusEvent.kt
@@ -1,8 +1,8 @@
 package com.devil.phoenixproject.domain.model
 
 /**
- * Carries the full machine status-word, position, and velocity from every BLE monitor
- * sample that has a non-zero status word. Supersedes the narrow [Unit]-typed
+ * Carries the full machine status-word, position, and velocity from every processed BLE monitor
+ * sample, including packets whose status word is zero. Supersedes the narrow [Unit]-typed
  * `deloadOccurredEvents` flow for downstream consumers that need richer context
  * (e.g. ROM-fraction stall detection in Issue #673 PR 2).
  *

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -684,7 +684,6 @@ class ActiveSessionEngine(
 
                     if (!params.stallDetectionEnabled || currentState !is WorkoutState.Active) return@collect
                     if (params.isEchoMode) return@collect
-                    if (!shouldEnableAutoStop(params)) return@collect
 
                     // Track ROM range from position observations (even during warmup,
                     // so the detector has a calibrated range when warmup ends)
@@ -694,8 +693,8 @@ class ActiveSessionEngine(
                     if (currentTop == null || pos > currentTop) coordinator.romRangeTop = pos
                     if (currentBottom == null || pos < currentBottom) coordinator.romRangeBottom = pos
 
-                    // Gate timer arming until warmup is complete
-                    if (!isWarmupGateOpenForAutoStop()) return@collect
+                    // Gate timer arming until warmup is complete and auto-stop is enabled.
+                    if (!shouldEnableAutoStop(params)) return@collect
 
                     val top = coordinator.romRangeTop ?: return@collect
                     val bottom = coordinator.romRangeBottom ?: return@collect

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -1240,8 +1240,6 @@ class ActiveSessionEngine(
         coordinator.stallStartTime = null
         coordinator.isCurrentlyStalled = false
         coordinator.stallArmedByDeload = false
-        // Issue #673 PR 2: also clear ROM-fraction stall arm
-        coordinator.stallArmedByRomFraction = false
         if (coordinator.autoStopStartTime == null && !coordinator.autoStopTriggered) {
             coordinator._autoStopState.value = AutoStopUiState()
         }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -684,15 +684,18 @@ class ActiveSessionEngine(
 
                     if (!params.stallDetectionEnabled || currentState !is WorkoutState.Active) return@collect
                     if (params.isEchoMode) return@collect
-                    if (!isWarmupGateOpenForAutoStop()) return@collect
                     if (!shouldEnableAutoStop(params)) return@collect
 
-                    // Track ROM range from position observations
+                    // Track ROM range from position observations (even during warmup,
+                    // so the detector has a calibrated range when warmup ends)
                     val pos = event.position
                     val currentTop = coordinator.romRangeTop
                     val currentBottom = coordinator.romRangeBottom
                     if (currentTop == null || pos > currentTop) coordinator.romRangeTop = pos
                     if (currentBottom == null || pos < currentBottom) coordinator.romRangeBottom = pos
+
+                    // Gate timer arming until warmup is complete
+                    if (!isWarmupGateOpenForAutoStop()) return@collect
 
                     val top = coordinator.romRangeTop ?: return@collect
                     val bottom = coordinator.romRangeBottom ?: return@collect
@@ -700,7 +703,6 @@ class ActiveSessionEngine(
                     if (range < WorkoutCoordinator.MIN_RANGE_THRESHOLD) return@collect
 
                     val fraction = (pos - bottom) / range
-                    coordinator.romFraction = fraction
 
                     val velocity = event.velocity.toDouble()
 
@@ -719,7 +721,6 @@ class ActiveSessionEngine(
                         if (coordinator.stallStartTime == null) {
                             coordinator.stallStartTime = currentTimeMillis()
                             coordinator.isCurrentlyStalled = true
-                            coordinator.stallArmedByRomFraction = true
                             Logger.d("Auto-stop stall timer STARTED via ROM-fraction signal (fraction=$fraction, velocity=$velocity)")
                         }
                     }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -74,6 +74,7 @@ import com.devil.phoenixproject.util.DataBackupManager
 import com.devil.phoenixproject.util.KmpUtils
 import com.devil.phoenixproject.util.WorkoutCommandValidator
 import kotlin.coroutines.cancellation.CancellationException
+import kotlin.math.abs
 import kotlin.math.roundToInt
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
@@ -658,6 +659,7 @@ class ActiveSessionEngine(
                             coordinator.isCurrentlyStalled = true
                             coordinator.stallArmedByDeload = true
                             coordinator.stallArmedByRomFraction = false
+                            coordinator.romFractionStallAnchorPosition = null
                             Logger.d("Auto-stop stall timer STARTED via DELOAD_OCCURRED flag")
                         } else if (coordinator.stallStartTime != null && !inGrace) {
                             // F4: a real deload is the stronger signal — upgrade a
@@ -665,6 +667,7 @@ class ActiveSessionEngine(
                             // (position -> 0) don't cancel it via the racked-handles check.
                             coordinator.stallArmedByDeload = true
                             coordinator.stallArmedByRomFraction = false
+                            coordinator.romFractionStallAnchorPosition = null
                         } else if (inGrace) {
                             Logger.d("DELOAD_OCCURRED ignored - in AMRAP startup grace period")
                         }
@@ -724,7 +727,20 @@ class ActiveSessionEngine(
                             coordinator.isCurrentlyStalled = true
                             coordinator.stallArmedByDeload = false
                             coordinator.stallArmedByRomFraction = true
+                            coordinator.romFractionStallAnchorPosition = pos
                             Logger.d("Auto-stop stall timer STARTED via ROM-fraction signal (fraction=$fraction, velocity=$velocity)")
+                        } else if (coordinator.stallArmedByRomFraction && !coordinator.stallArmedByDeload) {
+                            val anchor = coordinator.romFractionStallAnchorPosition
+                            if (anchor == null) {
+                                coordinator.romFractionStallAnchorPosition = pos
+                            } else if (abs(pos - anchor) >= WorkoutCoordinator.ROM_FRACTION_STALL_PROGRESS_THRESHOLD_MM) {
+                                coordinator.stallStartTime = currentTimeMillis()
+                                coordinator.romFractionStallAnchorPosition = pos
+                                Logger.d(
+                                    "Auto-stop stall timer RESET via ROM-fraction progress " +
+                                        "(position=$pos, anchor=$anchor, velocity=$velocity)",
+                                )
+                            }
                         }
                     } else if (
                         coordinator.stallStartTime != null &&
@@ -1254,6 +1270,7 @@ class ActiveSessionEngine(
         coordinator.isCurrentlyStalled = false
         coordinator.stallArmedByDeload = false
         coordinator.stallArmedByRomFraction = false
+        coordinator.romFractionStallAnchorPosition = null
         if (coordinator.autoStopStartTime == null && !coordinator.autoStopTriggered) {
             coordinator._autoStopState.value = AutoStopUiState()
         }
@@ -1815,6 +1832,7 @@ class ActiveSessionEngine(
                 coordinator.isCurrentlyStalled = true
                 coordinator.stallArmedByDeload = false
                 coordinator.stallArmedByRomFraction = false
+                coordinator.romFractionStallAnchorPosition = null
             } else if (isDefinitelyMoving && coordinator.stallStartTime != null) {
                 resetStallTimer()
             }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -657,12 +657,14 @@ class ActiveSessionEngine(
                             coordinator.stallStartTime = currentTimeMillis()
                             coordinator.isCurrentlyStalled = true
                             coordinator.stallArmedByDeload = true
+                            coordinator.stallArmedByRomFraction = false
                             Logger.d("Auto-stop stall timer STARTED via DELOAD_OCCURRED flag")
                         } else if (coordinator.stallStartTime != null && !inGrace) {
                             // F4: a real deload is the stronger signal — upgrade a
                             // velocity-armed countdown so the retracting cables
                             // (position -> 0) don't cancel it via the racked-handles check.
                             coordinator.stallArmedByDeload = true
+                            coordinator.stallArmedByRomFraction = false
                         } else if (inGrace) {
                             Logger.d("DELOAD_OCCURRED ignored - in AMRAP startup grace period")
                         }
@@ -720,8 +722,20 @@ class ActiveSessionEngine(
                         if (coordinator.stallStartTime == null) {
                             coordinator.stallStartTime = currentTimeMillis()
                             coordinator.isCurrentlyStalled = true
+                            coordinator.stallArmedByDeload = false
+                            coordinator.stallArmedByRomFraction = true
                             Logger.d("Auto-stop stall timer STARTED via ROM-fraction signal (fraction=$fraction, velocity=$velocity)")
                         }
+                    } else if (
+                        coordinator.stallStartTime != null &&
+                        coordinator.stallArmedByRomFraction &&
+                        !coordinator.stallArmedByDeload
+                    ) {
+                        Logger.d(
+                            "Auto-stop stall timer CANCELLED via ROM-fraction signal " +
+                                "(fraction=$fraction, velocity=$velocity)",
+                        )
+                        resetStallTimer()
                     }
                 }
         }
@@ -1239,6 +1253,7 @@ class ActiveSessionEngine(
         coordinator.stallStartTime = null
         coordinator.isCurrentlyStalled = false
         coordinator.stallArmedByDeload = false
+        coordinator.stallArmedByRomFraction = false
         if (coordinator.autoStopStartTime == null && !coordinator.autoStopTriggered) {
             coordinator._autoStopState.value = AutoStopUiState()
         }
@@ -1799,6 +1814,7 @@ class ActiveSessionEngine(
                 coordinator.stallStartTime = currentTimeMillis()
                 coordinator.isCurrentlyStalled = true
                 coordinator.stallArmedByDeload = false
+                coordinator.stallArmedByRomFraction = false
             } else if (isDefinitelyMoving && coordinator.stallStartTime != null) {
                 resetStallTimer()
             }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -670,6 +670,62 @@ class ActiveSessionEngine(
                 }
         }
 
+        // #5b: Issue #673 PR 2: ROM-fraction stall detection collector.
+        // Consumes MachineStatusEvent carrying the full SampleStatus + position + velocity.
+        // When velocity is in the dead band (2.5–10 mm/s) AND position is mid-ROM
+        // (30–80%), arms the stall timer as a secondary signal.  Rep events cancel
+        // any position-armed countdown (handled via resetStallTimer in rep processing).
+        scope.launch {
+            bleRepository.machineStatusEvents
+                .catch { e -> Logger.e(e) { "machineStatusEvents collector error" } }
+                .collect { event ->
+                    val params = coordinator._workoutParameters.value
+                    val currentState = coordinator._workoutState.value
+
+                    if (!params.stallDetectionEnabled || currentState !is WorkoutState.Active) return@collect
+                    if (params.isEchoMode) return@collect
+                    if (!isWarmupGateOpenForAutoStop()) return@collect
+                    if (!shouldEnableAutoStop(params)) return@collect
+
+                    // Track ROM range from position observations
+                    val pos = event.position
+                    val currentTop = coordinator.romRangeTop
+                    val currentBottom = coordinator.romRangeBottom
+                    if (currentTop == null || pos > currentTop) coordinator.romRangeTop = pos
+                    if (currentBottom == null || pos < currentBottom) coordinator.romRangeBottom = pos
+
+                    val top = coordinator.romRangeTop ?: return@collect
+                    val bottom = coordinator.romRangeBottom ?: return@collect
+                    val range = top - bottom
+                    if (range < WorkoutCoordinator.MIN_RANGE_THRESHOLD) return@collect
+
+                    val fraction = (pos - bottom) / range
+                    coordinator.romFraction = fraction
+
+                    val velocity = event.velocity.toDouble()
+
+                    // Arm conditions: mid-ROM (30–80%) AND velocity in dead band (2.5–10 mm/s)
+                    val inMidRom = fraction in 0.3f..0.8f
+                    val inDeadBand = velocity >= WorkoutCoordinator.STALL_VELOCITY_LOW &&
+                        velocity <= WorkoutCoordinator.STALL_VELOCITY_HIGH
+
+                    if (inMidRom && inDeadBand) {
+                        val repCount = coordinator._repCount.value
+                        if (shouldDeferStandardSetStall(params, repCount)) return@collect
+
+                        val hasMeaningfulRange = repCounter.hasMeaningfulRange(WorkoutCoordinator.MIN_RANGE_THRESHOLD)
+                        if (isInAmrapStartupGrace(hasMeaningfulRange)) return@collect
+
+                        if (coordinator.stallStartTime == null) {
+                            coordinator.stallStartTime = currentTimeMillis()
+                            coordinator.isCurrentlyStalled = true
+                            coordinator.stallArmedByRomFraction = true
+                            Logger.d("Auto-stop stall timer STARTED via ROM-fraction signal (fraction=$fraction, velocity=$velocity)")
+                        }
+                    }
+                }
+        }
+
         // #6: Rep events collector for handling machine rep notifications
         coordinator.repEventsCollectionJob = scope.launch {
             bleRepository.repEvents
@@ -1183,6 +1239,8 @@ class ActiveSessionEngine(
         coordinator.stallStartTime = null
         coordinator.isCurrentlyStalled = false
         coordinator.stallArmedByDeload = false
+        // Issue #673 PR 2: also clear ROM-fraction stall arm
+        coordinator.stallArmedByRomFraction = false
         if (coordinator.autoStopStartTime == null && !coordinator.autoStopTriggered) {
             coordinator._autoStopState.value = AutoStopUiState()
         }
@@ -1752,6 +1810,8 @@ class ActiveSessionEngine(
                 // F4: re-check per sample — a velocity-armed countdown must not keep
                 // running once the handles return to rest (racked pause). A deload-armed
                 // countdown must survive this (real cable release retracts to ~0mm).
+                // Issue #673 PR 2: ROM-fraction-armed countdown also cancels at rest,
+                // same as velocity-armed — racking handles means the user stopped.
                 if (!coordinator.stallArmedByDeload && maxPosition <= WorkoutCoordinator.STALL_MIN_POSITION) {
                     resetStallTimer()
                     return

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutCoordinator.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutCoordinator.kt
@@ -431,6 +431,13 @@ class WorkoutCoordinator(
     @Volatile
     internal var stallArmedByDeload = false
 
+    // True only while the current stall countdown was armed by the ROM-fraction
+    // collector. That collector may cancel its own countdown when later status
+    // samples leave the geometric/velocity window, but must not cancel a timer
+    // that was upgraded to the stronger DELOAD signal.
+    @Volatile
+    internal var stallArmedByRomFraction = false
+
     // Issue #673 PR 2: ROM-fraction stall detection state.
     // Geometric signal: when velocity is in the dead band (2.5–10 mm/s) AND
     // the cable position is mid-ROM (30–80% of observed range), the user is
@@ -469,6 +476,7 @@ class WorkoutCoordinator(
         stallStartTime = null
         isCurrentlyStalled = false
         stallArmedByDeload = false
+        stallArmedByRomFraction = false
         // Issue #673 PR 2: clear ROM-fraction stall state on set start/reset
         romRangeTop = null
         romRangeBottom = null

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutCoordinator.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutCoordinator.kt
@@ -442,14 +442,6 @@ class WorkoutCoordinator(
     @Volatile
     internal var romRangeBottom: Float? = null
 
-    @Volatile
-    internal var romFraction: Float? = null
-
-    // True when the stall countdown was armed by the ROM-fraction geometric
-    // signal (velocity dead band + mid-ROM position). Rep events cancel it.
-    @Volatile
-    internal var stallArmedByRomFraction = false
-
     // Issue #649: defer position/stall auto-stop until the verbal-cue + short
     // transition window elapses, or a completed working rep clears it. The
     // deadline (@Volatile Long) is the single source of truth — 0L means no
@@ -480,8 +472,6 @@ class WorkoutCoordinator(
         // Issue #673 PR 2: clear ROM-fraction stall state on set start/reset
         romRangeTop = null
         romRangeBottom = null
-        romFraction = null
-        stallArmedByRomFraction = false
         deferAutoStopDeadlineMs = 0L
         _autoStopState.value = AutoStopUiState()
     }

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutCoordinator.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutCoordinator.kt
@@ -84,6 +84,12 @@ class WorkoutCoordinator(
         /** Minimum position range to consider "meaningful" for auto-stop detection (in mm) */
         const val MIN_RANGE_THRESHOLD = 50f
 
+        /**
+         * Minimum cable travel that proves deliberate progress while the ROM-fraction
+         * stall countdown is armed. Five millimetres filters ordinary sample noise.
+         */
+        const val ROM_FRACTION_STALL_PROGRESS_THRESHOLD_MM = 5f
+
         /** Issue #204: Startup grace period for AMRAP exercises (ms)
          * Prevents auto-stop from triggering before user has time to grab handles
          * when transitioning from a normal rep-based exercise to an AMRAP exercise.
@@ -438,6 +444,12 @@ class WorkoutCoordinator(
     @Volatile
     internal var stallArmedByRomFraction = false
 
+    // Position at which the current ROM-fraction countdown was armed or last
+    // refreshed. A later qualifying sample must travel far enough from this
+    // anchor to prove slow but deliberate cable progress.
+    @Volatile
+    internal var romFractionStallAnchorPosition: Float? = null
+
     // Issue #673 PR 2: ROM-fraction stall detection state.
     // Geometric signal: when velocity is in the dead band (2.5–10 mm/s) AND
     // the cable position is mid-ROM (30–80% of observed range), the user is
@@ -477,6 +489,7 @@ class WorkoutCoordinator(
         isCurrentlyStalled = false
         stallArmedByDeload = false
         stallArmedByRomFraction = false
+        romFractionStallAnchorPosition = null
         // Issue #673 PR 2: clear ROM-fraction stall state on set start/reset
         romRangeTop = null
         romRangeBottom = null

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutCoordinator.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutCoordinator.kt
@@ -431,6 +431,25 @@ class WorkoutCoordinator(
     @Volatile
     internal var stallArmedByDeload = false
 
+    // Issue #673 PR 2: ROM-fraction stall detection state.
+    // Geometric signal: when velocity is in the dead band (2.5–10 mm/s) AND
+    // the cable position is mid-ROM (30–80% of observed range), the user is
+    // likely pressing against the machine without moving — arm a secondary
+    // stall countdown that does NOT depend on firmware DELOAD_OCCURRED.
+    @Volatile
+    internal var romRangeTop: Float? = null
+
+    @Volatile
+    internal var romRangeBottom: Float? = null
+
+    @Volatile
+    internal var romFraction: Float? = null
+
+    // True when the stall countdown was armed by the ROM-fraction geometric
+    // signal (velocity dead band + mid-ROM position). Rep events cancel it.
+    @Volatile
+    internal var stallArmedByRomFraction = false
+
     // Issue #649: defer position/stall auto-stop until the verbal-cue + short
     // transition window elapses, or a completed working rep clears it. The
     // deadline (@Volatile Long) is the single source of truth — 0L means no
@@ -458,6 +477,11 @@ class WorkoutCoordinator(
         stallStartTime = null
         isCurrentlyStalled = false
         stallArmedByDeload = false
+        // Issue #673 PR 2: clear ROM-fraction stall state on set start/reset
+        romRangeTop = null
+        romRangeBottom = null
+        romFraction = null
+        stallArmedByRomFraction = false
         deferAutoStopDeadlineMs = 0L
         _autoStopState.value = AutoStopUiState()
     }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/ble/MonitorDataProcessorStatusEventTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/ble/MonitorDataProcessorStatusEventTest.kt
@@ -1,0 +1,125 @@
+package com.devil.phoenixproject.data.ble
+
+import com.devil.phoenixproject.domain.model.MachineStatusEvent
+import com.devil.phoenixproject.domain.model.SampleStatus
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Issue #673 PR 2: Tests for MachineStatusEvent emission from MonitorDataProcessor.
+ *
+ * Verifies that the onStatusEvent callback fires after velocity smoothing with
+ * correct position and velocity values, and that the existing deload/ROM-violation
+ * callbacks remain functional.
+ */
+class MonitorDataProcessorStatusEventTest {
+
+    @Test
+    fun `onStatusEvent fires for non-zero status after velocity smoothing`() {
+        val events = mutableListOf<MachineStatusEvent>()
+        val processor = MonitorDataProcessor(
+            onStatusEvent = { events.add(it) },
+            timeProvider = { 1000L },
+        )
+
+        // Build a packet with DELOAD_OCCURRED flag (bit 7 = 0x80)
+        val packet = MonitorPacket(
+            ticks = 0L,
+            posA = 200.0f,
+            posB = 200.0f,
+            loadA = 10.0f,
+            loadB = 10.0f,
+            firmwareVelA = 50,  // 5.0 mm/s
+            firmwareVelB = 50,
+            status = 0x80, // DELOAD_OCCURRED
+        )
+
+        processor.process(packet)
+
+        assertEquals(1, events.size)
+        val event = events[0]
+        assertEquals(0x80, event.sampleStatus.raw)
+        assertTrue(event.sampleStatus.isDeloadOccurred())
+        assertEquals(200.0f, event.position) // max(200, 200)
+        // Velocity is max(smoothedA, smoothedB) — first sample seeds EMA
+        assertTrue(event.velocity > 0f)
+    }
+
+    @Test
+    fun `onStatusEvent does not fire for zero status`() {
+        val events = mutableListOf<MachineStatusEvent>()
+        val processor = MonitorDataProcessor(
+            onStatusEvent = { events.add(it) },
+            timeProvider = { 1000L },
+        )
+
+        val packet = MonitorPacket(
+            ticks = 0L,
+            posA = 200.0f,
+            posB = 200.0f,
+            loadA = 10.0f,
+            loadB = 10.0f,
+            firmwareVelA = 50,
+            firmwareVelB = 50,
+            status = 0, // No flags
+        )
+
+        processor.process(packet)
+
+        assertEquals(0, events.size)
+    }
+
+    @Test
+    fun `onStatusEvent uses max position of A and B`() {
+        val events = mutableListOf<MachineStatusEvent>()
+        val processor = MonitorDataProcessor(
+            onStatusEvent = { events.add(it) },
+            timeProvider = { 1000L },
+        )
+
+        val packet = MonitorPacket(
+            ticks = 0L,
+            posA = 100.0f,
+            posB = 350.0f,
+            loadA = 10.0f,
+            loadB = 10.0f,
+            firmwareVelA = 50,
+            firmwareVelB = 100, // B is faster
+            status = 0x01, // REP_TOP_READY
+        )
+
+        processor.process(packet)
+
+        assertEquals(1, events.size)
+        assertEquals(350.0f, events[0].position) // max(100, 350)
+    }
+
+    @Test
+    fun `onStatusEvent preserves existing deload callback`() {
+        var deloadFired = false
+        val events = mutableListOf<MachineStatusEvent>()
+        val processor = MonitorDataProcessor(
+            onDeloadOccurred = { deloadFired = true },
+            onStatusEvent = { events.add(it) },
+            timeProvider = { 1000L },
+        )
+
+        val packet = MonitorPacket(
+            ticks = 0L,
+            posA = 200.0f,
+            posB = 200.0f,
+            loadA = 10.0f,
+            loadB = 10.0f,
+            firmwareVelA = 50,
+            firmwareVelB = 50,
+            status = 0x80, // DELOAD_OCCURRED
+        )
+
+        processor.process(packet)
+
+        assertTrue(deloadFired, "deloadOccurred callback must still fire")
+        assertEquals(1, events.size, "onStatusEvent must also fire")
+    }
+}

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/ble/MonitorDataProcessorStatusEventTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/ble/MonitorDataProcessorStatusEventTest.kt
@@ -48,7 +48,7 @@ class MonitorDataProcessorStatusEventTest {
     }
 
     @Test
-    fun `onStatusEvent fires for zero status with SampleStatus(0)`() {
+    fun `onStatusEvent fires for zero status with SampleStatus zero`() {
         val events = mutableListOf<MachineStatusEvent>()
         val processor = MonitorDataProcessor(
             onStatusEvent = { events.add(it) },

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/ble/MonitorDataProcessorStatusEventTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/ble/MonitorDataProcessorStatusEventTest.kt
@@ -21,10 +21,10 @@ class MonitorDataProcessorStatusEventTest {
         val events = mutableListOf<MachineStatusEvent>()
         val processor = MonitorDataProcessor(
             onStatusEvent = { events.add(it) },
-            timeProvider = { 1000L },
+            timeProvider = { 3000L }, // > DELOAD_EVENT_DEBOUNCE_MS so debounce never blocks
         )
 
-        // Build a packet with DELOAD_OCCURRED flag (bit 7 = 0x80)
+        // Build a packet with DELOAD_OCCURRED flag (bit 15 = 0x8000)
         val packet = MonitorPacket(
             ticks = 0L,
             posA = 200.0f,
@@ -33,14 +33,14 @@ class MonitorDataProcessorStatusEventTest {
             loadB = 10.0f,
             firmwareVelA = 50,  // 5.0 mm/s
             firmwareVelB = 50,
-            status = 0x80, // DELOAD_OCCURRED
+            status = 0x8000, // DELOAD_OCCURRED
         )
 
         processor.process(packet)
 
         assertEquals(1, events.size)
         val event = events[0]
-        assertEquals(0x80, event.sampleStatus.raw)
+        assertEquals(0x8000, event.sampleStatus.raw)
         assertTrue(event.sampleStatus.isDeloadOccurred())
         assertEquals(200.0f, event.position) // max(200, 200)
         // Velocity is max(smoothedA, smoothedB) — first sample seeds EMA
@@ -103,7 +103,7 @@ class MonitorDataProcessorStatusEventTest {
         val processor = MonitorDataProcessor(
             onDeloadOccurred = { deloadFired = true },
             onStatusEvent = { events.add(it) },
-            timeProvider = { 1000L },
+            timeProvider = { 3000L }, // > DELOAD_EVENT_DEBOUNCE_MS so debounce never blocks
         )
 
         val packet = MonitorPacket(
@@ -114,7 +114,7 @@ class MonitorDataProcessorStatusEventTest {
             loadB = 10.0f,
             firmwareVelA = 50,
             firmwareVelB = 50,
-            status = 0x80, // DELOAD_OCCURRED
+            status = 0x8000, // DELOAD_OCCURRED
         )
 
         processor.process(packet)

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/ble/MonitorDataProcessorStatusEventTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/data/ble/MonitorDataProcessorStatusEventTest.kt
@@ -48,7 +48,7 @@ class MonitorDataProcessorStatusEventTest {
     }
 
     @Test
-    fun `onStatusEvent does not fire for zero status`() {
+    fun `onStatusEvent fires for zero status with SampleStatus(0)`() {
         val events = mutableListOf<MachineStatusEvent>()
         val processor = MonitorDataProcessor(
             onStatusEvent = { events.add(it) },
@@ -68,7 +68,9 @@ class MonitorDataProcessorStatusEventTest {
 
         processor.process(packet)
 
-        assertEquals(0, events.size)
+        // Now fires for every processed packet (ROM-fraction collector needs continuous data)
+        assertEquals(1, events.size)
+        assertEquals(0, events[0].sampleStatus.raw)
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMWorkoutLifecycleTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMWorkoutLifecycleTest.kt
@@ -1055,6 +1055,35 @@ class DWSMWorkoutLifecycleTest {
     }
 
     @Test
+    fun `Issue 673 ROM fraction timer cancels when status leaves qualifying window`() = runTest {
+        val harness = DWSMTestHarness(this)
+        try {
+            prepareRomFractionStallHarness(harness) { advanceUntilIdle() }
+
+            // Mid-ROM at 5 mm/s arms the ROM-fraction countdown.
+            harness.fakeBleRepo.emitMachineStatusEvent(
+                MachineStatusEvent(harness.nowMs + 2L, SampleStatus(0), position = 50f, velocity = 5f),
+            )
+            advanceUntilIdle()
+            assertNotNull(harness.dwsm.coordinator.stallStartTime)
+            assertTrue(harness.dwsm.coordinator.isCurrentlyStalled)
+
+            // A later sample outside the 30–80% window means the geometric
+            // condition no longer holds, so the ROM-specific countdown must stop.
+            harness.fakeBleRepo.emitMachineStatusEvent(
+                MachineStatusEvent(harness.nowMs + 3L, SampleStatus(0), position = 90f, velocity = 5f),
+            )
+            advanceUntilIdle()
+
+            assertEquals(null, harness.dwsm.coordinator.stallStartTime)
+            assertFalse(harness.dwsm.coordinator.isCurrentlyStalled)
+            assertFalse(harness.dwsm.coordinator.autoStopState.value.isActive)
+        } finally {
+            harness.cleanup()
+        }
+    }
+
+    @Test
     fun `Issue 673 completed working rep cancels ROM fraction stall timer`() = runTest {
         val harness = DWSMTestHarness(this)
         try {

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMWorkoutLifecycleTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMWorkoutLifecycleTest.kt
@@ -1084,6 +1084,77 @@ class DWSMWorkoutLifecycleTest {
     }
 
     @Test
+    fun `Issue 697 ROM fraction progress resets a backdated stall timer`() = runTest {
+        val harness = DWSMTestHarness(this)
+        try {
+            prepareRomFractionStallHarness(harness) { advanceUntilIdle() }
+
+            // Establish a ROM-fraction countdown at 50% ROM, then make its
+            // deadline intentionally stale. A 10 mm move at 5 mm/s remains in
+            // the dead band but is deliberate cable progress, not a stall.
+            harness.fakeBleRepo.emitMachineStatusEvent(
+                MachineStatusEvent(harness.nowMs + 2L, SampleStatus(0), position = 50f, velocity = 5f),
+            )
+            advanceUntilIdle()
+            assertNotNull(harness.dwsm.coordinator.stallStartTime)
+
+            val expiredTimer = currentTimeMillis() - 6_000L
+            harness.dwsm.coordinator.stallStartTime = expiredTimer
+            harness.fakeBleRepo.emitMachineStatusEvent(
+                MachineStatusEvent(harness.nowMs + 3L, SampleStatus(0), position = 60f, velocity = 5f),
+            )
+            advanceUntilIdle()
+
+            val refreshedTimer = assertNotNull(harness.dwsm.coordinator.stallStartTime)
+            assertTrue(
+                refreshedTimer > expiredTimer,
+                "A 10 mm in-window ROM advance at 5 mm/s must reset the stall countdown",
+            )
+            assertTrue(harness.dwsm.coordinator.stallArmedByRomFraction)
+            assertFalse(harness.dwsm.coordinator.stallArmedByDeload)
+        } finally {
+            harness.cleanup()
+        }
+    }
+
+    @Test
+    fun `Issue 697 out of window status does not clear a deload upgraded ROM timer`() = runTest {
+        val harness = DWSMTestHarness(this)
+        try {
+            prepareRomFractionStallHarness(harness) { advanceUntilIdle() }
+
+            harness.fakeBleRepo.emitMachineStatusEvent(
+                MachineStatusEvent(harness.nowMs + 2L, SampleStatus(0), position = 50f, velocity = 5f),
+            )
+            advanceUntilIdle()
+            val romTimer = assertNotNull(harness.dwsm.coordinator.stallStartTime)
+            assertTrue(harness.dwsm.coordinator.stallArmedByRomFraction)
+
+            // DELOAD is a stronger event and now owns the existing timer.
+            harness.fakeBleRepo.emitDeloadOccurred()
+            advanceUntilIdle()
+            assertTrue(harness.dwsm.coordinator.stallArmedByDeload)
+            assertFalse(harness.dwsm.coordinator.stallArmedByRomFraction)
+
+            // 90% ROM leaves the ROM-fraction window. It must not clear the
+            // timer after DELOAD has taken ownership.
+            harness.fakeBleRepo.emitMachineStatusEvent(
+                MachineStatusEvent(harness.nowMs + 3L, SampleStatus(0), position = 90f, velocity = 5f),
+            )
+            advanceUntilIdle()
+
+            assertEquals(
+                romTimer,
+                harness.dwsm.coordinator.stallStartTime,
+                "An out-of-window status sample must not clear a DELOAD-owned timer",
+            )
+            assertTrue(harness.dwsm.coordinator.stallArmedByDeload)
+        } finally {
+            harness.cleanup()
+        }
+    }
+
+    @Test
     fun `Issue 673 completed working rep cancels ROM fraction stall timer`() = runTest {
         val harness = DWSMTestHarness(this)
         try {

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMWorkoutLifecycleTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/DWSMWorkoutLifecycleTest.kt
@@ -12,7 +12,9 @@ import com.devil.phoenixproject.domain.model.EchoLevel
 import com.devil.phoenixproject.domain.model.Exercise
 import com.devil.phoenixproject.domain.model.ExerciseCableIntent
 import com.devil.phoenixproject.domain.model.HapticEvent
+import com.devil.phoenixproject.domain.model.MachineStatusEvent
 import com.devil.phoenixproject.domain.model.PRType
+import com.devil.phoenixproject.domain.model.SampleStatus
 import com.devil.phoenixproject.domain.model.PersonalRecord
 import com.devil.phoenixproject.domain.model.ProgramMode
 import com.devil.phoenixproject.domain.model.RepCount
@@ -965,6 +967,132 @@ class DWSMWorkoutLifecycleTest {
         val autoStop = harness.dwsm.coordinator.autoStopState.value
         assertNotNull(autoStop, "autoStopState should be reset after startWorkout")
         harness.cleanup()
+    }
+
+    @Test
+    fun `Issue 673 warmup status samples calibrate ROM before stall arming`() = runTest {
+        val harness = DWSMTestHarness(this)
+        try {
+            harness.fakeBleRepo.simulateConnect("Vee_Test")
+            harness.dwsm.updateWorkoutParameters(
+                WorkoutParameters(
+                    programMode = ProgramMode.OldSchool,
+                    reps = 8,
+                    warmupReps = 0,
+                    weightPerCableKg = 35f,
+                    stallDetectionEnabled = true,
+                    isAMRAP = false,
+                    isJustLift = false,
+                ),
+            )
+            harness.dwsm.startWorkout(skipCountdown = true)
+            advanceUntilIdle()
+            assertIs<WorkoutState.Active>(harness.dwsm.coordinator.workoutState.value)
+            assertFalse(harness.dwsm.coordinator.repCount.value.isWarmupComplete)
+
+            // These arrive before the warmup gate opens: they must calibrate ROM,
+            // but must not arm an auto-stop stall timer yet.
+            harness.fakeBleRepo.emitMachineStatusEvent(
+                MachineStatusEvent(harness.nowMs, SampleStatus(0), position = 0f, velocity = 5f),
+            )
+            harness.fakeBleRepo.emitMachineStatusEvent(
+                MachineStatusEvent(harness.nowMs + 1L, SampleStatus(0), position = 100f, velocity = 5f),
+            )
+            advanceUntilIdle()
+            assertEquals(null, harness.dwsm.coordinator.stallStartTime)
+
+            completeWarmupReps(harness, warmupTarget = 3, workingTarget = 8)
+            completeFirstWorkingRep(harness, warmupTarget = 3, workingTarget = 8)
+            advanceUntilIdle()
+            assertTrue(harness.dwsm.coordinator.repCount.value.isWarmupComplete)
+            assertEquals(1, harness.dwsm.coordinator.repCount.value.workingReps)
+
+            // With the 0–100 mm warmup calibration retained, 50 mm is mid-ROM
+            // and 5 mm/s is inside the stall dead band, so the real engine arms.
+            harness.fakeBleRepo.emitMachineStatusEvent(
+                MachineStatusEvent(harness.nowMs + 2L, SampleStatus(0), position = 50f, velocity = 5f),
+            )
+            advanceUntilIdle()
+
+            assertNotNull(
+                harness.dwsm.coordinator.stallStartTime,
+                "Warmup status samples must calibrate ROM so a later mid-ROM dead-band event can arm the stall timer",
+            )
+            assertEquals(100f, harness.dwsm.coordinator.romRangeTop)
+            assertEquals(0f, harness.dwsm.coordinator.romRangeBottom)
+        } finally {
+            harness.cleanup()
+        }
+    }
+
+    @Test
+    fun `Issue 673 ROM fraction ignores events outside mid ROM or dead band`() = runTest {
+        val ignoredEvents = listOf(
+            Triple(90f, 5f, "outside the 30 to 80 percent mid-ROM band"),
+            Triple(50f, 10.1f, "outside the 2.5 to 10 mm per second dead band"),
+        )
+        for ((position, velocity, description) in ignoredEvents) {
+            val harness = DWSMTestHarness(this)
+            try {
+                prepareRomFractionStallHarness(harness) { advanceUntilIdle() }
+                assertTrue(harness.dwsm.coordinator.repCount.value.isWarmupComplete)
+                assertEquals(1, harness.dwsm.coordinator.repCount.value.workingReps)
+
+                harness.fakeBleRepo.emitMachineStatusEvent(
+                    MachineStatusEvent(harness.nowMs + 2L, SampleStatus(0), position, velocity),
+                )
+                advanceUntilIdle()
+
+                assertEquals(
+                    null,
+                    harness.dwsm.coordinator.stallStartTime,
+                    "ROM-fraction event $description must not arm the stall timer",
+                )
+            } finally {
+                harness.cleanup()
+            }
+        }
+    }
+
+    @Test
+    fun `Issue 673 completed working rep cancels ROM fraction stall timer`() = runTest {
+        val harness = DWSMTestHarness(this)
+        try {
+            prepareRomFractionStallHarness(harness) { advanceUntilIdle() }
+            assertEquals(1, harness.dwsm.coordinator.repCount.value.workingReps)
+
+            harness.fakeBleRepo.emitMachineStatusEvent(
+                MachineStatusEvent(harness.nowMs + 2L, SampleStatus(0), position = 50f, velocity = 5f),
+            )
+            advanceUntilIdle()
+            assertNotNull(harness.dwsm.coordinator.stallStartTime)
+
+            harness.fakeBleRepo.emitRepNotification(
+                RepNotification(
+                    topCounter = 5,
+                    completeCounter = 5,
+                    repsRomCount = 3,
+                    repsRomTotal = 3,
+                    repsSetCount = 2,
+                    repsSetTotal = 8,
+                    rangeTop = 800f,
+                    rangeBottom = 0f,
+                    rawData = ByteArray(24),
+                    timestamp = harness.nowMs + 3L,
+                ),
+            )
+            advanceUntilIdle()
+
+            assertEquals(2, harness.dwsm.coordinator.repCount.value.workingReps)
+            assertEquals(
+                null,
+                harness.dwsm.coordinator.stallStartTime,
+                "A completed working rep must cancel a ROM-fraction-armed stall timer",
+            )
+            assertFalse(harness.dwsm.coordinator.isCurrentlyStalled)
+        } finally {
+            harness.cleanup()
+        }
     }
 
     @Test
@@ -2234,6 +2362,38 @@ class DWSMWorkoutLifecycleTest {
         assertEquals(1, harness.fakeGamificationRepo.updateStatsCallCount, "Valid untagged completions should update gamification stats")
         assertEquals(1, harness.fakeGamificationRepo.checkAndAwardBadgesCallCount, "Valid untagged completions should award stat badges")
         harness.cleanup()
+    }
+
+    private suspend fun prepareRomFractionStallHarness(
+        harness: DWSMTestHarness,
+        advance: suspend () -> Unit,
+    ) {
+        harness.fakeBleRepo.simulateConnect("Vee_Test")
+        harness.dwsm.updateWorkoutParameters(
+            WorkoutParameters(
+                programMode = ProgramMode.OldSchool,
+                reps = 8,
+                warmupReps = 0,
+                weightPerCableKg = 35f,
+                stallDetectionEnabled = true,
+                isAMRAP = false,
+                isJustLift = false,
+            ),
+        )
+        harness.dwsm.startWorkout(skipCountdown = true)
+        advance()
+
+        harness.fakeBleRepo.emitMachineStatusEvent(
+            MachineStatusEvent(harness.nowMs, SampleStatus(0), position = 0f, velocity = 5f),
+        )
+        harness.fakeBleRepo.emitMachineStatusEvent(
+            MachineStatusEvent(harness.nowMs + 1L, SampleStatus(0), position = 100f, velocity = 5f),
+        )
+        advance()
+
+        completeWarmupReps(harness, warmupTarget = 3, workingTarget = 8)
+        completeFirstWorkingRep(harness, warmupTarget = 3, workingTarget = 8)
+        advance()
     }
 
     private suspend fun completeWarmupReps(harness: DWSMTestHarness, warmupTarget: Int = 3, workingTarget: Int = 8) {

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutCoordinatorAutoStopResetTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutCoordinatorAutoStopResetTest.kt
@@ -24,6 +24,11 @@ class WorkoutCoordinatorAutoStopResetTest {
         coordinator.stallStartTime = 67_890L
         coordinator.isCurrentlyStalled = true
         coordinator.stallArmedByDeload = true
+        // Issue #673 PR 2: ROM-fraction stall state
+        coordinator.romRangeTop = 500.0f
+        coordinator.romRangeBottom = 100.0f
+        coordinator.romFraction = 0.6f
+        coordinator.stallArmedByRomFraction = true
         coordinator.deferAutoStopDeadlineMs = 99_999L
         coordinator._autoStopState.value = AutoStopUiState(
             isActive = true,
@@ -39,6 +44,11 @@ class WorkoutCoordinatorAutoStopResetTest {
         assertEquals(null, coordinator.stallStartTime)
         assertFalse(coordinator.isCurrentlyStalled)
         assertFalse(coordinator.stallArmedByDeload)
+        // Issue #673 PR 2: ROM-fraction state must also be cleared
+        assertEquals(null, coordinator.romRangeTop)
+        assertEquals(null, coordinator.romRangeBottom)
+        assertEquals(null, coordinator.romFraction)
+        assertFalse(coordinator.stallArmedByRomFraction)
         assertEquals(0L, coordinator.deferAutoStopDeadlineMs)
         assertEquals(AutoStopUiState(), coordinator._autoStopState.value)
     }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutCoordinatorAutoStopResetTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutCoordinatorAutoStopResetTest.kt
@@ -27,8 +27,6 @@ class WorkoutCoordinatorAutoStopResetTest {
         // Issue #673 PR 2: ROM-fraction stall state
         coordinator.romRangeTop = 500.0f
         coordinator.romRangeBottom = 100.0f
-        coordinator.romFraction = 0.6f
-        coordinator.stallArmedByRomFraction = true
         coordinator.deferAutoStopDeadlineMs = 99_999L
         coordinator._autoStopState.value = AutoStopUiState(
             isActive = true,
@@ -47,8 +45,6 @@ class WorkoutCoordinatorAutoStopResetTest {
         // Issue #673 PR 2: ROM-fraction state must also be cleared
         assertEquals(null, coordinator.romRangeTop)
         assertEquals(null, coordinator.romRangeBottom)
-        assertEquals(null, coordinator.romFraction)
-        assertFalse(coordinator.stallArmedByRomFraction)
         assertEquals(0L, coordinator.deferAutoStopDeadlineMs)
         assertEquals(AutoStopUiState(), coordinator._autoStopState.value)
     }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeBleRepository.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/testutil/FakeBleRepository.kt
@@ -9,6 +9,7 @@ import com.devil.phoenixproject.data.repository.RepNotification
 import com.devil.phoenixproject.data.repository.ScannedDevice
 import com.devil.phoenixproject.domain.model.ConnectionState
 import com.devil.phoenixproject.domain.model.HeuristicStatistics
+import com.devil.phoenixproject.domain.model.MachineStatusEvent
 import com.devil.phoenixproject.domain.model.WorkoutMetric
 import com.devil.phoenixproject.domain.model.WorkoutParameters
 import kotlinx.coroutines.flow.Flow
@@ -45,6 +46,9 @@ class FakeBleRepository : BleRepository {
 
     private val _deloadOccurredEvents = MutableSharedFlow<Unit>(replay = 0)
     override val deloadOccurredEvents: Flow<Unit> = _deloadOccurredEvents.asSharedFlow()
+
+    private val _machineStatusEvents = MutableSharedFlow<MachineStatusEvent>(replay = 0)
+    override val machineStatusEvents: Flow<MachineStatusEvent> = _machineStatusEvents.asSharedFlow()
 
     private val _reconnectionRequested = MutableSharedFlow<ReconnectionRequest>(replay = 0)
     override val reconnectionRequested: Flow<ReconnectionRequest> = _reconnectionRequested.asSharedFlow()
@@ -120,6 +124,10 @@ class FakeBleRepository : BleRepository {
 
     suspend fun emitDeloadOccurred() {
         _deloadOccurredEvents.emit(Unit)
+    }
+
+    suspend fun emitMachineStatusEvent(event: MachineStatusEvent) {
+        _machineStatusEvents.emit(event)
     }
 
     suspend fun emitReconnectionRequest(request: ReconnectionRequest) {


### PR DESCRIPTION
## Summary

PR 2 of 3 for Issue #673. It widens the narrow `deloadOccurredEvents: Flow<Unit>` to `Flow<MachineStatusEvent>`, carrying the full `SampleStatus`, position, and velocity for every processed BLE monitor packet. It adds a geometric ROM-fraction signal as a secondary stall-arm path.

**Refs #673** — non-final phase; PR 3 owns the closing keyword.

## Independent value

- More reliable set-ending detection from continuous status, position, and velocity data.
- Conservative mid-ROM/dead-band detection that does not depend on `DELOAD_WARN`.
- A richer machine-status flow for future hardware behavior.

> Audit correction: F5 was already resolved by earlier audit work. This PR adds a complementary reliability signal; it does not claim to close F5.

## Changes

### Machine-status flow

- New `MachineStatusEvent(timestamp, sampleStatus, position, velocity)` model.
- `BleRepository.machineStatusEvents: Flow<MachineStatusEvent>`.
- `MonitorDataProcessor` emits an event after smoothing for every processed packet, including `status = 0`, with maximum position and velocity magnitude.
- `KableBleRepository` forwards the rich event while retaining the existing derived `deloadOccurredEvents` flow for compatibility.
- `FakeBleRepository` supports deterministic event injection for behavioral tests.

### ROM-fraction stall signal

- `WorkoutCoordinator` retains only ROM range extrema and clears them on auto-stop reset.
- `ActiveSessionEngine` calibrates ROM extrema from warmup samples, then permits arming only after normal auto-stop eligibility is open.
- The timer arms only when position is 30–80% of a meaningful calibrated ROM, velocity is 2.5–10 mm/s, standard-set/AMRAP guards permit it, and no timer is already active.
- Completed rep processing cancels the same shared stall timer.

## Tests

- `MonitorDataProcessorStatusEventTest`: status event emission for non-zero and zero status packets, position selection, and legacy deload callback preservation.
- `DWSMWorkoutLifecycleTest`: warmup calibration enables later mid-ROM arming; out-of-band ROM/velocity does not arm; sustained in-window cable progress resets the countdown; DELOAD takeover survives ROM-window exit; and a completed working rep cancels a ROM-fraction timer.
- Fresh local verification:
  - `./gradlew -Pskip.supabase.check=true :shared:testAndroidHostTest`
  - `./gradlew -Pskip.supabase.check=true :shared:compileKotlinIosArm64 :shared:compileTestKotlinIosArm64`

## Sequential phase requirement

PR #686 (Phase 1) was merged to `working_branch`, not `main`. It must be promoted into `main` before this Phase-2 PR is merged, preserving the signed-off three-phase sequence.

## UI visual evidence

Not required for this non-UI phase. PR 3 is UI-involved and requires final in-app visual evidence.
