### PR TITLE
fix(ui): disable routine save until name and exercises are set

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RoutineEditorScreen.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/screen/RoutineEditorScreen.kt
@@ -259,6 +259,7 @@ fun RoutineEditorScreen(
             state.exercises != snapshotExercises ||
             state.supersets != snapshotSupersets
         )
+    val canSaveRoutine = state.exercises.isNotEmpty() && state.routineName.isNotBlank()
 
     // Drag and Drop State
     val lazyListState = rememberLazyListState()
@@ -504,18 +505,19 @@ fun RoutineEditorScreen(
                         val routineToSave = if (base != null) {
                             base.copy(
                                 id = finalRoutineId,
-                                name = state.routineName.ifBlank { "Unnamed Routine" },
+                                name = state.routineName.trim(),
                                 supersets = base.supersets.map { it.copy(routineId = finalRoutineId) },
                             )
                         } else {
                             Routine(
                                 id = finalRoutineId,
-                                name = state.routineName.ifBlank { "Unnamed Routine" },
+                                name = state.routineName.trim(),
                             )
                         }
                         viewModel.saveRoutine(routineToSave)
                         navController.popBackStack()
                     },
+                    enabled = canSaveRoutine,
                 ) {
                     Text(stringResource(Res.string.action_save))
                 }


### PR DESCRIPTION
## Summary

Fixes audit finding **01-F-002**: the Routine Editor Save button could persist empty routines or fall back to `"Unnamed Routine"`.

- Disable Save until the routine has **at least one exercise** and a **non-blank name**
- Save the trimmed routine name directly instead of silently defaulting to `"Unnamed Routine"`

## Test plan

- [ ] Open Routine Editor with no exercises → Save is disabled
- [ ] Add an exercise but clear the name → Save stays disabled
- [ ] Enter a name and add an exercise → Save enables and saves correctly
- [ ] Existing routines with content still save normally

Contributed from [@Jdub7575](https://github.com/Jdub7575).

Made with [Cursor](https://cursor.com)