### PR TITLE
fix: flush _repCount before WORKOUT_COMPLETE handles set completion (#703)

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -532,9 +532,10 @@ class ActiveSessionEngine(
                         if (executionGuard.isCurrent(eventLease) && coordinator._workoutState.value is WorkoutState.Active) {
                             // Issue #703: Flush _repCount.value BEFORE handleSetCompletion reads it.
                             // repCounter.process() has already updated its internal workingReps,
-                            // but coordinator._repCount.value is still stale (updated later at line 1334
-                            // in handleRepNotification). handleSetCompletion -> captureExitSnapshot reads
-                            // _repCount.value, so we must ensure it reflects the final rep count.
+                            // but coordinator._repCount.value is still stale (the StateFlow write in
+                            // handleRepNotification happens after this callback returns). handleSetCompletion
+                            // -> captureExitSnapshot reads _repCount.value, so we must ensure it reflects
+                            // the final rep count before the snapshot is captured.
                             coordinator._repCount.value = repCounter.getRepCount()
                             Logger.d("WORKOUT_COMPLETE event received - triggering immediate set completion")
                             handleSetCompletion(eventLease)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -530,6 +530,12 @@ class ActiveSessionEngine(
                         // Playing both was causing multiple sounds to fire at once (sound stacking bug).
                         // Issue #182: Trigger set completion immediately on WORKOUT_COMPLETE event.
                         if (executionGuard.isCurrent(eventLease) && coordinator._workoutState.value is WorkoutState.Active) {
+                            // Issue #703: Flush _repCount.value BEFORE handleSetCompletion reads it.
+                            // repCounter.process() has already updated its internal workingReps,
+                            // but coordinator._repCount.value is still stale (updated later at line 1334
+                            // in handleRepNotification). handleSetCompletion -> captureExitSnapshot reads
+                            // _repCount.value, so we must ensure it reflects the final rep count.
+                            coordinator._repCount.value = repCounter.getRepCount()
                             Logger.d("WORKOUT_COMPLETE event received - triggering immediate set completion")
                             handleSetCompletion(eventLease)
                         }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutExitPersistenceTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutExitPersistenceTest.kt
@@ -951,8 +951,9 @@ class WorkoutExitPersistenceTest {
             // Simulate 3 ROM/warmup reps
             repeat(3) { romRep ->
                 harness.fakeBleRepo.emitRepNotification(
-                    harness.repNotification(
+                    harness.modernRepPacket(
                         repsSetCount = romRep,
+                        repsSetTotal = 7,
                         timestamp = nowMs() + romRep * 1000L,
                         repsRomCount = romRep + 1,
                         repsRomTotal = 3,
@@ -964,8 +965,9 @@ class WorkoutExitPersistenceTest {
             // Simulate 7 working reps (repsSetCount 0..6, repsRomCount stays at 3)
             repeat(7) { workingRep ->
                 harness.fakeBleRepo.emitRepNotification(
-                    harness.repNotification(
+                    harness.modernRepPacket(
                         repsSetCount = workingRep + 1,
+                        repsSetTotal = 7,
                         timestamp = nowMs() + (3 + workingRep) * 1000L,
                         repsRomCount = 3,
                         repsRomTotal = 3,

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutExitPersistenceTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutExitPersistenceTest.kt
@@ -917,4 +917,92 @@ class WorkoutExitPersistenceTest {
             velocityB = 130.0,
         ),
     )
+
+    /**
+     * Issue #703: Rep count off-by-one when ROM reps precede working set.
+     *
+     * When the Nth rep notification triggers WORKOUT_COMPLETE, handleSetCompletion
+     * reads coordinator._repCount.value which was still stale (N-1) because the
+     * StateFlow write at handleRepNotification line 1334 occurs AFTER repCounter.process()
+     * returns. The fix flushes _repCount.value inside the WORKOUT_COMPLETE handler
+     * before calling handleSetCompletion.
+     */
+    @Test
+    fun `issue 703 - working reps persist correctly when ROM reps precede working set`() = runTest {
+        val harness = DWSMTestHarness(this)
+        try {
+            // Setup: reps=7, warmupReps=3 (matching reporter's scenario)
+            harness.fakeExerciseRepo.addExercise(TestFixtures.benchPress)
+            harness.fakeBleRepo.simulateConnect("Vee_Test")
+            harness.dwsm.updateWorkoutParameters(
+                WorkoutParameters(
+                    programMode = ProgramMode.OldSchool,
+                    reps = 7,
+                    warmupReps = 3,
+                    weightPerCableKg = 25f,
+                    selectedExerciseId = TestFixtures.benchPress.id,
+                ),
+            )
+            harness.dwsm.startWorkout(skipCountdown = true)
+            harness.testScope.testScheduler.advanceUntilIdle()
+
+            val lease = harness.activeSessionEngine.currentExecutionLeaseForTest()
+
+            // Simulate 3 ROM/warmup reps
+            repeat(3) { romRep ->
+                harness.fakeBleRepo.emitRepNotification(
+                    harness.repNotification(
+                        repsSetCount = romRep,
+                        timestamp = nowMs() + romRep * 1000L,
+                        repsRomCount = romRep + 1,
+                        repsRomTotal = 3,
+                    ),
+                )
+                harness.testScope.testScheduler.advanceUntilIdle()
+            }
+
+            // Simulate 7 working reps (repsSetCount 0..6, repsRomCount stays at 3)
+            repeat(7) { workingRep ->
+                harness.fakeBleRepo.emitRepNotification(
+                    harness.repNotification(
+                        repsSetCount = workingRep + 1,
+                        timestamp = nowMs() + (3 + workingRep) * 1000L,
+                        repsRomCount = 3,
+                        repsRomTotal = 3,
+                    ),
+                )
+                harness.testScope.testScheduler.advanceUntilIdle()
+            }
+
+            // Verify the persisted session has workingReps=7, not 6
+            val savedSessions = harness.fakeWorkoutRepo.saveSessionAttempts
+            assertTrue(savedSessions.isNotEmpty(), "Expected at least one saved session")
+            val lastSession = savedSessions.last()
+            assertEquals(
+                7,
+                lastSession.workingReps,
+                "Issue #703: workingReps should be 7, not ${lastSession.workingReps}. " +
+                    "The StateFlow was stale when WORKOUT_COMPLETE fired.",
+            )
+            assertEquals(
+                7,
+                lastSession.totalReps,
+                "Issue #703: totalReps should be 7",
+            )
+
+            // Verify completedSet also has correct rep count
+            val savedCompletedSets = harness.fakeCompletedSetRepo.saved
+            assertTrue(savedCompletedSets.isNotEmpty(), "Expected at least one completed set")
+            val lastCompletedSet = savedCompletedSets.last()
+            assertEquals(
+                7,
+                lastCompletedSet.actualReps,
+                "Issue #703: CompletedSet.actualReps should be 7, not ${lastCompletedSet.actualReps}",
+            )
+        } finally {
+            harness.cleanup()
+        }
+    }
+
+    private fun nowMs() = DWSMTestHarness.TEST_WALL_CLOCK_EPOCH_MS
 }

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutExitPersistenceTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutExitPersistenceTest.kt
@@ -923,7 +923,7 @@ class WorkoutExitPersistenceTest {
      *
      * When the Nth rep notification triggers WORKOUT_COMPLETE, handleSetCompletion
      * reads coordinator._repCount.value which was still stale (N-1) because the
-     * StateFlow write at handleRepNotification line 1334 occurs AFTER repCounter.process()
+     * StateFlow write in handleRepNotification occurs AFTER repCounter.process()
      * returns. The fix flushes _repCount.value inside the WORKOUT_COMPLETE handler
      * before calling handleSetCompletion.
      */
@@ -954,7 +954,7 @@ class WorkoutExitPersistenceTest {
                     harness.modernRepPacket(
                         repsSetCount = romRep,
                         repsSetTotal = 7,
-                        timestamp = nowMs() + romRep * 1000L,
+                        timestamp = harness.nowMs + romRep * 1000L,
                         repsRomCount = romRep + 1,
                         repsRomTotal = 3,
                     ),
@@ -968,7 +968,7 @@ class WorkoutExitPersistenceTest {
                     harness.modernRepPacket(
                         repsSetCount = workingRep + 1,
                         repsSetTotal = 7,
-                        timestamp = nowMs() + (3 + workingRep) * 1000L,
+                        timestamp = harness.nowMs + (3 + workingRep) * 1000L,
                         repsRomCount = 3,
                         repsRomTotal = 3,
                     ),
@@ -1005,6 +1005,4 @@ class WorkoutExitPersistenceTest {
             harness.cleanup()
         }
     }
-
-    private fun nowMs() = DWSMTestHarness.TEST_WALL_CLOCK_EPOCH_MS
 }


### PR DESCRIPTION
## Summary

Fixes off-by-one rep count when ROM reps precede the working set (Issue #703).

## Root Cause

When the Nth rep notification triggers `WORKOUT_COMPLETE`, `handleSetCompletion` reads `coordinator._repCount.value` which was still stale (N-1) because the StateFlow write at `handleRepNotification` line 1334 occurs AFTER `repCounter.process()` returns.

The race:
1. `repCounter.process()` updates internal `workingReps` to N
2. `process()` fires `WORKOUT_COMPLETE` via `onRepEvent` callback
3. Callback launches coroutine -> `handleSetCompletion(eventLease)`
4. `handleSetCompletion` reads `coordinator._repCount.value` -> still N-1
5. `captureExitSnapshot` persists `workingReps = N-1` instead of N

## Fix

Flush `coordinator._repCount.value = repCounter.getRepCount()` inside the `WORKOUT_COMPLETE` handler **before** calling `handleSetCompletion`, ensuring the snapshot sees the correct rep count.

## Changes

- `ActiveSessionEngine.kt`: Added `_repCount.value` flush in WORKOUT_COMPLETE handler
- `WorkoutExitPersistenceTest.kt`: Added targeted test for the full repNotification -> handleRepNotification -> WORKOUT_COMPLETE -> handleSetCompletion -> captureExitSnapshot -> persistence path

## RCA Reference

- RCA owner: gpt-5.6-terra-xhigh
- RCA model: gpt-5.6-terra
- Architecture review: approved (gpt-5.6-terra)

Fixes #703
