### PR TITLE
fix: accept unlimited AMRAP reps for finite routine leases

### DIFF
--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/ActiveSessionEngine.kt
@@ -7752,6 +7752,11 @@ class ActiveSessionEngine(
         } else {
             variableWarmupTarget ?: seedParams.reps
         }
+        val usesUnlimitedRepTarget = requiresMachine &&
+            !isBodyweightAtStart &&
+            !isTimedCableAtStart &&
+            variableWarmupTarget == null &&
+            (isJustLiftMode || seedParams.isJustLift || seedParams.isAMRAP)
         val outgoingLease = executionGuard.currentLease
         val executionSeed = ExecutionSeed(
             sessionId = KmpUtils.randomUUID(),
@@ -7762,6 +7767,7 @@ class ActiveSessionEngine(
             isJustLift = isJustLiftMode || seedParams.isJustLift,
             isAmrap = seedParams.isAMRAP,
             isTimedCable = isTimedCableAtStart,
+            usesUnlimitedRepTarget = usesUnlimitedRepTarget,
         )
         beforeExecutionBeginForTest?.invoke()
         val leaseResult = when {

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/RepNotificationFreshnessGate.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/RepNotificationFreshnessGate.kt
@@ -2,6 +2,8 @@ package com.devil.phoenixproject.presentation.manager
 
 import com.devil.phoenixproject.data.repository.RepNotification
 
+private const val UNLIMITED_REPS_SET_TOTAL = 252
+
 internal sealed interface RepFreshnessState {
     data object AwaitingEvidence : RepFreshnessState
     data class LegacyBaseline(val topCounter: Int, val completeCounter: Int) : RepFreshnessState
@@ -56,13 +58,15 @@ internal class RepNotificationFreshnessGate {
         val identity = lease.identity()
         if (notification.isLegacyFormat) return evaluateLegacy(identity, notification)
 
-        // Issue #698/#700: Just Lift and AMRAP with target=0 use unlimited
-        // target semantics (0xFF/252), so the device-reported repsSetTotal
-        // will never match the finite UI lease target. Exempt both from
-        // target equality check. AMRAP with a finite target (>0) must still
-        // match — only unlimited AMRAP gets the exemption.
+        // Issue #698/#700/#712: Just Lift and AMRAP use unlimited target
+        // semantics on the wire (0xFF, reported back as 252). Routine AMRAP
+        // leases retain their configured finite UI fallback target (for
+        // example 10), so lease.workingRepTarget == 0 is not a reliable
+        // unlimited discriminator. The notification sentinel is.
+        val isUnlimitedAmrapPacket = lease.isAmrap &&
+            notification.repsSetTotal == UNLIMITED_REPS_SET_TOTAL
         val targetMatches = lease.isJustLift ||
-            (lease.isAmrap && lease.workingRepTarget == 0) ||
+            isUnlimitedAmrapPacket ||
             notification.repsSetTotal == 0 ||
             notification.repsSetTotal == lease.workingRepTarget
         if (!targetMatches) return RepFreshnessDecision.Drop(RepDropReason.TARGET_MISMATCH)

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/RepNotificationFreshnessGate.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/RepNotificationFreshnessGate.kt
@@ -64,6 +64,7 @@ internal class RepNotificationFreshnessGate {
         // example 10), so lease.workingRepTarget == 0 is not a reliable
         // unlimited discriminator. The notification sentinel is.
         val isUnlimitedAmrapPacket = lease.isAmrap &&
+            lease.usesUnlimitedRepTarget &&
             notification.repsSetTotal == UNLIMITED_REPS_SET_TOTAL
         val targetMatches = lease.isJustLift ||
             isUnlimitedAmrapPacket ||

--- a/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutExecutionGuard.kt
+++ b/shared/src/commonMain/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutExecutionGuard.kt
@@ -55,6 +55,7 @@ internal data class ExecutionSeed(
     val isJustLift: Boolean = false,
     val isAmrap: Boolean = false,
     val isTimedCable: Boolean = false,
+    val usesUnlimitedRepTarget: Boolean = false,
 )
 
 internal data class ExecutionLease(
@@ -67,6 +68,7 @@ internal data class ExecutionLease(
     val isJustLift: Boolean,
     val isAmrap: Boolean,
     val isTimedCable: Boolean,
+    val usesUnlimitedRepTarget: Boolean = false,
     val activationCutoverTimestampMs: Long? = null,
 )
 
@@ -405,6 +407,7 @@ internal class WorkoutExecutionGuard(
             isJustLift = seed.isJustLift,
             isAmrap = seed.isAmrap,
             isTimedCable = seed.isTimedCable,
+            usesUnlimitedRepTarget = seed.usesUnlimitedRepTarget,
         )
         currentLeaseRef.value?.let { outgoingLease ->
             if (sameIdentity(completionClaim?.lease, outgoingLease)) {

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/RoutineSetWeightResolverTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/domain/usecase/RoutineSetWeightResolverTest.kt
@@ -14,7 +14,7 @@ class RoutineSetWeightResolverTest {
     )
 
     @Test
-    fun `resolves programmed, scaled, and manually adjusted routine set weights`() {
+    fun `resolves programmed scaled and manually adjusted routine set weights`() {
         data class Case(
             val name: String,
             val routineExercise: RoutineExercise,

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/RepNotificationFreshnessGateTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/RepNotificationFreshnessGateTest.kt
@@ -204,7 +204,10 @@ class RepNotificationFreshnessGateTest {
         val gate = RepNotificationFreshnessGate()
         // Routine AMRAP retains its configured UI fallback target on the lease
         // even though the machine command uses the unlimited 0xFF sentinel.
-        val lease = activeLease(target = 10, cutover = 1_000L).copy(isAmrap = true)
+        val lease = activeLease(target = 10, cutover = 1_000L).copy(
+            isAmrap = true,
+            usesUnlimitedRepTarget = true,
+        )
 
         // First packet establishes baseline and arms
         assertEquals(RepFreshnessDecision.BaselineOnly, gate.evaluate(lease, modernPacket(timestamp = 1_001L)))
@@ -220,13 +223,30 @@ class RepNotificationFreshnessGateTest {
     @Test
     fun `amrap lease does not treat repsSetCount as terminal`() {
         val gate = RepNotificationFreshnessGate()
-        val lease = activeLease(target = 0, cutover = 1_000L).copy(isAmrap = true)
+        val lease = activeLease(target = 0, cutover = 1_000L).copy(
+            isAmrap = true,
+            usesUnlimitedRepTarget = true,
+        )
 
         // AMRAP should never treat repsSetCount as terminal, same as Just Lift
         assertEquals(RepFreshnessDecision.BaselineOnly, gate.evaluate(lease, modernPacket(timestamp = 1_001L)))
         assertEquals(
             RepFreshnessDecision.Process,
             gate.evaluate(lease, modernPacket(repsSetCount = 5, repsSetTotal = 252, timestamp = 1_002L)),
+        )
+    }
+
+    @Test
+    fun `amrap variable warmup execution rejects delayed unlimited packet`() {
+        val gate = RepNotificationFreshnessGate()
+        val lease = activeLease(target = 3, cutover = 1_000L).copy(
+            isAmrap = true,
+            usesUnlimitedRepTarget = false,
+        )
+
+        assertEquals(
+            RepFreshnessDecision.Drop(RepDropReason.TARGET_MISMATCH),
+            gate.evaluate(lease, modernPacket(repsSetCount = 1, repsSetTotal = 252, timestamp = 1_001L)),
         )
     }
 

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/RepNotificationFreshnessGateTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/RepNotificationFreshnessGateTest.kt
@@ -202,7 +202,9 @@ class RepNotificationFreshnessGateTest {
     @Test
     fun `amrap lease accepts repsSetTotal 252 despite finite UI target`() {
         val gate = RepNotificationFreshnessGate()
-        val lease = activeLease(target = 0, cutover = 1_000L).copy(isAmrap = true)
+        // Routine AMRAP retains its configured UI fallback target on the lease
+        // even though the machine command uses the unlimited 0xFF sentinel.
+        val lease = activeLease(target = 10, cutover = 1_000L).copy(isAmrap = true)
 
         // First packet establishes baseline and arms
         assertEquals(RepFreshnessDecision.BaselineOnly, gate.evaluate(lease, modernPacket(timestamp = 1_001L)))

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/RestoredRuntimeTimerRaceTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/RestoredRuntimeTimerRaceTest.kt
@@ -101,7 +101,7 @@ class RestoredRuntimeTimerRaceTest {
             val staleReset = async(Dispatchers.Default) {
                 harness.dwsm.resetForNewWorkout()
             }
-            withContext(Dispatchers.IO) {
+            withContext(Dispatchers.Default) {
                 withTimeout(2_000L) { staleDetachEntered.await() }
             }
 
@@ -118,7 +118,7 @@ class RestoredRuntimeTimerRaceTest {
             assertTrue(newerJob.isActive)
 
             releaseStaleDetach.complete(Unit)
-            withContext(Dispatchers.IO) {
+            withContext(Dispatchers.Default) {
                 withTimeout(2_000L) { staleReset.await() }
             }
 

--- a/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutExecutionGuardRestoredRuntimeTest.kt
+++ b/shared/src/commonTest/kotlin/com/devil/phoenixproject/presentation/manager/WorkoutExecutionGuardRestoredRuntimeTest.kt
@@ -256,7 +256,7 @@ class WorkoutExecutionGuardRestoredRuntimeTest {
         var ownerWasCurrentBeforeCallbackReturned = false
         var publications = 0
 
-        val publication = async(Dispatchers.IO) {
+        val publication = async(Dispatchers.Default) {
             guard.commitRestoredTimerPublication(
                 owner = owner,
                 candidateStillCurrent = { true },
@@ -270,7 +270,7 @@ class WorkoutExecutionGuardRestoredRuntimeTest {
         }
 
         withTimeout(2_000) { callbackEntered.await() }
-        val supersession = async(Dispatchers.IO) {
+        val supersession = async(Dispatchers.Default) {
             supersessionStarted.complete(Unit)
             guard.supersedeRecoveryPublication()
             supersessionFinished.complete(Unit)


### PR DESCRIPTION
## Summary

Fixes #712.

Routine AMRAP commands send the unlimited `0xFF` target, which the machine reports as `repsSetTotal=252`. The execution lease retains the routine's finite UI fallback target (for example `10`). PR #701 only exempted AMRAP when `workingRepTarget == 0`, so every valid warmup and working rep was rejected as `TARGET_MISMATCH`.

The lease now records whether the **current machine command** uses the unlimited target. The freshness gate accepts sentinel `252` only when the active AMRAP command is explicitly unlimited. Finite variable-warmup executions remain protected from delayed stale unlimited packets.

## Runtime evidence

Corrected Android Phantom production path:

- Runtime: `isAMRAP=true`, warmup target `3`, lease target `10`, current command unlimited
- Sequence: warmup `1/3 → 2/3 → 3/3`, then working reps `1..3`
- Before fix: every notification dropped as `TARGET_MISMATCH`; UI remained `0/3`
- After fix: notifications processed, warmup gate opened, three working reps counted, and release/rest auto-stopped into Set Summary
- Review hardening rerun: same pass with explicit current-command authority

## Regression coverage

- Corrected the misleading “finite UI target” test from target `0` to `10`
- Added a variable-warmup regression proving a finite AMRAP warmup execution rejects delayed sentinel `252`
- Verified red before implementation

## CI portability follow-up

The first CI run exposed unrelated current-main common-test portability failures. Test-only fixes:

- removed commas from a Kotlin/Native-incompatible backtick test name;
- replaced common-test `Dispatchers.IO` references with portable `Dispatchers.Default`.

## Verification

- Full Android host suite
- Related freshness/rep-counter/lifecycle tests
- Android main compilation
- Exact iOS main and test-target compilation
- Live Phantom warmup, working-rep, and auto-stop flow

No version bump, schema change, firmware change, portal change, or unrelated production refactor.